### PR TITLE
fix(arch): S44 log redaction + M2 cache + M3 snapshot lock + M4 tracker + M7 docs

### DIFF
--- a/app/services/chat/decision_log.py
+++ b/app/services/chat/decision_log.py
@@ -36,8 +36,36 @@ class ToolDecisionRecord:
     def to_dict(self) -> dict:
         d = dataclasses.asdict(self)
         d["ts"] = datetime.datetime.now().isoformat(timespec="seconds")
+        # 审计 S44：user_message 截断到 200 字符（已有），tool_args 也截断。
+        # tool_args 常含完整 GeoJSON（可达 MB 级）+ 可能含路径/坐标 PII，
+        # 全量写日志会撑爆磁盘 + 泄漏敏感数据。整体 args JSON 截到 2000 字符。
         d["user_message"] = (self.user_message or "")[:200]
+        d["tool_args"] = _redact_and_truncate_args(d.get("tool_args"))
         return d
+
+
+def _redact_and_truncate_args(args: Any, max_len: int = 2000) -> Any:
+    """审计 S44：tool_args 截断 + 敏感 key 脱敏。
+
+    - 整体 JSON 字符串超 max_len 的，截断并加标记
+    - 含 'api_key'/'token'/'password'/'secret' 的 key 值替换为 '<redacted>'
+    """
+    if not isinstance(args, dict):
+        return args
+    REDACT_KEYS = {"api_key", "token", "password", "secret", "apikey", "Authorization"}
+    redacted = {}
+    for k, v in args.items():
+        if isinstance(k, str) and k.lower() in REDACT_KEYS:
+            redacted[k] = "<redacted>"
+        else:
+            redacted[k] = v
+    try:
+        s = json.dumps(redacted, ensure_ascii=False, default=str)
+        if len(s) > max_len:
+            return s[:max_len] + "...[truncated]"
+        return redacted
+    except (TypeError, ValueError):
+        return str(redacted)[:max_len]
 
 
 def _append_line(line: str) -> None:

--- a/app/services/chat_engine.py
+++ b/app/services/chat_engine.py
@@ -73,7 +73,12 @@ class ChatEngine:
         self.max_rounds = 60
         self.tracker = TaskTracker()
         # 内存对话存储: session_id -> messages list (LRU Cache to bound memory)
-        self._sessions: LRUCache = LRUCache(capacity=50)
+        # 审计 M2：之前 capacity=50，>50 并发会话会 evict 最老的 -> 后续请求
+        # 需从 DB 重载 + in-flight 持有旧 list 引用的请求可能与新请求分歧。
+        # 提到 200（与 _MAX_LOCKS 对齐），生产环境可通过环境变量进一步调。
+        import os as _os
+        _SESSION_CACHE_SIZE = int(_os.getenv("SESSION_CACHE_SIZE", "200"))
+        self._sessions: LRUCache = LRUCache(capacity=_SESSION_CACHE_SIZE)
         # 每会话锁，覆盖 _get_or_create_session 的检查-赋值竞态
         self._session_locks: dict[str, asyncio.Lock] = {}
 
@@ -413,75 +418,99 @@ class ChatEngine:
         # 非流式路径也需要重复调用拦截，避免 LLM 在同一任务里循环刷同一工具
         executed_tools: set[tuple[str, str]] = set()
 
+        # 审计 M4：非流式 chat() 之前不注册 TaskTracker -> 通过 /chat/completions
+        # 发起的任务在 /tasks 端点不可见，也无法 cancel。注册一个 task 让它可见。
+        task = self.tracker.create(session_id, message)
+
         # FC 循环
-        for _ in range(self.max_rounds):
-            messages_with_context = await self._compose_request_messages(session_id, messages)
+        try:
+            for _ in range(self.max_rounds):
+                # 审计 M4：cooperative cancel 检查（与 chat_stream 一致）
+                if self.tracker.is_cancelled(task.id):
+                    return {"session_id": session_id, "content": "任务已取消"}
 
-            tools = self._select_tools(session_id, messages)
-            response = await self._call_llm(messages_with_context, tools)
-            choice = response.get("choices", [{}])[0]
-            assistant_msg = choice.get("message", {})
+                messages_with_context = await self._compose_request_messages(session_id, messages)
 
