### PR TITLE
fix: skill library full-stack fix — Celery fallback, URL cleanup, SSE, WebSocket, skill security

### DIFF
--- a/app/tools/advanced_spatial.py
+++ b/app/tools/advanced_spatial.py
@@ -4,6 +4,7 @@ from typing import Any, List, Dict, Optional
 from pydantic import BaseModel, Field
 
 from app.tools.registry import ToolRegistry, tool
+from app.services.spatial_analyzer import SpatialAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
         try:
             from app.services.spatial_tasks import run_path_analysis
             features = network_features.get("features", network_features) if isinstance(network_features, dict) else network_features
-            
+
             task = run_path_analysis.apply_async(
                 args=[features, start_point, end_point]
             )
@@ -49,6 +50,12 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
             if result.get("success"):
                 return {"geojson": result.get("data"), "stats": result.get("stats")}
             return {"error": result.get("error")}
+        except ImportError:
+            features = network_features.get("features", network_features) if isinstance(network_features, dict) else network_features
+            r = SpatialAnalyzer.path_analysis(features, start_point=start_point, end_point=end_point)
+            if r.success:
+                return {"geojson": r.data, "stats": r.stats}
+            return {"error": r.error_message}
         except Exception as e:
             return {"error": str(e)}
 
@@ -59,7 +66,7 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
         try:
             from app.services.spatial_tasks import run_zonal_stats
             features = geojson.get("features", geojson) if isinstance(geojson, dict) else geojson
-            
+
             task = run_zonal_stats.apply_async(
                 args=[features, raster_path]
             )
@@ -67,6 +74,12 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
             if result.get("success"):
                 return {"zonal_stats": result.get("data").get("zonal_stats")}
             return {"error": result.get("error")}
+        except ImportError:
+            features = geojson.get("features", geojson) if isinstance(geojson, dict) else geojson
+            r = SpatialAnalyzer.zonal_statistics(features, raster_path=raster_path)
+            if r.success:
+                return {"zonal_stats": r.data.get("zonal_stats") if isinstance(r.data, dict) else r.data}
+            return {"error": r.error_message}
         except Exception as e:
             return {"error": str(e)}
 
@@ -79,7 +92,7 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
             # 解析要素
             features_a = layer_a.get("features", layer_a) if isinstance(layer_a, dict) else layer_a
             features_b = layer_b.get("features", layer_b) if isinstance(layer_b, dict) else layer_b
-            
+
             task = run_overlay_analysis.apply_async(
                 args=[features_a, features_b, how]
             )
@@ -87,6 +100,13 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
             if result.get("success"):
                 return {"geojson": result.get("data"), "stats": result.get("stats")}
             return {"error": result.get("error")}
+        except ImportError:
+            features_a = layer_a.get("features", layer_a) if isinstance(layer_a, dict) else layer_a
+            features_b = layer_b.get("features", layer_b) if isinstance(layer_b, dict) else layer_b
+            r = SpatialAnalyzer.overlay(features_a, features_b, how=how)
+            if r.success:
+                return {"geojson": r.data, "stats": r.stats}
+            return {"error": r.error_message}
         except Exception as e:
             return {"error": str(e)}
 
@@ -97,7 +117,7 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
         try:
             from app.services.spatial_tasks import run_attribute_filter
             features = geojson.get("features", geojson) if isinstance(geojson, dict) else geojson
-            
+
             task = run_attribute_filter.apply_async(
                 args=[features, query]
             )
@@ -105,6 +125,12 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
             if result.get("success"):
                 return {"geojson": result.get("data"), "stats": result.get("stats")}
             return {"error": result.get("error")}
+        except ImportError:
+            features = geojson.get("features", geojson) if isinstance(geojson, dict) else geojson
+            r = SpatialAnalyzer.attribute_filter(features, query=query)
+            if r.success:
+                return {"geojson": r.data, "stats": r.stats}
+            return {"error": r.error_message}
         except Exception as e:
             return {"error": str(e)}
 
@@ -116,7 +142,7 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
             from app.services.spatial_tasks import run_spatial_join
             features_left = left_layer.get("features", left_layer) if isinstance(left_layer, dict) else left_layer
             features_right = right_layer.get("features", right_layer) if isinstance(right_layer, dict) else right_layer
-            
+
             task = run_spatial_join.apply_async(
                 args=[features_left, features_right, join_type, predicate]
             )
@@ -124,5 +150,12 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
             if result.get("success"):
                 return {"geojson": result.get("data"), "stats": result.get("stats")}
             return {"error": result.get("error")}
+        except ImportError:
+            features_left = left_layer.get("features", left_layer) if isinstance(left_layer, dict) else left_layer
+            features_right = right_layer.get("features", right_layer) if isinstance(right_layer, dict) else right_layer
+            r = SpatialAnalyzer.spatial_join(features_left, features_right, join_type=join_type, predicate=predicate)
+            if r.success:
+                return {"geojson": r.data, "stats": r.stats}
+            return {"error": r.error_message}
         except Exception as e:
             return {"error": str(e)}

--- a/app/tools/skills.py
+++ b/app/tools/skills.py
@@ -1,4 +1,5 @@
 import os
+import ast
 import importlib.util
 import sys
 import logging
@@ -6,6 +7,42 @@ from typing import Optional
 from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
+
+_BLOCKED_IMPORTS = {"subprocess", "multiprocessing", "ctypes", "socket", "http", "urllib", "ftplib", "smtplib", "telnetlib", "xmlrpc"}
+_BLOCKED_BUILTINS = {"eval", "exec", "compile", "__import__", "open", "input"}
+_BLOCKED_ATTRS = {"system", "popen", "call", "run", "Popen"}
+
+
+def _validate_skill_code(code: str) -> list[str]:
+    """Validate skill code for dangerous patterns. Returns list of errors."""
+    errors = []
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as e:
+        return [f"Syntax error: {e}"]
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root_mod = alias.name.split(".")[0]
+                if root_mod in _BLOCKED_IMPORTS:
+                    errors.append(f"Blocked import: {alias.name}")
+
+        if isinstance(node, ast.ImportFrom):
+            if node.module:
+                root_mod = node.module.split(".")[0]
+                if root_mod in _BLOCKED_IMPORTS:
+                    errors.append(f"Blocked import: {node.module}")
+
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in _BLOCKED_BUILTINS:
+                errors.append(f"Blocked builtin: {func.id}")
+            if isinstance(func, ast.Attribute) and func.attr in _BLOCKED_ATTRS:
+                errors.append(f"Blocked attribute: {func.attr}")
+
+    return errors
+
 
 def register_skill_tools(registry: ToolRegistry):
     """注册用于管理和创建技能的元工具"""
@@ -23,9 +60,13 @@ def register_skill_tools(registry: ToolRegistry):
 
 async def create_new_skill(module_name: str, code: str, description: str) -> str:
     """Agent 调用的创建技能函数"""
+    errors = _validate_skill_code(code)
+    if errors:
+        return f"Skill validation failed:\n" + "\n".join(f"- {e}" for e in errors) + "\nPlease revise your code to remove dangerous patterns."
+
     from app.services.skill_creator import skill_creator
     from app.api.routes.chat import registry
-    
+
     result = skill_creator.create_skill(module_name, code, description)
     # 立即触发热加载
     load_skills(registry)
@@ -69,11 +110,33 @@ def load_skills(registry: ToolRegistry, skills_dir: str = "app/skills"):
                 logger.error(f"Failed to load skill {filename}: {e}")
 
 def watch_skills(registry: ToolRegistry, skills_dir: str = "app/skills"):
+    """Poll-based file watcher for hot-reloading skills.
+
+    Tracks file modification times. Returns a check function that can be
+    called periodically (e.g., every 5s) to detect new or changed skill files.
     """
-    TODO: Implement a file watcher (e.g., using watchdog) to hot-reload skills.
-    For now, we just load them once at startup.
-    """
-    load_skills(registry, skills_dir)
+    _mtimes: dict[str, float] = {}
+
+    def _check():
+        if not os.path.exists(skills_dir):
+            return
+        changed = False
+        for filename in os.listdir(skills_dir):
+            if not filename.endswith(".py") or filename.startswith("__"):
+                continue
+            filepath = os.path.join(skills_dir, filename)
+            try:
+                mtime = os.path.getmtime(filepath)
+            except OSError:
+                continue
+            if filepath not in _mtimes or _mtimes[filepath] < mtime:
+                _mtimes[filepath] = mtime
+                changed = True
+        if changed:
+            load_skills(registry, skills_dir)
+
+    _check()
+    return _check
 
 async def fetch_remote_skills(registry: ToolRegistry, repo_url: str):
     """

--- a/app/tools/skills.py
+++ b/app/tools/skills.py
@@ -72,55 +72,50 @@ async def create_new_skill(module_name: str, code: str, description: str) -> str
     load_skills(registry)
     return result
 
+def _load_single_skill(registry: ToolRegistry, file_path: str, filename: str):
+    """Load or reload a single skill file into the registry."""
+    module_name = f"app.skills.{filename[:-3]}"
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec and spec.loader:
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+
+            if hasattr(module, "register_skills"):
+                module.register_skills(registry)
+                logger.info(f"Loaded skill from {filename} via register_skills")
+            elif hasattr(module, "register"):
+                module.register(registry)
+                logger.info(f"Loaded skill from {filename} via register")
+            else:
+                logger.warning(f"Skill {filename} has no 'register' or 'register_skills' function.")
+    except Exception as e:
+        logger.error(f"Failed to load skill {filename}: {e}")
+
+
 def load_skills(registry: ToolRegistry, skills_dir: str = "app/skills"):
-    """
-    Dynamically load Python scripts from the skills directory and register them as tools.
-    Each script should have a 'register' function or use the @tool decorator with a global registry.
-    """
+    """Load all skill scripts from the skills directory."""
     if not os.path.exists(skills_dir):
         os.makedirs(skills_dir, exist_ok=True)
-        logger.info(f"Created skills directory: {skills_dir}")
         return
 
     for filename in os.listdir(skills_dir):
         if filename.endswith(".py") and not filename.startswith("__"):
-            file_path = os.path.join(skills_dir, filename)
-            module_name = f"app.skills.{filename[:-3]}"
-            
-            try:
-                spec = importlib.util.spec_from_file_location(module_name, file_path)
-                if spec and spec.loader:
-                    module = importlib.util.module_from_spec(spec)
-                    sys.modules[module_name] = module
-                    spec.loader.exec_module(module)
-                    
-                    # Look for a register function that takes the registry
-                    if hasattr(module, "register_skills"):
-                        module.register_skills(registry)
-                        logger.info(f"Loaded skills from {filename} via register_skills")
-                    elif hasattr(module, "register"):
-                        module.register(registry)
-                        logger.info(f"Loaded skills from {filename} via register")
-                    else:
-                        # Fallback: find all functions decorated with @tool if they were registered to a local registry
-                        # This depends on how the skill script is written. 
-                        # Usually, we expect a register(registry) function.
-                        logger.warning(f"Skill {filename} has no 'register' or 'register_skills' function.")
-            except Exception as e:
-                logger.error(f"Failed to load skill {filename}: {e}")
+            _load_single_skill(registry, os.path.join(skills_dir, filename), filename)
 
 def watch_skills(registry: ToolRegistry, skills_dir: str = "app/skills"):
     """Poll-based file watcher for hot-reloading skills.
 
     Tracks file modification times. Returns a check function that can be
     called periodically (e.g., every 5s) to detect new or changed skill files.
+    Only reloads files that actually changed.
     """
     _mtimes: dict[str, float] = {}
 
     def _check():
         if not os.path.exists(skills_dir):
             return
-        changed = False
         for filename in os.listdir(skills_dir):
             if not filename.endswith(".py") or filename.startswith("__"):
                 continue
@@ -131,9 +126,7 @@ def watch_skills(registry: ToolRegistry, skills_dir: str = "app/skills"):
                 continue
             if filepath not in _mtimes or _mtimes[filepath] < mtime:
                 _mtimes[filepath] = mtime
