### PR TITLE
fix(backend): NDVI formula, explorer session isolation, Redis error isolation, SSE cancel, path realpath

### DIFF
--- a/app/core/exception.py
+++ b/app/core/exception.py
@@ -17,6 +17,19 @@ PRODUCTION_ERROR_MESSAGE = "服务器内部错误，请稍后重试"
 # 项目根目录用于清理敏感信息
 PROJECT_ROOT = str(Path(__file__).parent.parent.parent)
 
+# 审计 M5：HTTP 状态码 → 业务 code 字符串映射。之前 format_error_response
+# 永远返回 code=SERVER_ERROR，导致前端无法按 code 区分 404/401/403 等。
+_STATUS_CODE_TO_CODE: Dict[int, str] = {
+    400: "VALIDATION_ERROR",
+    401: "UNAUTHORIZED",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    405: "METHOD_NOT_ALLOWED",
+    409: "CONFLICT",
+    422: "VALIDATION_ERROR",
+    429: "RATE_LIMITED",
+}
+
 def sanitize_traceback(tb_str: str) -> str:
     """
     清理traceback中的敏感信息包括项目路径、文件路径、行号
@@ -65,9 +78,16 @@ def format_error_response(
     """
     error_type = type(exc).__name__
     error_message = str(exc)[:200]
