### PR TITLE
refactor(test): remove importlib bypass from 10 route test files (T1)

### DIFF
--- a/tests/integration/test_session_api.py
+++ b/tests/integration/test_session_api.py
@@ -1,19 +1,10 @@
 """Integration tests for session map-state API endpoint."""
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
-import importlib.util
-import os
 from fastapi.testclient import TestClient
 
-# Load chat module directly without triggering __init__.py
-_spec = importlib.util.spec_from_file_location(
-    "app.api.routes.chat",
-    os.path.join(os.path.dirname(__file__), "..", "..", "app", "api", "routes", "chat.py"),
-    submodule_search_locations=[]
-)
-_chat_mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_chat_mod)
-router = _chat_mod.router
+from app.api.routes import chat as _chat_mod
+from app.api.routes.chat import router
 
 
 @pytest.fixture

--- a/tests/integration/test_skill_api.py
+++ b/tests/integration/test_skill_api.py
@@ -1,20 +1,10 @@
 """Integration tests for skill API endpoints using FastAPI TestClient."""
 import pytest
-import importlib.util
-import os
 from fastapi.testclient import TestClient
 
 from app.tools.skills import _md_skills
-
-# Load chat module directly without triggering __init__.py
-_spec = importlib.util.spec_from_file_location(
-    "app.api.routes.chat",
-    os.path.join(os.path.dirname(__file__), "..", "..", "app", "api", "routes", "chat.py"),
-    submodule_search_locations=[]
-)
-_chat_mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_chat_mod)
-router = _chat_mod.router
+from app.api.routes import chat as _chat_mod
+from app.api.routes.chat import router
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,38 +1,21 @@
 """Chat API 测试
 
-Uses importlib to bypass broken __init__.py (health.py issue).
-Run with: python -m pytest tests/test_chat_api.py -v --noconftest
+审计 T1：之前用 importlib bypass broken __init__.py。__init__.py 现在已健康
+（循环 import 已修），改为直接 import。
 """
 import pytest
 from httpx import AsyncClient, ASGITransport
 from unittest.mock import AsyncMock, patch, MagicMock
 from fastapi import FastAPI
-import importlib.util
-import os
 
-_chat_mod = None
-_router = None
-
-
-def _load_chat_module():
-    global _chat_mod, _router
-    if _chat_mod is None:
-        spec = importlib.util.spec_from_file_location(
-            "app.api.routes.chat",
-            os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "chat.py"),
-            submodule_search_locations=[]
-        )
-        _chat_mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(_chat_mod)
-        _router = _chat_mod.router
-    return _chat_mod, _router
+from app.api.routes import chat as _chat_mod
+from app.api.routes.chat import router as _router
 
 
 @pytest.fixture
 def app():
-    _chat_mod, router = _load_chat_module()
     app = FastAPI()
-    app.include_router(router, prefix="/api")
+    app.include_router(_router, prefix="/api")
     return app
 
 

--- a/tests/test_chat_history_routes.py
+++ b/tests/test_chat_history_routes.py
@@ -1,32 +1,11 @@
 """Tests for chat history API routes."""
-import os
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch, AsyncMock
 from datetime import datetime
-import importlib.util
 
-
-def _load_chat_module():
-    spec = importlib.util.spec_from_file_location(
-        "app.api.routes.chat",
-        os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "chat.py"),
-        submodule_search_locations=[]
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-_chat_mod = None
-
-
-def _get_chat_mod():
-    global _chat_mod
-    if _chat_mod is None:
-        _chat_mod = _load_chat_module()
-    return _chat_mod
+from app.api.routes import chat as _chat_mod
 
 
 def make_conv(id_, title, updated):
@@ -41,9 +20,8 @@ def make_conv(id_, title, updated):
 
 @pytest.fixture
 def client():
-    mod = _get_chat_mod()
     app = FastAPI()
-    app.include_router(mod.router, prefix="/api/v1")
+    app.include_router(_chat_mod.router, prefix="/api/v1")
     return TestClient(app)
 
 
@@ -52,8 +30,7 @@ BASE = "/api/v1/chat"
 
 def test_list_sessions_returns_json(client):
     conv = make_conv("s1", "Test", datetime(2026, 4, 10))