-                changed = True
-        if changed:
-            load_skills(registry, skills_dir)
+                _load_single_skill(registry, filepath, filename)
 
     _check()
     return _check

--- a/app/tools/skills.py
+++ b/app/tools/skills.py
@@ -8,8 +8,8 @@ from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-_BLOCKED_IMPORTS = {"subprocess", "multiprocessing", "ctypes", "socket", "http", "urllib", "ftplib", "smtplib", "telnetlib", "xmlrpc"}
-_BLOCKED_BUILTINS = {"eval", "exec", "compile", "__import__", "open", "input"}
+_BLOCKED_IMPORTS = {"os", "subprocess", "multiprocessing", "ctypes", "socket", "http", "urllib", "ftplib", "smtplib", "telnetlib", "xmlrpc", "shutil", "pathlib", "signal"}
+_BLOCKED_BUILTINS = {"eval", "exec", "compile", "__import__", "open", "input", "getattr", "setattr", "delattr", "globals", "locals", "vars", "dir"}
 _BLOCKED_ATTRS = {"system", "popen", "call", "run", "Popen"}
 
 

--- a/app/tools/spatial.py
+++ b/app/tools/spatial.py
@@ -52,6 +52,186 @@ class HeatmapDataArgs(BaseModel):
     palette: str = Field("classic", description="配色方案: classic, magma, viridis, thermal")
 
 
+def _generate_heatmap(features: list, cell_size: int = 500, radius: int = 1000,
+                       render_type: str = "raster", palette: str = "classic") -> dict:
+    """Generate heatmap data without Celery. Supports raster and grid render types."""
+    import base64
+    import io
+    import math
+
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib.colors import LinearSegmentedColormap
+    from scipy.ndimage import gaussian_filter
+    from shapely.geometry import box, mapping
+
+    fig = None
+    try:
+        points = []
+        for f in features or []:
+            if not isinstance(f, dict):
+                continue
+            geom = f.get("geometry") or {}
+            if geom.get("type") == "Point":
+                coords = geom.get("coordinates")
+                if coords and len(coords) >= 2:
+                    try:
+                        lon, lat = float(coords[0]), float(coords[1])
+                        if not math.isnan(lon) and not math.isnan(lat):
+                            points.append((lon, lat))
+                    except (ValueError, TypeError):
+                        continue
+
+        if not points:
+            return {"success": False, "error": "No valid point features found"}
+
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+
+        # 1 degree ≈ 111000 m
+        cell_deg = cell_size / 111000
+        margin = cell_deg * 2
+        x_min, x_max = min(xs) - margin, max(xs) + margin
+        y_min, y_max = min(ys) - margin, max(ys) + margin
+
+        if x_min == x_max:
+            x_max += cell_deg
+        if y_min == y_max:
+            y_max += cell_deg
+
+        x_bins = np.arange(x_min, x_max + cell_deg, cell_deg)
+        y_bins = np.arange(y_min, y_max + cell_deg, cell_deg)
+
+        if len(x_bins) > 5000 or len(y_bins) > 5000:
+            return {"success": False, "error": "Resolution too high for the data extent"}
+
+        H, xedges, yedges = np.histogram2d(xs, ys, bins=[x_bins, y_bins])
+
+        if render_type == "grid":
+            grid_features = []
+            max_val = float(H.max()) if H.max() > 0 else 1.0
+
+            MAX_GRID_FEATURES = 500_000
+            total_cells = H[H > 0].size
+            if total_cells > MAX_GRID_FEATURES:
+                return {"success": False, "error": f"Grid too dense ({total_cells} cells). Increase cell_size or reduce data extent. Max allowed: {MAX_GRID_FEATURES}"}
+
+            for i in range(len(xedges) - 1):
+                for j in range(len(yedges) - 1):
+                    count = H[i, j]
+                    if count > 0:
+                        rect = box(xedges[i], yedges[j], xedges[i + 1], yedges[j + 1])
+                        grid_features.append({
+                            "type": "Feature",
+                            "geometry": mapping(rect),
+                            "properties": {
+                                "count": int(count),
+                                "weight": round(float(count / max_val), 4)
+                            }
+                        })
+
+            return {
+                "success": True,
+                "data": {
+                    "type": "FeatureCollection",
+                    "features": grid_features,
+                    "metadata": {
+                        "render_type": "grid",
+                        "field": "weight",
+                        "cell_size": cell_size,
+                        "point_count": len(points),
+                        "palette": palette
+                    }
+                },
+                "status_desc": f"Vector grid heatmap generated with {len(grid_features)} cells."
+            }
+
+        else:
+            # Raster mode
+            sigma = max(1.0, radius / cell_size)
+            H_smooth = gaussian_filter(H.T, sigma=sigma)
+
+            PALETTES = {
+                "classic": [
+                    (0.00, (0.0, 0.0, 0.0, 0.0)),
+                    (0.15, (0.0, 1.0, 1.0, 0.4)),
+                    (0.40, (0.0, 1.0, 0.0, 0.6)),
+                    (0.70, (1.0, 1.0, 0.0, 0.8)),
+                    (0.90, (1.0, 0.5, 0.0, 0.9)),
+                    (1.00, (1.0, 0.0, 0.0, 1.0)),
+                ],
+                "magma": [
+                    (0.00, (0.0, 0.0, 0.0, 0.0)),
+                    (0.20, (0.2, 0.04, 0.48, 0.5)),
+                    (0.50, (0.7, 0.13, 0.45, 0.7)),
+                    (0.80, (0.99, 0.55, 0.35, 0.85)),
+                    (1.00, (0.98, 0.94, 0.60, 1.0)),
+                ],
+                "viridis": [
+                    (0.00, (0.0, 0.0, 0.0, 0.0)),
+                    (0.25, (0.27, 0.0, 0.33, 0.5)),
+                    (0.50, (0.13, 0.57, 0.55, 0.7)),
+                    (0.75, (0.37, 0.79, 0.36, 0.85)),
+                    (1.00, (0.99, 0.9, 0.14, 1.0)),
+                ],
+                "thermal": [
+                    (0.00, (0.0, 0.0, 0.0, 0.0)),
+                    (0.33, (0.0, 0.0, 1.0, 0.5)),
+                    (0.66, (1.0, 1.0, 0.0, 0.8)),
+                    (1.00, (1.0, 0.0, 0.0, 1.0)),
+                ]
+            }
+
+            colors = PALETTES.get(palette, PALETTES["classic"])
+            cmap = LinearSegmentedColormap.from_list("dynamic_heat", colors, N=256)
+
+            fig, ax = plt.subplots(figsize=(10, 10), dpi=100)
+            v_max = np.percentile(H_smooth, 98) if H_smooth.max() > 0 else 1.0
+            if v_max <= 0:
+                v_max = H_smooth.max() or 1.0
+
+            ax.imshow(
+                H_smooth,
+                cmap=cmap,
+                origin="lower",
+                aspect="auto",
+                vmin=0,
+                vmax=v_max,
+                interpolation="bilinear",
+            )
+            ax.axis("off")
+            plt.subplots_adjust(left=0, right=1, top=1, bottom=0)
+
+            buf = io.BytesIO()
+            fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0, transparent=True)
+            buf.seek(0)
+            img_b64 = "data:image/png;base64," + base64.b64encode(buf.read()).decode()
+
+            return {
+                "success": True,
+                "data": {
+                    "type": "heatmap_raster",
+                    "image": img_b64,
+                    "bbox": [float(xedges[0]), float(yedges[0]), float(xedges[-1]), float(yedges[-1])],
+                    "total_points": len(points),
+                    "metadata": {
+                        "render_type": "raster",
+                        "point_count": len(points),
+                        "palette": palette
+                    }
+                },
+                "status_desc": f"Raster heatmap generated (palette: {palette}) covering {len(points)} points."
+            }
+    except Exception as e:
+        logger.error(f"Heatmap generation failed: {e}", exc_info=True)
+        return {"success": False, "error": str(e)}
+    finally:
+        if fig:
+            plt.close(fig)
+
+
 def register_spatial_tools(registry: ToolRegistry):
     """注册空间分析工具"""
 
@@ -201,7 +381,7 @@ def register_spatial_tools(registry: ToolRegistry):
                 )
                 result = task.get(timeout=120)
             except ImportError:
-                return {"error": "Heatmap generation requires Celery. Use render_type='native' for client-side rendering."}
+                result = _generate_heatmap(features, cell_size, radius, render_type, palette)
             if result.get("success"):
                 data = result.get("data")
                 # 注入 render 指令暗示前端

--- a/app/tools/spatial.py
+++ b/app/tools/spatial.py
@@ -5,6 +5,7 @@ from typing import Optional, List, Dict, Any
 from pydantic import BaseModel, Field
 
 from app.tools.registry import ToolRegistry, tool
+from app.services.spatial_analyzer import SpatialAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -63,11 +64,17 @@ def register_spatial_tools(registry: ToolRegistry):
             if not data:
                 return {"error": "Invalid GeoJSON input"}
             features = data.get("features", data) if isinstance(data, dict) else data
-            from app.services.spatial_tasks import run_buffer_analysis
-            task = run_buffer_analysis.apply_async(
-                args=[features, distance, unit]
-            )
-            result = task.get(timeout=120)
+
+            try:
+                from app.services.spatial_tasks import run_buffer_analysis
+                task = run_buffer_analysis.apply_async(args=[features, distance, unit])
+                result = task.get(timeout=120)
+            except ImportError:
+                r = SpatialAnalyzer.buffer(features, distance=distance, unit=unit)
+                result = {"success": r.success, "data": r.data, "stats": r.stats}
+                if not r.success:
+                    result["error"] = r.error_message
+
             if result.get("success"):
                 return {"geojson": result.get("data"), "stats": result.get("stats")}
             return {"error": result.get("error")}
@@ -83,11 +90,17 @@ def register_spatial_tools(registry: ToolRegistry):
             if not data:
                 return {"error": "Invalid GeoJSON input"}
             features = data.get("features", [])
-            from app.services.spatial_tasks import run_spatial_stats
-            task = run_spatial_stats.apply_async(
-                args=[features]
-            )
-            result = task.get(timeout=60)
+
+            try:
+                from app.services.spatial_tasks import run_spatial_stats
+                task = run_spatial_stats.apply_async(args=[features])
+                result = task.get(timeout=60)
+            except ImportError:
+                r = SpatialAnalyzer.statistics(features, spatial_stats=True)
+                result = {"success": r.success, "stats": r.stats}
+                if not r.success:
+                    result["error"] = r.error_message
+
             if result.get("success"):
                 return {"stats": result.get("stats")}
             return {"error": result.get("error")}
@@ -103,11 +116,18 @@ def register_spatial_tools(registry: ToolRegistry):
             if not data:
                 return {"error": "Invalid GeoJSON input"}
             features = data.get("features", [])
-            from app.services.spatial_tasks import run_nearest_neighbor
-            task = run_nearest_neighbor.apply_async(
-                args=[features]
-            )
-            result = task.get(timeout=60)
+
+            try:
+                from app.services.spatial_tasks import run_nearest_neighbor
+                task = run_nearest_neighbor.apply_async(args=[features])
+                result = task.get(timeout=60)
+            except ImportError:
+                r = SpatialAnalyzer.nearest(features)
+                if r.success:
+                    result = {"success": True, "data": r.data}
+                else:
+                    result = {"success": False, "error": r.error_message}
+
             if result.get("success"):
                 return result.get("data")
             return {"error": result.get("error")}
@@ -136,11 +156,14 @@ def register_spatial_tools(registry: ToolRegistry):
                     }
                 return data
 
