### PR TITLE
fix(ui): F24 safePop + F28 image cache-bust + F26 renderLayersRef + F34 baseLayer lazy init

### DIFF
--- a/frontend/components/map/map-action-handler.tsx
+++ b/frontend/components/map/map-action-handler.tsx
@@ -123,6 +123,15 @@ export function MapActionHandler() {
     // F5: 默认在 finally 同步 popAction；某些 case 走异步 map.once 回调，
     // 把 deferredPop 设为 true，由 case 自己负责出队。
     let deferredPop = false;
+    // 审计 F24：export_map 的 deferred pop 在 map.once('render') 回调里，
+    // 期间若 mapInstance 因 base layer 切换而变化，effect 会重跑 + cleanup
+    // 不取消 once 监听 -> 两次 popAction（队列下溢）。用 poppedRef 保证只 pop 一次。
+    let poppedRef = false;
+    const safePop = () => {
+      if (poppedRef) return;
+      poppedRef = true;
+      popAction();
+    };
 
     try {
       switch (action.command) {
@@ -587,7 +596,8 @@ export function MapActionHandler() {
                 map.setPixelRatio(origPixelRatio);
               }
               // F5: 真正合成完才出队，杜绝重入
-              popAction();
+              // 审计 F24：用 safePop 防止 base layer 切换重入导致 double-pop
+              safePop();
             }
           });
           map.triggerRepaint();
@@ -714,7 +724,7 @@ export function MapActionHandler() {
         /* defensive: store unavailable */
       }
     } finally {
-      if (!deferredPop) popAction();
+      if (!deferredPop) safePop();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [action, mapInstance, popAction]);

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -145,6 +145,9 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
 
   const renderTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const isUpdatingRef = useRef(false)
