### PR TITLE
fix(build): chart-renderer use-client directive must precede imports [BLOCKER]

### DIFF
--- a/frontend/components/chat/chart-renderer.tsx
+++ b/frontend/components/chat/chart-renderer.tsx
@@ -1,6 +1,6 @@
-import { devOnly } from "@/lib/utils/logger";
 "use client"
 
+import { devOnly } from "@/lib/utils/logger";
 import {
   BarChart, Bar, LineChart, Line, PieChart, Pie, Cell,
   ScatterChart, Scatter, XAxis, YAxis, CartesianGrid,


### PR DESCRIPTION
## 🚨 Blocker — master Docker build is broken

The production Docker build on `master` has been failing since the last push:

```
Failed to compile.
./components/chat/chart-renderer.tsx
The "use client" directive must be placed before other expressions. Move it to the top of the file to resolve this issue.
```

## Root cause
`chart-renderer.tsx` line 1 was an `import` statement, with `"use client"` on line 2. Next.js requires the `"use client"` directive to be the **first expression** in the file.

## Why it wasn't caught
- `tsc --noEmit` — passes (TypeScript doesn't enforce directive order)
- `vitest run` — passes (test environment tolerates it)
- `next dev` — tolerates the misordering
- `next build` (webpack) — **fails** ← only the production build catches this

The CI `Frontend Tests` job runs `vitest`, not `next build`, so this slipped through. The `Build Docker Image` job catches it but is not a required check for PR merges.

## Fix
Move `"use client"` above the `import` statement (1-line change).

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — **succeeds** (was failing)

## Follow-up
Consider adding `next build` as a required CI check to prevent this class of issue. Currently only `vitest` runs in the Frontend Tests job.