### PR TITLE
fix: 认证安全加固 - C5中间件 + 环境变量迁移 + TS类型

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,37 @@
+# WebGIS AI Agent - Environment Variables
+# Copy this file to .env and fill in the values
+
+# === Application ===
+DEBUG=true
+ENV=development
+
+# === JWT Authentication ===
+# Required for persistent sessions. If empty, a random key is generated each startup.
+JWT_SECRET_KEY=
+
+# === Database ===
+DATABASE_URL=sqlite:///./data/webgis.db
+
+# === LLM (OpenAI-compatible API) ===
 LLM_BASE_URL=http://localhost:8000/v1
 LLM_API_KEY=not-needed
 LLM_MODEL=MiniMax-M2.5
-JWT_SECRET_KEY=change-me-to-a-random-secret
+
+# === Tianditu (天地图) ===
 TIANDITU_TOKEN=
+
+# === Sentinel Hub ===
 SENTINELHUB_CLIENT_ID=
 SENTINELHUB_CLIENT_SECRET=
+
+# === NASA EarthData ===
 NASA_EARTHDATA_USERNAME=
 NASA_EARTHDATA_PASSWORD=
+
+# === OpenTopography ===
 OPENTOPOGRAPHY_API_KEY=
+
+# === Redis & Celery ===
+REDIS_URL=redis://localhost:16379/0
+CELERY_BROKER_URL=redis://localhost:16379/0
+CELERY_RESULT_BACKEND=redis://localhost:16379/1

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -2,11 +2,12 @@
 import json
 import logging
 from collections import OrderedDict
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from typing import Optional
 
+from app.core.auth import get_current_user, get_current_user_optional
 from app.services.chat_engine import ChatEngine
 from app.services.history_service import HistoryService
 from app.core.database import SessionLocal
@@ -49,7 +50,7 @@ class ChatResponse(BaseModel):
 
 
 @router.post("/completions", response_model=ChatResponse)
-async def chat_completions(req: ChatRequest):
+async def chat_completions(req: ChatRequest, _user: dict = Depends(get_current_user_optional)):
     """非流式对话接口"""
     try:
         result = await engine.chat(req.message, session_id=req.session_id)
@@ -60,7 +61,7 @@ async def chat_completions(req: ChatRequest):
 
 
 @router.post("/stream")
-async def chat_stream(req: ChatRequest):
+async def chat_stream(req: ChatRequest, _user: dict = Depends(get_current_user_optional)):
     """SSE 流式对话接口"""
     async def event_generator():
         try:
@@ -83,7 +84,7 @@ async def chat_stream(req: ChatRequest):
 
 
 @router.get("/sessions")
-async def list_sessions():
+async def list_sessions(_user: dict = Depends(get_current_user_optional)):
     """列出所有历史会话（最多1000条，按最近更新排序）"""
     db = SessionLocal()
     try:
@@ -104,7 +105,7 @@ async def list_sessions():
 
 
 @router.get("/sessions/{session_id}")
-async def get_session_detail(session_id: str):
+async def get_session_detail(session_id: str, _user: dict = Depends(get_current_user_optional)):
     """获取会话详情（只读）"""
     db = SessionLocal()
     try:
@@ -132,7 +133,7 @@ async def get_session_detail(session_id: str):
 
 
 @router.delete("/sessions/{session_id}")
-async def clear_session(session_id: str):
+async def clear_session(session_id: str, _user: dict = Depends(get_current_user_optional)):
     """清除会话（内存 + DB）"""
     engine.clear_session(session_id)
     return {"status": "ok"}
@@ -154,7 +155,7 @@ class ToolExecuteRequest(BaseModel):
 
 
 @router.post("/tools/execute")
-async def execute_tool_direct(req: ToolExecuteRequest):
+async def execute_tool_direct(req: ToolExecuteRequest, _user: dict = Depends(get_current_user)):
     """直接执行单个工具（非流式通过 chat）"""
     tool_name = req.tool
     args = req.arguments
@@ -171,7 +172,7 @@ async def execute_tool_direct(req: ToolExecuteRequest):
 
 
 @router.get("/tools/results")
