### PR TITLE
fix(ci): deploy-prod IMAGE_NAME case mismatch breaks manifest inspect

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -357,6 +357,13 @@ jobs:
       contents: read
       packages: read
     steps:
+      - name: Lowercase IMAGE_NAME
+        # 审计：全局 env.IMAGE_NAME = ${{ github.repository }} 是混合大小写
+        # （WindWang2/...），但 docker tag/manifest 要求全小写。build job 和
+        # rollback job 各自有此步骤，deploy-prod 之前漏了 —— 导致 manifest
+        # inspect 查的是 WindWang2/... 而 registry 里是 windwang2/...，找不到。
+        run: echo "IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Download Image Artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Problem

Follow-up to #153. The `Deploy to Production` job now fails at the "Confirm Image Available in Registry" step:

```
❌ 镜像不在 registry —— build job 的 'Push Image to Registry' step 可能失败
   registry: ghcr.io/WindWang2/webgis-ai-agent:186de7b...
```

But the build job's push **succeeded**:
```
186de7b5a74122b3f9d1425a66a2d47da8c1fb71: digest: sha256:66414b1d... size: 3679
```

## Root cause

**Case mismatch in the image path:**
- Build job pushes to: `ghcr.io/windwang2/webgis-ai-agent:SHA` (lowercase — from its "Lowercase IMAGE_NAME" step)
- deploy-prod queries: `ghcr.io/WindWang2/webgis-ai-agent:SHA` (mixed case — from the global `env.IMAGE_NAME = ${{ github.repository }}`)

Docker registries are case-sensitive on the repository path. The global workflow env `IMAGE_NAME` is `WindWang2/webgis-ai-agent` (mixed case from `github.repository`), but Docker requires lowercase. The build job (line 222) and rollback job (line 469) each have a "Lowercase IMAGE_NAME" step that overrides it — **deploy-prod was missing this step**.

## Fix

Add the same "Lowercase IMAGE_NAME" step to deploy-prod as its first step (before any step uses `${{ env.IMAGE_NAME }}`), matching the existing pattern in build and rollback jobs.

```
- name: Lowercase IMAGE_NAME
  run: echo "IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
```

## Verification
- [x] YAML syntax valid
- [x] All 3 jobs (build, deploy-prod, rollback) now have the Lowercase step (lines 222, 360, 469)
- [ ] CI `Deploy to Production` should pass on merge