### PR TITLE
ci: add next build to test-frontend job (catch prod build errors at PR stage)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -158,6 +158,19 @@ jobs:
         working-directory: ./frontend
         run: npm run test:ci
 
+      - name: TypeScript Check
+        # tsc --noEmit 抓类型错误（比 next build 快，单独跑让类型错误优先暴露）。
+        working-directory: ./frontend
+        run: npm run typecheck
+
+      - name: Production Build
+        # 审计 CI-GAP（PR #151 暴露）：之前 test-frontend 只跑 vitest，不跑 next build。
+        # use-client 指令顺序错误（webpack-only 检查）直到 Docker prod build 才被发现，
+        # 已合入 master。在此 PR 阶段跑 next build，把生产构建错误前移到快速反馈环。
+        # next build 同时校验：指令顺序、SSR 兼容性、静态导出、webpack 配置。
+        working-directory: ./frontend
+        run: npm run build
+
       - name: Upload Coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -144,9 +144,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Node.js
+        # Node 20 已被 GitHub Actions 弃用（runner 强制升到 Node 24 运行 action）。
+        # 用当前 LTS (22) 保持与本地开发环境兼容。
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 


### PR DESCRIPTION
## Problem

PR #151 exposed a CI gap: the `test-frontend` job only ran `vitest`, not `next build`. The `chart-renderer.tsx` `"use client"` directive ordering error (a webpack-only check, not caught by `tsc --noEmit` or `vitest`) slipped through PR review and only surfaced in the post-merge Docker production build — after it was already on master.

```
Failed to compile.
./components/chat/chart-renderer.tsx
The "use client" directive must be placed before other expressions.
```

## Fix

Add two steps to `test-frontend` (after vitest, before coverage upload):

1. **TypeScript Check** (`npm run typecheck`) — `tsc --noEmit`, surfaces type errors faster than the full build
2. **Production Build** (`npm run build`) — `next build`, catches webpack/SSR/directive errors that tsc and vitest miss

This moves the entire class of production-build failures from the slow Docker stage (post-merge, ~15min feedback loop) to the fast PR stage (~2min added).

## Why both typecheck AND build?

| Check | Catches | Speed |
|-------|---------|-------|
| `tsc --noEmit` | Type errors | ~30s |
| `next build` | Directive order, SSR compat, webpack config, static export | ~90s |

Running typecheck first means type errors (the common case) surface quickly without waiting for the full webpack build.

## Verification
- [x] `npm run build` passes locally (master is green after #151 fix)
- [x] YAML syntax valid
- [ ] CI will validate on this PR

## Follow-up considered, not done
The `Lowercase IMAGE_NAME` step is repeated in 3 jobs (build, deploy-prod, rollback). GitHub Actions expression language has no lowercase filter, so per-step `tr` is the only native option. The pattern is now consistent across all 3 jobs — extracting to a composite action would add complexity for minimal benefit.