### PR TITLE
fix(frontend): HIGH a11y + type safety + map-action params validation

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -6,7 +6,7 @@ import { UploadZone } from "@/components/upload/upload-zone"
 import type { UploadResponse } from "@/lib/api/upload"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import { ChartRenderer } from "@/components/chat/chart-renderer"
+import { ChartRenderer, adaptChartData } from "@/components/chat/chart-renderer"
 import { MapActionRenderer } from "@/components/chat/map-action-renderer"
 import { safeUrlTransform } from "@/components/chat/mini-md"  // FE-06: 复用 F36 XSS 防护
 import { TaskProgress } from "./task-progress"
@@ -195,14 +195,21 @@ export function ChatHud({
                         <MapActionRenderer content={message.content} />
                       </div>
                     )}
-                    {(message.charts as any[])?.map((chart: any, idx: number) => (
-                      <div
-                        key={`chart-${message.id}-${idx}`}
-                        className="mt-3 p-3 rounded-lg bg-white/[0.02] border border-white/[0.04]"
-                      >
-                        <ChartRenderer chart={chart} />
-                      </div>
-                    ))}
+                    {/* 审计 FE-05：之前用 `as any[]` 强转绕过类型，且把未验证的
+                        chart 直接送进 ChartRenderer（它声明 ChartData 但实际拿到 any）。
+                        现在用 adaptChartData 做运行时校验，丢弃畸形 chart。 */}
+                    {message.charts?.map((raw, idx) => {
+                      const chart = adaptChartData(raw)
+                      if (!chart) return null
+                      return (
+                        <div
+                          key={`chart-${message.id}-${idx}`}
+                          className="mt-3 p-3 rounded-lg bg-white/[0.02] border border-white/[0.04]"
+                        >
+                          <ChartRenderer chart={chart} />
+                        </div>
+                      )
+                    })}
                   </div>
                 )}
               </div>

--- a/frontend/components/chat/map-action-renderer.test.tsx
+++ b/frontend/components/chat/map-action-renderer.test.tsx
@@ -15,19 +15,25 @@ describe('MapActionRenderer', () => {
     vi.clearAllMocks();
   });
 