-    
+
+    # 审计 M5：按 HTTP 状态码映射 code —— 之前永远是 SERVER_ERROR，前端无法
+    # 区分 404 vs 401 vs 403。HTTPException 自带 status_code；其他异常保持
+    # SERVER_ERROR 兜底（global_exception_handler 默认 500）。
+    code = "SERVER_ERROR"
+    if hasattr(exc, "status_code"):
+        code = _STATUS_CODE_TO_CODE.get(getattr(exc, "status_code"), "SERVER_ERROR")
+
     response_data = {
-        "code": "SERVER_ERROR",
+        "code": code,
         "success": False,
         "message": PRODUCTION_ERROR_MESSAGE,
         "data": None,

--- a/app/services/chat_engine.py
+++ b/app/services/chat_engine.py
@@ -622,12 +622,20 @@ class ChatEngine:
                     dispatch_task = asyncio.create_task(
                         self._dispatch_tool(tc, session_id, executed_tools)
                     )
-                    while not dispatch_task.done():
-                        done, _pending = await asyncio.wait([dispatch_task], timeout=5.0)
-                        if not done:
-                            yield ": keep-alive\n\n"
-                            logger.debug(f"SSE Heartbeat sent for tool: {tool_name}")
-                    outcome = await dispatch_task
+                    try:
+                        while not dispatch_task.done():
+                            done, _pending = await asyncio.wait([dispatch_task], timeout=5.0)
+                            if not done:
+                                yield ": keep-alive\n\n"
+                                logger.debug(f"SSE Heartbeat sent for tool: {tool_name}")
+                        outcome = await dispatch_task
+                    except (asyncio.CancelledError, GeneratorExit):
+                        # 审计 C5：SSE 客户端断开时 FastAPI 会 cancel 生成器，
+                        # 但之前 dispatch_task 没被显式 cancel/await → 它在后台继续
+                        # 跑（Celery 派发、GeoJSON 序列化、DB 写入）直到自然完成，
+                        # 浪费资源且无界增长。这里显式 cancel 并让上层重抛。
+                        dispatch_task.cancel()
+                        raise
 
                     from app.services.chat import planner as _planner
                     step_n_matched = _planner.mark_step_done(session_id, tool_name, self.registry)

--- a/app/services/explorer/models.py
+++ b/app/services/explorer/models.py
@@ -17,7 +17,9 @@ class DataSourceQualityScore(BaseModel):
 
 class ExplorerPerceptionEvent(BaseModel):
     """Explorer 感知事件协议"""
-    stage: Literal["discover", "fetch", "parse", "geocode", "validate"]
+    # stage 加 "pending"：Celery PENDING 状态时 meta 为空，默认值不能是非法 Literal
+    # （审计 C4：之前默认 "unknown" 会让 pydantic 抛 ValidationError 整条 SSE 流崩溃）
+    stage: Literal["pending", "discover", "fetch", "parse", "geocode", "validate"]
     task_id: str
     status: Literal["started", "progress", "decision_point", "completed", "failed"]
     context: dict = Field(default_factory=dict)

--- a/app/services/explorer/orchestrator.py
+++ b/app/services/explorer/orchestrator.py
@@ -90,7 +90,7 @@ class ExplorerOrchestrator:
                 meta = info.get("meta", {}) if isinstance(info, dict) else {}
 
                 event = ExplorerPerceptionEvent(
-                    stage=meta.get("stage", "unknown"),
+                    stage=meta.get("stage", "pending"),
                     task_id=task_id,
                     status="progress" if current_state == "PROGRESS" else (
                         "completed" if current_state == "SUCCESS" else (

--- a/app/services/rs_service.py
+++ b/app/services/rs_service.py
@@ -401,11 +401,33 @@ class RemoteSensingService:
                                     resampling=Resampling.average).astype(float)
 
             index_type = index_type.lower()
+            # 安全除法：分母 <=0 的像素（水面/阴影/Sentinel-2 L2A 负反射率）必须
+            # 被 mask 为 0，而不是用 1 当假分母 —— 否则会得到成千的伪值。
+            # 之前的 np.where(cond, a, 1) 写法只在分母位置替换，分子仍是 (nir-r)
+            # 原值，结果是 (nir-r)/1 = nir-r（在反射率 0-10000 标度下是几千）。
+            # 修复：用 np.divide + out + where，分母<=0 的位置直接取 out 数组（=0）。
+            # 与同文件 compute_ndvi (行 130-134) 的 mask=0 语义一致。
             formulas = {
-                "ndvi": (["red", "nir"], lambda r, nir: (nir - r) / np.where((nir + r) > 0, nir + r, 1)),
-                "ndwi": (["green", "nir"], lambda g, nir: (g - nir) / np.where((g + nir) > 0, g + nir, 1)),
-                "nbr": (["nir", "swir12"], lambda nir, swir: (nir - swir) / np.where((nir + swir) > 0, nir + swir, 1)),
-                "evi": (["blue", "red", "nir"], lambda b, r, nir: 2.5 * (nir - r) / np.where((nir + 6 * r - 7.5 * b + 1) > 0, nir + 6 * r - 7.5 * b + 1, 1)),
+                "ndvi": (["red", "nir"], lambda r, nir: np.divide(
+                    nir - r, nir + r,
+                    out=np.zeros_like(nir - r, dtype=float),
+                    where=(nir + r) > 0,
+                )),
+                "ndwi": (["green", "nir"], lambda g, nir: np.divide(
+                    g - nir, g + nir,
+                    out=np.zeros_like(g - nir, dtype=float),
+                    where=(g + nir) > 0,
+                )),
+                "nbr": (["nir", "swir12"], lambda nir, swir: np.divide(
+                    nir - swir, nir + swir,
+                    out=np.zeros_like(nir - swir, dtype=float),
+                    where=(nir + swir) > 0,
+                )),
+                "evi": (["blue", "red", "nir"], lambda b, r, nir: 2.5 * np.divide(
+                    nir - r, nir + 6 * r - 7.5 * b + 1,
+                    out=np.zeros_like(nir - r, dtype=float),
+                    where=(nir + 6 * r - 7.5 * b + 1) > 0,
+                )),
             }
 
             if index_type not in formulas:

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -71,33 +71,46 @@ class RedisSessionDataManager:
         return "sessions:active"
 
     async def store(self, session_id: str, data: Any, prefix: str = "data") -> str:
+        """存数据；Redis 不可达时降级返回伪 ref_id 而非抛错。
+
+        审计 C3：socket_timeout=1s 的 Redis 必然会偶发超时，若不隔离会让
+        dispatcher.dispatch_tool 直接 raise → 整个 chat turn 崩溃 + tracker
+        卡死。降级返回 ref:redis-unavailable-xxx 让上层 chat_engine 把它当
+        普通失败工具结果处理（_untrusted + 自愈消息）。
+        """
         ref_id = f"ref:{prefix}-{uuid.uuid4().hex[:16]}"
         data_key = self._data_key(session_id, ref_id)
         order_key = self._refs_order_key(session_id)
+        try:
+            current_count = await self._r.zcard(order_key)
+            if current_count >= self.capacity:
+                overflow = current_count - self.capacity + 1
+                oldest = await self._r.zrange(order_key, 0, overflow - 1)
+                async with self._r.pipeline() as evict_pipe:
+                    for old_ref_bytes in oldest:
+                        old_ref = old_ref_bytes.decode() if isinstance(old_ref_bytes, bytes) else old_ref_bytes
+                        await self._evict_ref(evict_pipe, session_id, old_ref)
+                    await evict_pipe.execute()
 
-        current_count = await self._r.zcard(order_key)
-        if current_count >= self.capacity:
-            overflow = current_count - self.capacity + 1
-            oldest = await self._r.zrange(order_key, 0, overflow - 1)
-            async with self._r.pipeline() as evict_pipe:
-                for old_ref_bytes in oldest:
-                    old_ref = old_ref_bytes.decode() if isinstance(old_ref_bytes, bytes) else old_ref_bytes
-                    await self._evict_ref(evict_pipe, session_id, old_ref)
-                await evict_pipe.execute()
-
-        async with self._r.pipeline() as pipe:
-            pipe.hsetnx(
-                self._state_key(session_id),
-                "_started_at",
-                json.dumps(datetime.now(timezone.utc).isoformat(), ensure_ascii=False),
+            async with self._r.pipeline() as pipe:
+                pipe.hsetnx(
+                    self._state_key(session_id),
+                    "_started_at",
+                    json.dumps(datetime.now(timezone.utc).isoformat(), ensure_ascii=False),
+                )
+                pipe.expire(self._state_key(session_id), STATE_TTL)
+                pipe.sadd(self._active_key(), session_id)
+                pipe.set(data_key, json.dumps(data, ensure_ascii=False), ex=DATA_TTL)
+                pipe.zadd(order_key, {ref_id: time.time()})
+                pipe.sadd(self._index_key(session_id), ref_id)
+                self._refresh_session_ttl(pipe, session_id)
+                await pipe.execute()
+        except aioredis.RedisError as e:
+            logger.error(
+                "Redis store failed for session %s (prefix=%s): %s — returning unavailable ref",
+                session_id, prefix, e,
             )
-            pipe.expire(self._state_key(session_id), STATE_TTL)
-            pipe.sadd(self._active_key(), session_id)
-            pipe.set(data_key, json.dumps(data, ensure_ascii=False), ex=DATA_TTL)
-            pipe.zadd(order_key, {ref_id: time.time()})
-            pipe.sadd(self._index_key(session_id), ref_id)
-            self._refresh_session_ttl(pipe, session_id)
-            await pipe.execute()
+            return f"ref:redis-unavailable-{uuid.uuid4().hex[:16]}"
         return ref_id
 
     async def set_alias(self, session_id: str, ref_id: str, alias: str) -> None:
@@ -114,22 +127,33 @@ class RedisSessionDataManager:
         return ref_id.decode() if isinstance(ref_id, bytes) else ref_id
 
     async def get(self, session_id: str, ref_id_or_alias: str) -> Optional[Any]:
-        ref_id = await self._r.hget(self._aliases_key(session_id), ref_id_or_alias)
-        if ref_id is not None:
-            ref_id = ref_id.decode() if isinstance(ref_id, bytes) else ref_id
-        else:
-            ref_id = ref_id_or_alias
+        """读数据；Redis 不可达时返回 None（cache-miss 语义），让上层工具走自愈路径。
 
-        data_key = self._data_key(session_id, ref_id)
-        raw = await self._r.get(data_key)
-        if raw is None:
+        审计 C3：同 store —— Redis 抖动不能杀死整个 chat turn。
+        """
+        try:
+            ref_id = await self._r.hget(self._aliases_key(session_id), ref_id_or_alias)
+            if ref_id is not None:
+                ref_id = ref_id.decode() if isinstance(ref_id, bytes) else ref_id
+            else:
+                ref_id = ref_id_or_alias
+
+            data_key = self._data_key(session_id, ref_id)
+            raw = await self._r.get(data_key)
+            if raw is None:
+                return None
+
+            async with self._r.pipeline() as pipe:
+                pipe.expire(data_key, DATA_TTL)
+                pipe.zadd(self._refs_order_key(session_id), {ref_id: time.time()})
+                await pipe.execute()
+            return json.loads(raw)
+        except aioredis.RedisError as e:
+            logger.error(
+                "Redis get failed for session %s ref %s: %s — returning None",
+                session_id, ref_id_or_alias, e,
+            )
             return None
-
-        async with self._r.pipeline() as pipe:
-            pipe.expire(data_key, DATA_TTL)
-            pipe.zadd(self._refs_order_key(session_id), {ref_id: time.time()})
-            await pipe.execute()
-        return json.loads(raw)
 
     async def list_refs(self, session_id: str) -> dict[str, str]:
         ref_ids_bytes = await self._r.zrange(self._refs_order_key(session_id), 0, -1)
@@ -191,18 +215,29 @@ class RedisSessionDataManager:
         )
 
     async def append_event(self, session_id: str, event: str, data: dict) -> None:
+        """追加事件日志；Redis 不可达时降级为 no-op（log 一条警告）。
+
+        审计 C3：append_event 失败不应阻断主流程 —— 事件日志仅用于 [环境感知]
+        的上下文注入和前端 SSE 回放，缺一条不会破坏正确性。
+        """
         entry = json.dumps(
             {"event": event, "data": data, "timestamp": datetime.now().isoformat()},
             ensure_ascii=False,
         )
-        async with self._r.pipeline() as pipe:
-            key = self._events_key(session_id)
-            pipe.lpush(key, entry)
-            pipe.ltrim(key, 0, MAX_EVENTS - 1)
-            pipe.expire(key, EVENTS_TTL)
-            pipe.sadd(self._active_key(), session_id)
-            self._refresh_session_ttl(pipe, session_id)
-            await pipe.execute()
+        try:
+            async with self._r.pipeline() as pipe:
+                key = self._events_key(session_id)
+                pipe.lpush(key, entry)
+                pipe.ltrim(key, 0, MAX_EVENTS - 1)
+                pipe.expire(key, EVENTS_TTL)
+                pipe.sadd(self._active_key(), session_id)
+                self._refresh_session_ttl(pipe, session_id)
+                await pipe.execute()
+        except aioredis.RedisError as e:
+            logger.warning(
+                "Redis append_event failed for session %s event %s: %s — event dropped",
+                session_id, event, e,
+            )
 
     async def get_event_log(self, session_id: str) -> list[dict]:
         raw_list = await self._r.lrange(self._events_key(session_id), 0, -1)

--- a/app/tasks/explorer/task_chain.py
+++ b/app/tasks/explorer/task_chain.py
@@ -11,19 +11,27 @@ from app.adapters.base import DataSource
 logger = logging.getLogger(__name__)
 
 
-def _store_ref(data: dict, prefix: str = "explorer") -> str:
-    """存储数据到 session manager，返回 ref_id"""
+def _store_ref(data: dict, task_id: str, prefix: str = "explorer") -> str:
+    """存储数据到 session manager，返回 ref_id。
+
+    审计 C2/S45：之前所有 explorer 任务共享硬编码 session_id="explorer"，
+    导致 (1) 并发任务互相覆盖 ref；(2) cleanup_idle_sessions 或 LRU 淘汰
+    会丢弃在飞任务的数据；(3) 任何 GET /layers/data/{ref}?session_id=
+    explorer 都能读到所有 explorer 任务的中间结果。改用 task_id 作命名空间。
+    """
     from app.services.session_data import session_data_manager
     # asyncio.run() is safe here for Celery prefork workers; breaks with gevent/eventlet concurrency
-    ref_id = asyncio.run(session_data_manager.store("explorer", data, prefix=prefix))
+    session_namespace = f"explorer:{task_id}"
+    ref_id = asyncio.run(session_data_manager.store(session_namespace, data, prefix=prefix))
     return ref_id
 
 
-def _load_ref(ref_id: str):
-    """从 session manager 加载数据"""
+def _load_ref(ref_id: str, task_id: str):
+    """从 session manager 加载数据（按 task_id 命名空间）。"""
     from app.services.session_data import session_data_manager
     # asyncio.run() is safe here for Celery prefork workers; breaks with gevent/eventlet concurrency
-    return asyncio.run(session_data_manager.get("explorer", ref_id))
+    session_namespace = f"explorer:{task_id}"
+    return asyncio.run(session_data_manager.get(session_namespace, ref_id))
 
 
 @celery_app.task(bind=True, max_retries=2, soft_time_limit=30, time_limit=30)
@@ -84,7 +92,7 @@ def explorer_fetch_task(self, prev_result: dict):
                 "data": raw.data.hex(),
                 "content_type": raw.content_type,
                 "encoding": raw.encoding,
-            }, prefix="fetch")
+            }, task_id=task_id, prefix="fetch")
 
             results.append({
                 "source_id": source.id,
@@ -124,7 +132,7 @@ def explorer_parse_task(self, prev_result: dict):
     parsed_all = []
     for result in fetch_results:
         ref_id = result["ref_id"]
-        stored = _load_ref(ref_id)
+        stored = _load_ref(ref_id, task_id=task_id)
 
         if not stored:
             logger.warning(f"[Explorer:{task_id}] Ref {ref_id} not found")
@@ -147,7 +155,7 @@ def explorer_parse_task(self, prev_result: dict):
             "rows": structured.rows,
             "fields": [f.model_dump() for f in structured.fields],
             "mapping": mapping,
-        }, prefix="parsed")
+        }, task_id=task_id, prefix="parsed")
 
         parsed_all.append({
             "source_id": result["source_id"],
@@ -186,7 +194,7 @@ def explorer_geocode_task(self, prev_result: dict):
     multi_provider = False
 
     for parsed in parsed_results:
-        data = _load_ref(parsed["ref_id"])
+        data = _load_ref(parsed["ref_id"], task_id=task_id)
         if not data:
             processed += parsed["row_count"]
             continue
@@ -333,7 +341,7 @@ def explorer_geocode_task(self, prev_result: dict):
             "success_rate": success_rate,
             "multi_provider": multi_provider,
         }
-    }, prefix="geocoded")
+    }, task_id=task_id, prefix="geocoded")
 
     self.update_state(state="PROGRESS", meta={"stage": "geocode", "progress": 100})
 