-            # 提取文本内容，优先 content，次之 reasoning
-            raw_content = assistant_msg.get("content") or ""
-            reasoning = assistant_msg.get("reasoning") or assistant_msg.get("reasoning_content") or ""
+                tools = self._select_tools(session_id, messages)
+                response = await self._call_llm(messages_with_context, tools)
+                choice = response.get("choices", [{}])[0]
+                assistant_msg = choice.get("message", {})
 
-            # 检查是否有 tool_calls（OpenAI 标准格式或 MiniMax XML 格式）
-            standard_calls = assistant_msg.get("tool_calls") or []
-            xml_calls: list[dict] = []
-            if not standard_calls:
-                if "minimax:tool_call" in raw_content:
-                    xml_calls = _parse_minimax_xml_tool_calls(raw_content)
+                # 提取文本内容，优先 content，次之 reasoning
+                raw_content = assistant_msg.get("content") or ""
+                reasoning = assistant_msg.get("reasoning") or assistant_msg.get("reasoning_content") or ""
 
-            tc_list = standard_calls or xml_calls
+                # 检查是否有 tool_calls（OpenAI 标准格式或 MiniMax XML 格式）
+                standard_calls = assistant_msg.get("tool_calls") or []
+                xml_calls: list[dict] = []
+                if not standard_calls:
+                    if "minimax:tool_call" in raw_content:
+                        xml_calls = _parse_minimax_xml_tool_calls(raw_content)
 
-            if tc_list:
-                content_text = raw_content
-                if xml_calls:
-                    # Strip XML artifact from content before storing
-                    content_text = re.sub(r'\s*minimax:tool_call[\s\S]*', '', content_text).strip()
+                tc_list = standard_calls or xml_calls
 
-                entry: dict = {"role": "assistant", "content": content_text}
-                if reasoning:
-                    entry["reasoning_content"] = reasoning
-                if standard_calls:
-                    entry["tool_calls"] = standard_calls
-                messages.append(entry)
-                await self._save_msg_async(session_id, "assistant", content_text, tc_list, reasoning_content=reasoning)
+                if tc_list:
+                    content_text = raw_content
+                    if xml_calls:
+                        # Strip XML artifact from content before storing
+                        content_text = re.sub(r'\s*minimax:tool_call[\s\S]*', '', content_text).strip()
 
-                tool_result_msgs: list[str] = []
-                for tc in tc_list:
-                    outcome = await self._dispatch_tool(tc, session_id, executed_tools)
-                    llm_payload = outcome["llm_payload"]
-
+                    entry: dict = {"role": "assistant", "content": content_text}
+                    if reasoning:
+                        entry["reasoning_content"] = reasoning
                     if standard_calls:
+                        entry["tool_calls"] = standard_calls
+                    messages.append(entry)
+                    await self._save_msg_async(session_id, "assistant", content_text, tc_list, reasoning_content=reasoning)
+
+                    tool_result_msgs: list[str] = []
+                    for tc in tc_list:
+                        # 审计 M4：注册 step（与 chat_stream 一致），让进度可查
+                        tool_name = tc["function"]["name"]
+                        tool_args_dict = tc["function"]["arguments"]
+                        if isinstance(tool_args_dict, str):
+                            try:
+                                tool_args_dict = json.loads(tool_args_dict)
+                            except Exception:
+                                tool_args_dict = {}
+                        step = self.tracker.start_step(task.id, tool_name, tool_args_dict if isinstance(tool_args_dict, dict) else {})
+                        outcome = await self._dispatch_tool(tc, session_id, executed_tools)
+                        self.tracker.complete_step(task.id, step.id, outcome["result"])
+                        llm_payload = outcome["llm_payload"]
+
+                        if standard_calls:
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tc["id"],
+                                "content": llm_payload,
+                            })
+                            await self._save_msg_async(session_id, "tool", "", None, llm_payload, tc["id"])
+                        else:
+                            tool_result_msgs.append(f"{tc['function']['name']}: {llm_payload}")
+
+                    if xml_calls and tool_result_msgs:
                         messages.append({
-                            "role": "tool",
-                            "tool_call_id": tc["id"],
-                            "content": llm_payload,
+                            "role": "user",
+                            "content": "[工具执行结果]\n" + "\n".join(tool_result_msgs),
                         })
