### PR TITLE
fix: quick wins + PyJWT migration (DEPS-01, SEC-12, BUG-08/15, CONFIG-04)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Dependency Audit (Backend)
         # pip-audit 抓到多个传递依赖 CVE（starlette 0.38.6 的 PYSEC-2026-161/1941/
         # 1943/2280/2281/248/249 + ecdsa 0.19.2 的 PYSEC-2026-1325）。这些需要升级
-        # FastAPI / python-jose 上游依赖，是独立工作。
+        # FastAPI / PyJWT 上游依赖，是独立工作。
         # 审计 P1：去掉 --fix 防止 CI 自动修改依赖版本（未经 review 的变更可能引入回归）。
         # || true 兜底因为 pip-audit 不像 ruff 没有 --exit-zero 选项。
         run: |

--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -30,11 +30,26 @@ PI_RPC_ENTRY = Path(__file__).parent.parent.parent / "vendor" / "pi" / "packages
 DEFAULT_SESSION_DIR = Path(__file__).parent.parent.parent / ".pi" / "sessions"
 
 # Timeout constants (seconds)
-# 审计: 之前硬编码在代码中，提取为常量便于运维调参。
-PI_RPC_TIMEOUT = 300.0        # _send_request 等待 Pi 响应的上限
-PI_EVENT_DRAIN_TIMEOUT = 2.0  # prompt() 非流式模式下 drain event queue 的单次超时
-PI_EVENT_STREAM_TIMEOUT = 30.0  # stream_prompt 等待下一个 event 的超时
-PI_STARTUP_READY_TIMEOUT = 10.0  # start()  readiness check 的总超时
+# CONFIG-04: 之前硬编码在代码中，运维调参需改代码重发。现改为从环境变量读取，
+# 括号内为默认值，保持原行为。数值非法时回退默认值并告警（避免单次拼写错误
+# 导致整个 Pi bridge 启动失败）。
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "CONFIG-04: ignoring invalid %s=%r, using default %s", name, raw, default,
+        )
+        return default
+
+
+PI_RPC_TIMEOUT = _env_float("PI_RPC_TIMEOUT", 300.0)        # _send_request 等待 Pi 响应的上限
+PI_EVENT_DRAIN_TIMEOUT = _env_float("PI_EVENT_DRAIN_TIMEOUT", 2.0)  # prompt() 非流式模式下 drain event queue 的单次超时
+PI_EVENT_STREAM_TIMEOUT = _env_float("PI_EVENT_STREAM_TIMEOUT", 30.0)  # stream_prompt 等待下一个 event 的超时
+PI_STARTUP_READY_TIMEOUT = _env_float("PI_STARTUP_READY_TIMEOUT", 10.0)  # start()  readiness check 的总超时
 
 # SSE content strings for compaction events.
 # TODO: Replace with i18n-aware strings when the frontend supports localized SSE events.

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from jose import JWTError, jwt
+import jwt
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -166,7 +166,7 @@ def verify_token(token: str) -> Optional[dict]:
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         return payload
-    except JWTError:
+    except jwt.PyJWTError:
         return None
 
 

--- a/app/lib/tool_cache.py
+++ b/app/lib/tool_cache.py
@@ -104,6 +104,13 @@ def set_cached(key: str, value: Any, ttl: int) -> None:
 # Registry 的 timing wrapper 读此变量判断当前 dispatch 是否命中缓存。
 cache_hit_var: ContextVar[bool] = ContextVar("tool_cache_hit", default=False)
 