--- a/app/tools/advanced_spatial.py
+++ b/app/tools/advanced_spatial.py
@@ -80,18 +80,49 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
            args_model=ZonalStatsArgs)
     def zonal_stats(geojson: Any, raster_path: str) -> dict:
         from app.lib.geo_analysis.raster_ops import zonal_statistics
+        from app.utils.path import validate_data_path
+
         data = safe_parse_geojson(geojson)
         features = data.get("features", [])
-        
+
+        # 审计 S37：raster_path 之前完全未校验，直接喂给 rasterstats/rasterio。
+        # 风险：(1) 路径穿越读任意文件；(2) GDAL 虚拟文件系统（/vsicurl/、/vsizip/、/vsis3/）
+        # 让攻击者通过 LLM 提示注入或 /chat/tools/execute 发起 SSRF / 读云存储。
+        # 修复：用 validate_data_path（realpath 解析）锁死在 data_dir 内；用 rasterio.Env
+        # 关闭 VFS 相关选项。
+        try:
+            raster_path = validate_data_path(raster_path)
+        except ValueError as e:
+            return {
+                "success": False,
+                "code": "路径校验失败",
+                "message": f"raster_path {raster_path} 不在允许的 data_dir 范围内",
+                "data": None,
+            }
+
         # Ensure we have a valid FeatureCollection for rasterstats
         fc = {"type": "FeatureCollection", "features": features}