-                        await self._save_msg_async(session_id, "tool", "", None, llm_payload, tc["id"])
-                    else:
-                        tool_result_msgs.append(f"{tc['function']['name']}: {llm_payload}")
+                    continue  # 继续循环让 LLM 处理工具结果
+                else:
+                    # 无 tool_calls，最终回复
+                    content = raw_content
 
-                if xml_calls and tool_result_msgs:
-                    messages.append({
-                        "role": "user",
-                        "content": "[工具执行结果]\n" + "\n".join(tool_result_msgs),
-                    })
-                continue  # 继续循环让 LLM 处理工具结果
-            else:
-                # 无 tool_calls，最终回复
-                content = raw_content
+                    entry = {"role": "assistant", "content": content}
+                    if reasoning:
+                        entry["reasoning_content"] = reasoning
+                    messages.append(entry)
+                    await self._save_msg_async(session_id, "assistant", content, reasoning_content=reasoning)
+                    self.tracker.complete_task(task.id)
+                    return {"session_id": session_id, "content": content, "reasoning": reasoning}
 
-                entry = {"role": "assistant", "content": content}
-                if reasoning:
-                    entry["reasoning_content"] = reasoning
-                messages.append(entry)
-                await self._save_msg_async(session_id, "assistant", content, reasoning_content=reasoning)
-                return {"session_id": session_id, "content": content, "reasoning": reasoning}
-
-        return {"content": "达到最大工具调用轮数", "session_id": session_id}
+            self.tracker.complete_task(task.id)
+            return {"content": "达到最大工具调用轮数", "session_id": session_id}
+        except Exception:
+            self.tracker.fail_task(task.id, "non-streaming chat exception")
+            raise
 
     async def chat_stream(self, message: str, session_id: Optional[str] = None, map_state: Optional[dict] = None, skill_name: Optional[str] = None, user_id: Optional[str] = None) -> AsyncGenerator[str, None]:
         """流式对话，yield SSE 格式事件含任务跟踪"""

--- a/app/services/provider_health.py
+++ b/app/services/provider_health.py
@@ -107,18 +107,24 @@ class ProviderHealthTracker:
 
     # ── 诊断用 ────────────────────────────────────────────────────────────────
 
-    def snapshot(self) -> dict[str, dict]:
-        """返回不含锁的可读快照（仅供监控/日志）。"""
+    async def snapshot(self) -> dict[str, dict]:
+        """返回可读快照（仅供监控/日志）。
+
+        审计 M3：之前 snapshot 不加锁，并发 record_attempt 可能修改 self._state
+        导致 RuntimeError 'dictionary changed size during iteration' 或重复/缺失。
+        snapshot 现在加锁（与 record_* 一致），用 copy 防 release 后 mutate。
+        """
         now = time.time()
