### PR TITLE
feat: CRS reprojection service and upload CRS preservation

### DIFF
--- a/app/services/data_parser.py
+++ b/app/services/data_parser.py
@@ -124,8 +124,10 @@ def parse_vector(
     if gdf.empty:
         raise ParseError("文件中没有要素数据")
 
-    # 统一转 EPSG:4326
+    # 统一转 EPSG:4326，保存原始 CRS
+    original_crs = None
     if gdf.crs is not None:
+        original_crs = str(gdf.crs)
         try:
             gdf = gdf.to_crs(epsg=4326)
         except Exception as e:
@@ -156,6 +158,7 @@ def parse_vector(
         "file_type": "vector",
         "format": _get_format(ext)[1],
         "crs": crs_str,
+        "original_crs": original_crs if original_crs and original_crs != "EPSG:4326" else None,
         "geometry_type": geometry_type,
         "feature_count": feature_count,
         "bbox": bbox,

--- a/app/tools/__init__.py
+++ b/app/tools/__init__.py
@@ -33,6 +33,7 @@ _TOOL_MODULES = [
     ("app.tools.skills", "register_skill_tools"),
     ("app.tools.explorer_tools", "register_explorer_tools"),
     ("app.tools.coord_transform", "register_coord_transform_tools"),
+    ("app.tools.coord_transform", "register_epsg_transform_tools"),
     ("app.tools.plan_mode", "register_plan_mode_tools"),
     ("app.tools.subagent", "register_subagent_tools"),
     ("app.tools.meta_tools", "register_meta_tools"),

--- a/app/tools/coord_transform.py
+++ b/app/tools/coord_transform.py
@@ -14,13 +14,13 @@ import logging
 from typing import Any, Optional
 
 from app.tools.registry import ToolRegistry, tool
-from app.lib.geo_processor.core import (
+from app.utils.coord_transform import (
     wgs84_to_gcj02,
     gcj02_to_wgs84,
     gcj02_to_bd09,
     bd09_to_gcj02,
-    safe_parse,
 )
+from app.lib.geo_processor.core import safe_parse
 
 logger = logging.getLogger(__name__)
 
@@ -131,3 +131,88 @@ def register_coord_transform_tools(registry: ToolRegistry):
             "summary": f"已将图层从 {src} 转换为 {dst}",
             "metadata": {"from_crs": src, "to_crs": dst},
         }
+
+
+def register_epsg_transform_tools(registry: ToolRegistry):
+    """Register general-purpose EPSG-to-EPSG reprojection tool."""
+
+    @tool(registry, name="reproject_coordinates",
+          tier=2,
+          description=(
+              "通用坐标参考系 (CRS) 转换：将 GeoJSON 图层从一种 EPSG 坐标系重投影到另一种。"
+              "\n何时用：(1) 上传的 Shapefile/GPKG 使用了地方坐标系（如 CGCS2000 / EPSG:4490），"
+              "需要转为 WGS84 (EPSG:4326) 以叠加底图；"
+              "(2) 分析结果需要转到 UTM 投影以计算精确面积/距离；"
+              "(3) 客户要求输出特定坐标系的成果。"
+              "\n何时不用：(1) 中国坐标偏移 (WGS84↔GCJ-02↔BD-09) — 用 transform_coordinates；"
+              "(2) 数据已经在目标 CRS — 不要重复投影。"
+              "\n参数格式：EPSG 代码，如 'EPSG:4326'、'EPSG:32650'。"
+          ),
+          param_descriptions={
+              "geojson": "输入图层 GeoJSON 或引用(ref:xxx)",
+              "from_epsg": "源坐标系 EPSG 代码，如 'EPSG:4326'",
+              "to_epsg": "目标坐标系 EPSG 代码，如 'EPSG:32650'",
+          })
+    def reproject_coordinates(geojson: Any, from_epsg: str, to_epsg: str) -> dict:
+        if from_epsg == to_epsg:
+            data = safe_parse(geojson)
+            return {
+                "success": True,
+                "data": data or geojson,
+                "summary": f"源 = 目标 CRS ({from_epsg})，原样返回。",
+            }
+
+        try:
+            import pyproj
+            from shapely.geometry import shape as to_shape
+            transformer = pyproj.Transformer.from_crs(
+                pyproj.CRS(from_epsg), pyproj.CRS(to_epsg), always_xy=True
+            )
+
+            data = safe_parse(geojson)
+            if not data:
+                return {"success": False, "error": "无法解析输入 GeoJSON"}
+
+            def reproject_coords(coords):
+                if not isinstance(coords, list) or not coords:
+                    return coords
+                if isinstance(coords[0], (int, float)) and len(coords) >= 2:
+                    x, y = transformer.transform(float(coords[0]), float(coords[1]))
+                    return [x, y, *coords[2:]]
+                return [reproject_coords(c) for c in coords]
+
+            def reproject_geom(geom):
+                if not isinstance(geom, dict):
+                    return geom
+                new = dict(geom)
+                if "coordinates" in new:
+                    new["coordinates"] = reproject_coords(new["coordinates"])
+                if "geometries" in new:
+                    new["geometries"] = [reproject_geom(g) for g in new["geometries"]]
+                return new
+
+            geo_type = data.get("type")
+            if geo_type == "FeatureCollection":
+                new_features = []
+                for feat in data.get("features", []) or []:
+                    nf = dict(feat)
+                    nf["geometry"] = reproject_geom(feat.get("geometry") or {})
+                    new_features.append(nf)
+                out = {"type": "FeatureCollection", "features": new_features}
+            elif geo_type == "Feature":
+                out = dict(data)
+                out["geometry"] = reproject_geom(data.get("geometry") or {})
+            else:
+                out = reproject_geom(data)
+
+            return {
+                "success": True,
+                "data": out,
+                "summary": f"已将图层从 {from_epsg} 重投影到 {to_epsg}",
+                "metadata": {"from_epsg": from_epsg, "to_epsg": to_epsg},
+            }
+        except Exception as e:
+            err = str(e).lower()
+            if "crs" in err or "epsg" in err or "proj" in err:
+                return {"success": False, "error": f"不支持的 CRS: {from_epsg} → {to_epsg} ({e})"}
+            return {"success": False, "error": f"重投影失败: {e}"}

--- a/tests/test_crs_service.py
+++ b/tests/test_crs_service.py
@@ -1,0 +1,165 @@
+"""CRS conversion service tests — RED phase.
+
+Covers:
+1. General EPSG-to-EPSG reprojection tool
+2. Original CRS preservation on upload
+3. Datum-shift code dedup (single source of truth)
+"""
+import json
+import zipfile
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point, box
+
+from app.services.data_parser import ParseError, _get_format, parse_vector, VECTOR_FORMATS
+
+
+# ─── 1. General EPSG reprojection tool ──────────────────────────
+
+
+class TestEPSGReprojection:
+    """Test the reproject_coordinates tool (general EPSG-to-EPSG)."""
+
+    def test_reproject_epsg4326_to_utm(self):
+        """Reproject a point from EPSG:4326 to UTM Zone 50N (EPSG:32650)."""
+        from app.tools.coord_transform import register_epsg_transform_tools
+        from app.tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        register_epsg_transform_tools(reg)
+
+        tool_fn = reg._tools["reproject_coordinates"]
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [116.4, 39.9]},
+                "properties": {"name": "Beijing"},
+            }],
+        }
+        result = tool_fn(geojson=geojson, from_epsg="EPSG:4326", to_epsg="EPSG:32650")
+        assert result["success"] is True
+        coords = result["data"]["features"][0]["geometry"]["coordinates"]
+        # UTM Zone 50N for Beijing: x ~448000, y ~4418000
+        assert 400000 < coords[0] < 500000
+        assert 4400000 < coords[1] < 4500000
+        assert result["metadata"]["from_epsg"] == "EPSG:4326"
+        assert result["metadata"]["to_epsg"] == "EPSG:32650"
+
+    def test_reproject_roundtrip_preserves_coordinates(self):
+        """4326 → 32650 → 4326 should preserve original coords within tolerance."""
+        from app.tools.coord_transform import register_epsg_transform_tools
+        from app.tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        register_epsg_transform_tools(reg)
+        tool_fn = reg._tools["reproject_coordinates"]
+
+        original = {
+            "type": "Point",
+            "coordinates": [121.47, 31.23],
+        }
+        # Forward
+        fwd = tool_fn(geojson=original, from_epsg="EPSG:4326", to_epsg="EPSG:32651")
+        assert fwd["success"]
+        # Backward
+        bwd = tool_fn(geojson=fwd["data"], from_epsg="EPSG:32651", to_epsg="EPSG:4326")
+        assert bwd["success"]
+        lng, lat = bwd["data"]["coordinates"]
+        assert abs(lng - 121.47) < 0.001
+        assert abs(lat - 31.23) < 0.001
+
+    def test_rejects_invalid_epsg(self):
+        from app.tools.coord_transform import register_epsg_transform_tools
+        from app.tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        register_epsg_transform_tools(reg)
+        tool_fn = reg._tools["reproject_coordinates"]
+
+        result = tool_fn(geojson={"type": "Point", "coordinates": [0, 0]},
+                         from_epsg="EPSG:99999", to_epsg="EPSG:4326")
+        assert result["success"] is False
+        assert "不支持的" in result.get("error", "") or "invalid" in result.get("error", "").lower()
+
+    def test_same_epsg_returns_unchanged(self):
+        from app.tools.coord_transform import register_epsg_transform_tools
+        from app.tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        register_epsg_transform_tools(reg)
+        tool_fn = reg._tools["reproject_coordinates"]
+
+        geojson = {"type": "Point", "coordinates": [1.0, 2.0]}
+        result = tool_fn(geojson=geojson, from_epsg="EPSG:4326", to_epsg="EPSG:4326")
+        assert result["success"]
+        assert result["data"]["coordinates"] == [1.0, 2.0]
+
+
+# ─── 2. Original CRS preservation on upload ─────────────────────
+
+
+class TestOriginalCRSPreservation:
+    """Upload pipeline should store original CRS before converting to 4326."""
+
+    def test_preserves_original_crs_from_shapefile(self, tmp_path):
+        """A shapefile with a non-4326 CRS should preserve original_crs in result."""
+        # Create a GeoDataFrame in EPSG:32650 (UTM Zone 50N)
+        gdf = gpd.GeoDataFrame(
+            {"name": ["test"]},
+            geometry=[Point(448000, 4418000)],
+            crs="EPSG:32650",
+        )
+        shp_dir = tmp_path / "shp_src"
+        shp_dir.mkdir()
+        gdf.to_file(shp_dir / "test.shp", engine="pyogrio")
+
+        zip_path = tmp_path / "test.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for ext in [".shp", ".dbf", ".shx", ".prj"]:
+                p = shp_dir / f"test{ext}"
+                if p.exists():
+                    zf.write(p, f"test{ext}")
+
+        result = parse_vector(zip_path, tmp_path, "test-id")
+        assert result["crs"] == "EPSG:4326"  # data is normalized
+        assert result.get("original_crs") == "EPSG:32650"  # original preserved
+
+    def test_geojson_without_crs_defaults_to_4326(self, tmp_path):
+        """A GeoJSON with no CRS should not set original_crs."""
+        geojson_path = tmp_path / "test.geojson"
+        geojson_path.write_text(json.dumps({
+            "type": "FeatureCollection",
+            "features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]}, "properties": {}}],
+        }))
+        result = parse_vector(geojson_path, tmp_path, "test-id")
+        assert result["crs"] == "EPSG:4326"
+        # original_crs should be absent or None when input was already 4326/unknown
+        assert result.get("original_crs") in (None, "EPSG:4326")
+
+
+# ─── 3. Datum-shift code dedup ──────────────────────────────────
+
+
+class TestDatumShiftDedup:
+    """Verify the canonical datum-shift functions come from one source."""
+
+    def test_utils_coord_transform_is_canonical(self):
+        from app.utils.coord_transform import wgs84_to_gcj02, gcj02_to_wgs84
+        # Should be importable and functional
+        lng, lat = wgs84_to_gcj02(116.4, 39.9)
+        assert isinstance(lng, float) and isinstance(lat, float)
+        # Roundtrip
+        lng2, lat2 = gcj02_to_wgs84(lng, lat)
+        assert abs(lng2 - 116.4) < 0.001
+        assert abs(lat2 - 39.9) < 0.001
+
+    def test_tools_import_from_utils_not_core(self):
+        """coord_transform tool should import from app.utils.coord_transform (canonical)."""
+        import inspect
+        import app.tools.coord_transform as ct_module
+        source = inspect.getsource(ct_module)
+        assert "from app.utils.coord_transform import" in source, \
+            "Tool should import from app.utils (canonical), not app.lib.geo_processor.core"


### PR DESCRIPTION
## Summary

- New `reproject_coordinates` AI tool: general EPSG-to-EPSG transformation (e.g., 4326→32650, CGCS2000→WGS84) using pyproj
- Upload pipeline now preserves `original_crs` in metadata when source CRS differs from EPSG:4326
- Consolidated datum-shift code: tool imports from canonical `app.utils.coord_transform` instead of duplicated `app.lib.geo_processor.core`

## Test plan

- [x] 8 TDD tests: EPSG reprojection (4), CRS preservation (2), dedup verification (2)
- [x] 24 upload + CRS regression tests pass (zero failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)