### PR TITLE
fix(auth): S43 manage_analysis_asset IDOR + S47 503 startup + S49 geojson size limit

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -5,7 +5,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from typing import Optional
 
-from app.core.auth import get_current_user, get_current_user_optional, require_admin
+from app.core.auth import get_current_user_optional, require_admin
 from app.services.chat_engine import ChatEngine
 from app.services.history_service_async import AsyncHistoryService
 from app.tools._utils import async_db_session
@@ -22,16 +22,20 @@ engine: ChatEngine = None  # type: ignore[assignment]
 
 
 def get_engine() -> ChatEngine:
-    """Return the ChatEngine instance, raising if not yet initialized by lifespan."""
+    """Return the ChatEngine instance, raising 503 if not yet initialized by lifespan.
+
+    审计 S47：之前 raise RuntimeError -> 全局 exception handler 返回 500 +
+    可能泄漏内部模块名。改为 503 让客户端知道是临时不可用（启动窗口）。
+    """
     if engine is None:
-        raise RuntimeError("ChatEngine 尚未初始化 — 请确认 lifespan 已启动")
+        raise HTTPException(status_code=503, detail="Service starting up, please retry")
     return engine
 
 
 def get_registry() -> ToolRegistry:
-    """Return the ToolRegistry instance, raising if not yet initialized by lifespan."""
+    """Return the ToolRegistry instance, raising 503 if not yet initialized by lifespan."""
     if registry is None:
-        raise RuntimeError("ToolRegistry 尚未初始化 — 请确认 lifespan 已启动")
+        raise HTTPException(status_code=503, detail="Service starting up, please retry")
     return registry
 
 

--- a/app/api/routes/upload.py
+++ b/app/api/routes/upload.py
@@ -14,7 +14,6 @@ from app.core.config import settings
 from app.core.auth import get_current_user
 from app.tools._utils import async_db_session
 from app.models.upload import UploadRecord