-            from app.services.spatial_tasks import run_heatmap_generation
-            task = run_heatmap_generation.apply_async(
-                kwargs={"features": features, "cell_size": cell_size, "radius": radius, "render_type": render_type, "palette": palette}
-            )
-            result = task.get(timeout=120)
+            try:
+                from app.services.spatial_tasks import run_heatmap_generation
+                task = run_heatmap_generation.apply_async(
+                    kwargs={"features": features, "cell_size": cell_size, "radius": radius, "render_type": render_type, "palette": palette}
+                )
+                result = task.get(timeout=120)
+            except ImportError:
+                return {"error": "Heatmap generation requires Celery. Use render_type='native' for client-side rendering."}
             if result.get("success"):
                 data = result.get("data")
                 # 注入 render 指令暗示前端

--- a/app/tools/spatial.py
+++ b/app/tools/spatial.py
@@ -96,10 +96,29 @@ def register_spatial_tools(registry: ToolRegistry):
                 task = run_spatial_stats.apply_async(args=[features])
                 result = task.get(timeout=60)
             except ImportError:
-                r = SpatialAnalyzer.statistics(features, spatial_stats=True)
-                result = {"success": r.success, "stats": r.stats}
-                if not r.success:
-                    result["error"] = r.error_message
+                from shapely.geometry import shape
+                import geopandas as gpd
+                geometries = [shape(f["geometry"]) for f in features if f.get("geometry")]
+                if not geometries:
+                    return {"error": "No valid geometries"}
+                gdf = gpd.GeoSeries(geometries, crs="EPSG:4326")
+                gdf_proj = gdf.to_crs("ESRI:54009")
+                stats = {
+                    "feature_count": len(geometries),
+                    "total_area_sqkm": round(float(gdf_proj.area.sum()) / 1e6, 4),
+                    "total_length_km": round(float(gdf_proj.length.sum()) / 1000, 4),
+                    "centroid": {
+                        "lat": round(float(gdf.centroid.y.mean()), 6),
+                        "lon": round(float(gdf.centroid.x.mean()), 6),
+                    },
+                    "bounds": {
+                        "min_lon": round(float(gdf.bounds.minx.min()), 6),
+                        "min_lat": round(float(gdf.bounds.miny.min()), 6),
+                        "max_lon": round(float(gdf.bounds.maxx.max()), 6),
+                        "max_lat": round(float(gdf.bounds.maxy.max()), 6),
+                    },
+                }
+                result = {"success": True, "stats": stats}
 
             if result.get("success"):
                 return {"stats": result.get("stats")}
@@ -122,11 +141,30 @@ def register_spatial_tools(registry: ToolRegistry):
                 task = run_nearest_neighbor.apply_async(args=[features])
                 result = task.get(timeout=60)
             except ImportError:
-                r = SpatialAnalyzer.nearest(features)
-                if r.success:
-                    result = {"success": True, "data": r.data}
-                else:
-                    result = {"success": False, "error": r.error_message}
+                import numpy as np
+                from scipy.spatial import distance_matrix
+                points = []
+                for f in features:
+                    geom = f.get("geometry") or {}
+                    if geom.get("type") == "Point" and geom.get("coordinates"):
+                        coords = geom["coordinates"]
+                        points.append((coords[0], coords[1]))
+                if len(points) < 2:
+                    return {"error": "Need at least 2 points"}
+                coords_arr = np.array(points)
+                dist = distance_matrix(coords_arr, coords_arr)
+                np.fill_diagonal(dist, np.inf)
+                nn_distances = dist.min(axis=1)
+                result = {
+                    "success": True,
+                    "data": {
+                        "point_count": len(points),
+                        "mean_nearest_distance": round(float(nn_distances.mean()), 4),
+                        "std_nearest_distance": round(float(nn_distances.std()), 4),
+                        "min_distance": round(float(nn_distances.min()), 4),
+                        "max_distance": round(float(nn_distances.max()), 4),
+                    }
+                }
 
             if result.get("success"):
                 return result.get("data")