-  it('returns null for empty content', () => {
-    const { container } = render(<MapActionRenderer content="" />);
-    expect(container.innerHTML).toBe('');
+  // 审计 a11y：error 状态现在渲染 sr-only 状态提示而非返回 null，
+  // 避免把渲染失败藏起来。辅助技术可探测到 role="status"。
+  it('renders accessible error hint for empty content', async () => {
+    render(<MapActionRenderer content="" />);
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+    expect(screen.getByText('地图指令解析失败')).toBeInTheDocument();
   });
 
-  it('returns null for "undefined" content', () => {
-    const { container } = render(<MapActionRenderer content="undefined" />);
-    expect(container.innerHTML).toBe('');
+  it('renders accessible error hint for "undefined" content', async () => {
+    render(<MapActionRenderer content="undefined" />);
+    await waitFor(() => {
+      expect(screen.getByText('地图指令解析失败')).toBeInTheDocument();
+    });
   });
 
-  it.skip('dispatches action for bare JSON with command', async () => {
-    // The component's regex \{[\s\S]*?\} is non-greedy and may not capture nested JSON
-    // JSON is typically delivered in code fences from the backend
+  it('dispatches action for bare JSON with command', async () => {
+    // FE-03 修复：balanced brace matching 现在能正确捕获嵌套 JSON
     render(<MapActionRenderer content=' {"command":"fly_to","params":{"center":[116.4,39.9]}} ' />);
     await waitFor(() => {
       expect(dispatchAction).toHaveBeenCalledWith({
@@ -38,40 +44,64 @@ describe('MapActionRenderer', () => {
   });
 
   it('dispatches action for JSON in markdown code fence', async () => {
-    render(<MapActionRenderer content={'```json\n{"command":"add_layer","params":{"name":"test"}}\n```'} />);
+    render(<MapActionRenderer content={'```json\n{"command":"add_layer","params":{"id":"layer-1","name":"test"}}\n```'} />);
     await waitFor(() => {
       expect(dispatchAction).toHaveBeenCalledWith({
         command: 'add_layer',
-        params: { name: 'test' },
+        params: { id: 'layer-1', name: 'test' },
       });
     }, { timeout: 2000 });
   });
 
   it('dispatches multiple JSON blocks', async () => {
-    render(<MapActionRenderer content={'```json\n{"command":"fly_to","params":{"zoom":12}}\n```\n```json\n{"command":"add_layer","params":{}}\n```'} />);
+    render(<MapActionRenderer content={'```json\n{"command":"fly_to","params":{"center":[116.4,39.9]}}\n```\n```json\n{"command":"add_layer","params":{"id":"l2"}}\n```'} />);
     await waitFor(() => {
       expect(dispatchAction).toHaveBeenCalledTimes(2);
     }, { timeout: 2000 });
   });
 
   it('skips JSON without command field', async () => {
-    const { container } = render(<MapActionRenderer content='{"no_command":true}' />);
-    // Component returns null when no valid actions found
+    render(<MapActionRenderer content='{"no_command":true}' />);
     await waitFor(() => {
-      expect(container.innerHTML).toBe('');
+      expect(screen.getByText('地图指令解析失败')).toBeInTheDocument();
     });
     expect(dispatchAction).not.toHaveBeenCalled();
   });
 
   it('skips invalid JSON blocks', async () => {
-    const { container } = render(<MapActionRenderer content='not json at all' />);
+    render(<MapActionRenderer content='not json at all' />);
     await waitFor(() => {
-      expect(container.innerHTML).toBe('');
+      expect(screen.getByText('地图指令解析失败')).toBeInTheDocument();
     });
   });
 
+  // FE-04: per-command params schema validation
+  it('rejects action with missing required params (add_layer without id)', async () => {
+    render(<MapActionRenderer content={'```json\n{"command":"add_layer","params":{"name":"no-id"}}\n```'} />);
+    await waitFor(() => {
+      expect(screen.getByText('地图指令解析失败')).toBeInTheDocument();
+    }, { timeout: 2000 });
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  it('rejects action with wrong-type params (fly_to center not array)', async () => {
+    render(<MapActionRenderer content={'```json\n{"command":"fly_to","params":{"center":"not-array"}}\n```'} />);
+    await waitFor(() => {
+      expect(screen.getByText('地图指令解析失败')).toBeInTheDocument();
+    }, { timeout: 2000 });
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown command even with valid params', async () => {
+    render(<MapActionRenderer content={'```json\n{"command":"delete_everything","params":{}}\n```'} />);
+    await waitFor(() => {
+      expect(screen.getByText('地图指令解析失败')).toBeInTheDocument();
+    }, { timeout: 2000 });
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
   it('shows success status after parsing', async () => {
-    render(<MapActionRenderer content={'```json\n{"command":"fly_to","params":{}}\n```'} />);
+    render(<MapActionRenderer content={'```json\n{"command":"fly_to","params":{"center":[116.4,39.9]}}\n```'} />);
     await waitFor(() => {
       expect(screen.getByText('地图指令已同步')).toBeInTheDocument();
     }, { timeout: 2000 });

--- a/frontend/components/chat/map-action-renderer.tsx
+++ b/frontend/components/chat/map-action-renderer.tsx
@@ -13,6 +13,45 @@ const ALLOWED_COMMANDS = new Set([
   'apply_layer_filter',
 ]);
 
+/**
+ * 审计 FE-04（map-action-renderer params validation）：dispatch 前对每条命令
+ * 的关键 params 做最小 schema 校验。AI 输出可能带畸形 params，直接 dispatch
+ * 会让 MapLibre 抛未捕获异常或写入脏 store 状态。
+ *
+ * 这里只校验"该命令必须的字段存在且类型正确"，不做值域校验（值域由
+ * MapLibre / store reducer 兜底）。拒绝的 action 会被静默丢弃并记入 errorCount。
+ */
+const REQUIRED_PARAMS: Record<string, (p: Record<string, unknown>) => boolean> = {
+  add_layer: (p) => typeof p.id === 'string',
+  remove_layer: (p) => typeof p.id === 'string' || typeof p.layer_id === 'string',
+  fly_to: (p) => Array.isArray(p.center) && p.center.length === 2,
+  zoom_to_bbox: (p) => Array.isArray(p.bbox) && p.bbox.length === 4,
+  set_map_view: (p) => Array.isArray(p.center) || typeof p.zoom === 'number',
+  add_heatmap_raster: (p) => typeof p.url === 'string' || typeof p.image === 'string',
+  add_raster_layer: (p) => typeof p.url === 'string' || typeof p.image === 'string',
+  add_native_heatmap: (p) => !!p.geojson || typeof p.id === 'string',
+  base_layer_change: (p) => typeof p.name === 'string' || typeof p.id === 'string',
+  layer_visibility_update: (p) => typeof p.layer_id === 'string' || typeof p.id === 'string',
+  layer_style_update: (p) => typeof p.layer_id === 'string' || typeof p.id === 'string',
+  reorder_layer: (p) => Array.isArray(p.layers) || Array.isArray(p.order),
+  export_map: () => true,
+  add_marker: (p) => Array.isArray(p.center) || Array.isArray(p.coordinate),
+  draw_measurement: () => true,
+  clear_annotations: () => true,
+  apply_layer_filter: (p) => typeof p.layer_id === 'string' || typeof p.id === 'string',
+};
+
+function isValidAction(action: unknown): action is { command: string; params: Record<string, unknown> } {
+  if (typeof action !== 'object' || action === null) return false;
+  const a = action as { command?: unknown; params?: unknown };
+  if (typeof a.command !== 'string' || !ALLOWED_COMMANDS.has(a.command)) return false;
+  // params 可选（部分命令无参）；存在则必须是普通对象
+  const params = (a.params ?? {}) as Record<string, unknown>;
+  if (typeof params !== 'object' || params === null || Array.isArray(params)) return false;
+  const validator = REQUIRED_PARAMS[a.command];
+  return validator ? validator(params) : true;
+}
+
 interface MapActionRendererProps {
   content: string;
 }
@@ -96,21 +135,23 @@ export function MapActionRenderer({ content }: MapActionRendererProps) {
 
         try {
           const action = JSON.parse(block);
-          if (action && action.command && ALLOWED_COMMANDS.has(action.command)) {
+          // FE-04: schema-validate before dispatch
+          if (isValidAction(action)) {
             dispatchedRef.current.add(blockKey);
-            dispatchAction(action);
+            dispatchAction(action as Parameters<typeof dispatchAction>[0]);
             successCount++;
             newBlocks++;
           }
+          // else: malformed params or unknown command → silently skip
         } catch {
-          // Individual block failed, skip it
+          // Individual block failed to parse, skip it
         }
       }
 
       if (successCount > 0 && newBlocks > 0) {
         setStatus('success');
       } else if (jsonBlocks.length > 0 && newBlocks === 0 && successCount === 0) {
-        // All blocks were already dispatched or failed
+        // All blocks were already dispatched, malformed, or rejected
         if (dispatchedRef.current.size === 0) setStatus('error');
       }
     } catch {
@@ -118,10 +159,23 @@ export function MapActionRenderer({ content }: MapActionRendererProps) {
     }
   }, [content, dispatchAction]);
 
-  if (status === 'error') return null;
+  // 审计 a11y：之前 error 状态返回 null，把渲染失败藏起来。现在渲染一个
+  // 带 role="status" 的可访问提示，但用 aria-hidden 对可见用户保持安静
+  // （错误是 AI 输出畸形 JSON，不该打扰终端用户；保留给辅助技术探测）。
+  if (status === 'error') {
+    return (
+      <span role="status" aria-live="off" className="sr-only">
+        地图指令解析失败
+      </span>
+    );
+  }
 
   return (
-    <div className="my-2 flex items-center gap-2 rounded-md bg-blue-50/50 p-2 text-sm text-blue-600 dark:bg-blue-950/30 dark:text-blue-400">
+    <div
+      className="my-2 flex items-center gap-2 rounded-md bg-blue-50/50 p-2 text-sm text-blue-600 dark:bg-blue-950/30 dark:text-blue-400"
+      role="status"
+      aria-live="polite"
+    >
       {status === 'parsing' ? (
         <MapIcon className="h-4 w-4 animate-pulse" />
       ) : (

--- a/frontend/components/chat/mini-md.tsx
+++ b/frontend/components/chat/mini-md.tsx
@@ -69,11 +69,22 @@ export default function MiniMd({ text }: MiniMdProps) {
               </code>
             );
           },
-          a: ({ href, children }) => (
-            <a href={href} target="_blank" rel="noopener noreferrer" className="text-green-600 underline hover:text-green-700">
-              {children}
-            </a>
-          ),
+          a: ({ href, children }) => {
+            // 审计 F36：纵然顶层 urlTransform={safeUrlTransform} 已过滤，
+            // 这里再显式应用一次作为纵深防御 —— 避免未来 ReactMarkdown
+            // 版本变更 component props 传递顺序时绕过过滤。
+            const safeHref = safeUrlTransform(href ?? '', 'href', {
+              type: 'element',
+              tagName: 'a',
+              properties: {},
+              children: [],
+            });
+            return (
+              <a href={safeHref ?? undefined} target="_blank" rel="noopener noreferrer" className="text-green-600 underline hover:text-green-700">
+                {children}
+              </a>
+            );
+          },
           table: ({ children }) => (
             <div className="overflow-x-auto my-2 rounded-lg border border-slate-200/80">
               <table className="w-full text-[14px]">{children}</table>

--- a/frontend/components/drawers/history-drawer.tsx
+++ b/frontend/components/drawers/history-drawer.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { History, X, Plus, Search } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
+import type { SessionSummary } from '@/lib/store/hud-types';
 
 interface HistoryDrawerProps {
   open: boolean;
   onClose: () => void;
-  onSelect: (session: any) => void;
+  onSelect: (session: SessionSummary | null) => void;
   accentColor: string;
 }
 
@@ -25,10 +26,33 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
     );
   }, [sessions, search]);
 
-  const handleSelect = (session: any) => {
+  const handleSelect = (session: SessionSummary) => {
     onSelect(session);
     onClose();
-  };
+  }
+
+  // 审计 a11y HIGH：drawer 缺 Escape 键关闭 + 焦点恢复。打开时聚焦 drawer，
+  // 关闭时把焦点还给之前活跃的元素。
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    // 聚焦 drawer 面板（搜搜索框，便于键盘用户立刻操作）
+    const searchInput = panelRef.current?.querySelector<HTMLInputElement>('input[type="text"], input');
+    searchInput?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open, onClose]);
 
   if (!open) return null;
 
@@ -39,11 +63,17 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
         className="flex-1 bg-slate-900/20"
         style={{ backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)' }}
         onClick={onClose}
+        aria-hidden="true"
       />
 
       {/* Drawer panel */}
       <div
-        className="w-[340px] shrink-0 flex flex-col border-l border-slate-200/60 shadow-[-2px_0_24px_rgba(15,23,42,0.09)]"
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="history-drawer-title"
+        tabIndex={-1}
+        className="w-[340px] shrink-0 flex flex-col border-l border-slate-200/60 shadow-[-2px_0_24px_rgba(15,23,42,0.09)] outline-none"
         style={{
           background: 'rgba(252,253,254,0.92)',
           backdropFilter: 'blur(28px)',
@@ -61,9 +91,10 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
         {/* Header */}
         <div className="shrink-0 flex items-center gap-2 px-4 py-3 border-b border-slate-200/60">
           <History size={16} style={{ color: accentColor }} />
-          <h2 className="flex-1 text-[15px] font-semibold text-slate-800">历史会话</h2>
+          <h2 id="history-drawer-title" className="flex-1 text-[15px] font-semibold text-slate-800">历史会话</h2>
           <button
             onClick={() => { onSelect(null); onClose(); }}
+            aria-label="新建会话"
             className="flex items-center gap-1 px-2 py-1 rounded-md text-[10.5px] font-medium text-white transition-opacity hover:opacity-90"
             style={{ backgroundColor: accentColor }}
           >
@@ -72,6 +103,7 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
           </button>
           <button
             onClick={onClose}
+            aria-label="关闭历史会话"
             className="p-1.5 rounded-md text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
           >
             <X size={15} />
@@ -83,8 +115,10 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
           <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-slate-100/60 border border-slate-200/60">
             <Search size={13} className="text-slate-300 shrink-0" />
             <input
+              type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              aria-label="搜索历史会话"
               placeholder="搜索会话..."
               className="flex-1 bg-transparent text-[14px] text-slate-700 placeholder:text-slate-300 outline-none"
             />
@@ -92,9 +126,13 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
         </div>
 
         {/* Session list */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto" role="list" aria-label="历史会话列表">
           {filtered.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full text-center px-6">
+            <div
+              className="flex flex-col items-center justify-center h-full text-center px-6"
+              role="status"
+              aria-live="polite"
+            >
               <History size={20} className="text-slate-200 mb-2" />
               <p className="text-[13.5px] text-slate-400">
                 {search ? '没有匹配的会话' : '暂无历史会话'}
@@ -107,6 +145,7 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
                   key={session.id}
                   onClick={() => handleSelect(session)}
                   className="w-full text-left px-3 py-2.5 rounded-xl hover:bg-slate-50/80 transition-colors group"
+                  role="listitem"
                 >
                   {/* Title */}
                   <p className="text-[12.5px] font-medium text-slate-700 truncate group-hover:text-slate-900">

--- a/frontend/components/sidebar/chat-tab.tsx
+++ b/frontend/components/sidebar/chat-tab.tsx
@@ -71,19 +71,22 @@ function SuggestedPromptButtons({ onSend, accentColor, isDark }: { onSend: (text
 }
 
 /* ─── Props ─── */
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  think?: string;
+  timestamp: Date | number | null;
+  isThinking?: boolean;
+  charts?: unknown[];
+  toolCalls?: import('@/lib/store/hud-types').ToolCallEntry[];
+  plan?: import('@/lib/store/hud-types').PlanProposalPayload;
+  agentPlan?: import('@/lib/types/agent-plan').AgentPlanState;
+  layerAdded?: string;
+}
+
 interface ChatTabProps {
-  messages: Array<{
-    id: string;
-    role: 'user' | 'assistant';
-    content: string;
-    timestamp: Date | number | null;
-    isThinking?: boolean;
-    charts?: unknown[];
-    toolCalls?: import('@/lib/store/hud-types').ToolCallEntry[];
-    plan?: import('@/lib/store/hud-types').PlanProposalPayload;
-    agentPlan?: import('@/lib/types/agent-plan').AgentPlanState;
-    layerAdded?: string;
-  }>;
+  messages: ChatMessage[];
   aiStatus: AiStatus;
   onSend: (text: string) => void;
   accentColor: string;
@@ -167,7 +170,7 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction 
 
         {/* Message list */}
         <div className="px-3 py-3 space-y-3">
-          {messages.map((msg: any, idx: number) => {
+          {messages.map((msg, idx) => {
             const isUser = msg.role === 'user';
             const time = (mounted && msg.timestamp)
               ? new Date(msg.timestamp).toLocaleTimeString('zh-CN', {
@@ -325,6 +328,7 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction 
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
+            aria-label="输入空间分析指令"
             placeholder="输入空间分析指令..."
             rows={1}
             style={{

--- a/tests/test_map_action_whitelist.py
+++ b/tests/test_map_action_whitelist.py
@@ -1,4 +1,11 @@
-"""H13: Map action renderer must validate commands against a whitelist."""
+"""H13: Map action renderer must validate commands against a whitelist.
+
+注：这里做的是结构校验（whitelist 存在 + dispatch 前有 guard），不是
+源码字面量匹配。真正的行为校验（拒绝未知命令、拒绝畸形 params）在前端
+vitest 套件 map-action-renderer.test.tsx 里。之前用 `has(action` 字面量
+匹配会因变量重命名（action → a）误判 —— 已改为匹配 ALLOWED_COMMANDS
+被实际调用的结构。
+"""
 import re
 
 
@@ -22,12 +29,29 @@ class TestMapActionWhitelist:
         )
 
     def test_renderer_checks_command_against_whitelist(self):
-        """dispatchAction must only be called if command is in whitelist."""
+        """dispatchAction must only be called if command passes whitelist + schema guard.
+
+        行为要求：在 dispatchAction 调用之前，必须有一个 guard 函数同时校验
+        (a) command 在 ALLOWED_COMMANDS 内，(b) params 通过 schema 校验。
+        之前断言字面量 `has(action` 会在变量重命名时误判 —— 现在断言
+        ALLOWED_COMMANDS 被引用 + 存在 guard 函数（isValidAction）。
+        """
         source = _read_renderer_source()
-        # There should be a guard like: ALLOWED_COMMANDS.has(action.command)
-        assert "ALLOWED_COMMANDS" in source and "has(action" in source, (
-            "Renderer must check action.command against ALLOWED_COMMANDS.has() before dispatch. "
-            "Currently dispatches any JSON with a truthy 'command' field."
+        assert "ALLOWED_COMMANDS" in source, (
+            "Renderer must define ALLOWED_COMMANDS whitelist."
+        )
+        # Guard must exist and be called before dispatch.
+        # Accepts either inline `ALLOWED_COMMANDS.has(...)` or a named guard
+        # function (current impl uses isValidAction which internally checks both).
+        has_inline_check = bool(re.search(r"ALLOWED_COMMANDS\.has\(", source))
+        has_guard_fn = bool(
+            re.search(r"function\s+isValidAction\s*\(", source)
+        ) and "dispatchAction" in source
+        assert has_inline_check or has_guard_fn, (
+            "Renderer must guard dispatchAction with a whitelist check "
+            "(either inline ALLOWED_COMMANDS.has() or a validation function "
+            "like isValidAction). Currently dispatches any JSON with a "
+            "truthy 'command' field."
         )
 
     def test_whitelist_covers_handler_commands(self):


### PR DESCRIPTION
## Summary

Addresses the actionable HIGH/Medium findings from the frontend component review (`findings.md`):

### HIGH severity
- **history-drawer.tsx** (a11y): Complete dialog pattern — `role="dialog"`, `aria-modal`, `aria-labelledby`, Escape-to-close, focus management (focus search on open, restore to trigger element on close), `aria-label` on close/new-session/search controls, `role="list"/`listitem`, `role="status"` + `aria-live` on empty state. Previously had zero dialog semantics.
- **chat-tab.tsx** (type safety): Extracted inline message type into named `ChatMessage` interface, removed `(msg: any)` cast, added missing `think` field.
- **map-action-renderer.tsx** (security): Per-command params schema validation (`REQUIRED_PARAMS`) — dispatch now rejects malformed payloads (add_layer without id, fly_to center not array, unknown commands). Closes the "unvalidated params passed to dispatchAction" HIGH finding.

### Medium severity
- **chat-panel.tsx** (type safety): Replaced `(charts as any[])` cast with `adaptChartData()` runtime validation; malformed charts dropped instead of reaching `ChartRenderer`.
- **mini-md.tsx** (security, defense-in-depth): Explicitly applies `safeUrlTransform` to anchor `href` in addition to top-level `urlTransform`.

### Error-surface fix
- **map-action-renderer.tsx** (a11y): Error state no longer returns `null` (which hid failures from assistive tech). Renders `sr-only` `role="status"` hint instead.

## Test changes
- Un-skipped the bare-JSON dispatch test — FE-03 balanced-brace matching (PR #129) fixed the original regex bug.
- Added 3 new tests for params validation (missing required params, wrong-type params, unknown command).
- Updated error-state tests to assert the new accessible status hint instead of empty DOM.

## Verification
- `npx tsc --noEmit` — clean
- `npx vitest run` — **272 passed**, 3 skipped (unrelated)
- ESLint config has pre-existing v8/v9 mismatch (tracked separately, CI uses `|| true`)

## Findings not addressed in this PR (deferred)
- chat-panel ReactMarkdown XSS (findings.md HIGH) — verified `rehype-raw` is NOT installed and `urlTransform={safeUrlTransform}` already applied; concern is moot.
- 59 Medium + 45 Low a11y/perf findings — these are incremental polish (aria-expanded on toggles, style memoization, requestAnimationFrame pausing) better handled in a dedicated a11y pass.