+  // 审计 F26：styledata 监听器用此 ref 调最新版 renderLayers，
+  // 防止 effect 重跑时旧闭包用 stale layers 触发渲染。
+  const renderLayersRef = useRef<() => void>(() => {})
 
   // Dynamic layer rendering with debounce optimization
   useEffect(() => {
@@ -152,6 +155,9 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
     if (!map || !mapReady) return
 
     const renderLayers = () => {
+      // 审计 F26：每次 effect 重跑都把最新版存入 ref，让 styledata 监听
+      // 始终调当前闭包（避免 stale layers）。
+      renderLayersRef.current = renderLayers
       if (isUpdatingRef.current) return
       // Style not loaded yet — retry after a short delay instead of silently dropping.
       // 必须把 timeout id 存进 renderTimeoutRef，让 effect cleanup 清掉，
@@ -379,12 +385,13 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
     renderTimeoutRef.current = setTimeout(renderLayers, 50)
 
     // Re-apply layers after basemap style changes (MapLibre destroys custom layers on style change)
+    // 审计 F26：用 renderLayersRef 而非闭包内的 renderLayers，确保调最新版。
     const onStyleData = () => {
       if (isUpdatingRef.current) {
         isUpdatingRef.current = false
       }
       if (renderTimeoutRef.current) clearTimeout(renderTimeoutRef.current)
-      renderTimeoutRef.current = setTimeout(renderLayers, 100)
+      renderTimeoutRef.current = setTimeout(() => renderLayersRef.current(), 100)
     }
     map.on('styledata', onStyleData)
 

--- a/frontend/lib/contexts/map-action-context.tsx
+++ b/frontend/lib/contexts/map-action-context.tsx
@@ -3,6 +3,10 @@
 import React, { createContext, useContext, useState, useCallback, useRef } from 'react';
 import type { MapActionPayload } from '@/lib/types';
 import { useHudStore } from '@/lib/store/useHudStore';
+// 审计 follow-up：原 PR 用 require() 是为了避免 "circular dep"，但 providers.ts
+// 是叶子模块（零 import）—— 不存在循环。改为正常 ESM import，避免触发
+// @typescript-eslint/no-require-imports（CI Docker 内 next build 严格模式）。
+import { TILE_PROVIDERS } from '@/lib/providers';
 
 export type { MapActionPayload };
 
@@ -33,8 +37,7 @@ export function MapActionProvider({ children }: { children: React.ReactNode }) {
   const [selectedBaseLayer, setSelectedBaseLayer] = useState<number>(() => {
     try {
       const persistedName = useHudStore.getState().baseLayer;
-      // 动态 import 避免 circular dep；TILE_PROVIDERS 在 providers.ts
-      const { TILE_PROVIDERS } = require('@/lib/providers');
+      // TILE_PROVIDERS 通过顶部 ESM import 引入；providers.ts 是叶子模块无循环依赖。
       const idx = TILE_PROVIDERS.findIndex(
         (p: any) => p.name === persistedName || p.name === 'Carto 深色'
       );

--- a/frontend/lib/contexts/map-action-context.tsx
+++ b/frontend/lib/contexts/map-action-context.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useCallback, useRef } from 'react';
 import type { MapActionPayload } from '@/lib/types';
+import { useHudStore } from '@/lib/store/useHudStore';
 
 export type { MapActionPayload };
 
@@ -27,7 +28,21 @@ export const MapActionContext = createContext<MapActionContextType | undefined>(
 
 export function MapActionProvider({ children }: { children: React.ReactNode }) {
   const [actions, setActions] = useState<MapActionPayload[]>([]);
-  const [selectedBaseLayer, setSelectedBaseLayer] = useState(1);
+  // 审计 F34：lazy init 从持久化的 useHudStore.baseLayer name 反查 index，
+  // 防刷新后 index 重置为 1 与持久化 name 不一致 -> 底图闪烁。
+  const [selectedBaseLayer, setSelectedBaseLayer] = useState<number>(() => {
+    try {
+      const persistedName = useHudStore.getState().baseLayer;
+      // 动态 import 避免 circular dep；TILE_PROVIDERS 在 providers.ts
+      const { TILE_PROVIDERS } = require('@/lib/providers');
+      const idx = TILE_PROVIDERS.findIndex(
+        (p: any) => p.name === persistedName || p.name === 'Carto 深色'
+      );
+      return idx >= 0 ? idx : 1;
+    } catch {
+      return 1;
+    }
+  });
   const snapshotFnRef = useRef<(() => MapSnapshot) | null>(null);
 
   // Last fly_to tracking for physical throttling.

--- a/frontend/lib/map-kit/renderer.ts
+++ b/frontend/lib/map-kit/renderer.ts
@@ -2,13 +2,27 @@ import maplibregl from 'maplibre-gl';
 import { ThematicStyleDef } from './types';
 
 /**
+ * 审计 F28：缓存每个 image source 上次用的 url。
+ * 如果 url 相同，MapLibre 的 ImageSource 会用内部缓存不重新拉取 ->
+ * 后端在同一 URL 覆盖文件时用户看到旧图。加 ?v=cacheBuster 强制刷新。
+ * 用 WeakMap 让 source 被 GC 时自动清理。
+ */
+const _lastImageUrl = new WeakMap<object, string>();
+
+/**
  * Safely adds or updates an image source.
  */
 export function addImageSource(map: any, id: string, url: string, coordinates: [[number, number], [number, number], [number, number], [number, number]]) {
   const source = map.getSource(id) as maplibregl.ImageSource;
   if (source) {
     if (source.updateImage) {
-      source.updateImage({ url, coordinates });
+      // 审计 F28：同 url 加 cache-buster，防 MapLibre 内部缓存命中显示旧图
+      const lastUrl = _lastImageUrl.get(source);
+      const effectiveUrl = lastUrl === url
+        ? `${url}${url.includes('?') ? '&' : '?'}_=${Date.now()}`
+        : url;
+      _lastImageUrl.set(source, url);  // 记录原始 url（不含 cache-buster）
+      source.updateImage({ url: effectiveUrl, coordinates });
     }
   } else {
     map.addSource(id, {
@@ -16,6 +30,8 @@ export function addImageSource(map: any, id: string, url: string, coordinates: [
       url,
       coordinates
     });
+    const newSource = map.getSource(id);
+    if (newSource) _lastImageUrl.set(newSource, url);
   }
 }
 


### PR DESCRIPTION
Final frontend Medium batch - 4 map-interaction timing / cache findings.

## F24 - export_map double-pop
`popAction()` inside `map.once('render')` could fire twice if mapInstance changed mid-await (base layer switch). Added `poppedRef` guard via `safePop()` - idempotent.

## F28 - addImageSource same URL no refresh
Same URL let MapLibre serve internal cache -> backend overwriting at stable URL showed old image. Added WeakMap + `?_=<timestamp>` cache-buster when URL unchanged.

## F26 - stale styledata listener
`renderLayers` was closure-captured; queued setTimeout could fire with stale layers after effect re-run. Added `renderLayersRef` updated every invocation; listener calls ref.

## F34 - baseLayer index/name drift
`selectedBaseLayer` hardcoded to 1 -> flash on refresh + drift if TILE_PROVIDERS reordered. Changed to lazy useState reading persisted baseLayer name.

## Tests
38 files / 267 tests passing.

Completes the frontend Medium series (17/17 with #118 + #119).