--- a/docs/superpowers/plans/2026-04-26-skill-library-fix.md
+++ b/docs/superpowers/plans/2026-04-26-skill-library-fix.md
@@ -1,0 +1,875 @@
+# Skill Library Full-Stack Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all broken tools and frontend gaps to get the WebGIS AI Agent to a solid, deployable baseline.
+
+**Architecture:** Backend: each Celery-dependent tool function gets a try/except ImportError branch — if `spatial_tasks` can't import (no Celery), fall back to calling `SpatialAnalyzer` methods directly. Frontend: centralized API config, missing SSE handlers, sessionId prop, WebSocket reconnection, console.log cleanup.
+
+**Tech Stack:** Python 3.x (FastAPI, Pydantic, shapely, geopandas), TypeScript (Next.js 14, React 18, Zustand, MapLibre GL)
+
+---
+
+## File Structure
+
+### Backend
+- **Modify** `app/tools/spatial.py` — Add ImportError fallback to SpatialAnalyzer for all 4 tools
+- **Modify** `app/tools/advanced_spatial.py` — Add ImportError fallback to SpatialAnalyzer for all 6 tools
+- **Modify** `app/tools/skills.py` — Add AST validation to `create_new_skill()`, implement `watch_skills()` file watcher
+
+### Frontend
+- **Create** `frontend/lib/api/config.ts` — Centralized API base URL + WS URL
+- **Modify** `frontend/app/page.tsx` — Replace 8 hardcoded URLs, add sessionId prop, add SSE handlers
+- **Modify** `frontend/app/story/page.tsx` — Replace 1 hardcoded URL
+- **Modify** `frontend/components/map/map-action-handler.tsx` — Replace 2 hardcoded URLs
+- **Modify** `frontend/components/panel/results-panel.tsx` — Replace 2 hardcoded URLs
+- **Modify** `frontend/components/panel/asset-card.tsx` — Replace 1 hardcoded URL
+- **Modify** `frontend/components/hud/settings-panel.tsx` — Replace 5 hardcoded URLs
+- **Modify** `frontend/lib/store/useHudStore.ts` — Replace 2 hardcoded URLs
+- **Modify** `frontend/lib/hooks/use-websocket.ts` — Import config, add reconnection with exponential backoff
+- **Modify** `frontend/lib/contexts/task-context.tsx` — Remove 7 console.log
+- **Modify** `frontend/lib/contexts/map-action-context.tsx` — Remove 2 console.log
+- **Modify** `frontend/components/map/map-action-handler.tsx` — Remove 2 console.log
+- **Modify** `frontend/app/page.tsx` — Remove 2 console.log
+- **Modify** `frontend/lib/hooks/use-websocket.ts` — Remove 2 console.log
+
+---
+
+### Task 1: Fix spatial.py — Add Celery fallback (4 tools)
+
+**Files:**
+- Modify: `app/tools/spatial.py`
+
+`spatial_tasks.py` imports `celery` at module level, so `from app.services.spatial_tasks import run_buffer_analysis` fails when Celery isn't installed. Each tool function needs a try/except ImportError that falls back to calling `SpatialAnalyzer` directly. `SpatialAnalyzer` methods return `AnalysisResult(success, data, error_message, stats)`.
+
+- [ ] **Step 1: Add SpatialAnalyzer import and refactor buffer_analysis**
+
+Add at top of file after line 7:
+```python
+from app.services.spatial_analyzer import SpatialAnalyzer
+```
+
+Replace the body of `buffer_analysis` (lines 61-76) with:
+```python
+    def buffer_analysis(geojson: Any, distance: float, unit: str = "m") -> dict:
+        try:
+            data = _safe_parse_geojson(geojson)
+            if not data:
+                return {"error": "Invalid GeoJSON input"}
+            features = data.get("features", data) if isinstance(data, dict) else data
+
+            try:
+                from app.services.spatial_tasks import run_buffer_analysis
+                task = run_buffer_analysis.apply_async(args=[features, distance, unit])
+                result = task.get(timeout=120)
+            except ImportError:
+                r = SpatialAnalyzer.buffer(features, distance=distance, unit=unit)
+                result = {"success": r.success, "data": r.data, "stats": r.stats}
+                if not r.success:
+                    result["error"] = r.error_message
+
+            if result.get("success"):
+                return {"geojson": result.get("data"), "stats": result.get("stats")}
+            return {"error": result.get("error")}
+        except Exception as e:
+            logger.error(f"Buffer analysis error: {e}")
+            return {"error": str(e)}
+```
+
+- [ ] **Step 2: Refactor spatial_stats**
+
+Replace the body of `spatial_stats` (lines 80-96) with:
+```python
+    def spatial_stats(geojson: Any) -> dict:
+        try:
+            data = _safe_parse_geojson(geojson)
+            if not data:
+                return {"error": "Invalid GeoJSON input"}
+            features = data.get("features", [])
+
+            try:
+                from app.services.spatial_tasks import run_spatial_stats
+                task = run_spatial_stats.apply_async(args=[features])
+                result = task.get(timeout=60)
+            except ImportError:
+                r = SpatialAnalyzer.statistics(features, spatial_stats=True)
+                result = {"success": r.success, "stats": r.stats}
+                if not r.success:
+                    result["error"] = r.error_message
+
+            if result.get("success"):
+                return {"stats": result.get("stats")}
+            return {"error": result.get("error")}
+        except Exception as e:
+            logger.error(f"Spatial stats error: {e}")
+            return {"error": str(e)}
+```
+
+- [ ] **Step 3: Refactor nearest_neighbor**
+
+Replace the body of `nearest_neighbor` (lines 100-116) with:
+```python
+    def nearest_neighbor(geojson: Any) -> dict:
+        try:
+            data = _safe_parse_geojson(geojson)
+            if not data:
+                return {"error": "Invalid GeoJSON input"}
+            features = data.get("features", [])
+
+            try:
+                from app.services.spatial_tasks import run_nearest_neighbor
+                task = run_nearest_neighbor.apply_async(args=[features])
+                result = task.get(timeout=60)
+            except ImportError:
+                r = SpatialAnalyzer.nearest(features)
+                if r.success:
+                    result = {"success": True, "data": r.data}
+                else:
+                    result = {"success": False, "error": r.error_message}
+
+            if result.get("success"):
+                return result.get("data")
+            return {"error": result.get("error")}
+        except Exception as e:
+            logger.error(f"NN analysis error: {e}")
+            return {"error": str(e)}
+```
+
+- [ ] **Step 4: Refactor heatmap_data**
+
+Replace the Celery-dependent branch (lines 139-153) inside heatmap_data. Keep the native render branch unchanged (lines 129-137). The change is:
+
+Replace lines 139-153:
+```python
+            from app.services.spatial_tasks import run_heatmap_generation
+            task = run_heatmap_generation.apply_async(
+                kwargs={"features": features, "cell_size": cell_size, "radius": radius, "render_type": render_type, "palette": palette}
+            )
+            result = task.get(timeout=120)
+```
+
+With:
+```python
+            try:
+                from app.services.spatial_tasks import run_heatmap_generation
+                task = run_heatmap_generation.apply_async(
+                    kwargs={"features": features, "cell_size": cell_size, "radius": radius, "render_type": render_type, "palette": palette}
+                )
+                result = task.get(timeout=120)
+            except ImportError:
+                return {"error": "Heatmap generation requires Celery. Use render_type='native' for client-side rendering."}
+```
+
+Note: Heatmap generation has complex matplotlib logic with no direct `SpatialAnalyzer` equivalent, so we return an error suggesting the native mode instead. The native mode (lines 129-137) works without any backend processing.
+
+- [ ] **Step 5: Verify imports work**
+
+Run: `cd /home/kevin/projects/webgis-ai-agent && python -c "from app.tools.spatial import register_spatial_tools; print('OK')"`
+
+Expected: `OK` (no ImportError)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/tools/spatial.py
+git commit -m "fix: add Celery ImportError fallback for 4 spatial tools (buffer, stats, nearest, heatmap)"
+```
+
+---
+
+### Task 2: Fix advanced_spatial.py — Add Celery fallback (6 tools)
+
+**Files:**
+- Modify: `app/tools/advanced_spatial.py`
+
+Same pattern as Task 1. Each tool wraps the `spatial_tasks` import in try/except ImportError and falls back to `SpatialAnalyzer`.
+
+- [ ] **Step 1: Add SpatialAnalyzer import**
+
+Add after line 6:
+```python
+from app.services.spatial_analyzer import SpatialAnalyzer
+```
+
+- [ ] **Step 2: Refactor path_analysis**
+
+Replace the body of `path_analysis` (lines 41-53) with:
+```python
+    def path_analysis(network_features: Any, start_point: List[float], end_point: List[float]) -> dict:
+        try:
+            features = network_features.get("features", network_features) if isinstance(network_features, dict) else network_features
+
+            try:
+                from app.services.spatial_tasks import run_path_analysis
+                task = run_path_analysis.apply_async(args=[features, start_point, end_point])
+                result = task.get(timeout=120)
+            except ImportError:
+                r = SpatialAnalyzer.path_analysis(features, start_point=start_point, end_point=end_point)
+                result = {"success": r.success, "data": r.data, "stats": r.stats}
+                if not r.success:
+                    result["error"] = r.error_message
+
+            if result.get("success"):
+                return {"geojson": result.get("data"), "stats": result.get("stats")}
+            return {"error": result.get("error")}
+        except Exception as e:
+            return {"error": str(e)}
+```
+
+- [ ] **Step 3: Refactor zonal_stats**
+
+Replace the body of `zonal_stats` (lines 58-71) with:
+```python
+    def zonal_stats(geojson: Any, raster_path: str) -> dict:
+        try:
+            features = geojson.get("features", geojson) if isinstance(geojson, dict) else geojson
+
+            try:
+                from app.services.spatial_tasks import run_zonal_stats
+                task = run_zonal_stats.apply_async(args=[features, raster_path])
+                result = task.get(timeout=120)
+            except ImportError:
+                r = SpatialAnalyzer.zonal_statistics(features, raster_path=raster_path)
+                if r.success:
+                    result = {"success": True, "data": r.data}
+                else:
+                    result = {"success": False, "error": r.error_message}
+
+            if result.get("success"):
+                return {"zonal_stats": result.get("data", {}).get("zonal_stats")}
+            return {"error": result.get("error")}
+        except Exception as e:
+            return {"error": str(e)}
+```
+
+- [ ] **Step 4: Refactor overlay_analysis**
+
+Replace the body of `overlay_analysis` (lines 76-91) with:
+```python
+    def overlay_analysis(layer_a: Any, layer_b: Any, how: str = "intersection") -> dict:
+        try:
+            features_a = layer_a.get("features", layer_a) if isinstance(layer_a, dict) else layer_a
+            features_b = layer_b.get("features", layer_b) if isinstance(layer_b, dict) else layer_b
+
+            try:
+                from app.services.spatial_tasks import run_overlay_analysis
+                task = run_overlay_analysis.apply_async(args=[features_a, features_b, how])
+                result = task.get(timeout=120)
+            except ImportError:
+                r = SpatialAnalyzer.overlay(features_a, features_b, how=how)
+                result = {"success": r.success, "data": r.data, "stats": r.stats}
+                if not r.success:
+                    result["error"] = r.error_message
+
+            if result.get("success"):
+                return {"geojson": result.get("data"), "stats": result.get("stats")}
+            return {"error": result.get("error")}
+        except Exception as e:
+            return {"error": str(e)}
+```
+
+- [ ] **Step 5: Refactor attribute_filter**
+
+Replace the body of `attribute_filter` (lines 96-109) with:
+```python
+    def attribute_filter(geojson: Any, query: str) -> dict:
+        try:
+            features = geojson.get("features", geojson) if isinstance(geojson, dict) else geojson
+
+            try:
+                from app.services.spatial_tasks import run_attribute_filter
+                task = run_attribute_filter.apply_async(args=[features, query])
+                result = task.get(timeout=60)
+            except ImportError:
+                r = SpatialAnalyzer.attribute_filter(features, query=query)
+                result = {"success": r.success, "data": r.data, "stats": r.stats}
+                if not r.success:
+                    result["error"] = r.error_message
+
+            if result.get("success"):
+                return {"geojson": result.get("data"), "stats": result.get("stats")}
+            return {"error": result.get("error")}
+        except Exception as e:
+            return {"error": str(e)}
+```
+
+- [ ] **Step 6: Refactor spatial_join**
+
+Replace the body of `spatial_join` (lines 114-128) with:
+```python
+    def spatial_join(left_layer: Any, right_layer: Any, join_type: str = "inner", predicate: str = "intersects") -> dict:
+        try:
+            features_left = left_layer.get("features", left_layer) if isinstance(left_layer, dict) else left_layer
+            features_right = right_layer.get("features", right_layer) if isinstance(right_layer, dict) else right_layer
+
+            try:
+                from app.services.spatial_tasks import run_spatial_join
+                task = run_spatial_join.apply_async(args=[features_left, features_right, join_type, predicate])
+                result = task.get(timeout=120)
+            except ImportError:
+                r = SpatialAnalyzer.spatial_join(features_left, features_right, join_type=join_type, predicate=predicate)
+                result = {"success": r.success, "data": r.data, "stats": r.stats}
+                if not r.success:
+                    result["error"] = r.error_message
+
+            if result.get("success"):
+                return {"geojson": result.get("data"), "stats": result.get("stats")}
+            return {"error": result.get("error")}
+        except Exception as e:
+            return {"error": str(e)}
+```
+
+- [ ] **Step 7: Verify imports work**
+
+Run: `cd /home/kevin/projects/webgis-ai-agent && python -c "from app.tools.advanced_spatial import register_advanced_spatial_tools; print('OK')"`
+
+Expected: `OK`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/tools/advanced_spatial.py
+git commit -m "fix: add Celery ImportError fallback for 6 advanced spatial tools (path, zonal, overlay, filter, join)"
+```
+
+---
+
+### Task 3: Create centralized API config
+
+**Files:**
+- Create: `frontend/lib/api/config.ts`
+
+- [ ] **Step 1: Create the config module**
+
+```typescript
+/**
+ * Centralized API configuration
+ * All API and WebSocket URLs should import from this module.
+ */
+export const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
+export const WS_BASE = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8001';
+```
+
+- [ ] **Step 2: Update chat.ts to use config**
+
+In `frontend/lib/api/chat.ts`, add import at top (after line 4):
+```typescript
+import { API_BASE } from './config';
+```
+
+Remove line 7 (`const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/lib/api/config.ts frontend/lib/api/chat.ts
+git commit -m "feat: create centralized API config module"
+```
+
+---
+
+### Task 4: Replace all hardcoded URLs in frontend
+
+**Files:**
+- Modify: `frontend/app/page.tsx` (8 URLs)
+- Modify: `frontend/app/story/page.tsx` (1 URL)
+- Modify: `frontend/components/map/map-action-handler.tsx` (2 URLs)
+- Modify: `frontend/components/panel/results-panel.tsx` (2 URLs)
+- Modify: `frontend/components/panel/asset-card.tsx` (1 URL)
+- Modify: `frontend/components/hud/settings-panel.tsx` (5 URLs)
+- Modify: `frontend/lib/store/useHudStore.ts` (2 URLs)
+- Modify: `frontend/lib/hooks/use-websocket.ts` (1 URL)
+
+- [ ] **Step 1: page.tsx — Add import and replace all 8 URLs**
+
+Add import near top of file (after other imports, around line 17):
+```typescript
+import { API_BASE } from '@/lib/api/config';
+```
+
+Replace all 8 occurrences of `http://localhost:8001` with the value of `API_BASE`:
+- Line 22: `fetch(\`http://localhost:8001/api/v1/chat/sessions/${sessionId}\`)` → `fetch(\`${API_BASE}/api/v1/chat/sessions/${sessionId}\`)`
+- Line 73: `fetch("http://localhost:8001/api/v1/chat/sessions")` → `fetch(\`${API_BASE}/api/v1/chat/sessions\`)`
+- Line 85: `fetch("http://localhost:8001/api/v1/chat/sessions")` → `fetch(\`${API_BASE}/api/v1/chat/sessions\`)`
+- Line 97: `fetch(\`http://localhost:8001/api/v1/chat/sessions/${sid}\`)` → `fetch(\`${API_BASE}/api/v1/chat/sessions/${sid}\`)`
+- Line 136: `fetch(\`http://localhost:8001/api/v1/chat/sessions/${sid}\`, { method: "DELETE" })` → `fetch(\`${API_BASE}/api/v1/chat/sessions/${sid}\`, { method: "DELETE" })`
+- Line 152: `fetch(\`http://localhost:8001/api/v1/chat/sessions/${savedSessionId}\`)` → `fetch(\`${API_BASE}/api/v1/chat/sessions/${savedSessionId}\`)`
+- Line 188: `fetch(\`http://localhost:8001/api/v1/layers/data/${result.geojson_ref}?session_id=${sid}\`)` → `fetch(\`${API_BASE}/api/v1/layers/data/${result.geojson_ref}?session_id=${sid}\`)`
+- Line 331: `fetch("http://localhost:8001/api/v1/chat/completions",` → `fetch(\`${API_BASE}/api/v1/chat/completions\`,`
+
+- [ ] **Step 2: story/page.tsx — Replace 1 URL**
+
+Add import: `import { API_BASE } from '@/lib/api/config';`
+Replace line 22: `http://localhost:8001` → `${API_BASE}`
+
+- [ ] **Step 3: map-action-handler.tsx — Replace 2 URLs**
+
+Add import: `import { API_BASE } from '@/lib/api/config';`
+- Line 300: `http://localhost:8001/api/v1/export` → `${API_BASE}/api/v1/export`
+- Line 311: `http://localhost:8001${url}` → `${API_BASE}${url}`
+
+- [ ] **Step 4: results-panel.tsx — Replace 2 URLs**
+
+Add import: `import { API_BASE } from '@/lib/api/config';`
+- Line 181: `http://localhost:8001/api/v1/chat/tools/call?tool=manage_analysis_asset&asset_id=${id}&action=delete` → `${API_BASE}/api/v1/chat/tools/call?tool=manage_analysis_asset&asset_id=${id}&action=delete`
+- Line 185: `http://localhost:8001/api/v1/chat/tools/call?tool=manage_analysis_asset&asset_id=${id}&action=rename&new_name=${encodeURIComponent(newName)}` → `${API_BASE}/api/v1/chat/tools/call?tool=manage_analysis_asset&asset_id=${id}&action=rename&new_name=${encodeURIComponent(newName)}`
+
+- [ ] **Step 5: asset-card.tsx — Replace 1 URL**
+
+Add import: `import { API_BASE } from '@/lib/api/config';`
+- Line 99: `http://localhost:8001/api/v1/layers/data/${asset.id}?download=true` → `${API_BASE}/api/v1/layers/data/${asset.id}?download=true`
+
+- [ ] **Step 6: settings-panel.tsx — Replace 5 URLs**
+
+Add import: `import { API_BASE } from '@/lib/api/config';`
+- Line 34: `http://localhost:8001/api/v1/config/llm` → `${API_BASE}/api/v1/config/llm`
+- Line 35: `http://localhost:8001/api/v1/config/mcp` → `${API_BASE}/api/v1/config/mcp`
+- Line 36: `http://localhost:8001/api/v1/config/skills` → `${API_BASE}/api/v1/config/skills`
+- Line 61: `http://localhost:8001/api/v1/config/llm` → `${API_BASE}/api/v1/config/llm`
+- Line 78: `http://localhost:8001/api/v1/config/mcp` → `${API_BASE}/api/v1/config/mcp`
+
+- [ ] **Step 7: useHudStore.ts — Replace 2 URLs**
+
+Add import: `import { API_BASE } from '../api/config';`
+- Line 229: `http://localhost:8001/api/v1/chat/tools/call?tool=list_analysis_assets&session_id=${sessionId || ''}` → `${API_BASE}/api/v1/chat/tools/call?tool=list_analysis_assets&session_id=${sessionId || ''}`
+- Line 234: `http://localhost:8001/api/v1/uploads?session_id=${sessionId || ''}` → `${API_BASE}/api/v1/uploads?session_id=${sessionId || ''}`
+
+- [ ] **Step 8: use-websocket.ts — Replace WS URL**
+
+Add import: `import { WS_BASE } from '../api/config';`
+Replace line 4: `const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8001/api/v1/ws';` → `const WS_URL = \`${WS_BASE}/api/v1/ws\`;`
+
+- [ ] **Step 9: Verify build compiles**
+
+Run: `cd /home/kevin/projects/webgis-ai-agent/frontend && npx next build 2>&1 | tail -20`
+
+Expected: Build completes (may have warnings but no errors related to the changed files)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/
+git commit -m "fix: replace 21 hardcoded localhost URLs with centralized API config"
+```
+
+---
+
+### Task 5: Fix missing sessionId prop for DataHud
+
+**Files:**
+- Modify: `frontend/app/page.tsx`
+
+- [ ] **Step 1: Pass sessionId to DataHud**
+
+In page.tsx, the `DataHud` component at line 654. Change:
+
+```tsx
+        <DataHud
+          layers={layers}
+          onToggleLayer={toggleLayer}
+          onRemoveLayer={removeLayer}
+          onUpdateLayer={updateLayer}
+          onReorderLayers={reorderLayers}
+        />
+```
+
+To:
+
+```tsx
+        <DataHud
+          layers={layers}
+          sessionId={sessionId}
+          onToggleLayer={toggleLayer}
+          onRemoveLayer={removeLayer}
+          onUpdateLayer={updateLayer}
+          onReorderLayers={reorderLayers}
+        />
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/app/page.tsx
+git commit -m "fix: pass sessionId prop to DataHud so assets tab loads data"
+```
+
+---
+
+### Task 6: Add missing SSE event handlers
+
+**Files:**
+- Modify: `frontend/app/page.tsx`
+
+The SSE event loop in `handleSend` (around lines 396-478) handles `session`, `task_start`, `step_start`, `step_result`, `step_error`, `task_complete`, `message`/`content`/`token`, `done`/`end`, `task_error`/`tool_error`. Missing: `tool_call`, `task_plan`, `task_cancelled`.
+
+- [ ] **Step 1: Add tool_call handler**
+
+After the `eventType === "task_error" || eventType === "tool_error"` block (around line 470), add:
+
+```typescript
+          } else if (eventType === "tool_call" && data?.tool) {
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === thinkingMessage.id
+                  ? { ...msg, content: assistantContent + `\n\n> 🔧 **执行工具**: ${data.tool}...` }
+                  : msg
+              )
+            )
+```
+
+- [ ] **Step 2: Add task_plan handler**
+
+After the tool_call handler:
+
+```typescript
+          } else if (eventType === "task_plan" && data?.steps) {
+            const planSteps = (data.steps as string[]).map((s, i) => `${i + 1}. ${s}`).join("\n")
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === thinkingMessage.id
+                  ? { ...msg, content: assistantContent + `\n\n📋 **任务计划**:\n${planSteps}` }
+                  : msg
+              )
+            )
+```
+
+- [ ] **Step 3: Add task_cancelled handler**
+
+After the task_plan handler:
+
+```typescript
+          } else if (eventType === "task_cancelled") {
+            clearTask()
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === thinkingMessage.id
+                  ? { ...msg, content: assistantContent + "\n\n> ⏹ 任务已取消" }
+                  : msg
+              )
+            )
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/app/page.tsx
+git commit -m "feat: add SSE handlers for tool_call, task_plan, and task_cancelled events"
+```
+
+---
+
+### Task 7: Add WebSocket reconnection with exponential backoff
+
+**Files:**
+- Modify: `frontend/lib/hooks/use-websocket.ts`
+
+- [ ] **Step 1: Rewrite use-websocket.ts with reconnection logic**
+
+Replace the entire file with:
+
+```typescript
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { WS_BASE } from '@/lib/api/config';
+
+const WS_URL = `${WS_BASE}/api/v1/ws`;
+
+export function useWebSocket(sessionId?: string) {
+  const socketRef = useRef<WebSocket | null>(null);
+  const retryCountRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [connected, setConnected] = useState(false);
+  const { addProcessLayer, removeProcessLayer } = useHudStore();
+
+  const connect = useCallback(() => {
+    if (!sessionId) return;
+
+    const url = `${WS_URL}/${sessionId}`;
+    const socket = new WebSocket(url);
+    socketRef.current = socket;
+
+    socket.onopen = () => {
+      retryCountRef.current = 0;
+      setConnected(true);
+    };
+
+    socket.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        const { event: eventType, data } = payload;
+
+        if (eventType === 'STEP_COMPLETED' || eventType === 'geojson_update') {
+          if (data.step_id && data.geojson) {
+            addProcessLayer(data.step_id, data.geojson);
+          }
+        } else if (eventType === 'STEP_REMOVED') {
+          if (data.step_id) {
+            removeProcessLayer(data.step_id);
+          }
+        }
+      } catch {}
+    };
+
+    socket.onclose = () => {
+      setConnected(false);
+      socketRef.current = null;
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s, max 30s
+      const delay = Math.min(1000 * Math.pow(2, retryCountRef.current), 30000);
+      retryCountRef.current += 1;
+      timerRef.current = setTimeout(connect, delay);
+    };
+
+    socket.onerror = () => {
+      socket.close();
+    };
+  }, [sessionId, addProcessLayer, removeProcessLayer]);
+
+  useEffect(() => {
+    connect();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (socketRef.current) {
+        socketRef.current.onclose = null;
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+      setConnected(false);
+    };
+  }, [connect]);
+
+  const sendMessage = useCallback((message: any) => {
+    if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN) {
+      socketRef.current.send(JSON.stringify(message));
+    }
+  }, []);
+
+  return { sendMessage, connected };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/lib/hooks/use-websocket.ts
+git commit -m "feat: add WebSocket reconnection with exponential backoff and connection state"
+```
+
+---
+
+### Task 8: Add AST validation to Skill Creator
+
+**Files:**
+- Modify: `app/tools/skills.py`
+
+- [ ] **Step 1: Add AST validation function**
+
+Add after the existing imports (line 6):
+
+```python
+import ast
+
+_BLOCKED_IMPORTS = {"subprocess", "multiprocessing", "ctypes", "socket", "http", "urllib", "ftplib", "smtplib", "telnetlib", "xmlrpc"}
+_BLOCKED_BUILTINS = {"eval", "exec", "compile", "__import__", "open", "input"}
+_BLOCKED_ATTRS = {"system", "popen", "call", "run", "Popen"}
+
+
+def _validate_skill_code(code: str) -> list[str]:
+    """Validate skill code for dangerous patterns. Returns list of errors."""
+    errors = []
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as e:
+        return [f"Syntax error: {e}"]
+
+    for node in ast.walk(tree):
+        # Block dangerous imports
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root_mod = alias.name.split(".")[0]
+                if root_mod in _BLOCKED_IMPORTS:
+                    errors.append(f"Blocked import: {alias.name}")
+
+        if isinstance(node, ast.ImportFrom):
+            if node.module:
+                root_mod = node.module.split(".")[0]
+                if root_mod in _BLOCKED_IMPORTS:
+                    errors.append(f"Blocked import: {node.module}")
+
+        # Block dangerous builtins
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in _BLOCKED_BUILTINS:
+                errors.append(f"Blocked builtin: {func.id}")
+            if isinstance(func, ast.Attribute) and func.attr in _BLOCKED_ATTRS:
+                errors.append(f"Blocked attribute: {func.attr}")
+
+    return errors
+```
+
+- [ ] **Step 2: Integrate validation into create_new_skill**
+
+In the `create_new_skill` function (line 24), add validation before `skill_creator.create_skill()`:
+
+Replace:
+```python
+async def create_new_skill(module_name: str, code: str, description: str) -> str:
+    """Agent 调用的创建技能函数"""
+    from app.services.skill_creator import skill_creator
+    from app.api.routes.chat import registry
+    
+    result = skill_creator.create_skill(module_name, code, description)
+```
+
+With:
+```python
+async def create_new_skill(module_name: str, code: str, description: str) -> str:
+    """Agent 调用的创建技能函数"""
+    errors = _validate_skill_code(code)
+    if errors:
+        return f"Skill validation failed:\n" + "\n".join(f"- {e}" for e in errors) + "\nPlease revise your code to remove dangerous patterns."
+
+    from app.services.skill_creator import skill_creator
+    from app.api.routes.chat import registry
+
+    result = skill_creator.create_skill(module_name, code, description)
+```
+
+- [ ] **Step 3: Verify import works**
+
+Run: `cd /home/kevin/projects/webgis-ai-agent && python -c "from app.tools.skills import _validate_skill_code; print(_validate_skill_code('import os'));"`
+
+Expected: `[]` (os is allowed)
+
+Run: `cd /home/kevin/projects/webgis-ai-agent && python -c "from app.tools.skills import _validate_skill_code; print(_validate_skill_code('import subprocess'));"`
+
+Expected: `['Blocked import: subprocess']`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/tools/skills.py
+git commit -m "feat: add AST-based code validation to Skill Creator, block dangerous imports and builtins"
+```
+
+---
+
+### Task 9: Implement watch_skills() file watcher
+
+**Files:**
+- Modify: `app/tools/skills.py`
+
+- [ ] **Step 1: Replace the stub watch_skills()**
+
+Replace the current `watch_skills` function (lines 71-76):
+
+```python
+def watch_skills(registry: ToolRegistry, skills_dir: str = "app/skills"):
+    """
+    TODO: Implement a file watcher (e.g., using watchdog) to hot-reload skills.
+    For now, we just load them once at startup.
+    """
+    load_skills(registry, skills_dir)
+```
+
+With:
+
+```python
+def watch_skills(registry: ToolRegistry, skills_dir: str = "app/skills"):
+    """Poll-based file watcher for hot-reloading skills.
+
+    Tracks file modification times. Call periodically (e.g., every 5s)
+    to detect new or changed skill files and reload them.
+    """
+    _mtimes: dict[str, float] = {}
+
+    def _check():
+        if not os.path.exists(skills_dir):
+            return
+        changed = False
+        for filename in os.listdir(skills_dir):
+            if not filename.endswith(".py") or filename.startswith("__"):
+                continue
+            filepath = os.path.join(skills_dir, filename)
+            try:
+                mtime = os.path.getmtime(filepath)
+            except OSError:
+                continue
+            if filepath not in _mtimes or _mtimes[filepath] < mtime:
+                _mtimes[filepath] = mtime
+                changed = True
+        if changed:
+            load_skills(registry, skills_dir)
+
+    _check()
+    return _check
+```
+
+- [ ] **Step 2: Verify import works**
+
+Run: `cd /home/kevin/projects/webgis-ai-agent && python -c "from app.tools.skills import watch_skills; print(type(watch_skills))"`
+
+Expected: `<class 'function'>`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/tools/skills.py
+git commit -m "feat: implement poll-based watch_skills() file watcher for hot-reloading"
+```
+
+---
+
+### Task 10: Remove console.log remnants
+
+**Files:**
+- Modify: `frontend/lib/contexts/task-context.tsx` (7 occurrences)
+- Modify: `frontend/lib/contexts/map-action-context.tsx` (2 occurrences)
+- Modify: `frontend/components/map/map-action-handler.tsx` (2 occurrences)
+- Modify: `frontend/app/page.tsx` (2 occurrences)
+
+- [ ] **Step 1: Remove console.log from task-context.tsx**
+
+Remove these 7 lines:
+- Line 41: `console.log('[Task] Starting task:', taskId);`
+- Line 50: `console.log('[Task] Step started:', taskId, stepId, stepIndex, tool);`
+- Line 68: `console.log('[Task] Step result:', taskId, stepId, tool);`
+- Line 85: `console.log('[Task] Step error:', taskId, stepId, error);`
+- Line 99: `console.log('[Task] Task completed:', taskId, stepCount, summary);`
+- Line 114: `console.log('[Task] Task error:', taskId, error);`
+- Line 126: `console.log('[Task] Task cancelled:', taskId);`
+- Line 137: `console.log('[Task] Clearing task');`
+
+- [ ] **Step 2: Remove console.log from map-action-context.tsx**
+
+Remove these 2 lines:
+- Line 38: `console.log('[MapAction] Throttled redundant command:', newAction.command);`
+- Line 57: `console.log('[MapAction] Dispatched to queue:', newAction.command, newAction.params);`
+
+- [ ] **Step 3: Remove console.log from map-action-handler.tsx**
+
+Remove these 2 lines:
+- Line 75: `console.log('[MapActionHandler] Processing action:', action.command, 'on map:', map.getContainer().id);`
+- Line 177: `console.log('[MapActionHandler] Directly setting base layer to:', MAP_STYLES[idx].name);`
+
+- [ ] **Step 4: Remove console.log from page.tsx**
+
+Remove these 2 lines:
+- Line 412: `console.log('[Home] Direct command dispatch from tool result:', result.command)`
+- Line 423: `console.log('[Home] Raster result detected, adding to map...')`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/
+git commit -m "chore: remove 13 console.log development remnants from frontend"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage**: P0 (sync fallback + URL cleanup) → Tasks 1-4. P1 (SSE + sessionId + WS) → Tasks 5-7. P2 (AST validation + file watcher) → Tasks 8-9. P3 (console.log) → Task 10.
+- [x] **Placeholder scan**: No TBD/TODO/fill-in-later. All code blocks are complete.
+- [x] **Type consistency**: `API_BASE` string used consistently. `AnalysisResult` fields (success, data, stats, error_message) matched correctly in fallback branches. `sessionId` prop type matches DataHud expectation.
+- [x] **No orphaned references**: All imports and function names referenced in later tasks are defined in earlier tasks.

--- a/docs/superpowers/specs/2026-04-26-skill-library-fix-design.md
+++ b/docs/superpowers/specs/2026-04-26-skill-library-fix-design.md
@@ -1,0 +1,140 @@
+# Skill Library Full-Stack Fix Design
+
+**Date**: 2026-04-26
+**Status**: Approved
+**Scope**: Fix broken tools, fill frontend gaps, solidify the "Agent is Everything" foundation before building multi-agent orchestration.
+
+## Problem
+
+34% of backend tools (10/29) are broken due to missing Celery dependency. Frontend has multiple functional gaps: missing SSE event handlers, hardcoded URLs that break non-local deployment, a missing sessionId prop that prevents asset loading, and a stub layer editor. The skill library is not solid enough to build higher-level agent features on top of.
+
+## Approach
+
+Full-stack fix with no new infrastructure dependencies. Use sync fallback for broken Celery-dependent tools, fix all frontend gaps, and harden the skill creator.
+
+---
+
+## P0: Backend — Sync Fallback for 10 Broken Spatial Tools
+
+**Files**: `app/tools/registry.py`, `app/tools/spatial.py`, `app/tools/advanced_spatial.py`
+
+**Current state**: `spatial.py` (4 tools) and `advanced_spatial.py` (6 tools) call Celery tasks (`run_buffer_analysis.apply_async()`, etc.). Celery is not installed, so these 10 tools fail with ImportError.
+
+**Fix**: Add a `safe_execute()` function in `registry.py` that detects Celery availability. When Celery is unavailable, route calls to the existing synchronous implementations in `app/services/spatial_analyzer.py`. The tool definitions themselves don't change — only the dispatch path in the registry.
+
+```python
+# registry.py — dispatch logic
+try:
+    from celery import Celery
+    CELERY_AVAILABLE = True
+except ImportError:
+    CELERY_AVAILABLE = False
+
+def safe_execute(task_func, *args, **kwargs):
+    if CELERY_AVAILABLE:
+        return task_func.apply_async(args=args, kwargs=kwargs).get()
+    else:
+        # Fall back to synchronous execution
+        return task_func(*args, **kwargs)
+```
+
+`spatial.py` and `advanced_spatial.py` import and call `safe_execute()` instead of `.apply_async()` directly.
+
+## P0: Frontend — Hardcoded URL Cleanup
+
+**Files**: `page.tsx`, `useHudStore.ts`, `results-panel.tsx`, `settings-panel.tsx`, `chat.ts`, `layer.ts`
+
+21 occurrences of `http://localhost:8001` hardcoded across these frontend files. `NEXT_PUBLIC_API_URL` is already defined in `chat.ts` but unused elsewhere.
+
+**Fix**: Create a centralized `lib/api/config.ts` module:
+
+```typescript
+export const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
+```
+
+Replace all hardcoded URLs with imports from this module.
+
+## P1: Frontend — SSE Event Handlers
+
+**Files**: `frontend/app/page.tsx`, `frontend/lib/store/useHudStore.ts`
+
+**Current state**: SSE stream parser handles `message`, `error`, `tool_result`, `tool_error`. Missing handlers for `tool_call`, `task_plan`, `task_cancelled`.
+
+**Fix**: Add handlers in the SSE parsing loop:
+
+- `tool_call` → Dispatch to store: show agent badge "Running {tool_name}..."
+- `task_plan` → Update TaskTimeline with step list from payload
+- `task_cancelled` → Clear task state in store
+
+## P1: Frontend — Missing sessionId Prop
+
+**File**: `frontend/app/page.tsx`
+
+**Current state**: `DataHud` component expects `sessionId` prop to fetch analysis assets, but `page.tsx` doesn't pass it.
+
+**Fix**: One-line change — pass `sessionId` from existing session state:
+
+```tsx
+<DataHud layers={layers} sessionId={sessionId} ... />
+```
+
+## P1: Frontend — WebSocket Reconnection
+
+**File**: `frontend/lib/hooks/use-websocket.ts`
+
+**Current state**: No error handling, no reconnection logic, no heartbeat. Connection silently drops.
+
+**Fix**: Add exponential backoff reconnection (1s → 2s → 4s → max 30s). Add a connection state indicator in HUD (subtle green/red dot on panel border).
+
+## P2: Frontend — Layer Edit Panel
+
+**Files**: `frontend/components/map/MapPanel.tsx`, new `frontend/components/map/LayerEditPanel.tsx`
+
+**Current state**: `onEditLayer={() => {}}` — button exists but does nothing.
+
+**Fix**: Create `LayerEditPanel` component with controls for name, color, opacity, visibility. Wire `onEditLayer` to open the panel with the selected layer's current state. Call existing `/layers/data/{ref_id}` API for persistence.
+
+## P2: Backend — Skill Creator AST Validation
+
+**File**: `app/tools/skills.py`
+
+**Current state**: Dynamic skill loading works but skill creator has no code validation. AI-generated Python code runs without safety checks.
+
+**Fix**: Add AST-based validation before skill deployment:
+
+- Parse the skill code with `ast.parse()`
+- Block dangerous imports: `os.system`, `subprocess`, `eval`, `exec`, `__import__`
+- Block file access patterns outside `app/skills/` directory
+- Reject code that fails to parse
+
+## P2: Backend — watch_skills() File Watcher
+
+**File**: `app/tools/skills.py`
+
+**Current state**: `watch_skills()` is a stub with a TODO comment.
+
+**Fix**: Implement a simple file watcher for `app/skills/` directory using `pathlib` polling (check mtime every 5 seconds). When a new or modified `.py` file is detected, reload it into the tool registry. Keep it simple — no watchdog dependency.
+
+## P3: Frontend — console.log Cleanup
+
+**Files**: ~10 frontend files
+
+Remove 30+ `console.log` development remnants across components.
+
+---
+
+## What Doesn't Change
+
+- No database schema changes
+- No new infrastructure (Redis, Celery, new services)
+- No API contract changes — existing endpoints keep their signatures
+- No new dependencies — all fixes use existing libraries
+
+## Success Criteria
+
+- All 29 backend tools return valid results (currently 19/29)
+- Frontend loads assets correctly in the DataHud panel
+- SSE events `tool_call`, `task_plan`, `task_cancelled` render in the UI
+- App works when deployed to non-localhost URL
+- WebSocket reconnects automatically after disconnect
+- AI-created skills are validated before execution

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -478,7 +478,7 @@ export default function Home() {
             setMessages((prev) =>
               prev.map((msg) =>
                 msg.id === thinkingMessage.id
-                  ? { ...msg, content: assistantContent + `\n\n> 🔧 **执行工具**: ${data.tool}...` }
+                  ? { ...msg, content: msg.content + `\n\n> 🔧 **执行工具**: ${data.tool}...` }
                   : msg
               )
             )
@@ -487,7 +487,7 @@ export default function Home() {
             setMessages((prev) =>
               prev.map((msg) =>
                 msg.id === thinkingMessage.id
-                  ? { ...msg, content: assistantContent + `\n\n📋 **任务计划**:\n${planSteps}` }
+                  ? { ...msg, content: msg.content + `\n\n📋 **任务计划**:\n${planSteps}` }
                   : msg
               )
             )
@@ -496,7 +496,7 @@ export default function Home() {
             setMessages((prev) =>
               prev.map((msg) =>
                 msg.id === thinkingMessage.id
-                  ? { ...msg, content: assistantContent + "\n\n> ⏹ 任务已取消" }
+                  ? { ...msg, content: msg.content + "\n\n> ⏹ 任务已取消" }
                   : msg
               )
             )

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -476,6 +476,32 @@ export default function Home() {
             setMessages((prev) =>
               prev.map((msg) => (msg.id === thinkingMessage.id ? { ...msg, content: assistantContent, isThinking: false } : msg))
             )
+          } else if (eventType === "tool_call" && data?.tool) {
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === thinkingMessage.id
+                  ? { ...msg, content: assistantContent + `\n\n> 🔧 **执行工具**: ${data.tool}...` }
+                  : msg
+              )
+            )
+          } else if (eventType === "task_plan" && data?.steps) {
+            const planSteps = (data.steps as string[]).map((s, i) => `${i + 1}. ${s}`).join("\n")
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === thinkingMessage.id
+                  ? { ...msg, content: assistantContent + `\n\n📋 **任务计划**:\n${planSteps}` }
+                  : msg
+              )
+            )
+          } else if (eventType === "task_cancelled") {
+            clearTask()
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === thinkingMessage.id
+                  ? { ...msg, content: assistantContent + "\n\n> ⏹ 任务已取消" }
+                  : msg
+              )
+            )
           }
         }
 
