### PR TITLE
fix(sidebar): unblock 图层/资产 tabs and tighten newly-added sidebar code

### DIFF
--- a/frontend/components/sidebar/assets-tab.tsx
+++ b/frontend/components/sidebar/assets-tab.tsx
@@ -34,8 +34,11 @@ export function AssetsTab() {
   const handleLoadToMap = async (asset: any) => {
     try {
       const geojson = await getUploadGeojson(asset.id);
-      if (geojson.features?.length > 0) {
+      if (geojson?.features?.length > 0) {
         const colors = ['#16a34a', '#2563eb', '#ea580c', '#8b5cf6', '#ec4899'];
+        const key = String(asset.id ?? '');
+        let hash = 0;
+        for (let i = 0; i < key.length; i++) hash = (hash + key.charCodeAt(i)) | 0;
         addLayer({
           id: `asset-${asset.id}`,
           name: asset.filename || asset.name || 'Asset',
@@ -44,7 +47,7 @@ export function AssetsTab() {
           opacity: 1,
           group: 'reference',
           source: geojson as any,
-          style: { color: colors[Number(asset.id) % colors.length] },
+          style: { color: colors[Math.abs(hash) % colors.length] },
         });
       }
     } catch (e) {
@@ -76,7 +79,10 @@ export function AssetsTab() {
 
       <div className="flex-1 overflow-y-auto px-2.5 py-2 space-y-2">
         {analysisAssets.map((asset: any) => {
-          const isRaster = asset.geometry_type === 'raster' || asset.type === 'raster';
+          const isRaster =
+            typeof asset.geometry_type === 'string'
+              ? asset.geometry_type.startsWith('raster')
+              : asset.type === 'raster';
           const dotColor = isRaster ? '#3b82f6' : '#16a34a';
           const Icon = isRaster ? Image : MapPin;
 

--- a/frontend/components/sidebar/assets-tab.tsx
+++ b/frontend/components/sidebar/assets-tab.tsx
@@ -2,7 +2,24 @@
 
 import { FileText, Image, MapPin } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
+import { useToastStore } from '@/components/ui/toast';
 import { getUploadGeojson } from '@/lib/api/upload';
+import type { GeoJSONFeatureCollection } from '@/lib/types';
+
+// The /uploads endpoint returns more fields than UploadResponse declares,
+// and the store keeps them as-is. This shape captures what AssetsTab reads.
+interface AnalysisAsset {
+  id: number | string;
+  filename?: string;
+  original_name?: string;
+  name?: string;
+  geometry_type?: string | null;
+  type?: string;
+  created_at?: string | null;
+  uploaded_at?: string | null;
+  file_size?: number | string | null;
+  size?: number | string | null;
+}
 
 function formatDate(dateStr: string | undefined | null): string {
   if (!dateStr) return '--';
@@ -27,31 +44,41 @@ function formatSize(bytes: number | string | undefined | null): string {
   return `${(num / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function AssetsTab() {
-  const analysisAssets = useHudStore((s) => s.analysisAssets);
-  const addLayer = useHudStore((s) => s.addLayer);
+const ASSET_COLORS = ['#16a34a', '#2563eb', '#ea580c', '#8b5cf6', '#ec4899'];
 
-  const handleLoadToMap = async (asset: any) => {
+function colorFor(id: AnalysisAsset['id']): string {
+  const key = String(id ?? '');
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) hash = (hash + key.charCodeAt(i)) | 0;
+  return ASSET_COLORS[Math.abs(hash) % ASSET_COLORS.length];
+}
+
+export function AssetsTab() {
+  const analysisAssets = useHudStore((s) => s.analysisAssets) as AnalysisAsset[];
+  const addLayer = useHudStore((s) => s.addLayer);
+  const addToast = useToastStore((s) => s.addToast);
+
+  const handleLoadToMap = async (asset: AnalysisAsset) => {
     try {
-      const geojson = await getUploadGeojson(asset.id);
-      if (geojson?.features?.length > 0) {
-        const colors = ['#16a34a', '#2563eb', '#ea580c', '#8b5cf6', '#ec4899'];
-        const key = String(asset.id ?? '');
-        let hash = 0;
-        for (let i = 0; i < key.length; i++) hash = (hash + key.charCodeAt(i)) | 0;
-        addLayer({
-          id: `asset-${asset.id}`,
-          name: asset.filename || asset.name || 'Asset',
-          type: 'vector',
-          visible: true,
-          opacity: 1,
-          group: 'reference',
-          source: geojson as any,
-          style: { color: colors[Math.abs(hash) % colors.length] },
-        });
+      const geojson = await getUploadGeojson(Number(asset.id));
+      if (!geojson?.features?.length) {
+        addToast('该资产不包含可加载的要素', 'warning');
+        return;
       }
+      addLayer({
+        id: `asset-${asset.id}`,
+        name: asset.filename || asset.original_name || asset.name || 'Asset',
+        type: 'vector',
+        visible: true,
+        opacity: 1,
+        group: 'reference',
+        source: geojson as unknown as GeoJSONFeatureCollection,
+        style: { color: colorFor(asset.id) },
+      });
+      addToast('资产已加载到地图', 'success');
     } catch (e) {
       console.error('加载资产到地图失败:', e);
+      addToast(e instanceof Error ? e.message : '加载资产失败', 'error');
     }
   };
 
@@ -78,7 +105,7 @@ export function AssetsTab() {
       </div>
 
       <div className="flex-1 overflow-y-auto px-2.5 py-2 space-y-2">
-        {analysisAssets.map((asset: any) => {
+        {analysisAssets.map((asset) => {
           const isRaster =
             typeof asset.geometry_type === 'string'
               ? asset.geometry_type.startsWith('raster')
@@ -103,7 +130,7 @@ export function AssetsTab() {
                   <div className="flex items-center gap-1.5">
                     <Icon size={11} className="text-slate-400 shrink-0" />
                     <span className="text-[11.5px] font-mono text-slate-700 truncate">
-                      {asset.filename || asset.name || 'unnamed'}
+                      {asset.filename || asset.original_name || asset.name || 'unnamed'}
                     </span>
                   </div>
                   {/* Meta */}

--- a/frontend/components/sidebar/chat-tab.tsx
+++ b/frontend/components/sidebar/chat-tab.tsx
@@ -7,28 +7,20 @@ import MiniMd from '@/components/chat/mini-md';
 import { ToolCallCard, ToolCallChain } from '@/components/chat/tool-call-card';
 
 /* ─── Thinking dots animation ─── */
+const DOT_ANIMS = ['animate-dot-1', 'animate-dot-2', 'animate-dot-3'];
+
 function ThinkingDots({ text }: { text: string }) {
   return (
     <div className="flex items-center gap-2 py-1.5 px-1">
       <div className="flex gap-[3px]">
-        {[0, 1, 2].map((i) => (
+        {DOT_ANIMS.map((anim) => (
           <span
-            key={i}
-            className="block w-[5px] h-[5px] rounded-full bg-emerald-500"
-            style={{
-              animation: 'pulse-dot 1.2s ease-in-out infinite',
-              animationDelay: `${i * 0.2}s`,
-            }}
+            key={anim}
+            className={`block w-[5px] h-[5px] rounded-full bg-emerald-500 ${anim}`}
           />
         ))}
       </div>
       <span className="text-[11px] text-slate-400">{text}</span>
-      <style>{`
-        @keyframes pulse-dot {
-          0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
-          40% { opacity: 1; transform: scale(1); }
-        }
-      `}</style>
     </div>
   );
 }
@@ -230,7 +222,7 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor }: ChatTabProp
             className="shrink-0 flex items-center justify-center w-6 h-6 rounded-md text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
             title="上传文件"
           >
-            <Upload size={24} className="w-[14px] h-[14px]" />
+            <Upload size={14} />
           </button>
 
           {/* Textarea */}
@@ -254,7 +246,7 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor }: ChatTabProp
               color: input.trim() ? '#fff' : '#94a3b8',
             }}
           >
-            <Send size={26} className="w-[13px] h-[13px]" />
+            <Send size={13} />
           </button>
         </div>
 

--- a/frontend/components/sidebar/layers-tab.tsx
+++ b/frontend/components/sidebar/layers-tab.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useCallback } from 'react';
 import { Eye, EyeOff, Trash2, GripVertical } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
+import type { Layer } from '@/lib/types/layer';
 
 const GROUP_NAMES: Record<string, string> = {
   analysis: '分析结果',
@@ -10,6 +11,14 @@ const GROUP_NAMES: Record<string, string> = {
   reference: '参考数据',
   default: '未分组',
 };
+
+function getFeatureCount(layer: Layer): number {
+  const src = layer.source;
+  if (src && typeof src === 'object' && 'features' in src) {
+    return src.features?.length ?? 0;
+  }
+  return 0;
+}
 
 export function LayersTab() {
   const layers = useHudStore((s) => s.layers);
@@ -26,24 +35,20 @@ export function LayersTab() {
     [layers]
   );
 
-  const totalFeatures = useMemo(() => {
-    return layers.reduce((sum, l) => {
-      if (l.source && typeof l.source === 'object' && 'features' in l.source) {
-        return sum + ((l.source as any).features?.length ?? 0);
-      }
-      return sum;
-    }, 0);
-  }, [layers]);
+  const totalFeatures = useMemo(
+    () => layers.reduce((sum, l) => sum + getFeatureCount(l), 0),
+    [layers]
+  );
 
   // Group layers
   const groups = useMemo(() => {
-    const groupMap = new Map<string, any[]>();
+    const groupMap = new Map<string, Layer[]>();
     layers.forEach((layer) => {
       const key = layer.group || 'default';
       if (!groupMap.has(key)) groupMap.set(key, []);
       groupMap.get(key)!.push(layer);
     });
-    const result: { name: string; layers: any[] }[] = [];
+    const result: { name: string; layers: Layer[] }[] = [];
     groupMap.forEach((gLayers, key) => {
       result.push({ name: key, layers: gLayers });
     });
@@ -126,11 +131,8 @@ export function LayersTab() {
                 </div>
 
                 <div className="space-y-1">
-                  {group.layers.map((layer: any) => {
-                    const featureCount =
-                      layer.source && typeof layer.source === 'object' && 'features' in layer.source
-                        ? (layer.source as any).features?.length ?? 0
-                        : null;
+                  {group.layers.map((layer) => {
+                    const featureCount = getFeatureCount(layer);
 
                     const color = layer.style?.color || '#16a34a';
                     const isHeatmap = layer.type === 'heatmap';

--- a/frontend/components/sidebar/left-sidebar.tsx
+++ b/frontend/components/sidebar/left-sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import { MessageCircle, Layers, Hash } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import { ChatTab } from '@/components/sidebar/chat-tab';
 import { LayersTab } from '@/components/sidebar/layers-tab';
@@ -23,16 +23,29 @@ export interface LeftSidebarProps {
   accentColor?: string;
 }
 
+interface TabDef {
+  key: LeftTab;
+  icon: LucideIcon;
+  label: string;
+}
+
+const TAB_DEFS: TabDef[] = [
+  { key: 'chat', icon: MessageCircle, label: '对话' },
+  { key: 'layers', icon: Layers, label: '图层' },
+  { key: 'assets', icon: Hash, label: '资产' },
+];
+
 export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#16a34a' }: LeftSidebarProps) {
-  const [activeTab, setActiveTab] = useState<LeftTab>('chat');
+  const activeTab = useHudStore((s) => s.activeLeftTab);
+  const setActiveTab = useHudStore((s) => s.setActiveLeftTab);
   const layers = useHudStore((s) => s.layers);
   const analysisAssets = useHudStore((s) => s.analysisAssets);
 
-  const tabs: { key: LeftTab; icon: typeof MessageCircle; label: string; badge?: number }[] = [
-    { key: 'chat', icon: MessageCircle, label: '对话' },
-    { key: 'layers', icon: Layers, label: '图层', badge: layers.length },
-    { key: 'assets', icon: Hash, label: '资产', badge: analysisAssets.length },
-  ];
+  const badges: Record<LeftTab, number | undefined> = {
+    chat: undefined,
+    layers: layers.length,
+    assets: analysisAssets.length,
+  };
 
   return (
     <aside
@@ -50,8 +63,9 @@ export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#
     >
       {/* Tab bar */}
       <div className="flex shrink-0 border-b border-slate-200/60 bg-white/40">
-        {tabs.map(({ key, icon: Icon, label, badge }) => {
+        {TAB_DEFS.map(({ key, icon: Icon, label }) => {
           const isActive = activeTab === key;
+          const badge = badges[key];
           return (
             <button
               key={key}

--- a/frontend/components/sidebar/left-sidebar.tsx
+++ b/frontend/components/sidebar/left-sidebar.tsx
@@ -44,7 +44,7 @@ export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#
   return (
     <aside
       ref={sidebarRef}
-      className="fixed top-0 left-0 bottom-0 z-40 flex flex-col"
+      className="fixed top-[42px] left-0 bottom-[24px] z-40 flex flex-col"
       style={{
         width: 330,
         background: 'rgba(252,253,254,0.90)',

--- a/frontend/components/sidebar/left-sidebar.tsx
+++ b/frontend/components/sidebar/left-sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 import { MessageCircle, Layers, Hash } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import { ChatTab } from '@/components/sidebar/chat-tab';
@@ -27,7 +27,6 @@ export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#
   const [activeTab, setActiveTab] = useState<LeftTab>('chat');
   const layers = useHudStore((s) => s.layers);
   const analysisAssets = useHudStore((s) => s.analysisAssets);
-  const sidebarRef = useRef<HTMLDivElement>(null);
 
   const tabs: { key: LeftTab; icon: typeof MessageCircle; label: string; badge?: number }[] = [
     { key: 'chat', icon: MessageCircle, label: '对话' },
@@ -35,15 +34,8 @@ export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#
     { key: 'assets', icon: Hash, label: '资产', badge: analysisAssets.length },
   ];
 
-  useEffect(() => {
-    const el = sidebarRef.current;
-    if (!el) return;
-    el.style.transform = open ? 'translateX(0)' : 'translateX(-100%)';
-  }, [open]);
-
   return (
     <aside
-      ref={sidebarRef}
       className="fixed top-[42px] left-0 bottom-[24px] z-40 flex flex-col"
       style={{
         width: 330,


### PR DESCRIPTION
## Summary

Fixes the regression introduced by 2d58dcf (frontend layout redesign) where the LeftSidebar's tab bar was hidden behind the fixed TopBar, so users couldn't switch to the 图层 / 资产 tabs. Also addresses the code-review findings on the newly-added `sidebar/*` components.

### Bug fix

- **`left-sidebar.tsx`** — TopBar (`fixed top-0 z-50 h-[42px]`) and StatusBar (`fixed bottom-0 z-50 h-[24px]`) sat above the sidebar (`z-40`), so the tab buttons rendered at the top of the aside were occluded. Pin the sidebar between `top-[42px]` and `bottom-[24px]`.

### Refactor / hardening (code-review items)

- **`left-sidebar.tsx`**
  - Drop the redundant `useEffect`/`useRef` that was rewriting the `transform` already set via inline style.
  - Drive `activeTab` from the previously-dead `activeLeftTab` / `setActiveLeftTab` store fields so other components can drive tab switching.
  - Hoist tab definitions to a module-level `TAB_DEFS` constant; derive badges from a per-tab map.
- **`layers-tab.tsx`**
  - Replace `any` with the `Layer` type from `@/lib/types/layer`.
  - Extract a single `getFeatureCount(layer)` helper used for both totals and per-row counts.
- **`assets-tab.tsx`**
  - Introduce a local `AnalysisAsset` interface that describes the fields actually read from the `/uploads` payload; drop all `any`.
  - Factor `ASSET_COLORS` + `colorFor(id)` so non-numeric asset ids no longer collapse to `colors[NaN] === undefined`.
  - Wire `useToastStore` so success / empty-features / error paths in `handleLoadToMap` give UI feedback instead of silently failing.
  - Align the `isRaster` check (`geometry_type.startsWith('raster')`) with the store's `geometry_type === "raster_analysis"` filter — previously the check never hit so raster assets always rendered with the vector icon.
- **`chat-tab.tsx`**
  - Replace the inline `<style>{ @keyframes pulse-dot }` with the existing `animate-dot-1/2/3` Tailwind animations already configured in `tailwind.config.ts`.
  - Drop the lucide `size` prop / className width-height conflicts on the `Upload` and `Send` icons.

## Test plan

- [ ] Open the app: TopBar visible, sidebar tab bar visible right below it; clicking 图层 / 资产 switches the panel.
- [ ] Sidebar slide-out animation still works when toggling the panel.
- [ ] Click "加载到地图" on an asset → success toast; on an asset that returns empty features → warning toast; on a network error → error toast.
- [ ] Raster analysis assets show the raster icon.
- [ ] `npm run lint` / `tsc --noEmit` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_015SQoy8XMGrTWKa8DG1GyKH)_