### PR TITLE
fix(test): T3 AST->behavior + T5 config routes coverage

### DIFF
--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -1,0 +1,104 @@
+"""审计 T5: /config/* 路由的集成测试。
+
+config.py 之前没有任何路由级测试（只有 Settings 模块测试）。
+这些端点是 admin-only（PR #93 的 require_admin），是 RCE 等价入口
+（skills/upload 写盘 + importlib.exec_module），必须有测试覆盖。
+"""
+import os
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from fastapi import FastAPI
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-config-routes-32-chars")
+os.environ.setdefault("ENV", "development")
+
+
+@pytest_asyncio.fixture
+async def app_and_client():
+    """加载 config 路由 + chat 路由（config 依赖 chat.get_engine/get_registry）。"""
+    from app.api.routes import config as config_routes
+    from app.api.routes import chat as chat_routes
+    from app.services.chat_engine import ChatEngine
+    from app.tools.registry import ToolRegistry
+
+    # 给 chat 模块注入 engine + registry（config 路由会用）
+    registry = ToolRegistry()
+    chat_routes.registry = registry
+    chat_routes.engine = ChatEngine(registry)
+
+    app = FastAPI()
+    app.include_router(config_routes.router, prefix="/api/v1")
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield app, c
+    finally:
+        chat_routes.engine = None
+        chat_routes.registry = None
+
+
+@pytest.mark.asyncio
+async def test_config_llm_requires_admin_token(app_and_client):
+    """S29: /config/llm 必须 admin token，无 token -> 401。"""
+    _, client = app_and_client
+    resp = await client.get("/api/v1/config/llm")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_config_llm_rejects_viewer(app_and_client):
+    """S29: viewer token -> 403。"""
+    from app.core.auth import create_access_token
+    viewer_token = create_access_token({"sub": "v1", "username": "v", "role": "viewer"})
+    _, client = app_and_client
+    resp = await client.get(
+        "/api/v1/config/llm",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_config_llm_accepts_admin(app_and_client):
+    """S29: admin token -> 200。"""
+    from app.core.auth import create_access_token
+    admin_token = create_access_token({"sub": "a1", "username": "a", "role": "admin"})
+    _, client = app_and_client
+    resp = await client.get(
+        "/api/v1/config/llm",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_config_skills_list_requires_admin(app_and_client):
+    """S29: /config/skills 也需要 admin。"""
+    _, client = app_and_client
+    resp = await client.get("/api/v1/config/skills")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_config_skills_upload_rejects_non_admin(app_and_client):
+    """S29: skills/upload 是 RCE 等价，必须 admin。"""
+    from app.core.auth import create_access_token
+    viewer_token = create_access_token({"sub": "v1", "username": "v", "role": "viewer"})
+    _, client = app_and_client
+
+    # 即使带了文件，viewer 也应被 403 拒绝
+    resp = await client.post(
+        "/api/v1/config/skills/upload",
+        headers={"Authorization": f"Bearer {viewer_token}"},
+        files={"file": ("test.py", b"print('hello')", "text/python")},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_config_skills_refresh_requires_admin(app_and_client):
+    """S29: /config/skills/refresh 也需要 admin。"""
+    _, client = app_and_client
+    resp = await client.post("/api/v1/config/skills/refresh")
+    assert resp.status_code == 401

--- a/tests/test_duplicate_decorator.py
+++ b/tests/test_duplicate_decorator.py
@@ -1,4 +1,12 @@
-"""Test: no duplicate decorators in report_service."""
+"""Test: no duplicate decorators in report_service.
+
+审计 T3 注释：这是源码结构检查（AST），不是行为测试。保留是因为：
+(1) 它防御的 bug（@staticmethod 重复）会让函数在 import 时就崩，
+    行为测试和 AST 检查效果相同；
+(2) 转行为测试需要枚举 report_service 的每个函数并调用，但其中
+    PDF 生成依赖外部库（reportlab），调用成本高且不稳定。
+AST 检查在这里是更务实的选择。
+"""
 import ast
 
 

--- a/tests/test_mutable_default_arg.py
+++ b/tests/test_mutable_default_arg.py
@@ -1,4 +1,9 @@
-"""Test: multi_ring_buffer must not use mutable default argument."""
+"""Test: multi_ring_buffer must not use mutable default argument.
+
+审计 T3 注释：这是源码结构检查（AST）。保留是因为 mutable default arg
+是 Python 语言层面的陷阱 -- AST 检查比行为测试更直接（行为测试需要
+"恰好触发 mutation 才能发现"）。AST 检查在这里更可靠。
+"""
 import ast
 
 

--- a/tests/test_upload_delete_ordering.py
+++ b/tests/test_upload_delete_ordering.py
@@ -1,30 +1,98 @@
-"""Test: delete_upload must commit DB deletion BEFORE removing files."""
+"""Test: delete_upload must commit DB deletion BEFORE removing files.
+
+审计 T3：之前用 AST 源码检查验证 shutil.rmtree 在 async with 块之后。
+改写为行为测试：注入 DB commit 失败 + 真 tmp 文件，验证文件保留。
+"""
 import pytest
-import ast
-import inspect
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from httpx import ASGITransport, AsyncClient
+from fastapi import FastAPI
+
 from app.api.routes import upload as upload_module
 
 
-def test_delete_upload_file_cleanup_after_db_context():
-    """In delete_upload source, shutil.rmtree must appear AFTER the async with block."""
-    source = inspect.getsource(upload_module.delete_upload)
-    tree = ast.parse(source)
+@pytest.mark.asyncio
+async def test_delete_upload_preserves_file_when_db_fails(tmp_path, monkeypatch):
+    """DB commit 失败时，物理文件不应被删除（顺序正确性）。"""
+    # 准备一个真实的上传目录和文件
+    upload_dir = tmp_path / "upload-1"
+    upload_dir.mkdir()
+    fake_file = upload_dir / "data.geojson"
+    fake_file.write_text('{"type":"FeatureCollection"}')
 
-    # Find the async with block and the rmtree call
-    async_with_end = None
-    rmtree_line = None
+    # mock UploadRecord
+    fake_record = MagicMock()
+    fake_record.id = 1
+    fake_record.session_id = None  # 匿名会话，跳过所有权校验
+    fake_record.filename = str(fake_file)
 
-    for node in ast.walk(tree):
-        if isinstance(node, ast.AsyncWith):
-            async_with_end = node.end_lineno
-        if isinstance(node, ast.Attribute) and node.attr == "rmtree":
-            rmtree_line = node.end_lineno
+    fake_result = MagicMock()
+    fake_result.scalar_one_or_none.return_value = fake_record
 
-    assert rmtree_line is not None, "shutil.rmtree not found in delete_upload"
-    assert async_with_end is not None, "async with db session not found"
+    # mock DB session -- 让 db.delete 抛错（模拟 commit 失败）
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(return_value=fake_result)
+    fake_db.delete = AsyncMock(side_effect=RuntimeError("DB commit failed"))
 
-    # rmtree must be outside the async with block (line number > block end)
-    assert rmtree_line > async_with_end, (
-        f"shutil.rmtree at line {rmtree_line} is INSIDE the DB context "
-        f"(ends at line {async_with_end}). Files would be deleted before DB commit."
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_async_db_session():
+        yield fake_db
+
+    monkeypatch.setattr(upload_module, "async_db_session", fake_async_db_session)
+    # _verify_session_owner 在 session_id=None 时直接 return
+    async def noop_verify(db, sid, uid):
+        return None
+    monkeypatch.setattr(upload_module, "_verify_session_owner", noop_verify)
+
+    # 调用 delete_upload -- 应抛 RuntimeError（DB 失败）
+    with pytest.raises(RuntimeError, match="DB commit failed"):
+        await upload_module.delete_upload(1, {"user_id": "test", "role": "viewer"})
+
+    # 关键断言：DB 失败时文件必须保留
+    assert fake_file.exists(), (
+        "DB 删除失败时文件被删了 -- delete_upload 的 DB-then-file 顺序错误"
     )
+    assert upload_dir.exists(), "upload 目录也不应被清理"
+
+
+@pytest.mark.asyncio
+async def test_delete_upload_removes_file_when_db_succeeds(tmp_path, monkeypatch):
+    """DB 成功时，物理文件应被删除。"""
+    upload_dir = tmp_path / "upload-2"
+    upload_dir.mkdir()
+    fake_file = upload_dir / "data.geojson"
+    fake_file.write_text('{"type":"FeatureCollection"}')
+
+    fake_record = MagicMock()
+    fake_record.id = 2
+    fake_record.session_id = None
+    fake_record.filename = str(fake_file)
+
+    fake_result = MagicMock()
+    fake_result.scalar_one_or_none.return_value = fake_record
+
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(return_value=fake_result)
+    fake_db.delete = AsyncMock()  # 成功
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_async_db_session():
+        yield fake_db
+
+    monkeypatch.setattr(upload_module, "async_db_session", fake_async_db_session)
+    async def noop_verify(db, sid, uid):
+        return None
+    monkeypatch.setattr(upload_module, "_verify_session_owner", noop_verify)
+
+    result = await upload_module.delete_upload(2, {"user_id": "test", "role": "viewer"})
+
+    # 文件应被删除
+    assert not fake_file.exists(), "DB 成功后文件应被删除"
+    assert not upload_dir.exists(), "upload 目录应被清理"
+    assert result["success"] is True


### PR DESCRIPTION
Test infrastructure Medium findings.

## T3 - AST source inspection -> behavior tests
- **test_upload_delete_ordering.py**: rewrote from AST line-number check to behavioral test with real tmp file + mock DB. Verifies: DB failure -> file preserved.
- **test_duplicate_decorator.py + test_mutable_default_arg.py**: kept as AST with audit-T3 comments explaining why (import-time failure / language-level trap).

## T5 - untested /config/* routes
- New **test_config_routes.py**: 6 cases covering all config endpoints. Verifies S29 require_admin: no token -> 401, viewer -> 403, admin -> 200. Previously these RCE-equivalent endpoints had zero route tests.

## Tests
1042 passing (+6 config routes, upload AST test replaced by 2 behavior tests).

## Remaining (deferred)
- **T1** (importlib bypass): route tests bypass __init__.py; real fix needs healthy __init__.py
- **T2** (mocked integration): tests/integration/ are unit tests in disguise; needs fakeredis + real SQLite stack
- **S41** (token refresh): needs DB migration + frontend login UI