### PR TITLE
fix(ci): unblock Docker build — line-dasharray tuple type (TS2322)

### DIFF
--- a/frontend/lib/map-kit/renderer.ts
+++ b/frontend/lib/map-kit/renderer.ts
@@ -300,14 +300,17 @@ export function updateLayerStyle(map: any, id: string, style: StyleUpdateOptions
   }
 
   if (style.dashArray && layer.type === 'line') {
-    const patterns: Record<string, [number, number]> = {
+    // MapLibre line-dasharray 接受任意长度的 number 数组（odd-length 会被
+    // 自动重复），所以类型用 number[] 而非 tuple —— 之前 tuple 阻止了
+    // dashdot 的 4 段 pattern，导致 TS2322 + Docker 构建失败。
+    const patterns: Record<string, number[]> = {
       dashed: [4, 2],
       dotted: [1, 2],
       dashdot: [4, 2, 1, 2],
     };
     const pattern = patterns[style.dashArray];
     if (pattern) {
-      map.setPaintProperty(id, 'line-dasharray', style.dashArray === 'dashdot' ? [4, 2, 1, 2] : pattern);
+      map.setPaintProperty(id, 'line-dasharray', pattern);
     }
   }
 }


### PR DESCRIPTION
## Problem

Every open PR (#115–#125) is failing `Build Docker Image`. After merging master into all of them (which fixed the apt-get package name issue from `9679749`), the next blocker surfaced:

```
./lib/map-kit/renderer.ts:306:7
Type error: Type '[number, number, number, number]' is not assignable to type '[number, number]'.
  Source has 4 element(s) but target allows only 2.

> 306 |       dashdot: [4, 2, 1, 2],
```

This is a **pre-existing bug on master** (introduced by #90 — Phase 5 UI tools), not caused by any of the open PRs. It was masked because the author added a redundant ternary that re-asserted the literal `[4, 2, 1, 2]` at the call site, but `tsc`/`next build` still reject the source.

**Master's own CI is also red** — `run 29749655168` failed with the same error.

## Root cause

```ts
const patterns: Record<string, [number, number]> = {
  dashed: [4, 2],
  dotted: [1, 2],
  dashdot: [4, 2, 1, 2],  // ← 4 elements, type wants 2
};
```

## Fix

Widen the type to `number[]`. MapLibre's `line-dasharray` paint property accepts arbitrary-length number arrays (odd-length arrays are auto-repeated per the spec), so `dashdot: [4, 2, 1, 2]` is valid at runtime. Drop the now-redundant ternary.

```ts
const patterns: Record<string, number[]> = {
  dashed: [4, 2],
  dotted: [1, 2],
  dashdot: [4, 2, 1, 2],
};
const pattern = patterns[style.dashArray];
if (pattern) {
  map.setPaintProperty(id, 'line-dasharray', pattern);
}
```

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 267 passed, 4 skipped
- [x] Diff is minimal (5 lines)

## After merge

Once this lands on master, all 11 open PRs will need their branches re-synced (`update-branch`) to pick up the fix, after which their Docker builds should pass too. Their test/lint/security jobs already pass.

This PR has no reviewer-visible scope other than a 5-line type widening.