+# BUG-08: 嵌套深度计数。当某个 cached_tool 在另一个 cached_tool 的函数体内被
+# 调用时（嵌套 dispatch），内层 set 会覆盖外层 cache_hit_var 的值，导致外层
+# registry timing 误报。用深度计数区分：最外层（depth==0）的 cached_tool 不
+# reset —— 它的值留给 registry 读；嵌套层（depth>0）在 finally 里 reset 回外层
+# 值，保证内层状态不泄漏到外层。
+_cache_depth_var: ContextVar[int] = ContextVar("tool_cache_depth", default=0)
+
 
 def cached_tool(ttl: int = 3600, skip_if: Optional[Callable[[dict], bool]] = None):
     """工具函数装饰器：Redis 命中即返回，未命中调内层 + 写回。
@@ -126,16 +133,35 @@ def cached_tool(ttl: int = 3600, skip_if: Optional[Callable[[dict], bool]] = Non
                 key = make_cache_key(tool_name, kwargs)
                 if key is None:
                     return await func(**kwargs)
-                cached = get_cached(key)
-                if cached is not None:
-                    cache_hit_var.set(True)
-                    return cached
-                # 审计 M10：cache miss 必须显式 set(False)，否则 ContextVar
-                # 会保留前一次 hit 的 True 值 -> registry timing 误报 cache_hit。
-                cache_hit_var.set(False)
-                result = await func(**kwargs)
-                set_cached(key, result, ttl)
-                return result
+                # BUG-08: 进入嵌套层。最外层 is_outermost=True（depth 进入前为 0）。
+                # 注意：不能用 token.old_value 判定——ContextVar 的 default 值不算
+                # "已 set"，old_value 会是 Token.MISSING 而非 0。先 get() 再 set。
+                prev_depth = _cache_depth_var.get()
+                depth_token = _cache_depth_var.set(prev_depth + 1)
+                is_outermost = prev_depth == 0
+                try:
+                    cached = get_cached(key)
+                    if cached is not None:
+                        # 审计 M10：cache hit 显式 set(True)。
+                        hit_token = cache_hit_var.set(True)
+                        if is_outermost:
+                            return cached  # 最外层：留给 registry 读，不 reset
+                        try:
+                            return cached
+                        finally:
+                            cache_hit_var.reset(hit_token)
+                    # 审计 M10：cache miss 必须显式 set(False)，否则 ContextVar
+                    # 会保留前一次 hit 的 True 值 -> registry timing 误报 cache_hit。
+                    hit_token = cache_hit_var.set(False)
+                    try:
+                        result = await func(**kwargs)
+                        set_cached(key, result, ttl)
+                        return result
+                    finally:
+                        if not is_outermost:
+                            cache_hit_var.reset(hit_token)
+                finally:
+                    _cache_depth_var.reset(depth_token)
             return async_wrapper
 
         @functools.wraps(func)
@@ -145,15 +171,32 @@ def cached_tool(ttl: int = 3600, skip_if: Optional[Callable[[dict], bool]] = Non
             key = make_cache_key(tool_name, kwargs)
             if key is None:
                 return func(**kwargs)
-            cached = get_cached(key)
-            if cached is not None:
-                cache_hit_var.set(True)
-                return cached
-            # 审计 M10：同 async_wrapper，miss 时显式 set(False)
-            cache_hit_var.set(False)
-            result = func(**kwargs)
-            set_cached(key, result, ttl)
-            return result
+            # BUG-08: 同 async_wrapper，用深度计数区分最外层与嵌套层。
+            prev_depth = _cache_depth_var.get()
+            depth_token = _cache_depth_var.set(prev_depth + 1)
+            is_outermost = prev_depth == 0
+            try:
+                cached = get_cached(key)
+                if cached is not None:
+                    # 审计 M10：cache hit 显式 set(True)。
+                    hit_token = cache_hit_var.set(True)
+                    if is_outermost:
+                        return cached  # 最外层：留给 registry 读，不 reset
+                    try:
+                        return cached
+                    finally:
+                        cache_hit_var.reset(hit_token)
+                # 审计 M10：同 async_wrapper，miss 时显式 set(False)
+                hit_token = cache_hit_var.set(False)
+                try:
+                    result = func(**kwargs)
+                    set_cached(key, result, ttl)
+                    return result
+                finally:
+                    if not is_outermost:
+                        cache_hit_var.reset(hit_token)
+            finally:
+                _cache_depth_var.reset(depth_token)
         return sync_wrapper
 
     return decorator

--- a/app/models/db_model.py
+++ b/app/models/db_model.py
@@ -182,6 +182,9 @@ class Message(Base):
 
     __table_args__ = (
         CheckConstraint("role IN ('user', 'assistant', 'tool')", name="ck_message_role"),
+        # BUG-15: 按会话取消息列表（history load）几乎总是
+        # WHERE conversation_id = ? ORDER BY created_at，原表无覆盖索引 → 全表扫描 + filesort。
+        Index("idx_message_conversation_created", "conversation_id", "created_at"),
     )
 
 __all__ = ["Base", "Organization", "User", "Layer", "AnalysisTask", "LayerPermission", "Conversation", "Message", "get_init_sql"]

--- a/app/services/data_fetcher/adapters/local_file_adapter.py
+++ b/app/services/data_fetcher/adapters/local_file_adapter.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 from typing import Any, Dict
 import fiona
 from .base import DataSourceAdapter
@@ -17,12 +18,20 @@ class LocalFileAdapter(DataSourceAdapter):
         if not file_path:
             raise ValueError("File path is required for local file query")
 
-        # Make sure file is within allowed upload directory
-        full_path = os.path.join(settings.UPLOAD_DIR, file_path.lstrip("/"))
-        if not full_path.startswith(os.path.abspath(settings.UPLOAD_DIR)):
+        # SEC-12: 之前用 settings.UPLOAD_DIR（不存在，只有 DATA_DIR）+ startswith
+        # 做包含校验。startswith 可被路径前缀碰撞绕过（例如 /data_evil/x 或
+        # 符号链接）。改为：
+        #   1. 用 settings.DATA_DIR 作为根目录；
+        #   2. 用 os.path.realpath 解析符号链接 / ../ 拼接；
+        #   3. 用 Path.parents 严格包含校验，确保最终路径落在 DATA_DIR 之内。
+        base_dir = Path(os.path.realpath(settings.DATA_DIR))
+        full_path = Path(os.path.realpath(base_dir / file_path.lstrip("/")))
+
+        # 严格包含校验：full_path 必须等于 base_dir 或位于其下某一层父目录链中。
+        if full_path != base_dir and base_dir not in full_path.parents:
             raise ValueError("Invalid file path: access denied")
 
-        if not os.path.exists(full_path):
+        if not full_path.exists():
             raise FileNotFoundError(f"File not found: {file_path}")
 
         file_ext = file_path.split('.')[-1].lower()
@@ -32,7 +41,7 @@ class LocalFileAdapter(DataSourceAdapter):
             with open(full_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
         elif file_ext in ['zip', 'shp', 'kml', 'gml']:
-            with fiona.open(full_path) as src:
+            with fiona.open(str(full_path)) as src:
                 features = list(src)
                 return {"type": "FeatureCollection", "features": features}
         else:

--- a/migrations/versions/b2c3d4e5f6a7_add_message_conversation_created_index.py
+++ b/migrations/versions/b2c3d4e5f6a7_add_message_conversation_created_index.py
@@ -1,0 +1,55 @@
+"""Add composite index on messages (conversation_id, created_at)
+
+Revision ID: b2c3d4e5f6a7
+Revises: 6ef479051297
+Create Date: 2026-07-24
+
+BUG-15 - Message.created_at had no index. Loading a conversation's message
+history runs `WHERE conversation_id = ? ORDER BY created_at`, which without
+a covering index degrades to a full table scan + filesort on large
+conversations. This adds a composite index on (conversation_id, created_at)
+so that filter + sort are both served from the index.
+"""
+from typing import Sequence, Union
+
+from alembic import op, context
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b2c3d4e5f6a7'
+down_revision: Union[str, Sequence[str], None] = '6ef479051297'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _is_sqlite() -> bool:
+    """Detect if the target database is SQLite."""
+    return context.get_context().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Add index on messages(conversation_id, created_at)."""
+    if _is_sqlite():
+        # SQLite: use batch_alter_table (render_as_batch=True in env.py).
+        with op.batch_alter_table("messages", schema=None) as batch_op:
+            batch_op.create_index(
+                "idx_message_conversation_created",
+                ["conversation_id", "created_at"],
+            )
+    else:
+        # PostgreSQL
+        # IF NOT EXISTS: Base.metadata.create_all() 在启动时已按模型定义建好同名索引，
+        # alembic upgrade 会与此碰撞 -> "relation already exists"。幂等化以共存。
+        op.execute("""
+            CREATE INDEX IF NOT EXISTS idx_message_conversation_created
+                ON messages (conversation_id, created_at)
+        """)
+
+
+def downgrade() -> None:
+    """Remove the messages composite index."""
+    if _is_sqlite():
+        with op.batch_alter_table("messages", schema=None) as batch_op:
+            batch_op.drop_index("idx_message_conversation_created")
+    else:
+        op.execute("DROP INDEX IF EXISTS idx_message_conversation_created")

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,11 +54,10 @@ pytest>=7.4.4
 pytest-asyncio>=0.23.3
 pytest-cov>=7.1.0
 
