### PR TITLE
feat: Shapefile (.zip) upload support

### DIFF
--- a/app/services/data_parser.py
+++ b/app/services/data_parser.py
@@ -15,7 +15,7 @@ import rasterio
 logger = logging.getLogger(__name__)
 
 # 支持的格式
-VECTOR_FORMATS = {".geojson", ".json", ".shp", ".kml", ".gpkg", ".csv"}
+VECTOR_FORMATS = {".geojson", ".json", ".shp", ".zip", ".kml", ".gpkg", ".csv"}
 RASTER_FORMATS = {".tif", ".tiff"}
 VECTOR_EXTENSIONS = {".shp", ".shx", ".dbf", ".prj", ".cpg", ".sbn", ".sbx"}
 
@@ -31,6 +31,36 @@ LAT_COLUMNS = {"lat", "latitude", "y", "纬度"}
 class ParseError(Exception):
     """数据解析错误"""
     pass
+
+
+def _validate_shapefile_zip(file_path: Path) -> None:
+    """Validate a zip archive contains a valid shapefile and is safe to process."""
+    try:
+        with zipfile.ZipFile(file_path, "r") as zf:
+            names = zf.namelist()
+
+            # Reject path traversal
+            for name in names:
+                if name.startswith("/") or ".." in name:
+                    raise ParseError(f"Zip 包含不安全路径: {name}")
+
+            # Check required components
+            extensions = {Path(n).suffix.lower() for n in names if not n.endswith("/")}
+            required = {".shp", ".dbf"}
+            missing = required - extensions
+            if missing:
+                raise ParseError(f"Shapefile zip 缺少必要组件: {', '.join(sorted(missing))}")
+
+            # Check uncompressed size (zip bomb protection)
+            total_uncompressed = sum(info.file_size for info in zf.infolist())
+            if total_uncompressed > MAX_VECTOR_SIZE:
+                raise ParseError(
+                    f"Zip 解压后大小 ({total_uncompressed / 1024 / 1024:.1f}MB) 超过限制 ({MAX_VECTOR_SIZE / 1024 / 1024:.0f}MB)"
+                )
+    except ParseError:
+        raise
+    except zipfile.BadZipFile:
+        raise ParseError("无效的 Zip 文件")
 
 
 def _detect_csv_columns(df) -> Tuple[Optional[str], Optional[str]]:
@@ -51,7 +81,7 @@ def _get_format(ext: str) -> Tuple[str, str]:
     ext = ext.lower()
     if ext in {".tif", ".tiff"}:
         return "raster", "geotiff"
-    if ext in {".shp"}:
+    if ext in {".shp", ".zip"}:
         return "vector", "shapefile"
     if ext in {".kml"}:
         return "vector", "kml"