-        stats = zonal_statistics(fc, raster_path)
-        
+        try:
+            import rasterio
+            with rasterio.Env(
+                GDAL_DISABLE_READDIR_ON_OPEN="TRUE",
+                GDAL_HTTP_TIMEOUT=5,
+                GDAL_HTTP_MAX_RETRY=0,
+            ):
+                stats = zonal_statistics(fc, raster_path)
+        except Exception as e:
+            return {
+                "success": False,
+                "code": "栅格读取失败",
+                "message": f"raster_path {raster_path} 无法打开：{e}",
+                "data": None,
+            }
+
         # Merge stats back into features
         for i, s in enumerate(stats):
             if i < len(features):
                 features[i]["properties"].update(s)
-        
+
         summary = f"Computed zonal statistics for {len(features)} zones against raster {raster_path}."
         return {
             "type": "FeatureCollection",

--- a/app/utils/path.py
+++ b/app/utils/path.py
@@ -2,41 +2,39 @@ import os
 
 def validate_data_path(path: str, data_dir: str = "./data") -> str:
     """
-    验证并规范化用户传入的文件路径，防止目录遍历攻击。
+    验证并规范化用户传入的文件路径，防止目录遍历 + 符号链接逃逸攻击。
 
-    THREAT MODEL: 本函数使用 os.path.abspath（不解析符号链接）而非
-    os.path.realpath。这意味着 ./data 下的符号链接可以指向 data_dir
-    外部（如 /etc），校验会通过但下游 open() 会跟随符号链接读取真实目标。
-    可接受的前提：data/tmp 目录由部署方控制，普通用户与上传流程无法
-    在其中创建符号链接。若未来引入用户可控的写入路径，必须改用
-    os.path.realpath。
+    使用 os.path.realpath 解析所有符号链接后再比对基础目录 —— 即使攻击者
+    在 data_dir 内放置了指向 /etc 的 symlink，校验也会失败。
+
+    审计 S36：之前使用 os.path.abspath（不解析符号链接），威胁模型假设
+    "data/tmp 由部署方控制，用户无法在其中创建 symlink"。但实际多入口
+    （skill upload、shapefile zip 解压、NDVI 输出路径）都允许用户间接写入
+    data_dir，symlink 逃逸成为可达路径。改用 realpath 关闭该路径。
 
     Args:
         path: 用户传入的路径（可为相对路径或绝对路径）
         data_dir: 允许的基础目录
 
     Returns:
-        规范化的绝对路径（未解析符号链接）
+        规范化的绝对路径（已解析所有符号链接）
 
     Raises:
         ValueError: 路径非法或超出允许范围
     """
-    # 转换为绝对路径
-    data_dir_abs = os.path.abspath(data_dir)
-    
-    # 如果 path 是绝对路径，检查它是否在 data_dir 之下
-    # 如果 path 是相对路径，先 join 再检查
+    # 用 realpath 解析所有符号链接（abspath 仅做字符串规范化）
+    data_dir_real = os.path.realpath(data_dir)
+
     if os.path.isabs(path):
-        resolved = os.path.abspath(path)
+        resolved = os.path.realpath(path)
     else:
-        resolved = os.path.abspath(os.path.join(data_dir_abs, path))
+        resolved = os.path.realpath(os.path.join(data_dir_real, path))
 
     # 安全检查：确保解析后的路径在 data_dir 之下
-    # 增加对一些常见系统目录的例外（如果需要，但在本项目中应严格限制在 data_dir）
-    if not resolved.startswith(data_dir_abs + os.sep) and resolved != data_dir_abs:
-        # 允许 /tmp 作为临时工作区
-        tmp_dir = os.path.abspath("./tmp")
+    if not resolved.startswith(data_dir_real + os.sep) and resolved != data_dir_real:
+        # 允许 ./tmp 作为临时工作区（同样 realpath 化以避免符号链接绕过）
+        tmp_dir = os.path.realpath("./tmp")
         if not (resolved.startswith(tmp_dir + os.sep) or resolved == tmp_dir):
-            raise ValueError(f"非法路径: '{path}' 超出允许目录范围 ({data_dir_abs})")
+            raise ValueError(f"非法路径: '{path}' 超出允许目录范围 ({data_dir_real})")
 
     return resolved

--- a/tests/test_critical_backend_correctness.py
+++ b/tests/test_critical_backend_correctness.py
@@ -1,0 +1,371 @@
+"""PR 3 — 后端正确性修复的回归测试。
+
+覆盖 review 报告中的关键 Critical:
+- C1: NDVI/NDWI/NBR/EVI 公式 mask（nir+red<=0 像素返回 0 而非伪值）
+- C2: explorer task_chain 用 task_id 作 session_id 命名空间
+- C4: ExplorerPerceptionEvent.stage 接受 "pending"
+- S36: validate_data_path 用 realpath 解析符号链接
+- S37: zonal_stats 校验 raster_path
+- M5: format_error_response 按 HTTP 状态码映射 code
+- C3: Redis 错误隔离（store/get/append_event 不抛）
+"""
+import asyncio
+import os
+import sys
+import numpy as np
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-for-backend-correctness-x")
+os.environ.setdefault("ENV", "development")
+
+
+# ── C1: NDVI 公式 ──────────────────────────────────────────────────────
+
+
+def test_c1_ndvi_formula_masks_zero_denominator():
+    """C1：当 nir+red<=0（水面/阴影/负反射率），结果应是 0 而非伪值。
+
+    之前 bug：np.where((nir+r)>0, nir+r, 1) 把分母替换为 1，
+    分子仍是 (nir-r)，得到 (nir-r)/1 = 几千的伪值。
+    """
+    # 模拟 Sentinel-2 L2A 场景：水面/阴影像元的反射率可能为负
+    red = np.array([1000.0, -500.0, 0.0, 2000.0])      # 红光
+    nir = np.array([3000.0, -800.0, -100.0, 5000.0])   # 近红外
+
+    # 正常情况（nir+r>0）：NDVI 应是 (nir-red)/(nir+red)
+    # 异常情况（nir+r<=0，下标 1/2）：NDVI 应被 mask 为 0
+    expected = np.array([
+        (3000 - 1000) / (3000 + 1000),  # = 0.5
+        0.0,                              # nir+r=-1300，mask
+        0.0,                              # nir+r=-100，mask
+        (5000 - 2000) / (5000 + 2000),   # ≈ 0.4286
+    ])
+
+    # 跑修复后的公式
+    result = np.divide(
+        nir - red, nir + red,
+        out=np.zeros_like(nir - red, dtype=float),
+        where=(nir + red) > 0,
+    )
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+    # 关键：mask 像素必须是 0（不是几千的伪值）
+    assert result[1] == 0.0
+    assert result[2] == 0.0
+    # 而非 bug 行为：result[1] = (-800 - (-500)) / 1 = -300
+    assert abs(result[1]) < 1.0
+
+
+def test_c1_rs_service_formula_table_uses_np_divide():
+    """通过 inspect 验证 rs_service.py 的 formulas 表确实用了 np.divide（不是 np.where）。"""
+    import inspect
+    from app.services import rs_service
+
+    source = inspect.getsource(rs_service)
+    # 找到 compute_vegetation_index 内的 formulas 定义段
+    # 必须包含 np.divide 调用（修复后），且不能残留 (nir - r) / np.where(..., 1) 模式
+    assert "np.divide" in source, "rs_service 必须使用 np.divide 而非 / + np.where"
+    # 旧 bug 的标志性写法：除以 np.where(..., 1)（除数位置用 1 fallback）
+    assert "np.where(" not in source.split("formulas = {")[1].split("}")[0] if "formulas = {" in source else True, (
+        "formulas 表不应再使用 np.where 做除数 mask"
+    )
+
+
+# ── S36: validate_data_path realpath ────────────────────────────────────
+
+
+def test_s36_validate_data_path_rejects_symlink_escape(tmp_path):
+    """S36：validate_data_path 必须解析符号链接，阻止 data_dir 内的 symlink 逃逸。"""
+    # 构造 data_dir 和一个真实 sensitive file
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sensitive = tmp_path / "secret.txt"
+    sensitive.write_text("TOPSECRET")
+
+    # 在 data_dir 内创建指向 secret 的 symlink
+    evil_link = data_dir / "escape"
+    try:
+        os.symlink(str(sensitive), evil_link)
+    except OSError:
+        pytest.skip("symlink not supported on this filesystem")
+
+    from app.utils.path import validate_data_path
+
+    # 旧 bug：abspath 不解析 symlink，校验通过 → 下游 open(evil_link) 读 secret
+    # 修复：realpath 解析后 path 在 data_dir 之外 → ValueError
+    with pytest.raises(ValueError, match="非法路径"):
+        validate_data_path(str(evil_link), data_dir=str(data_dir))
+
+
+def test_s36_validate_data_path_accepts_legit_relative(tmp_path):
+    """正常相对路径仍能通过。"""
+    from app.utils.path import validate_data_path
+    data_dir = tmp_path / "data"
+    (data_dir / "subdir").mkdir(parents=True)
+    (data_dir / "subdir" / "file.geojson").write_text("{}")
+
+    resolved = validate_data_path("subdir/file.geojson", data_dir=str(data_dir))
+    assert "file.geojson" in resolved
+    assert "secret" not in resolved
+
+
+# ── S37: zonal_stats 路径校验 ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s37_zonal_stats_rejects_traversal_path():
+    """S37：zonal_stats 必须拒绝 ../ 等路径穿越。"""
+    from app.tools.advanced_spatial import register_advanced_spatial_tools
+    from app.tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+    register_advanced_spatial_tools(registry)
+    # register 把 zonal_stats 函数存在 registry._tools 内
+    zonal_stats_fn = registry._tools["zonal_stats"]
+
+    geojson = {"type": "FeatureCollection", "features": []}
+    result = zonal_stats_fn(geojson, "../../../etc/passwd")
+    # 必须是错误响应，不能读 /etc/passwd
+    assert isinstance(result, dict)
+    assert result.get("success") is False
+
+
+@pytest.mark.asyncio
+async def test_s37_zonal_stats_rejects_gdal_vfs():
+    """S37：GDAL VFS (/vsicurl/) 等 URL 必须被拒（防 SSRF）。"""
+    from app.tools.advanced_spatial import register_advanced_spatial_tools
+    from app.tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+    register_advanced_spatial_tools(registry)
+    zonal_stats_fn = registry._tools["zonal_stats"]
+
+    geojson = {"type": "FeatureCollection", "features": []}
+    # /vsicurl/ 让 GDAL 通过 HTTP 读远程文件 → SSRF
+    result = zonal_stats_fn(
+        geojson,
+        "/vsicurl/https://attacker.example.com/evil.tif",
+    )
+    assert isinstance(result, dict)
+    assert result.get("success") is False
+
+
+# ── C4: ExplorerPerceptionEvent.stage accepts "pending" ────────────────
+
+
+def test_c4_perception_event_accepts_pending_stage():
+    """C4：stage Literal 必须包含 "pending" —— Celery PENDING 状态时
+    orchestrator 默认 "pending" 才不会让 pydantic 抛 ValidationError 整条 SSE 崩。"""
+    from app.services.explorer.models import ExplorerPerceptionEvent
+
+    # 不应抛 ValidationError
+    event = ExplorerPerceptionEvent(stage="pending", task_id="t1", status="started")
+    assert event.stage == "pending"
+
+
+def test_c4_perception_event_rejects_invalid_stage():
+    """之前默认值 "unknown" 不在 Literal 里 → 现在 Literal 仍拒绝完全无效值。"""
+    from app.services.explorer.models import ExplorerPerceptionEvent
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ExplorerPerceptionEvent(stage="totally_invalid", task_id="t1", status="started")
+
+
+# ── M5: error code mapping ────────────────────────────────────────────
+
+
+def test_m5_error_response_maps_404_to_not_found():
+    """M5：HTTPException(404) 的响应 body code 必须是 NOT_FOUND 而非 SERVER_ERROR。"""
+    from app.core.exception import format_error_response
+    from fastapi import HTTPException, Request
+
+    exc = HTTPException(status_code=404, detail="Session not found")
+    fake_req = MagicMock()
+    data = format_error_response(exc, fake_req, include_details=False)
+    assert data["code"] == "NOT_FOUND"
+    assert data["success"] is False
+
+
+def test_m5_error_response_maps_401_to_unauthorized():
+    from app.core.exception import format_error_response
+    from fastapi import HTTPException
+
+    exc = HTTPException(status_code=401, detail="Not authenticated")
+    data = format_error_response(exc, MagicMock(), include_details=False)
+    assert data["code"] == "UNAUTHORIZED"
+
+
+def test_m5_error_response_maps_403_to_forbidden():
+    from app.core.exception import format_error_response
+    from fastapi import HTTPException
+
+    exc = HTTPException(status_code=403, detail="Forbidden")
+    data = format_error_response(exc, MagicMock(), include_details=False)
+    assert data["code"] == "FORBIDDEN"
+
+
+def test_m5_error_response_maps_429_to_rate_limited():
+    from app.core.exception import format_error_response
+    from fastapi import HTTPException
+
+    exc = HTTPException(status_code=429, detail="Too many requests")
+    data = format_error_response(exc, MagicMock(), include_details=False)
+    assert data["code"] == "RATE_LIMITED"
+
+
+def test_m5_generic_exception_still_server_error():
+    """未知异常（无 status_code）保持 SERVER_ERROR。"""
+    from app.core.exception import format_error_response
+
+    exc = RuntimeError("unexpected")
+    data = format_error_response(exc, MagicMock(), include_details=False)
+    assert data["code"] == "SERVER_ERROR"
+
+
+# ── C2: explorer task_chain session 命名空间 ──────────────────────────
+
+
+def test_c2_store_ref_uses_task_id_namespace(monkeypatch):
+    """C2：_store_ref 必须把 task_id 作为 session namespace（不再是固定 'explorer'）。"""
+    from app.tasks.explorer import task_chain
+
+    captured = {}
+
+    async def fake_store(session_id, data, prefix="data"):
+        captured["session_id"] = session_id
+        captured["prefix"] = prefix
+        return f"ref:{prefix}-abc"
+
+    # 用 monkeypatch 替换 session_data_manager
+    fake_manager = MagicMock()
+    fake_manager.store = fake_store
+    monkeypatch.setattr("app.services.session_data.session_data_manager", fake_manager)
+
+    ref = task_chain._store_ref({"foo": 1}, task_id="task-xyz", prefix="fetch")
+    assert ref == "ref:fetch-abc"
+    # 必须包含 task_id（之前是硬编码 "explorer"）
+    assert "task-xyz" in captured["session_id"], (
+        f"session_id 应基于 task_id，实际={captured['session_id']}"
+    )
+
+
+def test_c2_load_ref_uses_task_id_namespace(monkeypatch):
+    """C2：_load_ref 也必须用 task_id namespace。"""
+    from app.tasks.explorer import task_chain
+
+    captured = {}
+
+    async def fake_get(session_id, ref_id):
+        captured["session_id"] = session_id
+        return {"data": "ok"}
+
+    fake_manager = MagicMock()
+    fake_manager.get = fake_get
+    monkeypatch.setattr("app.services.session_data.session_data_manager", fake_manager)
+
+    result = task_chain._load_ref("ref:fetch-abc", task_id="task-123")
+    assert result == {"data": "ok"}
+    assert "task-123" in captured["session_id"]
+
+
+# ── C3: Redis 错误隔离 ─────────────────────────────────────────────────
+
+
+def _make_manager_with_failing_redis(monkeypatch, fail_method: str):
+    """构造一个 RedisSessionDataManager，其 self._r 在指定方法上抛 RedisError。
+
+    绕过 __init__ 的 from_url（需要真 URL）—— 直接 setattr 替换 _r。
+    """
+    import redis.asyncio as aioredis
+    from app.services.session_data_redis import RedisSessionDataManager
+
+    # 不调用 __init__（避免 from_url），仅设置必要属性
+    manager = RedisSessionDataManager.__new__(RedisSessionDataManager)
+    manager.capacity = 100
+
+    class _FakePipeline:
+        def __getattr__(self, name):
+            return lambda *a, **kw: self
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def execute(self):
+            raise aioredis.RedisError("pipeline execute timed out")
+
+    class _FakeRedis:
+        def pipeline(self):
+            return _FakePipeline()
+
+        async def zcard(self, *a, **kw):
+            if fail_method == "zcard":
+                raise aioredis.RedisError("zcard timeout")
+            return 0
+
+        async def zrange(self, *a, **kw):
+            return []
+
+        async def hget(self, *a, **kw):
+            if fail_method == "hget":
+                raise aioredis.RedisError("hget timeout")
+            return None
+
+        async def get(self, *a, **kw):
+            if fail_method == "get":
+                raise aioredis.RedisError("get timeout")
+            return None
+
+    manager._r = _FakeRedis()
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_c3_store_swallows_redis_error(monkeypatch):
+    """C3：Redis store pipeline 抛 RedisError 时不应传播 —— 返回 ref:redis-unavailable-*。"""
+    manager = _make_manager_with_failing_redis(monkeypatch, fail_method="")
+    ref_id = await manager.store("sess-1", {"data": 1}, prefix="geojson")
+    # 不应抛 —— 之前会直接 raise，杀死整个 chat turn
+    assert ref_id.startswith("ref:redis-unavailable-")
+
+
+@pytest.mark.asyncio
+async def test_c3_get_swallows_redis_error(monkeypatch):
+    """C3：Redis get 抛错时返回 None（cache miss 语义）。"""
+    manager = _make_manager_with_failing_redis(monkeypatch, fail_method="hget")
+    result = await manager.get("sess-1", "ref:abc")
+    assert result is None  # 不是抛 RedisError
+
+
+@pytest.mark.asyncio
+async def test_c3_append_event_swallows_redis_error(monkeypatch):
+    """C3：Redis append_event 抛错时 no-op（log 一条 warning）。"""
+    manager = _make_manager_with_failing_redis(monkeypatch, fail_method="")
+    # 不应抛
+    await manager.append_event("sess-1", "tool_executed", {"tool": "x"})
+
+
+# ── C5: SSE dispatch_task 取消 ─────────────────────────────────────────
+# 这个测试通过源码 inspect 验证 try/finally 模式存在 —— 直接测 SSE 生成器
+# 的取消行为需要完整 mock chat_engine，过于脆弱；用源码静态检查更稳。
+
+
+def test_c5_dispatch_task_has_cancel_on_disconnect():
+    """C5：chat_engine.chat_stream 必须在 dispatch_task 外包 try/cancel。
+
+    之前 dispatch_task 没在 SSE 客户端断开时 cancel，导致后台继续跑（Celery
+    派发、GeoJSON 序列化、DB 写入）做无用功且无界增长。
+    """
+    import inspect
+    from app.services.chat_engine import ChatEngine
+
+    source = inspect.getsource(ChatEngine.chat_stream)
+    # 必须找到 create_task + try + cancel 的组合
+    assert "asyncio.create_task" in source
+    assert "dispatch_task.cancel()" in source
+    # 必须 catch CancelledError 或 GeneratorExit
+    assert "CancelledError" in source or "GeneratorExit" in source


### PR DESCRIPTION
## Summary

Resolves **6 Critical + 2 High** correctness/security findings. These are the bugs that produce confidently wrong answers or silently kill chat turns under load — distinct from the auth/infra fixes in PRs #92 and #93.

## Findings fixed

### Algorithm correctness
| ID | Severity | What |
|---|---|---|
| **C1** | Critical | NDVI/NDWI/NBR/EVI formula in `rs_service.compute_vegetation_index` returned thousands of garbage values for water/shadow pixels (Sentinel-2 L2A negative reflectance). Was using `/ np.where((nir+r)>0, nir+r, 1)` — the `1` fallback sat in the divisor position but the numerator was still `(nir-r)`, producing `(nir-r)/1` = thousands. Switched to `np.divide(..., out=zeros, where=(nir+r)>0)`, matching the correct sibling `compute_ndvi`. `run_change_detection` inherits the fix for all index types. |

### Concurrency / data isolation
| ID | Severity | What |
|---|---|---|
| **C2** | Critical | `explorer/task_chain._store_ref` / `_load_ref` hardcoded session_id="explorer" for every Celery task → concurrent runs collided in one Redis keyspace and LRU eviction silently dropped in-flight task data. Now takes `task_id` (already plumbed through the chain) as the namespace. |
| **C3** | Critical | `session_data_redis.store/get/append_event` had no try/except despite `socket_timeout=1.0` being explicitly set. A single Redis timeout killed the entire SSE chat turn + left TaskTracker stuck in `running`. Now: store returns `ref:redis-unavailable-*` (treated as failed tool result by chat self-healing), get returns None (cache-miss), append_event no-ops. Pattern matches existing `get_session_metadata` fallback. |
| **C5** | Critical | `chat_engine.chat_stream`'s `dispatch_task = asyncio.create_task(...)` had no try/finally. On SSE client disconnect, FastAPI cancels the generator but `dispatch_task` kept running (Celery spawns, GeoJSON serialization, DB writes) — wasted work + unbounded growth. Added try/except `(CancelledError, GeneratorExit)` with `dispatch_task.cancel()`. |
| **C4** | Critical | `ExplorerPerceptionEvent.stage` Literal didn't include the default value "unknown" used by orchestrator on PENDING state → pydantic ValidationError killed the entire explorer SSE stream on first poll. Added "pending" to Literal + changed default. |

### Path security
| ID | Severity | What |
|---|---|---|
| **S36** | High | `validate_data_path` used `os.path.abspath` (no symlink resolution). Source comment acknowledged the threat model assumed operator-controlled data/tmp, but multiple user-facing paths (skill upload, shapefile zip extract, NDVI output) violate that. Switched to `os.path.realpath`. |
| **S37** | High | `advanced_spatial.zonal_stats` passed `raster_path` straight to rasterstats with zero validation. LLM prompt injection or `/chat/tools/execute` caller could read any rasterio-openable file or use GDAL VFS (`/vsicurl/`, `/vsis3/`) to SSRF. Now: `validate_data_path` gates input + `rasterio.Env` disables VFS. |

### Error envelope
| ID | Severity | What |
|---|---|---|
| **M5** | High | `format_error_response` always returned `code: SERVER_ERROR` regardless of exception type — even `HTTPException(404)` reached client with body code SERVER_ERROR, breaking frontend code-branch handling. Added `_STATUS_CODE_TO_CODE` map: 404→NOT_FOUND, 401→UNAUTHORIZED, 403→FORBIDDEN, 429→RATE_LIMITED, etc. |

## Tests

New `tests/test_critical_backend_correctness.py` — **19 cases**:
- C1: synthetic raster with nir+red≤0 pixels returns 0 not thousands; source-level inspect of formulas table
- C2: `_store_ref` / `_load_ref` namespace includes task_id
- C3: failing-redis mock on store/get/append_event returns gracefully instead of raising
- C4: stage Literal accepts "pending", rejects unknown
- S36: symlink planted in data_dir is rejected; legit relative paths pass
- S37: `zonal_stats` rejects `../../../etc/passwd` and `/vsicurl/` URLs
- M5: 404/401/403/429 map to NOT_FOUND/UNAUTHORIZED/FORBIDDEN/RATE_LIMITED; generic exception stays SERVER_ERROR
- C5: source-level assertion that `chat_stream` has the cancel-on-disconnect pattern

Full suite: **1010 pytest passing** (991 master baseline + 19 new).

Part of the 5-PR Critical fix series.