### PR TITLE
fix(types): pull in TypeScript fixes and lockfile update missed by PR #79

### DIFF
--- a/frontend/lib/api/upload.ts
+++ b/frontend/lib/api/upload.ts
@@ -2,6 +2,7 @@
  * Upload API - 用户数据上传接口
  */
 
+/// <reference types="geojson" />
 import { API_BASE } from './config';
 
 export interface UploadResponse {

--- a/frontend/lib/hooks/use-keyboard-shortcut.test.ts
+++ b/frontend/lib/hooks/use-keyboard-shortcut.test.ts
@@ -102,12 +102,8 @@ describe('useKeyboardShortcut Hook', () => {
       onSend,
     }));
 
-    const event = new KeyboardEvent('keydown', { 
-      key: 'Enter', 
-      ctrlKey: true,
-      preventDefault 
-    });
-    Object.defineProperty(event, 'preventDefault', { value: preventDefault });
+    const event = new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true });
+    Object.defineProperty(event, 'preventDefault', { value: preventDefault, writable: true });
     window.dispatchEvent(event);
 
     expect(preventDefault).toHaveBeenCalled();

--- a/frontend/lib/hooks/use-websocket.test.ts
+++ b/frontend/lib/hooks/use-websocket.test.ts
@@ -30,7 +30,10 @@ class MockWebSocket {
 
 let mockSocketInstance: MockWebSocket;
 
-const WebSocketMock = vi.fn(() => mockSocketInstance);
+const WebSocketMock = vi.fn(() => mockSocketInstance) as ReturnType<typeof vi.fn> & {
+  OPEN: number;
+  CLOSED: number;
+};
 WebSocketMock.OPEN = 1;
 WebSocketMock.CLOSED = 3;
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -89,7 +89,10 @@ export interface MapActionPayload {
     title?: string;
     subtitle?: string;
     include_legend?: boolean;
+    include_compass?: boolean;
+    include_scale?: boolean;
     dark_mode?: boolean;
+    format?: string;
   };
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2997,9 +2997,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3014,9 +3011,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3031,9 +3025,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3048,9 +3039,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3065,9 +3053,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3082,9 +3067,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3099,9 +3081,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3116,9 +3095,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3133,9 +3109,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3150,9 +3123,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3167,9 +3137,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3184,9 +3151,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3201,9 +3165,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "node"],
+    "noEmit": true
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "test/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

PR #79 merged the cartography map export feature, but two follow-up fixup commits were pushed to the same branch afterward and never made it to master. This PR brings them in.

### Commits being merged

- `fc019ca` — **fix(types): resolve all TypeScript errors in main and test configs**
  - `frontend/lib/types.ts` — add `include_compass`, `include_scale`, `format` to `MapActionPayload.params` (missing after `export_thematic_map` upgrade)
  - `frontend/tsconfig.json` — exclude `*.test.*` files from the Next.js build config
  - `frontend/tsconfig.test.json` — new test-only config extending main, adds `vitest/globals` types so `describe/it/expect/vi` are recognised in test files
  - `frontend/lib/api/upload.ts` — add `/// <reference types="geojson" />` to expose the `GeoJSON` namespace used by `getUploadGeojson`'s return type
  - `frontend/lib/hooks/use-keyboard-shortcut.test.ts` / `use-websocket.test.ts` — minor type fixes
- `c0c28e2` — **chore(deps): update frontend package-lock.json** (regenerated after the TS fix session)

### Why this is safe vs PR #80

The merge base is `5443b9f`, which still has the pre-#80 long `chat_engine.py`. The branch did NOT modify `chat_engine.py` relative to that base, so the three-way merge keeps master's current (post-#80) version. No revert risk.

## Test plan

- [x] `git merge-base origin/master origin/claude/export-map-image-LeoJF` → `5443b9f` (correct ancestor)
- [x] Confirmed neither fixup commit touches `app/services/chat_engine.py`
- [ ] After merge: `cd frontend && npx tsc --noEmit -p tsconfig.json` — clean
- [ ] After merge: `cd frontend && npx tsc --noEmit -p tsconfig.test.json` — clean
- [ ] After merge: `cd frontend && npx vitest run` — passes


---
_Generated by [Claude Code](https://claude.ai/code/session_015SQoy8XMGrTWKa8DG1GyKH)_