@@ -75,10 +105,14 @@ def parse_vector(
     if ext == ".csv":
         return _parse_csv(file_path, upload_dir, upload_id)
 
+    if ext == ".zip":
+        _validate_shapefile_zip(file_path)
+
     # 读取矢量数据
     try:
-        if ext == ".shp":
-            # shapefile: 解压 zip 后读取 .shp
+        if ext == ".zip":
+            gdf = gpd.read_file(file_path, engine="pyogrio")
+        elif ext == ".shp":
             gdf = gpd.read_file(file_path, engine="pyogrio")
         elif ext == ".kml":
             gdf = gpd.read_file(file_path, driver="KML", engine="pyogrio")

--- a/tests/test_shapefile_upload.py
+++ b/tests/test_shapefile_upload.py
@@ -1,0 +1,162 @@
+"""Shapefile (.zip) upload validation and parsing tests.
+
+RED phase: these should fail until data_parser.py is updated.
+"""
+import json
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from app.services.data_parser import (
+    VECTOR_FORMATS,
+    ParseError,
+    _get_format,
+    parse_vector,
+)
+
+
+# ─── helpers ────────────────────────────────────────────────────
+
+
+def _make_shapefile_zip(
+    dest: Path,
+    *,
+    include_shp: bool = True,
+    include_dbf: bool = True,
+    include_shx: bool = True,
+    extra_files: dict | None = None,
+    shp_content: bytes = b"",
+    dbf_content: bytes = b"\x03" + b"\x00" * 31 + b"\r",
+    shx_content: bytes = b"\x00" * 100,
+    compression: int = zipfile.ZIP_STORED,
+) -> Path:
+    """Build a zip with shapefile components. Returns path to the zip."""
+    with zipfile.ZipFile(dest, "w", compression=compression) as zf:
+        if include_shp:
+            zf.writestr("roads.shp", shp_content)
+        if include_dbf:
+            zf.writestr("roads.dbf", dbf_content)
+        if include_shx:
+            zf.writestr("roads.shx", shx_content)
+        if extra_files:
+            for name, data in extra_files.items():
+                zf.writestr(name, data)
+    return dest
+
+
+# ─── format registry ────────────────────────────────────────────
+
+
+class TestFormatRegistry:
+    def test_zip_in_vector_formats(self):
+        assert ".zip" in VECTOR_FORMATS
+
+    def test_get_format_zip_returns_shapefile(self):
+        file_type, fmt = _get_format(".zip")
+        assert file_type == "vector"
+        assert fmt == "shapefile"
+
+
+# ─── zip validation ─────────────────────────────────────────────
+
+
+class TestZipValidation:
+    def test_rejects_zip_without_shp(self, tmp_path):
+        zip_path = _make_shapefile_zip(tmp_path / "test.zip", include_shp=False)
+        with pytest.raises(ParseError, match="缺少.*shp"):
+            parse_vector(zip_path, tmp_path, "test-id")
+
+    def test_rejects_zip_without_dbf(self, tmp_path):
+        zip_path = _make_shapefile_zip(tmp_path / "test.zip", include_dbf=False)
+        with pytest.raises(ParseError, match="缺少.*dbf"):
+            parse_vector(zip_path, tmp_path, "test-id")
+
+    def test_rejects_zip_with_path_traversal(self, tmp_path):
+        zip_path = _make_shapefile_zip(
+            tmp_path / "evil.zip",
+            extra_files={"../../etc/passwd": "root:x:0:0"},
+        )
+        with pytest.raises(ParseError, match="路径"):
+            parse_vector(zip_path, tmp_path, "test-id")
+
+    def test_rejects_zip_bomb(self, tmp_path):
+        """A zip whose uncompressed size exceeds MAX_VECTOR_SIZE should be rejected."""
+        from app.services.data_parser import MAX_VECTOR_SIZE
+
+        # Create a zip with one huge entry that exceeds the limit
+        zip_path = tmp_path / "bomb.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            # Write a compressed entry that decompresses to > MAX_VECTOR_SIZE
+            zf.writestr("roads.shp", b"\x00" * (MAX_VECTOR_SIZE + 1))
+            zf.writestr("roads.dbf", b"\x00" * 100)
+            zf.writestr("roads.shx", b"\x00" * 100)
+        with pytest.raises(ParseError, match="大小|size|超过"):
+            parse_vector(zip_path, tmp_path, "test-id")
+
+
+# ─── valid shapefile parsing ────────────────────────────────────
+
+
+class TestValidShapefile:
+    def test_parses_valid_shapefile_zip(self, tmp_path):
+        """End-to-end: create a minimal valid shapefile zip and parse it."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        # Build a real shapefile zip via geopandas
+        gdf = gpd.GeoDataFrame(
+            {"name": ["foo", "bar"]},
+            geometry=[Point(0, 0), Point(1, 1)],
+            crs="EPSG:4326",
+        )
+        shp_dir = tmp_path / "shp_src"
+        shp_dir.mkdir()
+        shp_path = shp_dir / "test.shp"
+        gdf.to_file(shp_path, engine="pyogrio")
+
+        # Zip the shapefile components
+        zip_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for ext in [".shp", ".dbf", ".shx", ".prj", ".cpg"]:
+                p = shp_dir / f"test{ext}"
+                if p.exists():
+                    zf.write(p, f"test{ext}")
+
+        result = parse_vector(zip_path, tmp_path, "test-id")
+        assert result["file_type"] == "vector"
+        assert result["format"] == "shapefile"
+        assert result["feature_count"] == 2
+        assert result["crs"] == "EPSG:4326"
+        assert "output_path" in result
+        assert Path(result["output_path"]).exists()
+
+    def test_output_is_valid_geojson(self, tmp_path):
+        """The parsed output should be valid GeoJSON."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        gdf = gpd.GeoDataFrame(
+            {"val": [42]},
+            geometry=[Point(116.4, 39.9)],
+            crs="EPSG:4326",
+        )
+        shp_dir = tmp_path / "shp_src"
+        shp_dir.mkdir()
+        gdf.to_file(shp_dir / "data.shp", engine="pyogrio")
+
+        zip_path = tmp_path / "data.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for ext in [".shp", ".dbf", ".shx", ".prj"]:
+                p = shp_dir / f"data{ext}"
+                if p.exists():
+                    zf.write(p, f"data{ext}")
+
+        result = parse_vector(zip_path, tmp_path, "test-id")
+        geojson_path = Path(result["output_path"])
+        with open(geojson_path) as f:
+            geojson = json.load(f)
+        assert geojson["type"] == "FeatureCollection"
+        assert len(geojson["features"]) == 1


### PR DESCRIPTION
## Summary

- Add `.zip` to `VECTOR_FORMATS` so shapefile archives can be uploaded
- New `_validate_shapefile_zip()` — path traversal rejection, required component check (`.shp` + `.dbf`), zip bomb size enforcement
- `parse_vector()` validates then reads `.zip` via `gpd.read_file(engine="pyogrio")` — native `/vsizip/` support, **no new dependencies**
- Frontend already accepts `.zip` and shows "SHP" icon — no frontend changes needed

## Test plan

- [x] 8 TDD tests: format registry (2), validation rejections (4), valid shapefile parsing (2)
- [x] 16 upload-related regression tests pass (zero failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)