@@ -654,6 +680,7 @@ export default function Home() {
       >
         <DataHud
           layers={layers}
+          sessionId={sessionId}
           onToggleLayer={toggleLayer}
           onRemoveLayer={removeLayer}
           onUpdateLayer={updateLayer}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -16,6 +16,7 @@ import type { GeoJSONGeometry, GeoJSONFeature } from "@/lib/types"
 import type { ChatSession } from "@/lib/types/chat"
 import type { UploadResponse } from "@/lib/api/upload"
 import { getUploadGeojson } from "@/lib/api/upload"
+import { API_BASE } from '@/lib/api/config';
 import { useMapAction } from "@/lib/contexts/map-action-context"
 import {
   MessageSquare,
@@ -70,7 +71,7 @@ export default function Home() {
 
   // Fetch session list on mount
   useEffect(() => {
-    fetch("http://localhost:8001/api/v1/chat/sessions")
+    fetch(`${API_BASE}/api/v1/chat/sessions`)
       .then(res => res.json())
       .then(data => {
         if (data.sessions) setSessions(data.sessions)
@@ -82,7 +83,7 @@ export default function Home() {
   useEffect(() => {
     if (!sessionId) return
     const timer = setTimeout(() => {
-      fetch("http://localhost:8001/api/v1/chat/sessions")
+      fetch(`${API_BASE}/api/v1/chat/sessions`)
         .then(res => res.json())
         .then(data => {
           if (data.sessions) setSessions(data.sessions)
@@ -94,7 +95,7 @@ export default function Home() {
 
   const handleSelectSession = useCallback(async (sid: string) => {
     try {
-      const res = await fetch(`http://localhost:8001/api/v1/chat/sessions/${sid}`)
+      const res = await fetch(`${API_BASE}/api/v1/chat/sessions/${sid}`)
       const data = await res.json()
       if (data.messages && data.messages.length > 0) {
         const restored = data.messages.map((m: any) => ({
@@ -133,7 +134,7 @@ export default function Home() {
 
   const handleDeleteSession = useCallback(async (sid: string) => {
     try {
-      await fetch(`http://localhost:8001/api/v1/chat/sessions/${sid}`, { method: "DELETE" })
+      await fetch(`${API_BASE}/api/v1/chat/sessions/${sid}`, { method: "DELETE" })
       setSessions(prev => prev.filter(s => s.id !== sid))
       if (sessionId === sid) {
         handleNewSession()
@@ -149,7 +150,7 @@ export default function Home() {
     if (savedSessionId) {
       setSessionId(savedSessionId)
       // Fetch history if needed
-      fetch(`http://localhost:8001/api/v1/chat/sessions/${savedSessionId}`)
+      fetch(`${API_BASE}/api/v1/chat/sessions/${savedSessionId}`)
         .then(res => res.json())
         .then(data => {
           if (data.messages && data.messages.length > 0) {
@@ -185,7 +186,7 @@ export default function Home() {
       // Fetch deferred data via reference
       if (!geojson && result.geojson_ref && typeof result.geojson_ref === "string" && result.geojson_ref.startsWith("ref:") && sid) {
         try {
-          const resp = await fetch(`http://localhost:8001/api/v1/layers/data/${result.geojson_ref}?session_id=${sid}`)
+          const resp = await fetch(`${API_BASE}/api/v1/layers/data/${result.geojson_ref}?session_id=${sid}`)
           if (resp.ok) {
             const fullData = await resp.json()
             if (fullData.type === "FeatureCollection" || (typeof fullData === "object" && "features" in fullData)) {
@@ -328,7 +329,7 @@ export default function Home() {
               timestamp: new Date(),
             }])
             // Fire a silent background notification to the Agent backend
-            fetch("http://localhost:8001/api/v1/chat/completions", {
+            fetch(`${API_BASE}/api/v1/chat/completions`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -410,7 +410,6 @@ export default function Home() {
             // CRITICAL: Dispatch map commands (BASE_LAYER_CHANGE, etc.) regardless of geojson
             const result = data.result as any
             if (result && result.command) {
-              console.log('[Home] Direct command dispatch from tool result:', result.command)
               dispatchAction(result)
             }
             
@@ -421,7 +420,6 @@ export default function Home() {
             
             // ─── NDVI / Raster Result Perception ───
             if (result && result.type === "ndvi_result" && result.image && result.bbox) {
-              console.log('[Home] Raster result detected, adding to map...')
               dispatchAction({
                 type: 'add_raster_layer',
                 params: {

--- a/frontend/app/story/page.tsx
+++ b/frontend/app/story/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { MapPanel } from "@/components/map/map-panel"
+import { API_BASE } from '@/lib/api/config';
 import { useHudStore } from "@/lib/store/useHudStore"
 import { Play, SkipBack, Share2 } from "lucide-react"
 
@@ -19,7 +20,7 @@ export default function StoryPage() {
 
   useEffect(() => {
     if (sessionId) {
-      fetch(`http://localhost:8001/api/v1/chat/sessions/${sessionId}`)
+      fetch(`${API_BASE}/api/v1/chat/sessions/${sessionId}`)
         .then((res) => res.json())
         .then((data) => {
           if (data.messages && data.messages.length > 0) {

--- a/frontend/components/hud/settings-panel.tsx
+++ b/frontend/components/hud/settings-panel.tsx
@@ -6,6 +6,7 @@ import {
   X, Settings, Cpu, Network, Sparkles, Save, RefreshCw, 
   Upload, Download, ShieldCheck, Globe, Code, Terminal
 } from 'lucide-react';
+import { API_BASE } from '@/lib/api/config';
 import { useHudStore } from '@/lib/store/useHudStore';
 
 export function SettingsPanel() {
@@ -31,9 +32,9 @@ export function SettingsPanel() {
   const fetchConfig = async () => {
     try {
       const [llmResp, mcpResp, skillsResp] = await Promise.all([
-        fetch('http://localhost:8001/api/v1/config/llm'),
-        fetch('http://localhost:8001/api/v1/config/mcp'),
-        fetch('http://localhost:8001/api/v1/config/skills')
+        fetch(`${API_BASE}/api/v1/config/llm`),
+        fetch(`${API_BASE}/api/v1/config/mcp`),
+        fetch(`${API_BASE}/api/v1/config/skills`)
       ]);
 
       if (llmResp.ok) {
@@ -58,7 +59,7 @@ export function SettingsPanel() {
   const saveLlm = async () => {
     setIsSaving(true);
     try {
-      const resp = await fetch('http://localhost:8001/api/v1/config/llm', {
+      const resp = await fetch(`${API_BASE}/api/v1/config/llm`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(localLlm)
@@ -75,7 +76,7 @@ export function SettingsPanel() {
   const saveMcp = async () => {
     setIsSaving(true);
     try {
-      const resp = await fetch('http://localhost:8001/api/v1/config/mcp', {
+      const resp = await fetch(`${API_BASE}/api/v1/config/mcp`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ config_json: localMcp })

--- a/frontend/components/map/map-action-handler.tsx
+++ b/frontend/components/map/map-action-handler.tsx
@@ -52,6 +52,7 @@ function calculateBBox(geojson: GeoJSONFeatureCollection): [number, number, numb
 
 import { useMap } from 'react-map-gl/maplibre';
 
+import { API_BASE } from '@/lib/api/config';
 import { MAP_STYLES } from '@/lib/constants';
 import { useHudStore } from '@/lib/store/useHudStore';
 
@@ -297,7 +298,7 @@ export function MapActionHandler() {
               formData.append("file", blob, "export.png");
               if (title) formData.append("title", title);
               
-              const uploadRes = await fetch("http://localhost:8001/api/v1/export", {
+              const uploadRes = await fetch(`${API_BASE}/api/v1/export`, {
                 method: "POST",
                 body: formData
               });
@@ -308,7 +309,7 @@ export function MapActionHandler() {
                 // Important: Trigger background system ping implicitly so the Agent can speak
                 useHudStore.getState().setPendingSystemMessage(
                   `[系统通知] 专题地图 \`${title || '未命名'}\` 已成功排版合成，` +
-                  `文件已落盘并分配URL：${url}。 请利用Markdown的图片语法 \`![地图](http://localhost:8001${url})\` 将该成品展示给用户，并祝其研究顺利！注意展示完图片后直接结束。`
+                  `文件已落盘并分配URL：${url}。 请利用Markdown的图片语法 \`![地图](${API_BASE}${url})\` 将该成品展示给用户，并祝其研究顺利！注意展示完图片后直接结束。`
                 );
               } else {
                  throw new Error("Export URL generation failed");

--- a/frontend/components/map/map-action-handler.tsx
+++ b/frontend/components/map/map-action-handler.tsx
@@ -73,8 +73,6 @@ export function MapActionHandler() {
     const map = mapInstance.getMap();
     if (!map) return;
 
-    console.log('[MapActionHandler] Processing action:', action.command, 'on map:', map.getContainer().id);
-
     try {
       switch (action.command) {
         case 'add_layer': {
@@ -175,7 +173,6 @@ export function MapActionHandler() {
             }
 
             if (idx !== -1) {
-              console.log('[MapActionHandler] Directly setting base layer to:', MAP_STYLES[idx].name);
               setSelectedBaseLayer(idx);
             } else {
               console.warn('[MapActionHandler] Could not match base layer name:', name);

--- a/frontend/components/panel/asset-card.tsx
+++ b/frontend/components/panel/asset-card.tsx
@@ -12,6 +12,7 @@ import {
   Calendar
 } from "lucide-react"
 import { motion } from "framer-motion"
+import { API_BASE } from '@/lib/api/config';
 
 interface AssetCardProps {
   asset: any
@@ -96,7 +97,7 @@ export function AssetCard({ asset, onLoad, onDelete, onRename }: AssetCardProps)
               <Edit size={12} />
             </button>
             <button
-              onClick={() => window.open(`http://localhost:8001/api/v1/layers/data/${asset.id}?download=true`)}
+              onClick={() => window.open(`${API_BASE}/api/v1/layers/data/${asset.id}?download=true`)}
               className="p-1.5 rounded hover:bg-white/5 text-white/30 hover:text-white/60 transition-colors"
               title="下载 TIFF"
             >

--- a/frontend/components/panel/results-panel.tsx
+++ b/frontend/components/panel/results-panel.tsx
@@ -8,6 +8,7 @@ import {
 import { DraggableLayerList } from "../map/draggable-layer-list"
 import { TaskTimeline } from "@/components/hud/task-timeline"
 import { AssetCard } from "./asset-card"
+import { API_BASE } from '@/lib/api/config';
 import { useHudStore } from "@/lib/store/useHudStore"
 import { motion, AnimatePresence } from "framer-motion"
 import { Layer } from "@/lib/types/layer"
@@ -178,11 +179,11 @@ export function DataHud({
                     asset={asset}
                     onDelete={(id) => {
                       // Call backend manage_analysis_asset tool
-                      fetch(`http://localhost:8001/api/v1/chat/tools/call?tool=manage_analysis_asset&asset_id=${id}&action=delete`)
+                      fetch(`${API_BASE}/api/v1/chat/tools/call?tool=manage_analysis_asset&asset_id=${id}&action=delete`)
                         .then(() => deleteAsset(id))
                     }}
                     onRename={(id, newName) => {
-                      fetch(`http://localhost:8001/api/v1/chat/tools/call?tool=manage_analysis_asset&asset_id=${id}&action=rename&new_name=${encodeURIComponent(newName)}`)
+                      fetch(`${API_BASE}/api/v1/chat/tools/call?tool=manage_analysis_asset&asset_id=${id}&action=rename&new_name=${encodeURIComponent(newName)}`)
                         .then(() => updateAsset(id, { original_name: newName }))
                     }}
                     onLoad={(asset) => {

--- a/frontend/components/panel/results-panel.tsx
+++ b/frontend/components/panel/results-panel.tsx
@@ -16,6 +16,7 @@ import { useEffect } from "react"
 
 interface DataHudProps {
   layers?: Layer[]
+  sessionId?: string
   onToggleLayer?: (layerId: string) => void
   onRemoveLayer?: (layerId: string) => void
   onUpdateLayer?: (layerId: string, updates: Partial<Layer>) => void
@@ -25,6 +26,7 @@ interface DataHudProps {
 
 export function DataHud({
   layers = [],
+  sessionId: sessionIdProp,
   onToggleLayer,
   onRemoveLayer,
   onUpdateLayer,
@@ -34,21 +36,23 @@ export function DataHud({
   void _onMapMove;
 
   const [activeTab, setActiveTab] = useState<"tasks" | "layers" | "assets">("tasks")
-  const { 
-    currentTask, 
-    analysisAssets, 
-    fetchAnalysisAssets, 
-    deleteAsset, 
+  const {
+    currentTask,
+    analysisAssets,
+    fetchAnalysisAssets,
+    deleteAsset,
     updateAsset,
     addLayer,
-    sessionId 
+    sessionId: storeSessionId
   } = useHudStore()
+
+  const effectiveSessionId = sessionIdProp ?? storeSessionId
 
   useEffect(() => {
     if (activeTab === "assets") {
-      fetchAnalysisAssets(sessionId)
+      fetchAnalysisAssets(effectiveSessionId)
     }
-  }, [activeTab, fetchAnalysisAssets, sessionId])
+  }, [activeTab, fetchAnalysisAssets, effectiveSessionId])
 
   const totalFeatures = layers.reduce(
     (sum, l) => sum + (l.source && typeof l.source === 'object' && 'features' in l.source ? (l.source as any).features?.length || 0 : 0),

--- a/frontend/lib/api/chat.ts
+++ b/frontend/lib/api/chat.ts
@@ -3,8 +3,7 @@
  */
 
 import type { ToolResult } from '@/lib/types';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
+import { API_BASE } from './config';
 
 export interface ChatMessage {
   role: "user" | "assistant" | "tool";

--- a/frontend/lib/api/config.ts
+++ b/frontend/lib/api/config.ts
@@ -1,0 +1,6 @@
+/**
+ * Centralized API configuration
+ * All API and WebSocket URLs should import from this module.
+ */
+export const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001';
+export const WS_BASE = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8001';

--- a/frontend/lib/contexts/map-action-context.tsx
+++ b/frontend/lib/contexts/map-action-context.tsx
@@ -31,11 +31,10 @@ export function MapActionProvider({ children }: { children: React.ReactNode }) {
     const last = lastDispatchRef.current;
     
     // Physical Throttling: Ignore identical matches within 2 seconds
-    if (last && 
-        last.command === newAction.command && 
+    if (last &&
+        last.command === newAction.command &&
         JSON.stringify(last.params) === JSON.stringify(newAction.params) &&
         (now - last.timestamp) < 2000) {
-      console.log('[MapAction] Throttled redundant command:', newAction.command);
       return;
     }
     
@@ -53,8 +52,6 @@ export function MapActionProvider({ children }: { children: React.ReactNode }) {
       if (isDup) return prev;
       return [...prev, newAction];
     });
-
-    console.log('[MapAction] Dispatched to queue:', newAction.command, newAction.params);
   }, []);
 
   const popAction = useCallback(() => {

--- a/frontend/lib/contexts/task-context.tsx
+++ b/frontend/lib/contexts/task-context.tsx
@@ -38,7 +38,6 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
   const [currentTask, setCurrentTask] = useState<TaskState | null>(null);
 
   const handleTaskStart = useCallback((taskId: string) => {
-    console.log('[Task] Starting task:', taskId);
     setCurrentTask({
       id: taskId,
       steps: [],
@@ -47,7 +46,6 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const handleStepStart = useCallback((taskId: string, stepId: string, stepIndex: number, tool: string) => {
-    console.log('[Task] Step started:', taskId, stepId, stepIndex, tool);
     setCurrentTask((prev) => {
       if (!prev || prev.id !== taskId) return prev;
       const newStep: TaskStep = {
@@ -65,7 +63,6 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
 
   const handleStepResult = useCallback(
     (taskId: string, stepId: string, tool: string, result: unknown, hasGeojson: boolean) => {
-      console.log('[Task] Step result:', taskId, stepId, tool);
       setCurrentTask((prev) => {
         if (!prev || prev.id !== taskId) return prev;
         return {
@@ -82,7 +79,6 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
   );
 
   const handleStepError = useCallback((taskId: string, stepId: string, error: string) => {
-    console.log('[Task] Step error:', taskId, stepId, error);
     setCurrentTask((prev) => {
       if (!prev || prev.id !== taskId) return prev;
       return {
@@ -96,7 +92,6 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
 
   const handleTaskComplete = useCallback(
     (taskId: string, stepCount: number, summary: string) => {
-      console.log('[Task] Task completed:', taskId, stepCount, summary);
       setCurrentTask((prev) => {
         if (!prev || prev.id !== taskId) return prev;
         return {
@@ -111,7 +106,6 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
   );
 
   const handleTaskError = useCallback((taskId: string, error: string) => {
-    console.log('[Task] Task error:', taskId, error);
     setCurrentTask((prev) => {
       if (!prev || prev.id !== taskId) return prev;
       return {
@@ -123,7 +117,6 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const handleTaskCancelled = useCallback((taskId: string) => {
-    console.log('[Task] Task cancelled:', taskId);
     setCurrentTask((prev) => {
       if (!prev || prev.id !== taskId) return prev;
       return {
@@ -134,7 +127,6 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const clearTask = useCallback(() => {
-    console.log('[Task] Clearing task');
     setCurrentTask(null);
   }, []);
 

--- a/frontend/lib/hooks/use-websocket.ts
+++ b/frontend/lib/hooks/use-websocket.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useHudStore } from '@/lib/store/useHudStore';
+import { WS_BASE } from '../api/config';
 
-const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8001/api/v1/ws';
+const WS_URL = `${WS_BASE}/api/v1/ws`;
 
 export function useWebSocket(sessionId?: string) {
   const socketRef = useRef<WebSocket | null>(null);

--- a/frontend/lib/hooks/use-websocket.ts
+++ b/frontend/lib/hooks/use-websocket.ts
@@ -9,10 +9,11 @@ export function useWebSocket(sessionId?: string) {
   const retryCountRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [connected, setConnected] = useState(false);
-  const { addProcessLayer, removeProcessLayer } = useHudStore();
 
   const connect = useCallback(() => {
     if (!sessionId) return;
+
+    const { addProcessLayer, removeProcessLayer } = useHudStore.getState();
 
     const url = `${WS_URL}/${sessionId}`;
     const socket = new WebSocket(url);
@@ -51,7 +52,7 @@ export function useWebSocket(sessionId?: string) {
     socket.onerror = () => {
       socket.close();
     };
-  }, [sessionId, addProcessLayer, removeProcessLayer]);
+  }, [sessionId]);
 
   useEffect(() => {
     connect();

--- a/frontend/lib/hooks/use-websocket.ts
+++ b/frontend/lib/hooks/use-websocket.ts
@@ -1,14 +1,17 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, useState } from 'react';
 import { useHudStore } from '@/lib/store/useHudStore';
-import { WS_BASE } from '../api/config';
+import { WS_BASE } from '@/lib/api/config';
 
 const WS_URL = `${WS_BASE}/api/v1/ws`;
 
 export function useWebSocket(sessionId?: string) {
   const socketRef = useRef<WebSocket | null>(null);
+  const retryCountRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [connected, setConnected] = useState(false);
   const { addProcessLayer, removeProcessLayer } = useHudStore();
 
-  useEffect(() => {
+  const connect = useCallback(() => {
     if (!sessionId) return;
 
     const url = `${WS_URL}/${sessionId}`;
@@ -16,7 +19,8 @@ export function useWebSocket(sessionId?: string) {
     socketRef.current = socket;
 
     socket.onopen = () => {
-      console.log(`[WS] Connected to ${url}`);
+      retryCountRef.current = 0;
+      setConnected(true);
     };
 
     socket.onmessage = (event) => {
@@ -25,7 +29,6 @@ export function useWebSocket(sessionId?: string) {
         const { event: eventType, data } = payload;
 
         if (eventType === 'STEP_COMPLETED' || eventType === 'geojson_update') {
-          // data should contain { step_id, geojson }
           if (data.step_id && data.geojson) {
             addProcessLayer(data.step_id, data.geojson);
           }
@@ -34,25 +37,35 @@ export function useWebSocket(sessionId?: string) {
             removeProcessLayer(data.step_id);
           }
         }
-      } catch (err) {
-        console.error('[WS] Failed to parse message:', err);
-      }
+      } catch {}
     };
 
     socket.onclose = () => {
-      console.log(`[WS] Disconnected from ${url}`);
+      setConnected(false);
       socketRef.current = null;
+      const delay = Math.min(1000 * Math.pow(2, retryCountRef.current), 30000);
+      retryCountRef.current += 1;
+      timerRef.current = setTimeout(connect, delay);
     };
 
-    socket.onerror = (err) => {
-      console.error('[WS] Error:', err);
-    };
-
-    return () => {
+    socket.onerror = () => {
       socket.close();
-      socketRef.current = null;
     };
   }, [sessionId, addProcessLayer, removeProcessLayer]);
+
+  useEffect(() => {
+    connect();
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (socketRef.current) {
+        socketRef.current.onclose = null;
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+      setConnected(false);
+    };
+  }, [connect]);
 
   const sendMessage = useCallback((message: any) => {
     if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN) {
@@ -60,5 +73,5 @@ export function useWebSocket(sessionId?: string) {
     }
   }, []);
 
-  return { sendMessage };
+  return { sendMessage, connected };
 }

--- a/frontend/lib/store/useHudStore.ts
+++ b/frontend/lib/store/useHudStore.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand';
 import type { Layer } from '@/lib/types/layer';
 import type { AnalysisResult, GeoJSONFeatureCollection } from '@/lib/types';
+import { API_BASE } from '../api/config';
 
 /* ══════════════════════════════════════════
    Task Types
@@ -226,12 +227,12 @@ export const useHudStore = create<HudState>((set) => ({
   analysisAssets: [],
   fetchAnalysisAssets: async (sessionId) => {
     try {
-      const url = `http://localhost:8001/api/v1/chat/tools/call?tool=list_analysis_assets&session_id=${sessionId || ''}`;
+      const url = `${API_BASE}/api/v1/chat/tools/call?tool=list_analysis_assets&session_id=${sessionId || ''}`;
       // In a real app we'd have a specific GET route, but our current tools can be invoked via specific API if set up, 
       // or we just call the helper defined in nature_resources. 
       // For now, let's assume a direct GET endpoint for assets if we want to be clean, 
       // but I'll implement a fetch from the list_analysis_assets tool logic.
-      const resp = await fetch(`http://localhost:8001/api/v1/uploads?session_id=${sessionId || ''}`);
+      const resp = await fetch(`${API_BASE}/api/v1/uploads?session_id=${sessionId || ''}`);
       if (resp.ok) {
         const data = await resp.json();
         // Filter for raster_analysis types


### PR DESCRIPTION
## Summary

Full-stack fix to get the WebGIS AI Agent skill library to a solid, deployable baseline. Addresses 34% broken tools and multiple frontend gaps.

### Backend (10 broken tools fixed)
- **Celery sync fallback**: All 10 spatial tools (buffer, stats, nearest, heatmap, path, zonal, overlay, filter, join) now work without Celery installed — each tool tries Celery first, falls back to inline SpatialAnalyzer calls on ImportError
- **Heatmap extraction**: Raster/grid heatmap generation logic extracted from Celery task so it works standalone (matplotlib, scipy, numpy)
- **Skill Creator AST validation**: AI-generated skill code is validated before deployment — blocks dangerous imports (os, subprocess, socket, etc.) and builtins (eval, exec, getattr, etc.)
- **watch_skills() file watcher**: Poll-based mtime tracking that only reloads changed skill files instead of all

### Frontend (5 gaps fixed)
- **Centralized API config**: Created `config.ts` with `API_BASE`/`WS_BASE`, replaced 21 hardcoded `http://localhost:8001` URLs across 9 files
- **sessionId prop**: DataHud now receives sessionId so the Assets tab loads data
- **SSE event handlers**: Added handlers for `tool_call`, `task_plan`, `task_cancelled` events
- **WebSocket reconnection**: Exponential backoff (1s → max 30s), uses `useHudStore.getState()` to prevent reconnection loops
- **console.log cleanup**: Removed 14 dev log remnants

### Code Review Fixes
- `spatial_stats`: Inline stats computation matching Celery task output shape
- `nearest_neighbor`: Inline NN analysis with scipy distance_matrix matching Celery task
- SSE handlers: Use `msg.content` from React state instead of stale closure variable
- AST validation: Extended blocklist with os, shutil, pathlib, getattr, globals, etc.

## Files changed
- 15 files, +495/-123 lines

## Test plan
- [x] `python -c "from app.tools.spatial import register_spatial_tools"` — OK
- [x] `python -c "from app.tools.advanced_spatial import register_advanced_spatial_tools"` — OK
- [x] `python -c "from app.tools.skills import _validate_skill_code"` — blocks `import subprocess`, allows `import json`
- [x] `npx tsc --noEmit` — no new TypeScript errors
- [x] `grep -rn "localhost:8001"` — zero occurrences outside config.ts
- [x] `grep -rn "console\.log"` — zero occurrences in production frontend code

🤖 Generated with [Claude Code](https://claude.com/claude-code)