-async def get_latest_result(session_id: str = "", tool: str = ""):
+async def get_latest_result(session_id: str = "", tool: str = "", _user: dict = Depends(get_current_user)):
     """获取指定 session 的工具执行结果（需提供 session_id）"""
     if not session_id:
         raise HTTPException(status_code=400, detail="session_id is required")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,12 @@
 """核心配置模块"""
+import secrets
+import logging
+import warnings
 from typing import List, Optional
 from pydantic_settings import BaseSettings
-from pydantic import Field
+from pydantic import Field, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):
@@ -16,7 +21,7 @@ class Settings(BaseSettings):
         return self.ENV.lower() == "production"
 
     # JWT
-    JWT_SECRET_KEY: str = "your-secret-key-change-in-production"
+    JWT_SECRET_KEY: str = Field(default="", env="JWT_SECRET_KEY")
 
     # 数据库
     DATABASE_URL: str = Field(default="sqlite:///./data/webgis.db", env="DATABASE_URL")
@@ -32,15 +37,15 @@ class Settings(BaseSettings):
     NOMINATIM_URL: str = "https://nominatim.openstreetmap.org/search"
 
     # 天地图
-    TIANDITU_TOKEN: str = "2f2497677943d79a29e344e760c41f92"
+    TIANDITU_TOKEN: str = Field(default="", env="TIANDITU_TOKEN")
 
     # Sentinel Hub
-    SENTINELHUB_CLIENT_ID: str = ""
-    SENTINELHUB_CLIENT_SECRET: str = ""
+    SENTINELHUB_CLIENT_ID: str = Field(default="", env="SENTINELHUB_CLIENT_ID")
+    SENTINELHUB_CLIENT_SECRET: str = Field(default="", env="SENTINELHUB_CLIENT_SECRET")
 
     # NASA EarthData
-    NASA_EARTHDATA_USERNAME: str = ""
-    NASA_EARTHDATA_PASSWORD: str = ""
+    NASA_EARTHDATA_USERNAME: str = Field(default="", env="NASA_EARTHDATA_USERNAME")
+    NASA_EARTHDATA_PASSWORD: str = Field(default="", env="NASA_EARTHDATA_PASSWORD")
 
     # OpenTopography
     OPENTOPOGRAPHY_API_KEY: str = Field(default="", env="OPENTOPOGRAPHY_API_KEY")
@@ -57,6 +62,18 @@ class Settings(BaseSettings):
     CELERY_BROKER_URL: str = Field(default="redis://localhost:16379/0", env="CELERY_BROKER_URL")
     CELERY_RESULT_BACKEND: str = Field(default="redis://localhost:16379/1", env="CELERY_RESULT_BACKEND")
     USE_REDIS: bool = False # 默认不开启，除非显式配置且可用
+
+    @model_validator(mode="after")
+    def _ensure_jwt_secret(self) -> "Settings":
+        if not self.JWT_SECRET_KEY:
+            self.JWT_SECRET_KEY = secrets.token_urlsafe(32)
+            warnings.warn(
+                "JWT_SECRET_KEY is not set. A random secret has been generated. "
+                "Set JWT_SECRET_KEY in .env for persistent sessions.",
+                stacklevel=2,
+            )
+            logger.warning("JWT_SECRET_KEY not set, generated random secret for this session")
+        return self
 
     class Config:
         env_file = ".env"

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,14 +5,15 @@ import { MapPanel } from "@/components/map/map-panel"
 import { ResultsPanel } from "@/components/panel/results-panel"
 import { TaskProvider } from "@/lib/contexts/task-context"
 import type { Layer } from "@/lib/types/layer"
+import type { AnalysisResult, ToolResult, GeoJSONGeometry, GeoJSONFeature } from "@/lib/types"
 
 export default function Home() {
   const [layers, setLayers] = useState<Layer[]>([])
-  const [analysisResult, setAnalysisResult] = useState<any>(null)
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null)
 
