### PR TITLE
fix(security): SEC-03/07/08 — WS auth, SSRF DNS, session owner_token

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -1,7 +1,7 @@
 """Chat API Route - SSE 流式对话"""
 import logging
 import os
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Header, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from typing import Optional
@@ -34,6 +34,17 @@ SSE_HEADERS = {
 # true/1/yes 时使用 Pi 开源 agent (vendor/pi) 通过 RPC 调用
 # (imported from app.agent_pi_bridge to avoid duplication)
 pi_bridge = None  # type: ignore[assignment]  # 由 lifespan 初始化
+
+
+async def get_owner_token(
+    x_session_token: Optional[str] = Header(default=None, alias="X-Session-Token"),
+) -> Optional[str]:
+    """SEC-08：从请求头提取匿名会话的 owner_token。
+
+    匿名会话（user_id=NULL）在首次创建时由服务端签发 owner_token，前端在后续
+    请求里通过 `X-Session-Token` 头回传。认证会话忽略此值。
+    """
+    return x_session_token
 
 
 def get_engine() -> ChatEngine:
@@ -71,6 +82,8 @@ class ChatResponse(BaseModel):
     """聊天响应"""
     session_id: str
     content: str
+    # SEC-08：新建匿名会话时由服务端签发，前端需存储并在后续请求头里回传。
+    owner_token: Optional[str] = None
 
 
 @router.post("/completions", response_model=ChatResponse)
@@ -182,11 +195,17 @@ async def list_sessions(
 
 
 @router.get("/sessions/{session_id}")
-async def get_session_detail(session_id: str, _user: dict = Depends(get_current_user_optional)):
-    """获取会话详情（只读）— 受所有权检查保护（A2）。"""
+async def get_session_detail(
+    session_id: str,
+    _user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
+):
+    """获取会话详情（只读）— 受所有权检查保护（A2 + SEC-08）。"""
     user_id = _user.get("user_id")
     async with async_db_session() as db:
-        conv = await AsyncHistoryService(db).get_session(session_id, user_id=user_id)
+        conv = await AsyncHistoryService(db).get_session(
+            session_id, user_id=user_id, owner_token=owner_token
+        )
         if not conv:
             raise HTTPException(status_code=404, detail="Session not found")
         return {
@@ -211,15 +230,19 @@ async def get_session_detail(session_id: str, _user: dict = Depends(get_current_
 async def get_session_map_state(
     session_id: str,
     _user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
 ):
     """Return persisted map state (viewport, layers) for session restoration.
 
     审计 S31：之前 _user 注入但未做所有权校验 —— 任何认证用户知道 session_id
     就能读取他人的 viewport/layers。复用 get_session_detail 的同款检查。
+    SEC-08：匿名会话需匹配 owner_token。
     """
     user_id = _user.get("user_id")
     async with async_db_session() as db:
-        conv = await AsyncHistoryService(db).get_session(session_id, user_id=user_id)
+        conv = await AsyncHistoryService(db).get_session(
+            session_id, user_id=user_id, owner_token=owner_token
+        )
         if not conv:
             raise HTTPException(status_code=404, detail="Session not found")
     from app.services.session_data import session_data_manager
@@ -238,14 +261,18 @@ async def push_session_map_state(
     session_id: str,
     req: MapStatePushRequest,
     _user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
 ):
     """Persist live map state pushed by the frontend during agent execution.
 
     审计 S31：同 get_session_map_state，跨租户写入必须拒绝。
+    SEC-08：匿名会话需匹配 owner_token。
     """
     user_id = _user.get("user_id")
     async with async_db_session() as db:
-        conv = await AsyncHistoryService(db).get_session(session_id, user_id=user_id)
+        conv = await AsyncHistoryService(db).get_session(
+            session_id, user_id=user_id, owner_token=owner_token
+        )
         if not conv:
             raise HTTPException(status_code=404, detail="Session not found")
     from app.services.session_data import session_data_manager
@@ -265,14 +292,20 @@ async def list_skills_api(_user: dict = Depends(get_current_user_optional)):
 
 
 @router.delete("/sessions/{session_id}")
-async def clear_session(session_id: str, _user: dict = Depends(get_current_user_optional)):
-    """清除会话（内存 + DB）— 受所有权检查保护（A2）。"""
+async def clear_session(
+    session_id: str,
+    _user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
+):
+    """清除会话（内存 + DB）— 受所有权检查保护（A2 + SEC-08）。"""
     user_id = _user.get("user_id")
 
     # Pi session clear deferred: abort() semantics + file-based session cleanup
     # not yet verified. Legacy engine clears DB + memory below.
 
-    ok = await get_engine().clear_session(session_id, user_id=user_id)
+    ok = await get_engine().clear_session(
+        session_id, user_id=user_id, owner_token=owner_token
+    )
     if not ok:
         raise HTTPException(status_code=404, detail="Session not found")
     return {"status": "ok"}

--- a/app/api/routes/layer.py
+++ b/app/api/routes/layer.py
@@ -7,7 +7,9 @@
 - 空间分析任务端点已移除 — Agent 通过 tool calling 驱动分析，不再走 REST CRUD。
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 
 from app.services.session_data import session_data_manager
 from app.services.history_service_async import AsyncHistoryService
@@ -18,14 +20,21 @@ from app.core.auth import get_current_user_optional
 router = APIRouter()
 
 
-async def _verify_session_owner(session_id: str, user_id) -> None:
+async def _verify_session_owner(
+    session_id: str,
+    user_id,
+    owner_token: Optional[str] = None,
+) -> None:
     """跨租户隔离守卫：session_id 必须属于 user_id（或为旧匿名记录）。
 
     审计 S31/S32：所有按 session_id 读取的路由必须先过此关，否则用户 A
     可以通过猜/枚举 session_id 读取用户 B 的分析输出（GeoJSON 常含真实坐标 / PII）。
+    SEC-08：匿名会话若设置了 owner_token，调用方必须提供匹配值。
     """
     async with async_db_session() as db:
-        conv = await AsyncHistoryService(db).get_session(session_id, user_id=user_id)
+        conv = await AsyncHistoryService(db).get_session(
+            session_id, user_id=user_id, owner_token=owner_token
+        )
         if not conv:
             raise HTTPException(status_code=404, detail="Session not found")
 
@@ -35,12 +44,14 @@ async def get_session_layer_data(
     ref_id: str,
     session_id: str = Query(..., min_length=8, max_length=128, description="会话 ID"),
     _user: dict = Depends(get_current_user_optional),
+    x_session_token: Optional[str] = Header(default=None, alias="X-Session-Token"),
 ):
     """通过引用 ID 获取会话缓存中的大数据对象（如分析产生的 GeoJSON）。"""
     if not ref_id or len(ref_id) > 128 or any(c.isspace() for c in ref_id):
         raise HTTPException(status_code=400, detail="非法 ref_id")
     # 审计 S32：先校验 session 归属，再读 session 内的数据。
-    await _verify_session_owner(session_id, _user.get("user_id"))
+    # SEC-08：匿名会话需匹配 X-Session-Token。
+    await _verify_session_owner(session_id, _user.get("user_id"), x_session_token)
     data = await session_data_manager.get(session_id, ref_id)
     if not data:
         raise HTTPException(status_code=404, detail="数据已过期或不存在")

--- a/app/api/routes/ws.py
+++ b/app/api/routes/ws.py
@@ -1,3 +1,14 @@
+"""WebSocket endpoint for real-time GIS data updates.
+
+审计 SEC-03：之前 WS 端点完全无认证 + 无 session 所有权校验 —— 任意客户端
+知道 session_id 就能连接并写入他人的 map state（layer toggle/remove/snapshot）。
+
+现在：1) 要求合法 access token；2) 校验 session 属于该用户；3) rate limit
+keyed on client IP 而非 session_id（攻击者无法通过轮换 session_id 绕过）。
+
+WS 感知通道在前端是死代码（useWebSocket 从未挂载），所以收紧认证不会破坏
+任何活跃功能。
+"""
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
 import logging
 
@@ -9,12 +20,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/ws", tags=["WebSocket"])
 
-# 审计 P0：WebSocket 认证修复
-# 之前 `if token:` 对空字符串也为 falsy，导致 `?token=` 完全绕过认证。
-# 使用 sentinel 区分「未提供 token」（允许匿名）和「提供了空 token」（拒绝）。
-_UNSET = object()
-
-# WebSocket 连接频率限制：每 session 每 60 秒最多 5 次连接尝试
 _WS_RATE_LIMIT_MAX = 5
 _WS_RATE_LIMIT_WINDOW = 60
 
@@ -25,28 +30,58 @@ async def websocket_endpoint(
     session_id: str,
     token: str = Query(default=""),
 ):
-    """WebSocket endpoint for real-time GIS data updates and bidirectional perception.
+    """WebSocket endpoint — requires valid access token + session ownership.
 
-    Auth 是 optional：带合法 token 时验证放行；不带 token 参数允许匿名连接。
-    但显式传递空 token（?token=）会被拒绝，防止绕过认证守卫。
-    匿名连接受 rate limit 保护（每 session 每 60 秒最多 5 次连接）。
+    审计 SEC-03：
+    - 必须提供合法 access token（不再允许匿名连接）
+    - session_id 必须属于 token 中的 user（防 IDOR）
+    - rate limit per client IP（不是 per session_id）
     """
-    # 审计 P1：WebSocket 连接频率限制，防止匿名连接被滥用
+    # Rate limit per client IP
+    client_ip = websocket.client.host if websocket.client else "unknown"
     limiter = await get_rate_limiter()
-    rate_key = f"ws_connect:{session_id}"
-    if not await limiter.is_allowed(rate_key, _WS_RATE_LIMIT_MAX, _WS_RATE_LIMIT_WINDOW):
+    if not await limiter.is_allowed(
+        f"ws_connect:{client_ip}", _WS_RATE_LIMIT_MAX, _WS_RATE_LIMIT_WINDOW
+    ):
         await websocket.close(code=4029, reason="Rate limit exceeded")
         return
 
-    # 审计 P0：用 sentinel 区分「参数不存在」和「显式空字符串」
-    raw_token = token if token else _UNSET
+    # SEC-03: 必须有合法 access token
+    if not token:
+        await websocket.close(code=4001, reason="Access token required")
+        return
 
-    if raw_token is not _UNSET:
-        # 提供了 token（哪怕是空的）— 必须有效
-        payload = verify_token(raw_token)
-        if payload is None:
-            await websocket.close(code=4001, reason="Invalid token")
+    payload = verify_token(token)
+    if payload is None:
+        await websocket.close(code=4001, reason="Invalid token")
+        return
+
+    # 拒绝 refresh token 被当 access 用
+    tok_type = payload.get("type")
+    if tok_type is not None and tok_type != "access":
+        await websocket.close(code=4001, reason="Wrong token type")
+        return
+
+    user_id = payload.get("sub")
+    if not user_id:
+        await websocket.close(code=4001, reason="Invalid token payload")
+        return
+
+    # SEC-03: 校验 session 所有权
+    from app.tools._utils import async_db_session
+    from app.services.history_service_async import AsyncHistoryService
+
+    try:
+        async with async_db_session() as db:
+            conv = await AsyncHistoryService(db).get_session(session_id, user_id)
+        if conv is None:
+            await websocket.close(code=4003, reason="Session not found or not owned by user")
             return
+    except Exception as e:
+        logger.error(f"WS session ownership check failed for {session_id}: {e}")
+        # DB 不可用时拒绝连接（fail-closed）
+        await websocket.close(code=4500, reason="Internal error during session validation")
+        return
 
     await manager.connect(websocket, session_id)
     try:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -248,5 +248,39 @@ class Settings(BaseSettings):
                         f"{field}='{url}' uses blocked domain pattern '{pat}'."
                     )
 
+            # 审计 SEC-07：DNS 解析 — 阻止域名解析到私有 IP。
+            # 之前只做字符串模式匹配，攻击者可用解析到 169.254.169.254 的域名绕过。
+            # 注意：这是静态检查（validate 时解析一次）。真正的 DNS rebinding TOCTOU
+            # 需在 HTTP client 层 pin IP（aiohttp custom connector），是独立大工作。
+            import socket
+            try:
+                infos = socket.getaddrinfo(hostname, None)
+                for family, _, _, _, sockaddr in infos:
+                    ip_str = sockaddr[0]
+                    try:
+                        resolved_ip = ipaddress.ip_address(ip_str)
+                    except ValueError:
+                        continue
+                    if (
+                        resolved_ip.is_private
+                        or resolved_ip.is_loopback
+                        or resolved_ip.is_link_local
+                        or resolved_ip.is_reserved
+                        or resolved_ip.is_multicast
+                    ):
+                        raise ValueError(
+                            f"{field}='{url}' hostname '{hostname}' resolves to "
+                            f"private/reserved IP {resolved_ip}. Blocked (SSRF)."
+                        )
+            except socket.gaierror:
+                # DNS 解析失败 — 不阻断（可能是开发环境临时域名），
+                # 但 log warning 让运维知道。
+                import logging
+                logging.getLogger(__name__).warning(
+                    "SEC-07: DNS resolution failed for %s in %s — "
+                    "cannot verify SSRF safety, allowing with warning",
+                    hostname, field,
+                )
+
 
 settings = Settings()

--- a/app/models/db_model.py
+++ b/app/models/db_model.py
@@ -155,6 +155,11 @@ class Conversation(Base):
     # Nullable：兼容历史匿名会话；新认证会话写入 users.id；查询时按 owner 过滤
     user_id = Column(String(255), ForeignKey("users.id"), nullable=True, index=True)
     title = Column(String(200), default="新对话")
+    # SEC-08：匿名会话的 owner_token。仅新建的匿名会话会生成（非 NULL）。
+    # NULL = grandfather（旧匿名会话，知道 session_id 即能力令牌）。
+    # 认证会话从不依赖此列。访问带 token 的匿名会话需通过 X-Session-Token
+    # 提供匹配值（见 history_service_async.get_session）。
+    owner_token = Column(String(64), nullable=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/services/chat_engine.py
+++ b/app/services/chat_engine.py
@@ -79,6 +79,11 @@ class ChatEngine:
         # 超限时清理最旧的（按 dict 插入顺序，Python 3.7+ 保证有序）。
         self._session_locks: dict[str, asyncio.Lock] = {}
         self._MAX_LOCKS = 200
+        # SEC-08：缓存首次加载会话时读到的 owner_token（仅匿名新会话非 None）。
+        # 路由层通过 get_session_owner_token() 读取并回传给前端。
+        # 与 _sessions 解耦：_sessions 是 LRU 会被 evict，但 token 一旦发出就
+        # 不再变化，前端只需在会话首次创建时拿到一次。
+        self._session_owner_tokens: dict[str, str] = {}
 
     def _select_tools(self, session_id: Optional[str], messages: list[dict]) -> Optional[list[dict]]:
         """选出本轮要推给 LLM 的工具 schema 列表。
@@ -183,6 +188,10 @@ class ChatEngine:
         try:
             async with async_db_session() as db:
                 conv = await AsyncHistoryService(db).get_or_create_conversation(session_id, user_id=user_id)
+                # SEC-08：缓存匿名会话的 owner_token，供路由层在创建时回传给前端。
+                # 仅在尚未缓存时写入（token 首次创建后不变）；认证会话 token 为 None 不缓存。
+                if conv is not None and conv.owner_token and session_id not in self._session_owner_tokens:
+                    self._session_owner_tokens[session_id] = conv.owner_token
                 if conv and conv.messages:
                     sorted_msgs = sorted(conv.messages, key=lambda x: x.id)
                     history_messages = [self._db_msg_to_llm(m) for m in sorted_msgs]
@@ -194,6 +203,14 @@ class ChatEngine:
             history_messages.insert(0, {"role": "system", "content": self._build_system_prompt()})
 
         return history_messages
+
+    def get_session_owner_token(self, session_id: str) -> Optional[str]:
+        """SEC-08：取出并为调用方消费该会话的 owner_token（一次性）。
+
+        路由在创建/首次访问匿名会话时调用，把 token 回传给前端。取出后即清掉缓存，
+        避免同一 token 在后续请求里被重复泄漏（前端拿到一次后会自己存储）。
+        """
+        return self._session_owner_tokens.pop(session_id, None)
 
     # M1 深水区：上下文组装委托给 chat/context_builder.py（纯函数，方便单测）
     def _get_map_state_summary(self, session_id: str) -> str:
@@ -454,12 +471,16 @@ class ChatEngine:
         # 发起的任务在 /tasks 端点不可见，也无法 cancel。注册一个 task 让它可见。
         task = self.tracker.create(session_id, message)
 
+        # SEC-08：若本次创建了新的匿名会话，取出 owner_token 随响应回传给前端。
+        # get_session_owner_token 是一次性消费（取出即清缓存），故在循环外取一次。
+        owner_token = self.get_session_owner_token(session_id)
+
         # FC 循环
         try:
             for _ in range(self.max_rounds):
                 # 审计 M4：cooperative cancel 检查（与 chat_stream 一致）
                 if self.tracker.is_cancelled(task.id):
-                    return {"session_id": session_id, "content": "任务已取消"}
+                    return {"session_id": session_id, "content": "任务已取消", **({"owner_token": owner_token} if owner_token else {})}
 
                 messages_with_context = await self._compose_request_messages(session_id, messages)
 
@@ -537,10 +558,10 @@ class ChatEngine:
                     messages.append(entry)
                     await self._save_msg_async(session_id, "assistant", content, reasoning_content=reasoning)
                     self.tracker.complete_task(task.id)
-                    return {"session_id": session_id, "content": content, "reasoning": reasoning}
+                    return {"session_id": session_id, "content": content, "reasoning": reasoning, **({"owner_token": owner_token} if owner_token else {})}
 
             self.tracker.complete_task(task.id)
-            return {"content": "达到最大工具调用轮数", "session_id": session_id}
+            return {"content": "达到最大工具调用轮数", "session_id": session_id, **({"owner_token": owner_token} if owner_token else {})}
         except (asyncio.CancelledError, GeneratorExit):
             # BUG-07: CancelledError inherits BaseException (not Exception), so the
             # broad `except Exception` below wouldn't catch a client disconnect /
@@ -572,7 +593,13 @@ class ChatEngine:
 
         # 创建任务
         task = self.tracker.create(session_id, message)
-        yield sse_event("task_start", {"task_id": task.id, "session_id": session_id})
+        # SEC-08：若本次创建了新的匿名会话，把 owner_token 随 task_start 事件
+        # 回传给前端（一次性消费）。前端在收到后存入 ref，后续请求附在头里。
+        owner_token = self.get_session_owner_token(session_id)
+        task_start_data = {"task_id": task.id, "session_id": session_id}
+        if owner_token:
+            task_start_data["owner_token"] = owner_token
+        yield sse_event("task_start", task_start_data)
 
         plan = await self._maybe_plan(session_id, message, messages)
         try:
@@ -834,8 +861,13 @@ class ChatEngine:
             fire_broadcast=_broadcast,
         )
 
-    async def clear_session(self, session_id: str, user_id: Optional[str] = None) -> bool:
-        """删除会话；user_id 用于所有权检查（A2）。
+    async def clear_session(
+        self,
+        session_id: str,
+        user_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
+    ) -> bool:
+        """删除会话；user_id 用于所有权检查（A2），owner_token 用于 SEC-08。
 
         返回是否真的删除：False = 不存在或越权（让路由层映射成 404）。
         匿名调用 / NULL owner 仍走旧能力令牌语义。
@@ -843,7 +875,9 @@ class ChatEngine:
         deleted = False
         try:
             async with async_db_session() as db:
-                deleted = await AsyncHistoryService(db).delete_session(session_id, user_id=user_id)
+                deleted = await AsyncHistoryService(db).delete_session(
+                    session_id, user_id=user_id, owner_token=owner_token
+                )
         except Exception as e:
             logger.warning(f"History: failed to delete session {session_id}: {e}")
             return False
@@ -851,6 +885,8 @@ class ChatEngine:
             if session_id in self._sessions:
                 del self._sessions[session_id]
             self._session_locks.pop(session_id, None)
+            # SEC-08：同步清理 owner_token 缓存。
+            self._session_owner_tokens.pop(session_id, None)
             await session_data_manager.clear_session(session_id)
             from app.services.chat import planner
             planner.clear_plan(session_id)

--- a/app/services/history_service_async.py
+++ b/app/services/history_service_async.py
@@ -5,12 +5,19 @@
   匿名访问保持 NULL（与现有数据兼容）。
 - `list_sessions(user_id)` 仅返回该用户的会话；user_id=None 视为匿名调用方，
   返回空（匿名用户没有列表入口，会话只能凭 session_id 直访）。
-- `get_session(session_id, user_id)` / `delete_session(session_id, user_id)`：
-  - 会话 user_id 为 NULL → 允许（旧匿名记录，知道 session_id 即能力令牌）
-  - 会话 user_id == 调用方 user_id → 允许
+- `get_session(session_id, user_id, owner_token)` / `delete_session(session_id, user_id)`：
+  - 认证会话 user_id 已绑定：仅原用户可见
+  - 匿名会话 user_id IS NULL 且 owner_token IS NULL → grandfather 旧记录，允许
+  - 匿名会话 user_id IS NULL 且 owner_token 已设置 → 调用方必须提供匹配的
+    owner_token（SEC-08），否则视为不存在
   - 否则返回 None / 静默忽略，**统一 404 风格**避免泄露存在性。
+
+SEC-08：新建的匿名会话会生成 server-issued `owner_token`（secrets.token_urlsafe(32)）。
+前端必须在后续请求的 `X-Session-Token` 头里回传该 token 才能访问该会话。
+认证会话与历史匿名会话（token 为 NULL）不受影响。
 """
 import logging
+import secrets
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -41,6 +48,9 @@ class AsyncHistoryService:
     ) -> Conversation:
         import anyio
         owner = None if _is_anonymous(user_id) else user_id
+        # SEC-08：新建匿名会话时生成 owner_token。认证会话（owner 非空）不需要。
+        # token 写入 owner_token 列；调用方通过 conv.owner_token 读取并回传给前端。
+        new_owner_token = secrets.token_urlsafe(32) if owner is None else None
         for attempt in range(3):
             try:
                 stmt = select(Conversation).where(Conversation.id == session_id).options(selectinload(Conversation.messages))
@@ -52,6 +62,7 @@ class AsyncHistoryService:
                 conv = Conversation(
                     id=session_id,
                     user_id=owner,
+                    owner_token=new_owner_token,
                     title="新对话",
                     created_at=datetime.now(timezone.utc),
                     updated_at=datetime.now(timezone.utc),
@@ -134,11 +145,15 @@ class AsyncHistoryService:
         self,
         session_id: str,
         user_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
     ) -> Optional[Conversation]:
         """带所有权检查的会话取回。
 
-        - 会话 user_id IS NULL：视为旧匿名记录，知道 session_id 即可访问
-        - 会话 user_id 已绑定：仅原用户可见
+        - 会话 user_id 已绑定：仅原用户可见（认证用户校验）
+        - 会话 user_id IS NULL（匿名会话）：
+          - owner_token IS NULL：grandfather 旧记录，知道 session_id 即可访问
+          - owner_token 已设置：调用方必须提供匹配的 owner_token（SEC-08），
+            否则视为不存在（防止 session_id 泄漏后被任意人读取）
         - 不存在或越权：均返回 None（统一处理为 404，避免存在性泄露）
         """
         stmt = select(Conversation).where(Conversation.id == session_id).options(selectinload(Conversation.messages))
@@ -147,6 +162,12 @@ class AsyncHistoryService:
         if conv is None:
             return None
         if conv.user_id is None:
+            # SEC-08：匿名会话。若 owner_token 已设置则要求调用方提供匹配值；
+            # 使用 hmac.compare_digest 做常量时间比较以防时序侧信道。
+            if conv.owner_token is not None:
+                import hmac
+                if not owner_token or not hmac.compare_digest(conv.owner_token, owner_token):
+                    return None
             return conv
         if _is_anonymous(user_id):
             return None
@@ -158,6 +179,7 @@ class AsyncHistoryService:
         self,
         session_id: str,
         user_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
     ) -> bool:
         """所有权检查后删除；返回是否真正删除（用于路由层决定 404 vs 204）。"""
         conv = await self.db.get(Conversation, session_id)
@@ -166,6 +188,13 @@ class AsyncHistoryService:
         if conv.user_id is not None:
             if _is_anonymous(user_id) or conv.user_id != user_id:
                 return False
+        else:
+            # SEC-08：匿名会话删除同样受 owner_token 保护（与 get_session 对齐）。
+            # owner_token 为 NULL 的旧记录 grandfather 放行。
+            if conv.owner_token is not None:
+                import hmac
+                if not owner_token or not hmac.compare_digest(conv.owner_token, owner_token):
+                    return False
         await self.db.delete(conv)
         await self.db.commit()
         return True

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -65,6 +65,7 @@ export default function Home() {
     sessionId,
     setSessionId,
     sessionIdRef,
+    sessionTokenRef,
     sessions,
     selectSession,
     startNewSession,
@@ -92,7 +93,8 @@ export default function Home() {
     sessionIdRef,
     dispatchAction,
     getMapSnapshot,
-    userLocation
+    userLocation,
+    sessionTokenRef
   );
 
   const handleSelectSession = useCallback(

--- a/frontend/lib/api/chat.test.ts
+++ b/frontend/lib/api/chat.test.ts
@@ -67,13 +67,33 @@ describe('Chat API', () => {
       await deleteSession('s1');
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('/api/v1/chat/sessions/s1'),
-        { method: 'DELETE' }
+        expect.objectContaining({ method: 'DELETE' })
       );
     });
 
     it('throws on non-ok response', async () => {
       mockFetch.mockResolvedValueOnce({ ok: false, status: 403 });
       await expect(deleteSession('s1')).rejects.toThrow('API Error: 403');
+    });
+
+    // SEC-08: owner_token (when provided) is sent via X-Session-Token header.
+    it('includes X-Session-Token header when ownerToken is provided', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      await deleteSession('s1', 'tok-123');
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/chat/sessions/s1'),
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: { 'X-Session-Token': 'tok-123' },
+        })
+      );
+    });
+
+    it('omits X-Session-Token header when ownerToken is absent', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      await deleteSession('s1');
+      const callArgs = mockFetch.mock.calls[0][1];
+      expect(callArgs.headers).toEqual({});
     });
   });
 

--- a/frontend/lib/api/chat.ts
+++ b/frontend/lib/api/chat.ts
@@ -53,17 +53,24 @@ export interface SSEEvent {
 
 /**
  * 发送流式对话请求，返回 AsyncGenerator
+ *
+ * SEC-08：ownerToken 仅在匿名会话首次创建后由前端持有；提供时附在
+ * `X-Session-Token` 头里回传，后端据此放行该匿名会话的访问。
  */
 export async function* streamChat(
   message: string,
   sessionId?: string,
   mapState?: Record<string, unknown>,
   signal?: AbortSignal,
-  skillName?: string
+  skillName?: string,
+  ownerToken?: string | null
 ): AsyncGenerator<SSEEvent> {
   const response = await fetch(`${API_BASE}/api/v1/chat/stream`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(ownerToken ? { "X-Session-Token": ownerToken } : {}),
+    },
     body: JSON.stringify({
       message,
       session_id: sessionId,
@@ -141,15 +148,22 @@ export async function* streamChat(
 
 /**
  * 非流式对话
+ *
+ * SEC-08：ownerToken 用于匿名会话回传；提供时附在 X-Session-Token 头。
+ * 响应可能含 owner_token（新建匿名会话时由服务端签发），调用方需存储。
  */
 export async function sendChat(
   message: string,
   sessionId?: string,
-  mapState?: Record<string, unknown>
-): Promise<{ content: string; session_id: string }> {
+  mapState?: Record<string, unknown>,
+  ownerToken?: string | null
+): Promise<{ content: string; session_id: string; owner_token?: string }> {
   const response = await fetch(`${API_BASE}/api/v1/chat/completions`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(ownerToken ? { "X-Session-Token": ownerToken } : {}),
+    },
     body: JSON.stringify({ message, session_id: sessionId, map_state: mapState }),
   });
 
@@ -171,19 +185,26 @@ export async function getSessionList() {
 
 /**
  * 获取会话详细内容
+ *
+ * SEC-08：匿名会话需提供 ownerToken 匹配 X-Session-Token 头。
  */
-export async function getSessionDetail(sessionId: string) {
-  const res = await fetch(`${API_BASE}/api/v1/chat/sessions/${sessionId}`);
+export async function getSessionDetail(sessionId: string, ownerToken?: string | null) {
+  const res = await fetch(`${API_BASE}/api/v1/chat/sessions/${sessionId}`, {
+    headers: ownerToken ? { "X-Session-Token": ownerToken } : {},
+  });
   if (!res.ok) throw new Error(`API Error: ${res.status}`);
   return res.json();
 }
 
 /**
  * 删除会话
+ *
+ * SEC-08：匿名会话需提供 ownerToken 匹配 X-Session-Token 头。
  */
-export async function deleteSession(sessionId: string): Promise<void> {
+export async function deleteSession(sessionId: string, ownerToken?: string | null): Promise<void> {
   const res = await fetch(`${API_BASE}/api/v1/chat/sessions/${sessionId}`, {
     method: "DELETE",
+    headers: ownerToken ? { "X-Session-Token": ownerToken } : {},
   });
   if (!res.ok) throw new Error(`API Error: ${res.status}`);
 }

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -18,7 +18,8 @@ export function useSSEStream(
   sessionIdRef: React.MutableRefObject<string | undefined>,
   dispatchAction: (act: MapActionPayload) => void,
   getMapSnapshot: () => any,
-  userLocation: { lng: number; lat: number; accuracy?: number } | null
+  userLocation: { lng: number; lat: number; accuracy?: number } | null,
+  sessionTokenRef: React.MutableRefObject<string | null>
 ) {
   const [messages, setMessages] = useState<
     Array<{
@@ -83,6 +84,12 @@ export function useSSEStream(
       if (data?.session_id && data.session_id !== sessionIdRef.current) {
         setSessionId(data.session_id);
         sessionIdRef.current = data.session_id;
+      }
+
+      // SEC-08：服务端在新建匿名会话时签发 owner_token（随 task_start / session 事件下发）。
+      // 前端持有后在后续请求的 X-Session-Token 头里回传。认证会话不携带该字段。
+      if (data?.owner_token && typeof data.owner_token === 'string') {
+        sessionTokenRef.current = data.owner_token;
       }
 
       const thinkingId = thinkingMsgIdRef.current;
@@ -171,8 +178,11 @@ export function useSSEStream(
           if (data.geojson_ref) {
             const sid = sessionIdRef.current;
             const fetchRef = data.geojson_ref;
+            // SEC-08：匿名会话的图层引用数据受 owner_token 保护。
+            const token = sessionTokenRef.current;
             fetch(`${API_BASE}/api/v1/layers/data/${fetchRef}?session_id=${sid}`, {
               signal: layerFetchAbortRef.current?.signal,
+              headers: token ? { 'X-Session-Token': token } : {},
             })
               .then((r) => (r.ok ? r.json() : null))
               .then((geojson) => {
@@ -297,10 +307,10 @@ export function useSSEStream(
         });
       }
     },
-    [parseThink, setSessionId, sessionIdRef]
+    [parseThink, setSessionId, sessionIdRef, sessionTokenRef]
   );
 
-  const bridge = useMapBridge(sessionId, dispatchAction, onEvent);
+  const bridge = useMapBridge(sessionId, dispatchAction, onEvent, sessionTokenRef);
   const isLoading = bridge.aiStatus === 'thinking' || bridge.aiStatus === 'acting';
 
   const handlePlanAction = useCallback((planId: string, action: 'approve' | 'revise' | 'reject') => {

--- a/frontend/lib/hooks/use-workspace-session.ts
+++ b/frontend/lib/hooks/use-workspace-session.ts
@@ -11,6 +11,9 @@ import { devOnly } from "@/lib/utils/logger";
 export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) => void) {
   const [sessionId, setSessionId] = useState<string>();
   const sessionIdRef = useRef<string | undefined>(undefined);
+  // SEC-08：匿名会话的 owner_token。服务端在新建匿名会话时签发，前端持有并在
+  // 后续请求的 X-Session-Token 头里回传。认证会话 / 旧匿名会话该 ref 为 null。
+  const sessionTokenRef = useRef<string | null>(null);
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const sessionLoadAbortRef = useRef<AbortController | null>(null);
 
@@ -79,8 +82,14 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
       // 仍是旧值 -> 若用户在窗口内点 send，消息会发到旧 session。改为同步先 set。
       setSessionId(sid);
       sessionIdRef.current = sid;
+      // SEC-08：切回某个会话时，前端通常仍持有该会话的 token（同一浏览器会话内）。
+      // 旧会话 / 认证会话 token 为 null，头不发送，后端按 grandfather/认证放行。
+      const token = sessionTokenRef.current;
       try {
-        const res = await fetch(`${API_BASE}/api/v1/chat/sessions/${sid}`, { signal });
+        const res = await fetch(`${API_BASE}/api/v1/chat/sessions/${sid}`, {
+          signal,
+          headers: token ? { 'X-Session-Token': token } : {},
+        });
         const data = await res.json();
         if (signal.aborted) return;
 
@@ -102,7 +111,10 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
 
         // setSessionId 已在函数开头同步调用（审计 F38），这里不再重复
 
-        const stateRes = await fetch(`${API_BASE}/api/v1/chat/sessions/${sid}/map-state`, { signal });
+        const stateRes = await fetch(`${API_BASE}/api/v1/chat/sessions/${sid}/map-state`, {
+          signal,
+          headers: token ? { 'X-Session-Token': token } : {},
+        });
         if (signal.aborted) return;
         if (stateRes.ok) {
           const stateData = await stateRes.json();
@@ -123,7 +135,11 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
             if (state.base_layer) store.setBaseLayer(state.base_layer);
             for (const layer of state.layers || []) {
               if (layer._refId && layer._refId.startsWith('ref:')) {
-                fetch(`${API_BASE}/api/v1/layers/data/${layer._refId}?session_id=${sid}`, { signal })
+                // SEC-08：匿名会话的图层引用数据同样受 owner_token 保护。
+                fetch(`${API_BASE}/api/v1/layers/data/${layer._refId}?session_id=${sid}`, {
+                  signal,
+                  headers: token ? { 'X-Session-Token': token } : {},
+                })
                   .then((r) => (r.ok ? r.json() : null))
                   .then((geojson) => {
                     if (signal.aborted) return;
@@ -158,6 +174,8 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
   const startNewSession = useCallback(
     (onClearMessages: () => void) => {
       setSessionId(undefined);
+      // SEC-08：新会话清掉旧 token；新匿名会话创建后由 SSE 响应重新填充。
+      sessionTokenRef.current = null;
       // 审计 F20：同 selectSession，新会话必须重置跨会话状态。
       clearLayers();
       clearAnnotations();
@@ -177,6 +195,10 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
     sessionId,
     setSessionId,
     sessionIdRef,
+    // SEC-08：暴露 token ref + 设置器。useSSEStream 在收到新会话的 owner_token
+    // 时写入；其它调用方只读（getSessionToken）。
+    sessionTokenRef,
+    getSessionToken: () => sessionTokenRef.current,
     sessions,
     setSessions,
     refreshSessions,

--- a/frontend/lib/hooks/useMapBridge.test.ts
+++ b/frontend/lib/hooks/useMapBridge.test.ts
@@ -48,7 +48,7 @@ describe('useMapBridge', () => {
       await result.current.send('hello', {});
     });
     expect(mockStreamChat).toHaveBeenCalledWith(
-      'hello', undefined, {}, expect.any(AbortSignal)
+      'hello', undefined, {}, expect.any(AbortSignal), undefined, null
     );
   });
 
@@ -61,7 +61,7 @@ describe('useMapBridge', () => {
       await result.current.send('hello', { zoom: 10 });
     });
     expect(mockStreamChat).toHaveBeenCalledWith(
-      'hello', 'sid-123', { zoom: 10 }, expect.any(AbortSignal)
+      'hello', 'sid-123', { zoom: 10 }, expect.any(AbortSignal), undefined, null
     );
   });
 

--- a/frontend/lib/hooks/useMapBridge.ts
+++ b/frontend/lib/hooks/useMapBridge.ts
@@ -32,6 +32,7 @@ export function useMapBridge(
   sessionId: string | undefined,
   dispatchAction: (action: MapActionPayload) => void,
   onEvent: (event: SSEEvent) => void,
+  sessionTokenRef?: React.MutableRefObject<string | null>,
 ): {
   aiStatus: AiStatus;
   send: (content: string, mapSnapshot: Record<string, unknown>) => Promise<void>;
@@ -78,7 +79,8 @@ export function useMapBridge(
       setAiStatus('thinking');
 
       try {
-        for await (const event of streamChat(content, sessionId, mapSnapshot, controller.signal)) {
+        // SEC-08：把当前持有的 owner_token 附在请求头，匿名会话后端据此放行。
+        for await (const event of streamChat(content, sessionId, mapSnapshot, controller.signal, undefined, sessionTokenRef?.current ?? null)) {
           if (controller.signal.aborted) break;
 
           // Skip unparseable data — streamChat yields raw string on JSON.parse failure
@@ -162,7 +164,7 @@ export function useMapBridge(
         // If not the active controller, a new send() has taken over — leave aiStatus alone
       }
     },
-    [sessionId, dispatchAction, onEvent, setAiStatus]
+    [sessionId, dispatchAction, onEvent, setAiStatus, sessionTokenRef]
   );
 
   // [ENG-D3] useCallback([sessionId]) — stable ref so MapPanel's handleMove deps don't churn
@@ -173,13 +175,18 @@ export function useMapBridge(
       if (now - lastMapStatePushRef.current < MAP_STATE_THROTTLE_MS) return;
       lastMapStatePushRef.current = now;
       if (!sessionId) return;
+      // SEC-08：匿名会话的 map-state 写入同样受 owner_token 保护。
+      const token = sessionTokenRef?.current ?? null;
       fetch(`${API_BASE}/api/v1/chat/sessions/${sessionId}/map-state`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { 'X-Session-Token': token } : {}),
+        },
         body: JSON.stringify({ viewport: { center, zoom, bearing, pitch } }),
       }).catch((e) => devOnly.warn('[useMapBridge] map-state POST failed:', e));
     },
-    [sessionId]
+    [sessionId, sessionTokenRef]
   );
 
   // 审计 F25：返回对象用 useMemo 包裹，避免每次 render 都创建新对象引用

--- a/migrations/versions/6ef479051297_conversation_owner_token.py
+++ b/migrations/versions/6ef479051297_conversation_owner_token.py
@@ -1,0 +1,52 @@
+"""conversation owner_token column
+
+Revision ID: 6ef479051297
+Revises: f123456789ab
+Create Date: 2026-07-24
+
+SEC-08 - Anonymous session ownership:
+Anonymous conversations (user_id IS NULL) were world-readable: anyone who
+knew the session_id could read chat history, uploads, reports, and layer data.
+
+Add a server-issued `owner_token` to the `conversations` table. New anonymous
+sessions get a token generated via `secrets.token_urlsafe(32)`; access to such
+a session requires presenting the matching token via the `X-Session-Token`
+header.
+
+Back-compat:
+- The column is nullable. Existing rows (anonymous or not) have NULL.
+- A NULL owner_token is grandfathered: anonymous sessions created before this
+  deploy keep working without a token (knowing session_id remains a capability).
+- Authenticated sessions (user_id IS NOT NULL) are never gated by owner_token.
+- Only NEW anonymous sessions (created after this deploy) have the token set
+  and require it for anonymous access.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6ef479051297'
+down_revision: Union[str, Sequence[str], None] = 'f123456789ab'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add owner_token column to conversations."""
+    # batch_alter_table is required for SQLite (render_as_batch=True in env.py)
+    # and is a no-op wrapper on Postgres/MySQL.
+    with op.batch_alter_table('conversations', schema=None) as batch_op:
+        # nullable=True: grandfather existing rows (NULL = no token required).
+        # 64 chars comfortably holds secrets.token_urlsafe(32) (~43 chars).
+        batch_op.add_column(
+            sa.Column('owner_token', sa.String(length=64), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    """Drop owner_token column from conversations."""
+    with op.batch_alter_table('conversations', schema=None) as batch_op:
+        batch_op.drop_column('owner_token')

--- a/tests/test_chat_history_routes.py
+++ b/tests/test_chat_history_routes.py
@@ -80,5 +80,5 @@ def test_delete_session(client):
     with patch.object(_chat_mod, "engine", mock_engine):
         resp = client.delete(f"{BASE}/sessions/s1")
     assert resp.status_code == 200
-    # A2: 现在带 user_id kwarg
-    mock_engine.clear_session.assert_awaited_once_with("s1", user_id="anonymous")
+    # A2: 带 user_id kwarg；SEC-08: 带 owner_token kwarg（无头时为 None）
+    mock_engine.clear_session.assert_awaited_once_with("s1", user_id="anonymous", owner_token=None)

--- a/tests/test_layer_api.py
+++ b/tests/test_layer_api.py
@@ -11,7 +11,7 @@ from app.api.routes import layer as _mod
 def app(monkeypatch):
     """跨租户守卫 _verify_session_owner 在隔离测试里依赖真 DB；
     stub 成 always-pass（跨租户隔离由 test_cross_tenant_isolation 覆盖）。"""
-    async def _noop_verify(session_id, user_id):
+    async def _noop_verify(session_id, user_id, owner_token=None):
         return None
     monkeypatch.setattr(_mod, "_verify_session_owner", _noop_verify)
 

--- a/tests/test_sec08_session_owner_token.py
+++ b/tests/test_sec08_session_owner_token.py
@@ -1,0 +1,192 @@
+"""SEC-08: anonymous session ownership via owner_token.
+
+端到端验证（真路由 + 真 AsyncHistoryService + 临时 SQLite）：
+  - 新建匿名会话签发 owner_token
+  - 无 token / 错 token 访问匿名会话 → 404
+  - 正确 token 访问 → 200
+  - 旧匿名会话（owner_token IS NULL）grandfather 放行（向后兼容）
+  - 认证会话不受 owner_token 影响
+"""
+import os
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+# 必须在 import app.* 之前设置
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-sec08-32-chars-okxxxxx")
+os.environ.setdefault("ENV", "development")
+
+from app.models.db_model import Base, Conversation  # noqa: E402
+from app.core.database import get_async_db  # noqa: E402
+from app.tools import _utils  # noqa: E402
+from app.api.routes import chat as chat_routes  # noqa: E402
+from app.api.routes import layer as layer_routes  # noqa: E402
+from app.services.history_service_async import AsyncHistoryService  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def app_and_db(tmp_path, monkeypatch):
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'sec08.db'}"
+    test_engine = create_async_engine(db_url, connect_args={"check_same_thread": False})
+    test_session = async_sessionmaker(bind=test_engine, expire_on_commit=False)
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async def override_get_async_db():
+        async with test_session() as s:
+            yield s
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def override_async_db_session():
+        async with test_session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    monkeypatch.setattr(_utils, "async_db_session", override_async_db_session)
+    monkeypatch.setattr("app.api.routes.chat.async_db_session", override_async_db_session)
+    monkeypatch.setattr("app.api.routes.layer.async_db_session", override_async_db_session)
+
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(chat_routes.router, prefix="/api/v1")
+    app.include_router(layer_routes.router, prefix="/api/v1")
+    app.dependency_overrides[get_async_db] = override_get_async_db
+    try:
+        yield app, test_session
+    finally:
+        await test_engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(app_and_db):
+    app, _ = app_and_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def db(app_and_db):
+    _, session = app_and_db
+    async with session() as s:
+        yield s
+
+
+@pytest.mark.asyncio
+async def test_new_anon_session_404_without_token(client, db):
+    """新建匿名会话后，不带 X-Session-Token 访问详情 → 404。"""
+    async with db as session:
+        conv = await AsyncHistoryService(session).get_or_create_conversation(
+            "sec08-anon-1", user_id=None
+        )
+        assert conv.owner_token  # 签发了 token
+    resp = await client.get("/api/v1/chat/sessions/sec08-anon-1")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_new_anon_session_404_with_wrong_token(client, db):
+    """错 token → 404。"""
+    async with db as session:
+        await AsyncHistoryService(session).get_or_create_conversation(
+            "sec08-anon-2", user_id=None
+        )
+    resp = await client.get(
+        "/api/v1/chat/sessions/sec08-anon-2",
+        headers={"X-Session-Token": "totally-wrong"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_new_anon_session_200_with_correct_token(client, db):
+    """正确 token → 200。"""
+    async with db as session:
+        conv = await AsyncHistoryService(session).get_or_create_conversation(
+            "sec08-anon-3", user_id=None
+        )
+        token = conv.owner_token
+    resp = await client.get(
+        "/api/v1/chat/sessions/sec08-anon-3",
+        headers={"X-Session-Token": token},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "sec08-anon-3"
+
+
+@pytest.mark.asyncio
+async def test_grandfather_anon_session_accessible_without_token(client, db):
+    """owner_token IS NULL 的旧匿名会话仍可访问（向后兼容）。"""
+    async with db as session:
+        session.add(Conversation(id="sec08-legacy", user_id=None, owner_token=None, title="legacy"))
+        await session.commit()
+    resp = await client.get("/api/v1/chat/sessions/sec08-legacy")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_anon_session_delete_requires_token(client, db):
+    """删除匿名会话同样需要 owner_token。"""
+    async with db as session:
+        conv = await AsyncHistoryService(session).get_or_create_conversation(
+            "sec08-anon-del", user_id=None
+        )
+        token = conv.owner_token
+
+    # 引入一个最小 engine 让 DELETE 路由可用
+    from unittest.mock import AsyncMock
+    from app.api.routes import chat as chat_mod
+
+    class _StubEngine:
+        async def clear_session(self, sid, user_id=None, owner_token=None):
+            svc = AsyncHistoryService
+            return True
+
+    chat_mod.engine = _StubEngine()
+    try:
+        # 无 token → 404（stub clear_session 返回 False 经由真实 service）
+        # 这里直接验证带 token 的路径能调到 clear_session 并返回 200
+        resp = await client.delete(
+            "/api/v1/chat/sessions/sec08-anon-del",
+            headers={"X-Session-Token": token},
+        )
+        assert resp.status_code == 200
+    finally:
+        chat_mod.engine = None
+
+
+@pytest.mark.asyncio
+async def test_layer_data_requires_token_for_anon_session(client, db):
+    """匿名会话的图层引用数据同样受 owner_token 保护。"""
+    from unittest.mock import patch, AsyncMock
+    async with db as session:
+        conv = await AsyncHistoryService(session).get_or_create_conversation(
+            "sec08-anon-layer", user_id=None
+        )
+        token = conv.owner_token
+
+    sid = "sec08-anon-layer"
+    with patch(
+        "app.api.routes.layer.session_data_manager.get",
+        AsyncMock(return_value={"type": "FeatureCollection", "features": []}),
+    ):
+        # 无 token → 404
+        resp = await client.get(
+            f"/api/v1/layers/data/ref-1?session_id={sid}",
+        )
+        assert resp.status_code == 404
+        # 正确 token → 200
+        resp = await client.get(
+            f"/api/v1/layers/data/ref-1?session_id={sid}",
+            headers={"X-Session-Token": token},
+        )
+        assert resp.status_code == 200

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -21,9 +21,11 @@ async def session_factory(tmp_path):
     await eng.dispose()
 
 
-async def _seed_session(fac, session_id: str, owner: str | None) -> None:
+async def _seed_session(fac, session_id: str, owner: str | None) -> str | None:
+    """Seed a session. Returns the owner_token for new anonymous sessions (SEC-08)."""
     async with fac() as db:
-        await AsyncHistoryService(db).get_or_create_conversation(session_id, user_id=owner)
+        conv = await AsyncHistoryService(db).get_or_create_conversation(session_id, user_id=owner)
+        return conv.owner_token
 
 
 @pytest.mark.asyncio
@@ -66,13 +68,48 @@ async def test_get_session_allows_owner(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_anon_session_remains_accessible_to_anyone(session_factory):
-    """旧匿名记录靠 session_id 作能力令牌，谁知道 id 谁能读 — 保持兼容。"""
-    await _seed_session(session_factory, "s-legacy", None)
+async def test_grandfather_anon_session_without_token_remains_accessible(session_factory):
+    """SEC-08 grandfather：owner_token IS NULL 的旧匿名记录仍按能力令牌语义放行。"""
+    from app.models.db_model import Conversation
+    async with session_factory() as db:
+        db.add(Conversation(id="s-legacy", user_id=None, owner_token=None, title="legacy"))
+        await db.commit()
     async with session_factory() as db:
         svc = AsyncHistoryService(db)
+        # 无 token 也能访问（向后兼容）
         assert (await svc.get_session("s-legacy", user_id=None)) is not None
         assert (await svc.get_session("s-legacy", user_id="user-alice")) is not None
+
+
+@pytest.mark.asyncio
+async def test_new_anon_session_requires_owner_token(session_factory):
+    """SEC-08：新建匿名会话签发 owner_token；无 token / 错 token 拒绝（返回 None）。"""
+    token = await _seed_session(session_factory, "s-anon-new", None)
+    assert token is not None and len(token) >= 32
+
+    async with session_factory() as db:
+        svc = AsyncHistoryService(db)
+        # 无 token -> 拒绝
+        assert (await svc.get_session("s-anon-new", user_id=None)) is None
+        # 错 token -> 拒绝
+        assert (await svc.get_session("s-anon-new", user_id=None, owner_token="wrong")) is None
+        # 正确 token -> 放行
+        conv = await svc.get_session("s-anon-new", user_id=None, owner_token=token)
+        assert conv is not None and conv.id == "s-anon-new"
+
+
+@pytest.mark.asyncio
+async def test_new_anon_session_delete_requires_owner_token(session_factory):
+    """SEC-08：删除匿名会话同样受 owner_token 保护。"""
+    token = await _seed_session(session_factory, "s-anon-del", None)
+    async with session_factory() as db:
+        svc = AsyncHistoryService(db)
+        # 无 token 删除失败
+        assert (await svc.delete_session("s-anon-del", user_id=None)) is False
+    async with session_factory() as db:
+        svc = AsyncHistoryService(db)
+        # 正确 token 删除成功
+        assert (await svc.delete_session("s-anon-del", user_id=None, owner_token=token)) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_ws_auth.py
+++ b/tests/test_ws_auth.py
@@ -1,7 +1,8 @@
-"""WebSocket authentication tests — token 是 optional（审计 S50 还原 CHANGELOG 原意）。
+"""WebSocket authentication tests — SEC-03: WS now requires auth + session ownership.
 
-之前硬强制 token 导致前端无 token 的 WS 连接全部被拒（前端无登录基础设施）。
-现在：空 token 放行（匿名），带 token 时验证合法性，无效 token 拒绝。
+审计 SEC-03：WS 端点之前允许匿名连接（无 token），且不校验 session 所有权。
+现在：必须有合法 access token，且 session_id 属于该用户。WS 感知通道在前端
+是死代码（useWebSocket 从未挂载），所以收紧认证不破坏活跃功能。
 """
 import pytest
 from fastapi import FastAPI
@@ -12,45 +13,131 @@ from app.api.routes.ws import router as ws_router
 from app.core.auth import create_access_token
 
 
-@pytest.fixture
-def app():
+def _make_app_with_session(session_id: str = "sess-valid", user_id: str = "user-123"):
+    """Create a FastAPI app + temp DB with a user and owned session.
+
+    Uses sync sqlite3 for setup (avoids event loop conflicts with TestClient).
+    """
+    import sqlite3
+    import tempfile
+    import os
+    from contextlib import asynccontextmanager
+    from unittest.mock import AsyncMock
+    from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+    import app.tools._utils as _utils
+    import app.api.routes.ws as ws_module
+
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "ws_test.db")
+
+    # Create schema + seed data via sync sqlite3 (no event loop needed)
+    conn = sqlite3.connect(db_path)
+    conn.execute("""CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY, org_id INTEGER, username TEXT, email TEXT,
+        password_hash TEXT, full_name TEXT, avatar_url TEXT, role TEXT,
+        is_active INTEGER, email_verified INTEGER, last_login TEXT,
+        login_count INTEGER, token_version INTEGER DEFAULT 0,
+        created_at TEXT, updated_at TEXT
+    )""")
+    conn.execute("""CREATE TABLE IF NOT EXISTS conversations (
+        id TEXT PRIMARY KEY, user_id TEXT, title TEXT, owner_token TEXT,
+        created_at TEXT, updated_at TEXT
+    )""")
+    conn.execute("""CREATE TABLE IF NOT EXISTS messages (
+        id TEXT PRIMARY KEY, conversation_id TEXT, role TEXT, content TEXT,
+        reasoning_content TEXT, tool_calls TEXT, tool_call_id TEXT,
+        tool_result TEXT, created_at TEXT
+    )""")
+    conn.execute("INSERT INTO users (id, username, email, role, is_active, token_version) VALUES (?, ?, ?, ?, 1, 0)",
+                 (user_id, "testuser", "test@example.com", "viewer"))
+    conn.execute("INSERT INTO conversations (id, user_id, title) VALUES (?, ?, ?)",
+                 (session_id, user_id, "Test"))
+    conn.commit()
+    conn.close()
+
+    # Set up async session factory for the WS route
+    test_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    test_session_factory = async_sessionmaker(bind=test_engine, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def _test_db_session():
+        async with test_session_factory() as s:
+            yield s
+
+    # Patch the source module that ws.py does `from ... import async_db_session` from
+    _utils.async_db_session = _test_db_session
+
+    # Patch rate limiter to always allow (tests run fast, same IP)
+    class _NoOpLimiter:
+        async def is_allowed(self, *a, **kw):
+            return True
+    async def _stub():
+        return _NoOpLimiter()
+    ws_module.get_rate_limiter = _stub
+
     app = FastAPI()
     app.include_router(ws_router, prefix="/api/v1")
     return app
 
 
-def test_ws_connect_without_token_is_accepted(app):
-    """No token = 匿名连接允许（审计 S50：与前端无登录基础设施的现状对齐）。"""
-    client = TestClient(app)
-    with client.websocket_connect("/api/v1/ws/sess-no-token") as websocket:
-        websocket.send_json({"event": "ping"})
-        resp = websocket.receive_json()
-        assert resp == {"event": "pong"}
-
-
-def test_ws_connect_with_empty_token_is_accepted(app):
-    """Empty token = 视同未带 token，匿名连接允许。"""
-    client = TestClient(app)
-    with client.websocket_connect("/api/v1/ws/sess-empty-token?token=") as websocket:
-        websocket.send_json({"event": "ping"})
-        resp = websocket.receive_json()
-        assert resp == {"event": "pong"}
-
-
-def test_ws_connect_with_invalid_token_is_rejected(app):
-    """带 token 但签名无效 = 拒绝（code 4001）。"""
+def test_ws_connect_without_token_is_rejected():
+    """SEC-03: No token = 拒绝（不再允许匿名连接）。"""
+    app = _make_app_with_session()
     client = TestClient(app)
     with pytest.raises(WebSocketDisconnect) as exc_info:
-        with client.websocket_connect("/api/v1/ws/sess-invalid?token=invalid_jwt_signature"):
+        with client.websocket_connect("/api/v1/ws/sess-valid"):
             pass
     assert exc_info.value.code == 4001
 
 
-def test_ws_connect_with_valid_token_is_accepted(app):
-    """Valid JWT = connection accepted, ping/pong works."""
+def test_ws_connect_with_empty_token_is_rejected():
+    """SEC-03: Empty token = 拒绝。"""
+    app = _make_app_with_session()
     client = TestClient(app)
-    valid_token = create_access_token({"sub": "user-123"})
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/api/v1/ws/sess-valid?token="):
+            pass
+    assert exc_info.value.code == 4001
+
+
+def test_ws_connect_with_invalid_token_is_rejected():
+    """Invalid token = 拒绝 (code 4001)。"""
+    app = _make_app_with_session()
+    client = TestClient(app)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/api/v1/ws/sess-valid?token=invalid_jwt"):
+            pass
+    assert exc_info.value.code == 4001
+
+
+def test_ws_connect_with_valid_token_and_owned_session_is_accepted():
+    """SEC-03: Valid token + owned session = 连接成功, ping/pong works."""
+    app = _make_app_with_session()
+    client = TestClient(app)
+    valid_token = create_access_token({"sub": "user-123", "role": "viewer"})
     with client.websocket_connect(f"/api/v1/ws/sess-valid?token={valid_token}") as websocket:
         websocket.send_json({"event": "ping"})
         resp = websocket.receive_json()
         assert resp == {"event": "pong"}
+
+
+def test_ws_connect_with_valid_token_but_unowned_session_rejected():
+    """SEC-03: Valid token but session belongs to another user = 拒绝 (code 4003)."""
+    app = _make_app_with_session()
+    client = TestClient(app)
+    other_token = create_access_token({"sub": "user-456", "role": "viewer"})
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(f"/api/v1/ws/sess-valid?token={other_token}"):
+            pass
+    assert exc_info.value.code == 4003
+
+
+def test_ws_connect_with_nonexistent_session_rejected():
+    """SEC-03: Session doesn't exist = 拒绝 (code 4003)."""
+    app = _make_app_with_session()
+    client = TestClient(app)
+    valid_token = create_access_token({"sub": "user-123", "role": "viewer"})
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(f"/api/v1/ws/nonexistent?token={valid_token}"):
+            pass
+    assert exc_info.value.code == 4003


### PR DESCRIPTION
## Summary

Fixes the three remaining "needs session ownership redesign" security findings from the review.

## SEC-03: WebSocket IDOR (Critical → Fixed)
WS endpoint had no auth and no session ownership check. Any client knowing a session_id could inject fake layer toggles, corrupt viewport state, etc.

**Fix**: Require valid access token + verify session ownership before connecting. Rate limit per client IP. WS channel is dead code in frontend (useWebSocket never mounted), so no active functionality breaks.

## SEC-07: SSRF DNS rebinding (Medium → Fixed)
`_validate_no_ssrf` only checked hostname string patterns, never resolved DNS. A domain resolving to `169.254.169.254` bypassed all checks.

**Fix**: Added `socket.getaddrinfo()` resolution. Reject if any resolved IP is private/loopback/link-local/reserved. DNS rebinding TOCTOU (pin IP at HTTP client) documented as future work.

## SEC-08: Anonymous session ownership (Medium → Fixed)
Anonymous sessions (`user_id=NULL`) were world-readable: anyone with the session_id could read chat history, uploads, reports.

**Fix**: New `owner_token` column on `conversations`. New anonymous sessions get `secrets.token_urlsafe(32)`. `get_session` requires matching token (constant-time). Grandfather clause for existing sessions. Frontend stores/forwards via `X-Session-Token` header.

## Verification
- ✅ 1217 backend tests pass (was 1207, +10 new)
- ✅ 268 frontend tests pass (4 skipped)
- ✅ `tsc --noEmit` clean

## Backward compat
- Existing anonymous sessions without owner_token continue to work (grandfathered)
- Authenticated sessions completely unaffected
- WS channel was dead code, so no frontend breakage from auth requirement