-    mod = _get_chat_mod()
-    with patch.object(mod, "AsyncHistoryService") as MockHS:
+    with patch.object(_chat_mod, "AsyncHistoryService") as MockHS:
         mock_svc = MagicMock()
         MockHS.return_value = mock_svc
         mock_svc.list_sessions = AsyncMock(return_value=[conv])
@@ -76,8 +53,7 @@ def test_get_session_detail(client):
     msg.tool_result = None
     msg.created_at = datetime(2026, 4, 10)
     conv.messages = [msg]
-    mod = _get_chat_mod()
-    with patch.object(mod, "AsyncHistoryService") as MockHS:
+    with patch.object(_chat_mod, "AsyncHistoryService") as MockHS:
         mock_svc = MagicMock()
         MockHS.return_value = mock_svc
         mock_svc.get_session = AsyncMock(return_value=conv)
@@ -90,8 +66,7 @@ def test_get_session_detail(client):
 
 
 def test_get_session_detail_not_found(client):
-    mod = _get_chat_mod()
-    with patch.object(mod, "AsyncHistoryService") as MockHS:
+    with patch.object(_chat_mod, "AsyncHistoryService") as MockHS:
         mock_svc = MagicMock()
         MockHS.return_value = mock_svc
         mock_svc.get_session = AsyncMock(return_value=None)
@@ -100,10 +75,9 @@ def test_get_session_detail_not_found(client):
 
 
 def test_delete_session(client):
-    mod = _get_chat_mod()
     mock_engine = MagicMock()
     mock_engine.clear_session = AsyncMock(return_value=True)  # A2: 返回 bool
-    with patch.object(mod, "engine", mock_engine):
+    with patch.object(_chat_mod, "engine", mock_engine):
         resp = client.delete(f"{BASE}/sessions/s1")
     assert resp.status_code == 200
     # A2: 现在带 user_id kwarg

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -3,30 +3,14 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from unittest.mock import patch, MagicMock
 from fastapi import FastAPI
-import importlib.util
-import os
 
-_mod = None
-
-
-def _get_module():
-    global _mod
-    if _mod is None:
-        spec = importlib.util.spec_from_file_location(
-            "app.api.routes.health",
-            os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "health.py"),
-            submodule_search_locations=[]
-        )
-        _mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(_mod)
-    return _mod
+from app.api.routes import health as _mod
 
 
 @pytest.fixture
 def app():
-    mod = _get_module()
     app = FastAPI()
-    app.include_router(mod.router, prefix="/api/v1")
+    app.include_router(_mod.router, prefix="/api/v1")
     return app
 
 
@@ -49,11 +33,10 @@ async def test_health_check(client):
 
 @pytest.mark.asyncio
 async def test_readiness_check_healthy(client):
-    mod = _get_module()
-    with patch.object(mod, "_check_db", return_value=True), \
-         patch.object(mod, "_check_llm", return_value=True), \
-         patch.object(mod, "_check_redis", return_value=True), \
-         patch.object(mod, "_check_celery", return_value=True):
+    with patch.object(_mod, "_check_db", return_value=True), \
+         patch.object(_mod, "_check_llm", return_value=True), \
+         patch.object(_mod, "_check_redis", return_value=True), \
+         patch.object(_mod, "_check_celery", return_value=True):
         resp = await client.get("/api/v1/ready")
         assert resp.status_code == 200
         data = resp.json()
@@ -66,9 +49,8 @@ async def test_readiness_check_healthy(client):
 async def test_readiness_check_unhealthy(client):
     """依赖不可用时 /ready 必须返回 503 —— k8s readinessProbe 只看状态码，
     若返回 200 即使 body.ready=false 也会被当作就绪把流量打过来。"""
-    mod = _get_module()
-    with patch.object(mod, "_check_db", return_value=False), \
-         patch.object(mod, "_check_llm", return_value=False):
+    with patch.object(_mod, "_check_db", return_value=False), \
+         patch.object(_mod, "_check_llm", return_value=False):
         resp = await client.get("/api/v1/ready")
         assert resp.status_code == 503
         data = resp.json()

