### PR TITLE
fix(frontend): mock settings panel + destructive action guard + error visibility

### DIFF
--- a/frontend/components/chat/map-action-renderer.tsx
+++ b/frontend/components/chat/map-action-renderer.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useMapAction } from '@/lib/contexts/map-action-context';
 import { MapIcon, CheckCircle2 } from 'lucide-react';
+import { devOnly } from '@/lib/utils/logger';
 
 const ALLOWED_COMMANDS = new Set([
   'add_layer', 'fly_to', 'zoom_to_bbox', 'set_map_view',
@@ -143,8 +144,11 @@ export function MapActionRenderer({ content }: MapActionRendererProps) {
             newBlocks++;
           }
           // else: malformed params or unknown command → silently skip
-        } catch {
-          // Individual block failed to parse, skip it
+        } catch (e) {
+          // 审计 findings.md：之前空 catch 让 JSON 解析失败完全不可观测。
+          // 用 devOnly.warn 而非 error —— 流式内容中途的部分 JSON 是预期情况，
+          // 不是真正的错误；仅当完整块解析失败时才有诊断价值。
+          devOnly.warn('[MapActionRenderer] JSON block parse failed:', (e as Error).message, block.slice(0, 80));
         }
       }
 
@@ -154,7 +158,9 @@ export function MapActionRenderer({ content }: MapActionRendererProps) {
         // All blocks were already dispatched, malformed, or rejected
         if (dispatchedRef.current.size === 0) setStatus('error');
       }
-    } catch {
+    } catch (e) {
+      // 审计 findings.md：外层 catch 同样改为可观测。
+      devOnly.error('[MapActionRenderer] Unexpected error in effect:', e);
       setStatus('error');
     }
   }, [content, dispatchAction]);

--- a/frontend/components/settings/system-settings.tsx
+++ b/frontend/components/settings/system-settings.tsx
@@ -1,62 +1,74 @@
 'use client';
 
-import React, { useState } from 'react';
-import { STitle, SField, SButton } from '@/components/shared/section-title';
+import React from 'react';
+import { STitle } from '@/components/shared/section-title';
+import { API_BASE } from '@/lib/api/config';
 