-# 注意：python-jose 自 2024 起维护放缓，存在 JWT bomb (CVE-2024-33664)
-# 与算法混淆 (CVE-2024-33663) 风险。本项目通过 algorithms=["HS256"]
-# 白名单缓解算法混淆；JWT bomb 通过反代/中间件大小限制缓解。
-# 后续应迁移到 PyJWT>=2.8。
-python-jose[cryptography]>=3.3.0
+# JWT 库：使用 PyJWT (python-jose 自 2024 起维护放缓，存在 JWT bomb
+# CVE-2024-33664 与算法混淆 CVE-2024-33663 等未修复 CVE)。PyJWT 对 HS256
+# 用法是 drop-in，且其 algorithms 白名单是必填项，天然缓解算法混淆。
+PyJWT>=2.8.0,<3.0.0
 celery>=5.3.0
 # redis: 任务队列 broker + session_data 后端 + tool_cache。
 # 之前 requirements.txt 漏列此项，CI 干净环境跑 pytest 时直接

--- a/tests/test_token_refresh.py
+++ b/tests/test_token_refresh.py
@@ -255,7 +255,7 @@ async def test_refresh_rejects_expired_refresh_token(client):
         expires_delta=timedelta(seconds=-1),  # 已过期
         token_version=0,
     )