--- a/tests/test_knowledge_api.py
+++ b/tests/test_knowledge_api.py
@@ -3,31 +3,18 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from unittest.mock import patch, AsyncMock, MagicMock
 from fastapi import FastAPI
-import importlib.util
-import os
 
+from app.api.routes import knowledge as _mod
 from app.core.auth import get_current_user
 
 _mock_user = {"user_id": "test-user"}
 
 
-def _load_module():
-    spec = importlib.util.spec_from_file_location(
-        "app.api.routes.knowledge",
-        os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "knowledge.py"),
-        submodule_search_locations=[]
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
 @pytest.fixture
 def app():
-    mod = _load_module()
     app = FastAPI()
     app.dependency_overrides[get_current_user] = lambda: _mock_user
-    app.include_router(mod.router, prefix="/api/v1")
+    app.include_router(_mod.router, prefix="/api/v1")
     return app
 
 
@@ -50,8 +37,7 @@ async def test_add_document_empty_content(client):
 
 @pytest.mark.asyncio
 async def test_add_document_success(client):
-    mod = _load_module()
-    with patch.object(mod.rag_service, "add_document", new_callable=AsyncMock,
+    with patch.object(_mod.rag_service, "add_document", new_callable=AsyncMock,
                       return_value={"document_id": "doc-1", "chunk_count": 3, "status": "indexed"}):
         resp = await client.post("/api/v1/knowledge/documents", json={
             "title": "Test", "content": "Some content"
@@ -64,8 +50,7 @@ async def test_add_document_success(client):
 
 @pytest.mark.asyncio
 async def test_add_document_service_error(client):
-    mod = _load_module()
-    with patch.object(mod.rag_service, "add_document", new_callable=AsyncMock,
+    with patch.object(_mod.rag_service, "add_document", new_callable=AsyncMock,
                       return_value={"error": "FAISS not initialized"}):
         resp = await client.post("/api/v1/knowledge/documents", json={
             "title": "Test", "content": "Some content"
@@ -77,9 +62,8 @@ async def test_add_document_service_error(client):
 
 @pytest.mark.asyncio
 async def test_semantic_search_success(client):
-    mod = _load_module()
     mock_results = [{"text": "result 1", "score": 0.9}]
-    with patch.object(mod.rag_service, "semantic_search", new_callable=AsyncMock,
+    with patch.object(_mod.rag_service, "semantic_search", new_callable=AsyncMock,
                       return_value=mock_results):
         resp = await client.get("/api/v1/knowledge/search", params={"q": "test query"})
         assert resp.status_code == 200

--- a/tests/test_layer_api.py
+++ b/tests/test_layer_api.py
@@ -3,23 +3,8 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from unittest.mock import patch, MagicMock
 from fastapi import FastAPI
-import importlib.util
-import os
 
-_mod = None
-
-
-def _get_module():
-    global _mod
-    if _mod is None:
-        spec = importlib.util.spec_from_file_location(
-            "app.api.routes.layer",
-            os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "layer.py"),
-            submodule_search_locations=[]
-        )
-        _mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(_mod)
-    return _mod
+from app.api.routes import layer as _mod
 
 
 @pytest.fixture
@@ -28,11 +13,10 @@ def app(monkeypatch):
     stub 成 always-pass（跨租户隔离由 test_cross_tenant_isolation 覆盖）。"""
     async def _noop_verify(session_id, user_id):
         return None
-    mod = _get_module()
-    monkeypatch.setattr(mod, "_verify_session_owner", _noop_verify)
+    monkeypatch.setattr(_mod, "_verify_session_owner", _noop_verify)
 
     app = FastAPI()
-    app.include_router(mod.router, prefix="/api/v1")
+    app.include_router(_mod.router, prefix="/api/v1")
     return app
 
 
@@ -48,17 +32,15 @@ _VALID_SID = "session-aaaaaaaaaaaaaaaa"  # >= min_length=8
 
 @pytest.mark.asyncio
 async def test_get_session_layer_data_not_found(client):
-    mod = _get_module()
-    with patch.object(mod.session_data_manager, "get", return_value=None):
+    with patch.object(_mod.session_data_manager, "get", return_value=None):
         resp = await client.get("/api/v1/layers/data/ref-123", params={"session_id": _VALID_SID})
         assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
 async def test_get_session_layer_data_success(client):
-    mod = _get_module()
     mock_data = {"type": "FeatureCollection", "features": []}
-    with patch.object(mod.session_data_manager, "get", return_value=mock_data):
+    with patch.object(_mod.session_data_manager, "get", return_value=mock_data):
         resp = await client.get("/api/v1/layers/data/ref-123", params={"session_id": _VALID_SID})
         assert resp.status_code == 200
         assert resp.json()["type"] == "FeatureCollection"

--- a/tests/test_map_api.py
+++ b/tests/test_map_api.py
@@ -1,35 +1,29 @@
 """Map export API tests"""
 import io
 import os
-import importlib.util
 from unittest.mock import patch, MagicMock
 
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient, ASGITransport
 
+from app.api.routes import map as _mod
 from app.core.auth import get_current_user
 
 _mock_user = {"user_id": "test-user"}
 
-
-def _load_module():
-    spec = importlib.util.spec_from_file_location(
-        "app.api.routes.map",
-        os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "map.py"),
-        submodule_search_locations=[]
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+# Isolated EXPORT_DIR used by patch.object below. The module's real EXPORT_DIR
+# is created on import, but these tests patch in a temp location that must exist
+# for NamedTemporaryFile / fig.savefig to succeed.
+_TEST_EXPORT_DIR = "/tmp/test_exports"
+os.makedirs(_TEST_EXPORT_DIR, exist_ok=True)
 
 
 @pytest.fixture
 def app():
-    mod = _load_module()
     app = FastAPI()
     app.dependency_overrides[get_current_user] = lambda: _mock_user
-    app.include_router(mod.router, prefix="/api/v1")
+    app.include_router(_mod.router, prefix="/api/v1")
     return app
 
 
@@ -50,10 +44,9 @@ async def test_upload_map_export_no_filename(client):
 
 @pytest.mark.asyncio
 async def test_upload_map_export_success(client):
-    mod = _load_module()
     fake_content = b"fake-png-data"
     with patch("builtins.open", MagicMock()), \
-         patch.object(mod, "EXPORT_DIR", "/tmp/test_exports"):
+         patch.object(_mod, "EXPORT_DIR", _TEST_EXPORT_DIR):
         resp = await client.post(
             "/api/v1/export",
             files={"file": ("map.png", fake_content, "image/png")},
@@ -67,17 +60,15 @@ async def test_upload_map_export_success(client):
 
 @pytest.mark.asyncio
 async def test_download_map_export_not_found(client):
-    mod = _load_module()
-    with patch.object(mod, "EXPORT_DIR", "/tmp/nonexistent_exports"):
+    with patch.object(_mod, "EXPORT_DIR", "/tmp/nonexistent_exports"):
         resp = await client.get("/api/v1/export/download/nonexistent.png")
         assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
 async def test_upload_map_export_invalid_ext_becomes_png(client):
-    mod = _load_module()
     with patch("builtins.open", MagicMock()), \
-         patch.object(mod, "EXPORT_DIR", "/tmp/test_exports"):
+         patch.object(_mod, "EXPORT_DIR", _TEST_EXPORT_DIR):
         resp = await client.post(
             "/api/v1/export",
             files={"file": ("map.bmp", b"data", "image/bmp")},
@@ -99,9 +90,8 @@ def _make_tiny_png() -> bytes:
 
 @pytest.mark.asyncio
 async def test_export_pdf_success(client):
-    mod = _load_module()
     png_bytes = _make_tiny_png()
-    with patch.object(mod, "EXPORT_DIR", "/tmp/test_exports"):
+    with patch.object(_mod, "EXPORT_DIR", _TEST_EXPORT_DIR):
         resp = await client.post(
             "/api/v1/export/pdf",
             files={"file": ("map.png", png_bytes, "image/png")},
@@ -118,8 +108,7 @@ async def test_export_pdf_success(client):
 @pytest.mark.asyncio
 async def test_export_pdf_invalid_image(client):
     """Non-image bytes should return 500."""
-    mod = _load_module()
-    with patch.object(mod, "EXPORT_DIR", "/tmp/test_exports"):
+    with patch.object(_mod, "EXPORT_DIR", _TEST_EXPORT_DIR):
         resp = await client.post(
             "/api/v1/export/pdf",
             files={"file": ("bad.png", b"not-an-image", "image/png")},
@@ -130,14 +119,13 @@ async def test_export_pdf_invalid_image(client):
 @pytest.mark.asyncio
 async def test_download_pdf_media_type(tmp_path):
     """Download endpoint returns application/pdf for .pdf files."""
-    mod = _load_module()
     pdf_file = tmp_path / "test.pdf"
     pdf_file.write_bytes(b"%PDF-1.4 test")
 
-    with patch.object(mod, "EXPORT_DIR", str(tmp_path)):
+    with patch.object(_mod, "EXPORT_DIR", str(tmp_path)):
         app = FastAPI()
         app.dependency_overrides[get_current_user] = lambda: _mock_user
-        app.include_router(mod.router, prefix="/api/v1")
+        app.include_router(_mod.router, prefix="/api/v1")
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as c:
             resp = await c.get("/api/v1/export/download/test.pdf")

--- a/tests/test_report_api.py
+++ b/tests/test_report_api.py
@@ -3,31 +3,18 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi import FastAPI
-import importlib.util
-import os
 
+from app.api.routes import report as _mod
 from app.core.auth import get_current_user
 
 _mock_user = {"user_id": "test-user"}
 
 
-def _load_module():
-    spec = importlib.util.spec_from_file_location(
-        "app.api.routes.report",
-        os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "report.py"),
-        submodule_search_locations=[]
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
 @pytest.fixture
 def app():
-    mod = _load_module()
     app = FastAPI()
     app.dependency_overrides[get_current_user] = lambda: _mock_user
-    app.include_router(mod.router, prefix="/api/v1")
+    app.include_router(_mod.router, prefix="/api/v1")
     return app
 
 
@@ -51,17 +38,15 @@ async def test_create_report_unsupported_format(client):
 
 def test_allowed_formats():
     """Verify ALLOWED_FORMATS contains expected formats"""
-    mod = _load_module()
-    assert "pdf" in mod.ALLOWED_FORMATS
-    assert "html" in mod.ALLOWED_FORMATS
-    assert "markdown" in mod.ALLOWED_FORMATS
-    assert "md" in mod.ALLOWED_FORMATS
-    assert "docx" not in mod.ALLOWED_FORMATS
+    assert "pdf" in _mod.ALLOWED_FORMATS
+    assert "html" in _mod.ALLOWED_FORMATS
+    assert "markdown" in _mod.ALLOWED_FORMATS
+    assert "md" in _mod.ALLOWED_FORMATS
+    assert "docx" not in _mod.ALLOWED_FORMATS
 
 
 def test_serialize_report():
     """Test _serialize_report helper"""
-    mod = _load_module()
     mock_report = MagicMock()
     mock_report.id = "r-1"
     mock_report.session_id = "s-1"
@@ -75,25 +60,23 @@ def test_serialize_report():
     mock_report.created_at = MagicMock()
     mock_report.created_at.isoformat.return_value = "2026-01-01T00:00:00"
 
-    result = mod._serialize_report(mock_report)
+    result = _mod._serialize_report(mock_report)
     assert result["id"] == "r-1"
     assert result["status"] == "completed"
     assert result["download_url"] == "/api/v1/reports/r-1/download"
 
 
 def test_media_type():
-    mod = _load_module()
-    assert mod._media_type("pdf") == "application/pdf"
-    assert mod._media_type("html") == "text/html"
-    assert mod._media_type("markdown") == "text/markdown"
+    assert _mod._media_type("pdf") == "application/pdf"
+    assert _mod._media_type("html") == "text/html"
+    assert _mod._media_type("markdown") == "text/markdown"
 
 
 def test_file_ext():
-    mod = _load_module()
-    assert mod._file_ext("pdf") == "pdf"
-    assert mod._file_ext("html") == "html"
-    assert mod._file_ext("markdown") == "md"
-    assert mod._file_ext("md") == "md"
+    assert _mod._file_ext("pdf") == "pdf"
+    assert _mod._file_ext("html") == "html"
+    assert _mod._file_ext("markdown") == "md"
+    assert _mod._file_ext("md") == "md"
 
 
 # ── Bug fixes: title field + dead code ─────────────────────────────
@@ -101,23 +84,20 @@ def test_file_ext():
 
 def test_generate_report_request_accepts_title():
     """GenerateReportRequest must accept an optional title field."""
-    mod = _load_module()
-    req = mod.GenerateReportRequest(session_id="s1", title="My Report")
+    req = _mod.GenerateReportRequest(session_id="s1", title="My Report")
     assert req.title == "My Report"
 
 
 def test_generate_report_request_title_defaults_none():
     """GenerateReportRequest.title defaults to None when not provided."""
-    mod = _load_module()
-    req = mod.GenerateReportRequest(session_id="s1")
+    req = _mod.GenerateReportRequest(session_id="s1")
     assert req.title is None
 
 
 def test_validate_file_path_no_dead_code():
     """_validate_file_path returns a bool, no unreachable code after return."""
     import inspect
-    mod = _load_module()
-    source = inspect.getsource(mod._validate_file_path)
+    source = inspect.getsource(_mod._validate_file_path)
     lines = [l.strip() for l in source.splitlines()]
     # Find the return statement
     return_idx = next(i for i, l in enumerate(lines) if l.startswith("return "))

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -3,35 +3,18 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi import FastAPI
-import importlib.util
-import os
 
+from app.api.routes import upload as _mod
 from app.core.auth import get_current_user
 
 _mock_user = {"user_id": "test-user"}
 
-_mod = None
-
-
-def _get_module():
-    global _mod
-    if _mod is None:
-        spec = importlib.util.spec_from_file_location(
-            "app.api.routes.upload",
-            os.path.join(os.path.dirname(__file__), "..", "app", "api", "routes", "upload.py"),
-            submodule_search_locations=[]
-        )
-        _mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(_mod)
-    return _mod
-
 
 @pytest.fixture
 def app():
-    mod = _get_module()
     app = FastAPI()
     app.dependency_overrides[get_current_user] = lambda: _mock_user
-    app.include_router(mod.router, prefix="/api/v1")
+    app.include_router(_mod.router, prefix="/api/v1")
     return app
 
 
@@ -51,12 +34,11 @@ async def test_upload_unsupported_format(client):
 
 @pytest.mark.asyncio
 async def test_upload_raster_too_large(client):
-    mod = _get_module()
     from app.services.data_parser import MAX_RASTER_SIZE
     # Create a fake file just over the limit
     big_content = b"x" * (MAX_RASTER_SIZE + 1)
     with patch("builtins.open", MagicMock()), \
-         patch.object(mod, "get_upload_dir", return_value="/tmp/test"):
+         patch.object(_mod, "get_upload_dir", return_value="/tmp/test"):
         resp = await client.post("/api/v1/upload",
                                 files={"files": ("big.tif", big_content, "image/tiff")})
         assert resp.status_code == 400


### PR DESCRIPTION
## T1 - importlib bypass removal

`app/api/routes/__init__.py` was previously broken (circular import), forcing 11 test files to use `importlib.util.spec_from_file_location()` to load route modules in isolation. The `__init__.py` is now healthy (fixed during PR #93 auth refactor), so the bypass is dead weight.

## Changes
- **10 files** refactored: removed `importlib.util` + `spec_from_file_location` + `module_from_spec` + `exec_module` patterns
- Replaced with direct `from app.api.routes import XXX` 
- Net **-164 lines** (68 insertions, 232 deletions)

## Bonus fix (test_map_api.py)
The importlib bypass had a latent bug: `_load_module()` re-executed the route module into a throwaway namespace on every call, so `app.include_router(mod.router)` bound one instance while `patch.object(mod, 'EXPORT_DIR')` patched a *different* instance. Patches silently never took effect. After refactor, patches correctly isolate EXPORT_DIR (added `os.makedirs` for test export dir).

## Tests
1035 passing (no regression). The refactored tests now exercise the real module initialization path, catching import-time issues that the bypass previously masked.

## Remaining
- **T2** (mocked integration tests): needs fakeredis + real SQLite stack rewrite; separate work
- **S41** (token refresh): needs DB migration + frontend login UI