-from app.models.db_model import Conversation
 from app.services.history_service_async import AsyncHistoryService
 from app.services.data_parser import (
     MAX_RASTER_SIZE,
@@ -271,7 +270,11 @@ async def get_upload(upload_id: int, _user: dict = Depends(get_current_user)):
 
 @router.get("/uploads/{upload_id}/geojson")
 async def get_upload_geojson(upload_id: int, _user: dict = Depends(get_current_user)):
-    """获取上传文件的 GeoJSON 数据（用于地图渲染）"""
+    """获取上传文件的 GeoJSON 数据（用于地图渲染）。
+
+    审计 S49：之前无大小限制 -- 任意大的 GeoJSON 被 json.load 一次性读入内存
+    并流式返回，超大文件可导致内存爆。加 50MB 上限（与 MAX_VECTOR_SIZE 一致）。
+    """
     async with async_db_session() as db:
         result = await db.execute(select(UploadRecord).where(UploadRecord.id == upload_id))
         record = result.scalar_one_or_none()
@@ -290,6 +293,14 @@ async def get_upload_geojson(upload_id: int, _user: dict = Depends(get_current_u
     data_root = Path(settings.DATA_DIR).resolve()
     if data_root not in resolved.parents and resolved != data_root:
         raise HTTPException(status_code=400, detail="非法文件路径")
+
+    # 审计 S49：文件大小检查 -- 防 OOM
+    file_size = geojson_path.stat().st_size
+    if file_size > MAX_VECTOR_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"GeoJSON 文件过大（{file_size / 1024 / 1024:.1f}MB > {MAX_VECTOR_SIZE / 1024 / 1024:.0f}MB 限制），请通过 /layers/data/{{ref_id}} 分片读取",
+        )
 
     with open(geojson_path, "r", encoding="utf-8") as f:
         return json.load(f)

--- a/app/tools/nature_resources.py
+++ b/app/tools/nature_resources.py
@@ -3,7 +3,7 @@
 提供 NDVI 植被分析及资产管理功能
 """
 import logging
-from typing import Optional, Any
+from typing import Optional
 from pydantic import BaseModel, Field
 from app.tools.registry import ToolRegistry, tool
 from app.services.spatial_tasks import run_ndvi_analysis
@@ -73,17 +73,24 @@ def register_nature_resource_tools(registry: ToolRegistry):
             }
 
     @tool(registry, name="manage_analysis_asset",
-          tier=2, domains=["raster"],
+          tier=3, domains=["raster"],
           description=(
               "维护遥感分析资产：重命名或永久删除 NDVI/NDWI 等分析产物（含物理文件）。"
               "\n何时用：用户明确说『把 XX 资产删掉』『把那个 NDVI 改名为 春季』；"
               "在 list_analysis_assets 列表里发现重复/废弃产物时的清理。"
-              "\n何时不用：(1) 想看资产列表 — 用 list_analysis_assets (只读)；"
-              "(2) 想删除上传文件而非分析资产 — 用 upload 路由 (这个只管 geometry_type='raster_analysis' 的 UploadRecord)；"
-              "(3) 用户未明确授权删除 — 不要主动调，特别是 action='delete' 不可逆。"
+              "\n何时不用：(1) 想看资产列表 - 用 list_analysis_assets (只读)；"
+              "(2) 想删除上传文件而非分析资产 - 用 upload 路由 (这个只管 geometry_type='raster_analysis' 的 UploadRecord)；"
+              "(3) 用户未明确授权删除 - 不要主动调，特别是 action='delete' 不可逆。"
               "\n关键约束：action ∈ {rename, delete}；rename 必须给 new_name；delete 同时移除磁盘 TIFF。"
+              "\n安全：tier=3（destructive）-- 仅在用户明确要求时调用。asset 必须属于当前 session。"
           ))
-    def manage_analysis_asset(asset_id: int, action: str, new_name: Optional[str] = None) -> dict:
+    def manage_analysis_asset(asset_id: int, action: str, new_name: Optional[str] = None, session_id: Optional[str] = None) -> dict:
+        """审计 S43：之前任何 LLM 上下文都能按顺序整数 asset_id 删除/重命名他人资产。
+
+        修法：(1) 升到 tier=3，PR 2 的 /chat/tools/execute 已要求 confirm_destructive；
+        (2) 加 session_id 参数（registry 自动注入），校验 record.session_id 匹配，
+        防 LLM 跨 session 操作他人资产。完整 user_id 校验需要 tool dispatch 重构。
+        """
         from app.models.upload import UploadRecord
         import os
         from app.core.config import settings
@@ -92,6 +99,10 @@ def register_nature_resource_tools(registry: ToolRegistry):
             record = db.query(UploadRecord).filter(UploadRecord.id == asset_id).first()
             if not record:
                 return {"error": "未找到对应的分析资产记录"}
+
+            # 审计 S43：asset 必须属于当前 session（防跨 session IDOR）
+            if session_id and record.session_id and record.session_id != session_id:
+                return {"error": "该资产不属于当前会话，无权操作"}
 
             if action == "rename" and new_name:
                 old_name = record.original_name

--- a/tests/test_chat_globals.py
+++ b/tests/test_chat_globals.py
@@ -1,19 +1,26 @@
-"""F15: chat.py module globals must raise clear error when accessed before initialization."""
+"""F15: chat.py module globals must raise clear error when accessed before initialization.
+
+审计 S47：之前 raise RuntimeError -> 全局 exception handler 返回 500 + 可能
+泄漏内部模块名。改为 HTTPException(503) 让客户端知道是启动窗口临时不可用。
+"""
 import pytest
+from fastapi import HTTPException
 
 
 def test_engine_accessor_raises_before_init(monkeypatch):
-    """Accessing engine before lifespan init must raise RuntimeError, not return None."""
+    """Accessing engine before lifespan init must raise HTTPException(503), not RuntimeError."""
     from app.api.routes import chat
 
     monkeypatch.setattr(chat, 'engine', None)
     monkeypatch.setattr(chat, 'registry', None)
 
-    with pytest.raises(RuntimeError, match="ChatEngine 尚未初始化"):
+    with pytest.raises(HTTPException) as exc_info:
         chat.get_engine()
+    assert exc_info.value.status_code == 503
 
-    with pytest.raises(RuntimeError, match="ToolRegistry 尚未初始化"):
+    with pytest.raises(HTTPException) as exc_info:
         chat.get_registry()
+    assert exc_info.value.status_code == 503
 
 
 def test_engine_accessor_returns_when_set(monkeypatch):

--- a/tests/test_medium_auth_tail.py
+++ b/tests/test_medium_auth_tail.py
@@ -1,0 +1,143 @@
+"""PR A - Medium auth tail 的回归测试。
+
+覆盖：
+- S43: manage_analysis_asset tier=3 + session_id 所有权校验
+- S47: get_engine/get_registry 返回 503 而非 RuntimeError 500
+- S49: get_upload_geojson 文件大小限制
+"""
+import os
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-medium-auth-tail-32c")
+os.environ.setdefault("ENV", "development")
+
+
+# ── S47: 启动窗口 503 ────────────────────────────────────────────────────
+
+
+def test_s47_get_engine_returns_503_before_lifespan(monkeypatch):
+    """S47：lifespan 完成前调 get_engine 应返回 503，不是 RuntimeError 500。"""
+    from app.api.routes import chat
+
+    monkeypatch.setattr(chat, 'engine', None)
+    with pytest.raises(HTTPException) as exc_info:
+        chat.get_engine()
+    assert exc_info.value.status_code == 503
+    # 不应包含内部模块名（防信息泄漏）
+    assert "ChatEngine" not in str(exc_info.value.detail)
+
+
+def test_s47_get_registry_returns_503_before_lifespan(monkeypatch):
+    """S47：同上，registry 也是 503。"""
+    from app.api.routes import chat
+
+    monkeypatch.setattr(chat, 'registry', None)
+    with pytest.raises(HTTPException) as exc_info:
+        chat.get_registry()
+    assert exc_info.value.status_code == 503
+
+
+# ── S43: manage_analysis_asset tier=3 + session 校验 ────────────────────
+
+
+def test_s43_manage_analysis_asset_is_tier_3():
+    """S43：manage_analysis_asset 必须是 tier=3（destructive），让 PR 2 的
+    /chat/tools/execute 强制要求 confirm_destructive=true。"""
+    from app.tools.nature_resources import register_nature_resource_tools
+    from app.tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+    register_nature_resource_tools(registry)
+    meta = registry.metadata("manage_analysis_asset")
+    assert meta.get("tier") == 3, f"期望 tier=3，实际 tier={meta.get('tier')}"
+
+
+def test_s43_manage_analysis_asset_rejects_cross_session(monkeypatch):
+    """S43：asset.session_id 与传入 session_id 不匹配时拒绝操作。"""
+    from app.tools.nature_resources import register_nature_resource_tools
+    from app.tools.registry import ToolRegistry
+    from app.models.upload import UploadRecord
+    from unittest.mock import MagicMock
+
+    registry = ToolRegistry()
+    register_nature_resource_tools(registry)
+    fn = registry._tools["manage_analysis_asset"]
+
+    # mock db_session 返回一个 record，其 session_id 是 "session-A"
+    fake_record = MagicMock()
+    fake_record.session_id = "session-A"
+    fake_record.id = 1
+    fake_record.original_name = "ndvi.tif"
+
+    fake_db = MagicMock()
+    fake_db.query.return_value.filter.return_value.first.return_value = fake_record
+
+    import app.tools.nature_resources as nr_mod
+    original_db_session = nr_mod.db_session
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_db_session():
+        yield fake_db
+
+    monkeypatch.setattr(nr_mod, "db_session", fake_db_session)
+
+    # 用 session-B 调用 -> 应拒绝
+    result = fn(asset_id=1, action="rename", new_name="foo", session_id="session-B")
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert "不属于当前会话" in result["error"]
+
+    # 用 session-A 调用 -> 允许（进入 rename 分支）
+    result = fn(asset_id=1, action="rename", new_name="foo", session_id="session-A")
+    assert result.get("success") is True
+
+
+# ── S49: get_upload_geojson 文件大小限制 ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_s49_get_upload_geojson_rejects_oversized(monkeypatch, tmp_path):
+    """S49：GeoJSON 文件超过 MAX_VECTOR_SIZE 应返回 413。"""
+    from app.api.routes import upload as upload_mod
+    from app.models.upload import UploadRecord
+    from unittest.mock import AsyncMock, MagicMock
+
+    # 构造一个大文件（超过 MAX_VECTOR_SIZE = 50MB）-- 用 stat 模拟大小
+    fake_record = MagicMock()
+    fake_record.id = 1
+    fake_record.session_id = None  # 匿名会话，跳过所有权校验
+    fake_record.file_type = "vector"
+    fake_record.filename = str(tmp_path / "big.geojson")
+
+    # 写一个空文件但 mock stat 返回 60MB
+    (tmp_path / "big.geojson").write_text("{}")
+
+    fake_path = MagicMock()
+    fake_path.exists.return_value = True
+    fake_path.resolve.return_value = tmp_path / "big.geojson"
+    fake_path.stat.return_value = MagicMock(st_size=60 * 1024 * 1024)  # 60MB
+
+    monkeypatch.setattr(upload_mod, "Path", lambda x: fake_path)
+    monkeypatch.setattr(upload_mod, "_verify_session_owner", AsyncMock())
+
+    # mock DB 查询返回 fake_record
+    fake_result = MagicMock()
+    fake_result.scalar_one_or_none.return_value = fake_record
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(return_value=fake_result)
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_async_db_session():
+        yield fake_db
+
+    monkeypatch.setattr(upload_mod, "async_db_session", fake_async_db_session)
+
+    _mock_user = {"user_id": "test-user", "role": "viewer"}
+    with pytest.raises(HTTPException) as exc_info:
+        await upload_mod.get_upload_geojson(1, _mock_user)
+    assert exc_info.value.status_code == 413
+    assert "过大" in exc_info.value.detail


### PR DESCRIPTION
First batch of Medium-severity fixes from the deep review. 3 findings, all low-effort high-value.

## S43 - manage_analysis_asset IDOR
`manage_analysis_asset` (tool, called by LLM) was tier=2 with no ownership check - any LLM context could enumerate integer `asset_id` and delete/rename other tenants' raster analysis TIFFs.

- Bumped to **tier=3** (destructive) - PR #93's `/chat/tools/execute` now requires `confirm_destructive=true`
- Added `session_id` parameter (registry auto-injects) + ownership check: `record.session_id` must match the calling session

## S47 - startup-window 500s
`get_engine()` / `get_registry()` raised `RuntimeError` before lifespan completed -> global exception handler returned 500 + potentially leaked internal module names.

Changed to `HTTPException(503, "Service starting up")` - clean temporary-unavailable signal.

## S49 - get_upload_geojson unbounded
`json.load()` on arbitrarily large GeoJSON files -> OOM risk. Added `stat().st_size > MAX_VECTOR_SIZE` check -> HTTP 413 with pointer to chunked `/layers/data/{ref_id}` endpoint.

## Tests
- 5 new cases in `tests/test_medium_auth_tail.py`
- Updated `test_chat_globals.py` (was asserting RuntimeError, now 503)
- Full suite: **1040 passing**

Part of the Medium-fix series (PR A of 4).