-  const handleToolResult = useCallback((toolName: string, result: any) => {
+  const handleToolResult = useCallback((toolName: string, result: ToolResult) => {
     // 栅格热力图（base64 PNG + bbox）
-    if (result?.type === "heatmap_raster" && result?.image && result?.bbox) {
+    if (result?.type === "heatmap_raster" && result?.image && Array.isArray(result.bbox)) {
       const layerId = `heatmap_raster-${Date.now()}`
       const [west, south, east, north] = result.bbox
       const center: [number, number] = [(west + east) / 2, (south + north) / 2]
@@ -40,31 +41,32 @@ export default function Home() {
       const collectCoords = (coords: number[][]) => {
         coords.forEach((c: number[]) => { lngs.push(c[0]); lats.push(c[1]) })
       }
-      const collectFromGeometry = (geometry: any) => {
-        if (!geometry?.coordinates) return
+      const collectFromGeometry = (geometry: GeoJSONGeometry) => {
+        const c = geometry.coordinates as number[] | number[][]
+        if (!c) return
         switch (geometry.type) {
           case "Point":
-            lngs.push(geometry.coordinates[0])
-            lats.push(geometry.coordinates[1])
+            lngs.push((c as number[])[0])
+            lats.push((c as number[])[1])
             break
           case "MultiPoint":
-            collectCoords(geometry.coordinates)
+            collectCoords(c as number[][])
             break
           case "LineString":
-            collectCoords(geometry.coordinates)
+            collectCoords(c as number[][])
             break
           case "MultiLineString":
-            geometry.coordinates.forEach((ring: number[][]) => collectCoords(ring))
+            (c as number[][][]).forEach((ring: number[][]) => collectCoords(ring))
             break
           case "Polygon":
-            collectCoords(geometry.coordinates[0] || [])
+            collectCoords((c as number[][][])[0] || [])
             break
           case "MultiPolygon":
-            geometry.coordinates.forEach((poly: number[][][]) => collectCoords(poly[0] || []))
+            (c as number[][][][]).forEach((poly: number[][][]) => collectCoords(poly[0] || []))
             break
         }
       }
-      result.geojson.features.forEach((f: any) => collectFromGeometry(f.geometry))
+      result.geojson.features.forEach((f: GeoJSONFeature) => collectFromGeometry(f.geometry!))
 
       let center: [number, number] | undefined
       let zoom = 12

--- a/frontend/components/chat/chart-renderer.tsx
+++ b/frontend/components/chat/chart-renderer.tsx
@@ -24,7 +24,7 @@ export interface ChartData {
 const VALID_CHART_TYPES = new Set(["bar", "line", "pie", "scatter"] as const)
 
 // Runtime validation adapter - replaces unsafe "as ChartData" casts
-export function adaptChartData(raw: any): ChartData | null {
+export function adaptChartData(raw: unknown): ChartData | null {
   try {
     if (!raw || typeof raw !== "object") return null
 

--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -4,6 +4,7 @@ import { Send, Paperclip, Bot, User, Loader2, Upload, X, Check, AlertCircle, His
 import { streamChat, SSEEventType, getSessionList, getSessionDetail, deleteSession } from "@/lib/api/chat"
 import { ChatSession } from "@/lib/types/chat"
 import { useTask } from "@/lib/contexts/task-context"
+import type { ToolResult } from "@/lib/types"
 import { TaskProgress } from "@/components/chat/task-progress"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
@@ -31,7 +32,7 @@ interface ChatPanelProps {
   onAnalysisRequest?: (message: string, attachments?: Attachment[]) => void
   incomingMessage?: string
   incomingResponse?: string
-  onToolResult?: (toolName: string, result: any) => void
+  onToolResult?: (toolName: string, result: ToolResult) => void
 }
 
 export function ChatPanel({ onAnalysisRequest, incomingMessage, incomingResponse, onToolResult }: ChatPanelProps) {

--- a/frontend/components/layer-card.tsx
+++ b/frontend/components/layer-card.tsx
@@ -9,7 +9,7 @@ interface LayerCardProps {
   onDelete: (id: string) => void;
   onEdit: (layer: Layer) => void; // Keep for backward compatibility if needed
   onUpdate?: (id: string, updates: Partial<Layer>) => void;
-  dragHandleProps?: any;
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 export const LayerCard = memo(function LayerCard({

--- a/frontend/components/map/map-action-handler.tsx
+++ b/frontend/components/map/map-action-handler.tsx
@@ -1,22 +1,38 @@
 'use client';
 import { useEffect } from 'react';
 import { useMapAction } from '@/lib/contexts/map-action-context';
+import type { GeoJSONFeatureCollection } from '@/lib/types';
 
-function calculateBBox(geojson: any): [number, number, number, number] | null {
+interface MapInstanceLike {
+  getMap?: () => maplibregl.Map;
+  getSource?: (id: string) => { setData: (data: unknown) => void } | undefined;
+  addSource?: (id: string, source: unknown) => void;
+  addLayer?: (layer: unknown) => void;
+  getLayer?: (id: string) => unknown;
+  fitBounds?: (bounds: unknown, options?: unknown) => void;
+  flyTo?: (options: unknown) => void;
+}
+
+function calculateBBox(geojson: GeoJSONFeatureCollection): [number, number, number, number] | null {
   const bounds = [Infinity, Infinity, -Infinity, -Infinity];
   const coord: number[][] = [];
 
-  function extract(node: any) {
+  function extract(node: unknown) {
     if (Array.isArray(node) && typeof node[0] === 'number') {
       coord.push(node);
     } else if (Array.isArray(node)) {
       node.forEach(extract);
-    } else if (node?.type === 'FeatureCollection') {
-      node.features.forEach((f: any) => extract(f.geometry.coordinates));
-    } else if (node?.type === 'Feature') {
-      extract(node.geometry.coordinates);
-    } else if (node?.coordinates) {
-      extract(node.coordinates);
+    } else if (node && typeof node === 'object' && 'type' in node) {
+      const obj = node as Record<string, unknown>;
+      if (obj.type === 'FeatureCollection' && Array.isArray(obj.features)) {
+        (obj.features as Array<{ geometry?: { coordinates: unknown } }>).forEach(f => {
+          if (f.geometry?.coordinates) extract(f.geometry.coordinates);
+        });
+      } else if (obj.type === 'Feature' && (obj as { geometry?: { coordinates: unknown } }).geometry?.coordinates) {
+        extract((obj as { geometry: { coordinates: unknown } }).geometry.coordinates);
+      } else if ('coordinates' in obj) {
+        extract(obj.coordinates);
+      }
     }
   }
 
@@ -33,7 +49,7 @@ function calculateBBox(geojson: any): [number, number, number, number] | null {
   return bounds as [number, number, number, number];
 }
 
-export function MapActionHandler({ mapInstance }: { mapInstance?: any }) {
+export function MapActionHandler({ mapInstance }: { mapInstance?: MapInstanceLike }) {
   const { action, clearAction } = useMapAction();
 
   useEffect(() => {
@@ -48,10 +64,10 @@ export function MapActionHandler({ mapInstance }: { mapInstance?: any }) {
           const { layerId, type, geojson, style, flyTo } = action.params;
           if (!layerId || !geojson) break;
 
-          if (!map.getSource(layerId)) {
-            map.addSource(layerId, { type: 'geojson', data: geojson });
+          if (!map.getSource?.(layerId)) {
+            map.addSource?.(layerId, { type: 'geojson', data: geojson });
           } else {
-            (map.getSource(layerId) as any).setData(geojson);
+            map.getSource?.(layerId)?.setData(geojson);
           }
 
           if (!map.getLayer(layerId)) {

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -5,6 +5,7 @@ import maplibregl from "maplibre-gl"
 import { Layers, ZoomIn, ZoomOut, Maximize, MapPin, Eye, EyeOff, RotateCcw, Target, Trash2, ChevronDown, Plus, Edit, Settings, Download } from "lucide-react"
 import { LayerCard } from "@/components/layer-card"
 import type { Layer } from "@/lib/types/layer"
+import type { AnalysisResult, GeoJSONFeatureCollection, HeatmapRasterSource } from "@/lib/types"
 import { MapActionHandler } from "./map-action-handler"
 import { ThematicLegend } from "./thematic-legend"
 
@@ -13,7 +14,7 @@ interface MapPanelProps {
   onRemoveLayer: (id: string) => void
   onToggleLayer: (id: string) => void
   onEditLayer: (layer: Layer) => void
-  analysisResult?: any
+  analysisResult?: AnalysisResult
 }
 
 // Map layer types
@@ -65,6 +66,14 @@ const DEFAULT_VIEW_STATE = {
   longitude: 116.4074,
   latitude: 39.9042,
   zoom: 4,
+}
+
+function isHeatmapRasterSource(source: Layer['source']): source is HeatmapRasterSource {
+  return typeof source === 'object' && source !== null && 'image' in source && 'bbox' in source
+}
+
+function isGeoJSONSource(source: Layer['source']): source is GeoJSONFeatureCollection {
+  return typeof source === 'object' && source !== null && 'type' in source && source.type === 'FeatureCollection'
 }
 
 export function MapPanel({ layers, onRemoveLayer, onToggleLayer, onEditLayer, analysisResult }: MapPanelProps) {
@@ -173,21 +182,21 @@ export function MapPanel({ layers, onRemoveLayer, onToggleLayer, onEditLayer, an
           if (isNewSource) {
             if (layer.type === "raster" || layer.type === "tile") {
               map.addSource(sourceId, { type: "raster", tiles: [layer.source as string], tileSize: 256 })
-            } else if (layer.type === "heatmap" && (layer.source as any)?.image) {
-              const src = layer.source as any
+            } else if (layer.type === "heatmap" && isHeatmapRasterSource(layer.source)) {
+              const src = layer.source as HeatmapRasterSource
               const [west, south, east, north] = src.bbox
               map.addSource(sourceId, {
                 type: "image",
                 url: src.image,
                 coordinates: [[west, north], [east, north], [east, south], [west, south]],
-              } as any)
+              })
             } else {
-              map.addSource(sourceId, { type: "geojson", data: layer.source as any })
+              map.addSource(sourceId, { type: "geojson", data: layer.source as GeoJSONFeatureCollection })
             }
           } else {
             // Update existing source data if changed (only for GeoJSON)
-            if (layer.type !== "raster" && layer.type !== "tile" && !(layer.type === "heatmap" && (layer.source as any)?.image)) {
-              const src = map.getSource(sourceId) as any
+            if (layer.type !== "raster" && layer.type !== "tile" && !(layer.type === "heatmap" && isHeatmapRasterSource(layer.source))) {
+              const src = map.getSource(sourceId) as { setData: (data: unknown) => void }
               if (src.setData) src.setData(layer.source)
             }
           }
@@ -197,8 +206,8 @@ export function MapPanel({ layers, onRemoveLayer, onToggleLayer, onEditLayer, an
           const thematicField = layer.source && typeof layer.source === 'object' ? layer.source.metadata?.field : null
           const filterRanges = activeFilters[layer.id]
           
-          const getLayerFilter = (baseType: string) => {
-            const base: any = ["==", "$type", baseType]
+          const getLayerFilter = (baseType: string): unknown[] => {
+            const base: unknown[] = ["==", "$type", baseType]
             if (thematicField && filterRanges) {
               const rangeFilters = filterRanges.map((range: number[]) => (
                 ["all", [">=", ["get", thematicField], range[0]], ["<", ["get", thematicField], range[1]]]
@@ -208,7 +217,7 @@ export function MapPanel({ layers, onRemoveLayer, onToggleLayer, onEditLayer, an
             return base
           }
 
-          const addOrUpdate = (subId: string, layerConfig: any) => {
+          const addOrUpdate = (subId: string, layerConfig: Record<string, unknown>) => {
             const fullId = `custom-${layer.id}-${subId}`
             if (!map.getLayer(fullId)) {
               map.addLayer({ ...layerConfig, id: fullId, source: sourceId })
@@ -231,17 +240,17 @@ export function MapPanel({ layers, onRemoveLayer, onToggleLayer, onEditLayer, an
               type: "raster",
               paint: { "raster-opacity": layer.opacity || 1 },
             })
-          } else if (layer.type === "heatmap" && (layer.source as any)?.image) {
+          } else if (layer.type === "heatmap" && isHeatmapRasterSource(layer.source)) {
             addOrUpdate("raster", {
               type: "raster",
               paint: { "raster-opacity": layer.opacity ?? 0.85, "raster-resampling": "linear" },
             })
           } else {
-            const src = layer.source as any
-            const features = src.features || []
-            const hasPolygons = features.some((f: any) => f.geometry?.type?.includes("Polygon"))
-            const hasLines = features.some((f: any) => f.geometry?.type?.includes("Line"))
-            const hasPoints = features.some((f: any) => f.geometry?.type?.includes("Point"))
+            const src = isGeoJSONSource(layer.source) ? layer.source : null
+            const features = src?.features || []
+            const hasPolygons = features.some((f) => f.geometry?.type?.includes("Polygon"))
+            const hasLines = features.some((f) => f.geometry?.type?.includes("Line"))
+            const hasPoints = features.some((f) => f.geometry?.type?.includes("Point"))
             const isHeatmapMode = layer.type === "heatmap" || layer.style?.renderType === "heatmap"
 
             if (hasPolygons) {
@@ -292,7 +301,7 @@ export function MapPanel({ layers, onRemoveLayer, onToggleLayer, onEditLayer, an
                 type: "circle",
                 filter: getLayerFilter("Point"),
                 paint: {
-                  "circle-radius": features.some((f: any) => f.properties?.weight) ? ["interpolate", ["linear"], ["get", "weight"], 0, 4, 1, 8] : 7,
+                  "circle-radius": features.some((f) => f.properties?.weight != null) ? ["interpolate", ["linear"], ["get", "weight"], 0, 4, 1, 8] : 7,
                   "circle-color": ["coalesce", ["get", "fill_color"], color],
                   "circle-stroke-width": 2, "circle-stroke-color": "#fff", "circle-opacity": layer.opacity || 1
                 }
@@ -325,7 +334,7 @@ export function MapPanel({ layers, onRemoveLayer, onToggleLayer, onEditLayer, an
     setViewState(evt.viewState)
   }, [])
 
-  const handleMouseMove = useCallback((e: any) => {
+  const handleMouseMove = useCallback((e: { lngLat: { lng: number; lat: number } }) => {
     setCoordinates({
       lng: Number(e.lngLat.lng.toFixed(4)),
       lat: Number(e.lngLat.lat.toFixed(4)),

--- a/frontend/components/panel/chart-renderer.tsx
+++ b/frontend/components/panel/chart-renderer.tsx
@@ -9,14 +9,7 @@ import {
   XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
   ZAxis
 } from 'recharts';
-
-interface ChartData {
-  type: 'bar' | 'line' | 'pie' | 'scatter';
-  title: string;
-  data: any[];
-  x_label?: string;
-  y_label?: string;
-}
+import type { ChartData, RechartsTooltipProps } from '@/lib/types';
 
 interface ChartRendererProps {
   chart: ChartData;
@@ -24,12 +17,12 @@ interface ChartRendererProps {
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4'];
 
-const CustomTooltip = ({ active, payload, label }: any) => {
+const CustomTooltip = ({ active, payload, label }: RechartsTooltipProps) => {
   if (active && payload && payload.length) {
     return (
       <div className="bg-card/90 backdrop-blur-md border border-border p-3 rounded-lg shadow-xl text-xs">
         <p className="font-bold mb-1 text-foreground">{label || payload[0].payload.name}</p>
-        {payload.map((item: any, index: number) => (
+        {payload.map((item, index: number) => (
           <div key={index} className="flex items-center gap-2">
             <div className="w-2 h-2 rounded-full" style={{ backgroundColor: item.color || item.fill }} />
             <p className="text-muted-foreground">

--- a/frontend/components/panel/results-panel.tsx
+++ b/frontend/components/panel/results-panel.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react"
 import { ChartRenderer } from "./chart-renderer"
 import { DraggableLayerList } from "../map/draggable-layer-list"
+import type { ChartData, GeoJSONFeatureCollection, GeoJSONFeature, GeoJSONGeometry } from "@/lib/types"
 
 interface ResultItem {
   id: string
@@ -32,7 +33,7 @@ interface ResultItem {
   type: "text" | "chart" | "map" | "table"
   content: string
   timestamp: Date
-  chartData?: any
+  chartData?: ChartData
 }
 
 interface ReportData {
@@ -42,7 +43,7 @@ interface ReportData {
     id: string
     type: "bar" | "pie" | "line"
     title: string
-    data: any
+    data: unknown
   }>
   tables: Array<{
     headers: string[]
@@ -58,8 +59,8 @@ interface LayerItem {
   type: string
   visible: boolean
   opacity: number
-  source?: any
-  style?: any
+  source?: GeoJSONFeatureCollection
+  style?: Record<string, unknown>
 }
 
 // Props for receiving analysis results from parent
@@ -123,14 +124,14 @@ export function ResultsPanel({
     const lats: number[] = []
     const features = layer.source.features || []
     
-    features.forEach((f: any) => {
+    features.forEach((f: GeoJSONFeature) => {
       if (f.geometry?.type === "Point") {
-        lngs.push(f.geometry.coordinates[0])
-        lats.push(f.geometry.coordinates[1])
+        lngs.push((f.geometry.coordinates as [number, number])[0])
+        lats.push((f.geometry.coordinates as [number, number])[1])
       } else if (f.geometry?.coordinates) {
         // 简化：只取前几个点
         const coords = Array.isArray(f.geometry.coordinates[0]) ? f.geometry.coordinates[0] : [f.geometry.coordinates]
-        coords.forEach((c: any) => {
+        coords.forEach((c: number[]) => {
           if (Array.isArray(c)) {
             lngs.push(c[0]); lats.push(c[1])
           }
@@ -148,10 +149,10 @@ export function ResultsPanel({
   }
 
   // Get geometry types from a GeoJSON FeatureCollection
-  const getGeometryTypes = (geojson: any): string[] => {
+  const getGeometryTypes = (geojson: GeoJSONFeatureCollection): string[] => {
     if (!geojson?.features) return []
     const types = new Set<string>()
-    geojson.features.forEach((f: any) => {
+    geojson.features.forEach((f: GeoJSONFeature) => {
       if (f.geometry?.type) types.add(f.geometry.type)
     })
     return Array.from(types)
@@ -197,7 +198,7 @@ export function ResultsPanel({
         generatedAt: new Date(),
       })
       setActiveTab("report")
-    } catch (err: any) {
+    } catch (err: unknown) {
       // Fallback: generate report from local data
       setReportData({
         title: "空间分析报告",

--- a/frontend/lib/api/chat.ts
+++ b/frontend/lib/api/chat.ts
@@ -2,6 +2,8 @@
  * Chat API - 对接后端 SSE 流式接口
  */
 
+import type { ToolResult } from '@/lib/types';
+
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
 
 export interface ChatMessage {
@@ -13,7 +15,7 @@ export interface ChatMessage {
   }>;
   toolResults?: Array<{
     name: string;
-    result: any;
+    result: ToolResult;
   }>;
 }
 
@@ -39,7 +41,7 @@ export type SSEEventType =
 
 export interface SSEEvent {
   event: SSEEventType;
-  data: any;
+  data: Record<string, unknown>;
 }
 
 /**
@@ -155,7 +157,7 @@ export async function clearSessionMessages(sessionId: string): Promise<void> {
 /**
  * 直接执行单个工具（REST API，不依赖SSE）
  */
-export async function executeToolDirect(tool: string, argument: Record<string, any>): Promise<any> {
+export async function executeToolDirect(tool: string, argument: Record<string, unknown>): Promise<ToolResult> {
   const res = await fetch(`${API_BASE}/chat/tools/execute`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/frontend/lib/api/layer.ts
+++ b/frontend/lib/api/layer.ts
@@ -149,7 +149,7 @@ export const layerApi = {
   // 创建空间分析任务
   async createAnalysisTask(layerId: string | number, taskData: {
     task_type: string;
-    parameters: Record<string, any>;
+    parameters: Record<string, unknown>;
   }) {
     const response = await fetch(`${API_BASE}/layers/${layerId}/tasks`, {
       method: "POST",

--- a/frontend/lib/contexts/map-action-context.tsx
+++ b/frontend/lib/contexts/map-action-context.tsx
@@ -1,19 +1,9 @@
 'use client';
 
 import React, { createContext, useContext, useState, useCallback } from 'react';
+import type { MapActionPayload } from '@/lib/types';
 
-export interface MapActionPayload {
-  command: 'add_layer' | 'remove_layer' | 'fly_to';
-  params: {
-    layerId?: string;
-    type?: 'fill' | 'line' | 'circle' | 'symbol';
-    geojson?: any;
-    style?: any;
-    flyTo?: boolean;
-    center?: [number, number];
-    zoom?: number;
-  };
-}
+export type { MapActionPayload };
 
 export interface MapActionContextType {
   action: MapActionPayload | null;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,0 +1,98 @@
+/**
+ * Core shared types for WebGIS AI Agent
+ */
+
+// === GeoJSON types ===
+
+export interface GeoJSONGeometry {
+  type: string;
+  coordinates: unknown;
+}
+
+export interface GeoJSONFeature {
+  type: 'Feature';
+  geometry: GeoJSONGeometry | null;
+  properties: Record<string, unknown>;
+}
+
+export interface GeoJSONFeatureCollection {
+  type: 'FeatureCollection';
+  features: GeoJSONFeature[];
+  metadata?: Record<string, unknown>;
+}
+
+// === Tool result types ===
+
+export interface ToolResult {
+  type?: string;
+  geojson?: GeoJSONFeatureCollection;
+  bbox?: string | [number, number, number, number];
+  image?: string;
+  area?: string;
+  category?: string;
+  group?: string;
+  chart?: ChartData;
+  [key: string]: unknown;
+}
+
+// === Map view types ===
+
+export interface AnalysisResult {
+  center: [number, number];
+  zoom: number;
+}
+
+// === Layer source types ===
+
+export interface HeatmapRasterSource {
+  image: string;
+  bbox: [number, number, number, number];
+}
+
+// === Chart types (shared between panel/chart-renderer and chat/chart-renderer) ===
+
+export interface ChartDataPoint {
+  name: string;
+  value?: number;
+  x?: number;
+  y?: number;
+}
+
+export interface ChartData {
+  type: 'bar' | 'line' | 'pie' | 'scatter';
+  title: string;
+  data: ChartDataPoint[];
+  x_label?: string;
+  y_label?: string;
+}
+
+// === Map action types ===
+
+export interface MapActionPayload {
+  command: 'add_layer' | 'remove_layer' | 'fly_to';
+  params: {
+    layerId?: string;
+    type?: 'fill' | 'line' | 'circle' | 'symbol';
+    geojson?: GeoJSONFeatureCollection;
+    style?: Record<string, unknown>;
+    flyTo?: boolean;
+    center?: [number, number];
+    zoom?: number;
+  };
+}
+
+// === Recharts tooltip types ===
+
+export interface RechartsTooltipItem {
+  color?: string;
+  fill?: string;
+  name: string;
+  value: number;
+  payload: ChartDataPoint;
+}
+
+export interface RechartsTooltipProps {
+  active?: boolean;
+  payload?: RechartsTooltipItem[];
+  label?: string;
+}

--- a/frontend/lib/types/layer.ts
+++ b/frontend/lib/types/layer.ts
@@ -1,3 +1,11 @@
+import type { GeoJSONFeatureCollection, HeatmapRasterSource } from '../types';
+
+export interface LayerStyle {
+  color?: string;
+  renderType?: 'heatmap' | 'grid';
+  [key: string]: unknown;
+}
+
 export interface Layer {
   id: string;
   name: string;
@@ -5,8 +13,8 @@ export interface Layer {
   visible: boolean;
   opacity: number;
   group?: 'analysis' | 'base' | 'reference';
-  source?: string | Record<string, any>;
-  style?: Record<string, any>;
+  source?: string | GeoJSONFeatureCollection | HeatmapRasterSource;
+  style?: LayerStyle;
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## 安全加固修复

完成 CODE_REVIEW.md 中遗留的 3 项修复：

### 1. C-5 认证中间件
- `POST /tools/execute` 和 `GET /tools/results` 添加 `Depends(get_current_user)` 强制认证
- `sessions` 端点添加 `Depends(get_current_user_optional)` 可选认证
- `completions` 和 `stream` 端点添加可选认证

### 2. 环境变量迁移
- `JWT_SECRET_KEY` 移除硬编码默认值，未配置时自动生成随机值并 warn
- `TIANDITU_TOKEN` 移除硬编码真实 token，改为环境变量
- 所有敏感字段统一使用 `Field(default="", env="...")` 模式
- `.env.example` 补全所有环境变量说明

### 3. TypeScript 类型修复
- 新增 `frontend/lib/types.ts` 定义核心接口（GeoJSON、ToolResult、MapAction 等）
- 替换 30+ 处 `any` 类型为具体接口
- `Layer` 类型增强，支持 HeatmapRasterSource

**文件变更**: 16 files, +266/-101