-    # jose 可能缓存时间，sleep 1s 让 exp 真正过期
+    # PyJWT 可能缓存时间，sleep 1s 让 exp 真正过期
     time.sleep(1.1)
     resp = await client.post("/api/v1/auth/refresh", json={"refresh_token": expired})
     assert resp.status_code == 401
@@ -409,8 +409,8 @@ async def test_legacy_token_without_type_claim_works_for_one_ttl(client):
     user_id = body["user"]["id"]
 
     # 手动构造一个 "旧式" token: 只有 sub/username/role/exp，无 type/ver
-    # 直接用 jose 签
-    from jose import jwt
+    # 直接用 PyJWT 签
+    import jwt
     from app.core.auth import SECRET_KEY, ALGORITHM
     from datetime import datetime, timezone
 


### PR DESCRIPTION
## Summary

5 fixes: PyJWT migration (security CVE closure) + 4 quick wins.

| ID | Fix |
|---|---|
| **DEPS-01** | python-jose → PyJWT (closes CVE-2024-33664 JWT bomb + CVE-2024-33663 algo confusion) |
| **SEC-12** | local_file_adapter: realpath containment check (was bypassable startswith) |
| **BUG-15** | Message (conversation_id, created_at) composite index (faster report gen) |
| **CONFIG-04** | Pi bridge timeout constants now env-configurable |
| **BUG-08** | tool_cache ContextVar nesting-depth tracking (fixes nested dispatch metrics) |

## Verification
- ✅ 1217 backend tests pass
- ✅ 268 frontend tests pass
- ✅ 50 auth tests pass with PyJWT