### PR TITLE
fix(ui): F25 bridge memo + F31 setData ref + F32 interactiveIds dedup + F36 urlTransform + F39 fetchAnalysisAssets

### DIFF
--- a/frontend/components/chat/mini-md.tsx
+++ b/frontend/components/chat/mini-md.tsx
@@ -1,18 +1,39 @@
 'use client';
 
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type UrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 interface MiniMdProps {
   text: string;
 }
 
+// 审计 F36：默认 urlTransform 已经过滤 javascript:，但 data: 在某些浏览器
+// 仍可执行（image/svg+xml）。显式白名单只允许 http/https/mailto/相对路径。
+const safeUrlTransform: UrlTransform = (url) => {
+  if (!url) return url;
+  const trimmed = url.trim();
+  // 相对路径 / 同源锚点 / 标准协议放行
+  if (
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('#') ||
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://') ||
+    trimmed.startsWith('mailto:') ||
+    trimmed.startsWith('tel:')
+  ) {
+    return trimmed;
+  }
+  // 其他（javascript:, data:, file:, vbscript: 等）一律拒绝
+  return '';
+};
+
 export default function MiniMd({ text }: MiniMdProps) {
   return (
     <div className="prose-agent text-[12.5px] leading-[1.7] text-slate-600 max-w-none break-words">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        urlTransform={safeUrlTransform}
         components={{
           p: ({ children }) => <p className="mb-2 last:mb-0 leading-relaxed">{children}</p>,
           h1: ({ children }) => (

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -407,15 +407,23 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
 
   // /review C8: derive interactiveLayerIds from actual style sublayers.
   // The renderer adds sublayer ids like `custom-${id}-fill` / `-line` / `-circle`,
-  // not the bare `custom-${id}` — without enumerating sublayers, MapLibre never
+  // not the bare `custom-${id}` - without enumerating sublayers, MapLibre never
   // toggles pointer-cursor on hover and clickable features have no affordance.
   const [interactiveIds, setInteractiveIds] = useState<string[]>([])
+  // 审计 F32：缓存上次计算的 IDs joined 字符串，相同则跳过 setInteractiveIds
+  // -> 防止 styledata 频繁触发时产生 re-render 风暴。
+  const lastInteractiveIdsRef = useRef<string>('')
   useEffect(() => {
     const map = mapRef.current?.getMap()
     if (!map) return
     const recompute = () => {
       const all = (map.getStyle()?.layers || []) as Array<{ id: string }>
-      setInteractiveIds(all.map((l) => l.id).filter((id) => id.startsWith('custom-')))
+      const ids = all.map((l) => l.id).filter((id) => id.startsWith('custom-'))
+      const joined = ids.join(',')
+      if (joined !== lastInteractiveIdsRef.current) {
+        lastInteractiveIdsRef.current = joined
+        setInteractiveIds(ids)
+      }
     }
     recompute()
     map.on('styledata', recompute)

--- a/frontend/lib/hooks/use-workspace-session.ts
+++ b/frontend/lib/hooks/use-workspace-session.ts
@@ -132,6 +132,14 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
             }
           }
         }
+
+        // 审计 F39：切换会话后必须刷新分析资产列表，否则 session A 的资产
+        // 残留在 session B 的 AnalysisTab 里。之前 fetchAnalysisAssets 从未被调用。
+        try {
+          await useHudStore.getState().fetchAnalysisAssets(sid);
+        } catch (e) {
+          console.warn('[fetchAnalysisAssets] failed on session switch:', e);
+        }
       } catch (err: any) {
         if (err?.name !== 'AbortError') {
           console.error('Load session failed:', err);

--- a/frontend/lib/hooks/useMapBridge.ts
+++ b/frontend/lib/hooks/useMapBridge.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { streamChat } from '@/lib/api/chat';
 import type { SSEEvent } from '@/lib/api/chat';
 import { useHudStore } from '@/lib/store/useHudStore';
@@ -180,5 +180,7 @@ export function useMapBridge(
     [sessionId]
   );
 
-  return { aiStatus, send, onViewportChange };
+  // 审计 F25：返回对象用 useMemo 包裹，避免每次 render 都创建新对象引用
+  // -> 下游 useCallback/useMemo 依赖 bridge 的不会每次都失效。
+  return useMemo(() => ({ aiStatus, send, onViewportChange }), [aiStatus, send, onViewportChange]);
 }

--- a/frontend/lib/map-kit/renderer.ts
+++ b/frontend/lib/map-kit/renderer.ts
@@ -2,6 +2,13 @@ import maplibregl from 'maplibre-gl';
 import { ThematicStyleDef } from './types';
 
 /**
+ * 审计 F31：缓存每个 source 上次 setData 的 data 引用。
+ * 相同引用跳过 setData，避免每帧重新解析 GeoJSON（50k 要素层 ~100ms jank）。
+ * 用 WeakMap 让 source 被 GC 时自动清理。
+ */
+const _lastGeoJsonData = new WeakMap<object, unknown>();
+
+/**
  * Safely adds or updates an image source.
  */
 export function addImageSource(map: any, id: string, url: string, coordinates: [[number, number], [number, number], [number, number], [number, number]]) {
@@ -21,16 +28,25 @@ export function addImageSource(map: any, id: string, url: string, coordinates: [
 
 /**
  * Safely adds or updates a GeoJSON source.
+ *
+ * 审计 F31：如果 data 引用与上次相同，跳过 setData -- MapLibre 的 setData
+ * 即使 data 引用相同也会触发全量重新解析。
  */
 export function addGeoJsonSource(map: any, id: string, data: any) {
   const source = map.getSource(id) as maplibregl.GeoJSONSource;
   if (source) {
+    // 引用相同则跳过（最常见的优化 -- 大量 layer 重新渲染时）
+    if (_lastGeoJsonData.get(source) === data) return;
+    _lastGeoJsonData.set(source, data);
     source.setData(data);
   } else {
     map.addSource(id, {
       type: 'geojson',
       data
     });
+    // 新 source 也记录引用，便于后续比较
+    const newSource = map.getSource(id);
+    if (newSource) _lastGeoJsonData.set(newSource, data);
   }
 }
 


### PR DESCRIPTION
Fourth batch of Medium fixes - 5 frontend render-storm / XSS / dead-state findings.

## F25 - useMapBridge bridge object identity
Returned object literal recreated every render -> downstream useCallback/useMemo deps invalidated. Wrapped in `useMemo`.

## F31 - addGeoJsonSource no ref check
`source.setData(data)` called every render even when data ref identical -> MapLibre re-parsed 50k-feature GeoJSON (~100ms jank). Added `WeakMap<source, data>` cache; skip setData if same ref.

## F32 - setInteractiveIds re-render storm
`styledata` fires frequently; each fire created new array -> setState -> re-render -> more styledata. Added `lastInteractiveIdsRef` comparing join(',') of IDs; skip setState if identical.

## F36 - MiniMd XSS
ReactMarkdown relied on default urlTransform (sanitizes `javascript:` but allows `data:` in some browsers). Added explicit `safeUrlTransform` whitelist: http/https/mailto/tel/relative only.

## F39 - fetchAnalysisAssets never called
`fetchAnalysisAssets` defined in layersSlice but never invoked on session switch -> AnalysisTab showed stale assets. Added call in `selectSession`.

## Tests
38 files / 267 tests passing (no regression).

Part of the Medium-fix series (PR D of 4, final).