+/**
+ * 系统设置面板。
+ *
+ * 审计 findings.md：之前此面板是一个 mock —— handleSave 只切 saved 状态不持久化，
+ * API URL 字段无法覆盖构建时 NEXT_PUBLIC_API_URL，语言切换器无 i18n 后端。
+ *
+ * 现改为只读的真实系统信息展示：
+ * - API URL 从 lib/api/config.ts 的 API_BASE 读取（构建时确定），只读展示
+ * - 语言切换器标记为"规划中"并禁用（项目暂无 i18n 系统）
+ * - 版本号从 package.json 同步（通过构建时注入）
+ * - 移除 fake Save 按钮 —— 没有可持久化的状态
+ */
 export function SystemSettings() {
-  const [apiUrl, setApiUrl] = useState('http://localhost:8000');
-  const [language, setLanguage] = useState<'zh' | 'en'>('zh');
-  const [saved, setSaved] = useState(false);
-
-  const handleSave = () => {
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  };
-
   return (
     <div className="flex flex-col gap-5">
       <STitle title="系统设置" sub="System Settings" />
 
-      {/* Backend API URL */}
-      <SField
-        label="Backend API URL"
-        value={apiUrl}
-        onChange={setApiUrl}
-        placeholder="http://localhost:8000"
-      />
-
-      {/* Language selection */}
+      {/* Backend API URL — read-only, determined at build time */}
       <div>
         <div className="text-[14px] uppercase tracking-wide text-slate-400 font-medium mb-2">
-          Language / 语言
+          Backend API URL
         </div>
-        <div className="flex gap-2">
+        <div
+          className="rounded-lg border border-slate-900/8 bg-slate-50/50 px-3 py-2 text-[14px] font-mono text-slate-600"
+          aria-label="后端 API 地址（只读，由构建时环境变量决定）"
+        >
+          {API_BASE}
+        </div>
+        <div className="text-[15px] text-slate-400 mt-1">
+          由 <code className="text-[15px] text-slate-500">NEXT_PUBLIC_API_URL</code> 环境变量在构建时确定，运行时不可修改。
+        </div>
+      </div>
+
+      {/* Language selection — disabled, i18n not yet implemented */}
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-[14px] uppercase tracking-wide text-slate-400 font-medium">
+            Language / 语言
+          </span>
+          <span
+            className="text-[14px] rounded-full px-1.5 py-0.5 bg-slate-100 text-slate-400 font-medium"
+            title="国际化系统尚未实现"
+          >
+            规划中
+          </span>
+        </div>
+        <div className="flex gap-2 opacity-50" aria-disabled="true">
           <button
-            onClick={() => setLanguage('zh')}
-            className="flex-1 rounded-lg border-2 py-2 text-[14px] font-medium transition-all"
+            disabled
+            className="flex-1 rounded-lg border-2 py-2 text-[14px] font-medium cursor-not-allowed"
             style={{
-              borderColor:
-                language === 'zh' ? '#16a34a' : 'rgba(15,23,42,0.08)',
-              backgroundColor:
-                language === 'zh'
-                  ? 'rgba(22,163,74,0.04)'
-                  : 'rgba(255,255,255,0.5)',
-              color: language === 'zh' ? '#16a34a' : '#475569',
+              borderColor: '#16a34a',
+              backgroundColor: 'rgba(22,163,74,0.04)',
+              color: '#16a34a',
             }}
           >
             中文
           </button>
           <button
-            onClick={() => setLanguage('en')}
-            className="flex-1 rounded-lg border-2 py-2 text-[14px] font-medium transition-all"
+            disabled
+            className="flex-1 rounded-lg border-2 py-2 text-[14px] font-medium cursor-not-allowed"
             style={{
-              borderColor:
-                language === 'en' ? '#16a34a' : 'rgba(15,23,42,0.08)',
-              backgroundColor:
-                language === 'en'
-                  ? 'rgba(22,163,74,0.04)'
-                  : 'rgba(255,255,255,0.5)',
-              color: language === 'en' ? '#16a34a' : '#475569',
+              borderColor: 'rgba(15,23,42,0.08)',
+              backgroundColor: 'rgba(255,255,255,0.5)',
+              color: '#475569',
             }}
           >
             English
@@ -64,7 +76,7 @@ export function SystemSettings() {
         </div>
       </div>
 
-      {/* About section */}
+      {/* About section — version from build-time injection */}
       <div className="rounded-xl border border-slate-900/8 bg-white/50 px-4 py-3">
         <div className="flex items-center gap-2.5 mb-2">
           <div
@@ -95,20 +107,13 @@ export function SystemSettings() {
               GeoAgent
             </div>
             <div className="text-[14px] text-slate-400 font-mono">
-              v0.1.0
+              v{process.env.NEXT_PUBLIC_APP_VERSION || '0.1.2'}
             </div>
           </div>
         </div>
         <div className="text-[15px] text-slate-400 italic">
           &quot;All is Agent&quot;
         </div>
-      </div>
-
-      {/* Save */}
-      <div className="pt-2">
-        <SButton saved={saved} onClick={handleSave}>
-          {saved ? 'Saved' : 'Save'}
-        </SButton>
       </div>
     </div>
   );

--- a/frontend/components/sidebar/map-studio-tab.tsx
+++ b/frontend/components/sidebar/map-studio-tab.tsx
@@ -17,6 +17,8 @@ const iconForType: Record<string, string> = {
 
 export function MapStudioTab() {
   const [activeSubTab, setActiveSubTab] = useState<'layout' | 'history'>('layout');
+  // 审计 findings.md：清空列表是破坏性操作，加确认状态防误触。
+  const [confirmingClear, setConfirmingClear] = useState(false);
   const exportSettings = useHudStore((s) => s.exportSettings);
   const updateExportSettings = useHudStore((s) => s.updateExportSettings);
   const { dispatchAction } = useMapAction();
@@ -350,13 +352,24 @@ export function MapStudioTab() {
               </span>
               {exports.length > 0 && (
                 <button
-                  onClick={() => setExports([])}
+                  onClick={() => {
+                    if (confirmingClear) {
+                      setExports([]);
+                      setConfirmingClear(false);
+                    } else {
+                      setConfirmingClear(true);
+                      // 3 秒后自动取消确认状态，避免用户误点后永久停留在"确认"文字
+                      setTimeout(() => setConfirmingClear(false), 3000);
+                    }
+                  }}
+                  onBlur={() => setConfirmingClear(false)}
                   className="text-[14px] px-2 py-1 rounded transition-colors"
                   style={{ color: isDark ? '#fca5a5' : '#ef4444' }}
                   onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = isDark ? 'rgba(248,113,113,0.15)' : 'rgba(254,226,226,0.6)'; }}
                   onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+                  aria-label={confirmingClear ? '再次点击确认清空所有导出文件' : '清空导出列表'}
                 >
-                  清空列表
+                  {confirmingClear ? '确认清空？' : '清空列表'}
                 </button>
               )}
             </div>


### PR DESCRIPTION
## Summary

Three Medium-severity findings from the frontend component review (findings.md).

### 1. system-settings.tsx — mock panel honesty (Error Handling × 3)

The System Settings tab was a **mock**: `handleSave` only toggled a "Saved" text without persisting anything, the API URL field couldn't override the build-time `NEXT_PUBLIC_API_URL`, the language switcher had no i18n backend, and the version was stale (`v0.1.0` vs actual `0.1.2`).

**Fix**: Convert to an honest read-only system info display:
- API URL reads from `API_BASE` (build-time env, with explanation)
- Language switcher disabled + labeled "规划中" (i18n not implemented)
- Version from `NEXT_PUBLIC_APP_VERSION` env (fallback `0.1.2`)
- Removed fake Save button (nothing to persist)

### 2. map-studio-tab.tsx — destructive action guard (Error Handling)

"清空列表" button cleared all export history with no confirmation — a destructive one-click data loss.

**Fix**: Two-click confirmation pattern:
1. First click → button text changes to "确认清空？"
2. Second click → clears
3. Auto-resets after 3s timeout or on blur

### 3. map-action-renderer.tsx — error visibility (Error Handling)

Both `catch` blocks were empty (silent swallow), making JSON parse failures invisible to developers.

**Fix**: Log via existing `devOnly` utility:
- Per-block parse failure → `devOnly.warn` (streaming partial JSON is expected, not a real error)
- Unexpected effect error → `devOnly.error`
- Both suppressed in production via `devOnly` (already used across the codebase)

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 272 passed, 3 skipped
- [x] `npm run build` — succeeds

## Findings assessed as non-issues (not fixed)
- `embodied-hud.tsx` accentColor "CSS injection" — `accentColor` is NOT in `<style jsx>` string interpolation; it's only used in React inline `style={{}}` props (React escapes these). Source is user color picker, not attacker-controlled. Stale audit finding.