-        return {
-            p: {
-                "consecutive_errors": s.consecutive_errors,
-                "last_failure_ts": s.last_failure_ts,
-                "circuit_open": s.circuit_open,
-                "calls_last_minute": sum(1 for ts in s.call_timestamps if now - ts < 60),
+        async with self._lock:
+            return {
+                p: {
+                    "consecutive_errors": s.consecutive_errors,
+                    "last_failure_ts": s.last_failure_ts,
+                    "circuit_open": s.circuit_open,
+                    "calls_last_minute": sum(1 for ts in s.call_timestamps if now - ts < 60),
+                }
+                for p, s in list(self._state.items())  # list() copy 防迭代中 mutate
             }
-            for p, s in self._state.items()
-        }
 
 
 # 全局单例，chinese_maps.py 直接 import 使用

--- a/app/services/task_tracker.py
+++ b/app/services/task_tracker.py
@@ -183,7 +183,14 @@ class TaskTracker:
         # 可选：记录失败原因到任务中
 
     def cancel(self, task_id: str) -> bool:
-        """取消任务"""
+        """取消任务（cooperative - 不会打断正在执行的 tool）。
+
+        审计 M7：cancel 仅设置 _cancelled 标志，由 chat_engine 在每轮/每步
+        之间轮询 is_cancelled 决定是否退出。正在执行的单个 tool（如 NDVI 计算、
+        LLM 流式调用）会跑到自然完成才检查标志。完整 preemptive cancel 需要把
+        asyncio.Event 透传到每个 tool 的 dispatch 路径，是独立重构工作。
+        用户感知：长任务点 cancel 后可能等 30-60s 才真正停。
+        """
         task = self._tasks.get(task_id)
         if not task:
             return False

--- a/tests/test_medium_backend_arch.py
+++ b/tests/test_medium_backend_arch.py
@@ -1,0 +1,155 @@
+"""PR G - 后端架构 Medium 的回归测试。
+
+覆盖：
+- S44: decision_log tool_args 截断 + 脱敏
+- M2: _sessions LRU capacity 可配置
+- M3: provider_health.snapshot 加锁
+- M4: 非流式 chat() 注册 TaskTracker
+- M7: task_tracker cancel 文档化 cooperative 限制
+"""
+import asyncio
+import inspect
+import json
+import os
+import pytest
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-medium-backend-arch-32")
+os.environ.setdefault("ENV", "development")
+
+
+# ── S44: decision_log tool_args 截断 + 脱敏 ────────────────────────────
+
+
+def test_s44_tool_args_truncated():
+    """S44：tool_args 整体超 2000 字符时截断。"""
+    from app.services.chat.decision_log import ToolDecisionRecord, log_tool_decision
+    from unittest.mock import patch
+
+    big_args = {"geojson": {"features": ["x" * 5000]}}
+    record = ToolDecisionRecord(
+        session_id="s1", round=1, user_message="test",
+        active_domains=["raster"], from_plan=False,
+        subset_size=10, total_tools=100,
+        tool_chosen="zonal_stats", tool_args=big_args,
+        result_quality="ok", plan_step_matched=None,
+    )
+    d = record.to_dict()
+    args_str = d["tool_args"]
+    if isinstance(args_str, str):
+        # 截断到 2000 + "...[truncated]" 标记（共 ~2014）
+        assert len(args_str) <= 2020, f"args 未截断: {len(args_str)}"
+        assert "[truncated]" in args_str
+
+
+def test_s44_sensitive_keys_redacted():
+    """S44：api_key/token/password 等 key 值替换为 <redacted>。"""
+    from app.services.chat.decision_log import ToolDecisionRecord
+
+    record = ToolDecisionRecord(
+        session_id="s1", round=1, user_message="test",
+        active_domains=[], from_plan=False,
+        subset_size=1, total_tools=1,
+        tool_chosen="x", tool_args={"api_key": "sk-secret-123", "normal_param": "ok"},
+        result_quality="ok", plan_step_matched=None,
+    )
+    d = record.to_dict()
+    args = d["tool_args"]
+    if isinstance(args, dict):
+        assert args["api_key"] == "<redacted>"
+        assert args["normal_param"] == "ok"
+
+
+# ── M2: _sessions LRU capacity 可配置 ──────────────────────────────────
+
+
+def test_m2_session_cache_size_configurable(monkeypatch):
+    """M2：SESSION_CACHE_SIZE 环境变量可调整 LRU capacity。"""
+    monkeypatch.setenv("SESSION_CACHE_SIZE", "500")
+    # 重新 import ChatEngine 拿新 capacity（__init__ 里读 env）
+    from app.services.chat_engine import ChatEngine
+    from app.tools.registry import ToolRegistry
+
+    # 直接构造实例验证 capacity
+    engine = ChatEngine(ToolRegistry())
+    assert engine._sessions.capacity == 500, f"期望 500，实际 {engine._sessions.capacity}"
+
+
+def test_m2_session_cache_default_is_200():
+    """M2：默认 capacity 是 200（不是原来的 50）。"""
+    # 不设环境变量（用默认）
+    import os
+    saved = os.environ.pop("SESSION_CACHE_SIZE", None)
+    try:
+        from app.services.chat_engine import ChatEngine
+        from app.tools.registry import ToolRegistry
+        # capacity 在 __init__ 时读 env，所以新建实例拿默认
+        # 但如果 env 在模块加载时已缓存可能拿到旧值 -- 用源码 inspect 兜底
+        source = inspect.getsource(ChatEngine.__init__)
+        assert "200" in source, "默认 SESSION_CACHE_SIZE 应该是 200"
+    finally:
+        if saved is not None:
+            os.environ["SESSION_CACHE_SIZE"] = saved
+
+
+# ── M3: provider_health.snapshot 加锁 ──────────────────────────────────
+
+
+def test_m3_snapshot_is_async_and_locked():
+    """M3：snapshot 必须是 async + 加锁。"""
+    from app.services.provider_health import ProviderHealthTracker
+
+    assert inspect.iscoroutinefunction(ProviderHealthTracker.snapshot), (
+        "snapshot 必须是 async（之前 sync 不加锁会 race）"
+    )
+
+    source = inspect.getsource(ProviderHealthTracker.snapshot)
+    assert "async with self._lock" in source, "snapshot 必须加 self._lock"
+    assert "list(self._state" in source, "snapshot 应用 list() 防 iterate-mutate"
+
+
+@pytest.mark.asyncio
+async def test_m3_snapshot_does_not_raise_on_concurrent_mutation():
+    """M3：并发 record_attempt 时 snapshot 不应抛 RuntimeError。"""
+    from app.services.provider_health import ProviderHealthTracker
+
+    tracker = ProviderHealthTracker()
+    # 启动多个并发 record + 一个 snapshot
+    async def record_loop():
+        for _ in range(50):
+            await tracker.record_attempt("amap")
+
+    async def snap_loop():
+        for _ in range(10):
+            await tracker.snapshot()
+
+    await asyncio.gather(record_loop(), snap_loop(), return_exceptions=False)
+    # 不抛即通过
+
+
+# ── M4: 非流式 chat() 注册 TaskTracker ──────────────────────────────────
+
+
+def test_m4_chat_registers_tracker_task():
+    """M4：chat() 源码必须包含 tracker.create / complete_task。"""
+    from app.services.chat_engine import ChatEngine
+
+    source = inspect.getsource(ChatEngine.chat)
+    assert "self.tracker.create" in source, "chat() 未注册 TaskTracker task"
+    assert "self.tracker.complete_task" in source
+    assert "self.tracker.is_cancelled" in source, "chat() 缺 cooperative cancel 检查"
+    assert "self.tracker.fail_task" in source, "chat() 异常路径未调 fail_task"
+
+
+# ── M7: task_tracker cancel 文档化 ─────────────────────────────────────
+
+
+def test_m7_cancel_docstring_documents_cooperative_limitation():
+    """M7：cancel() docstring 必须说明 cooperative 限制。"""
+    from app.services.task_tracker import TaskTracker
+
+    doc = TaskTracker.cancel.__doc__ or ""
+    assert "cooperative" in doc.lower() or "协作" in doc, (
+        "cancel() docstring 应说明 cooperative 语义"
+    )
+    # 应提到不会打断正在执行的 tool
+    assert "打断" in doc or "interrupt" in doc.lower() or "preemptive" in doc.lower()


### PR DESCRIPTION
5 Medium backend architecture findings.

## S44 - decision_log tool_args verbatim
`tool_args` (often MB-scale GeoJSON + paths) written to JSONL logs unredacted. Added `_redact_and_truncate_args`: redacts api_key/token/password/secret keys; truncates JSON to 2000 chars.

## M2 - _sessions LRU bound of 50
>50 concurrent sessions evicted oldest -> DB reload + divergence. Raised to 200 (configurable via `SESSION_CACHE_SIZE` env).

## M3 - provider_health.snapshot no lock
`snapshot()` iterated state without lock -> RuntimeError on concurrent mutation. Changed to async + acquires lock + iterates list() copy.

## M4 - non-streaming chat() bypasses TaskTracker
`/chat/completions` tasks invisible to `/tasks` + couldn't cancel. Now registers TaskTracker task, tracks steps, checks cancel, calls complete/fail.

## M7 - cancel cooperative only (documented)
`cancel()` sets flag but can't interrupt running tool. Documented the cooperative limitation; full preemptive cancel is separate refactor.

## Deferred
**S41** (token refresh) - needs DB migration + frontend login UI, larger scope.

## Tests
8 new cases in `tests/test_medium_backend_arch.py`. Full suite: **1043 passing**.