### PR TITLE
fix(frontend): a11y batch — aria-expanded/controls + aria-label + live regions

### DIFF
--- a/frontend/components/chat/collapsible-think.tsx
+++ b/frontend/components/chat/collapsible-think.tsx
@@ -14,10 +14,15 @@ export function CollapsibleThink({ content, isDark, accentColor }: CollapsibleTh
 
   if (!content) return null;
 
+  // 审计 findings.md a11y Low：toggle 缺 aria-expanded + aria-controls 关联。
+  const panelId = 'think-content';
+
   return (
     <div className="mb-2">
       <button
         onClick={() => setIsExpanded(!isExpanded)}
+        aria-expanded={isExpanded}
+        aria-controls={panelId}
         className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors hover:bg-black/5"
         style={{ color: isDark ? '#94a3b8' : '#64748b' }}
       >
@@ -27,9 +32,10 @@ export function CollapsibleThink({ content, isDark, accentColor }: CollapsibleTh
       </button>
 
       {isExpanded && (
-        <div 
+        <div
+          id={panelId}
           className="mt-1 px-3 py-2 rounded-lg text-[13.5px] leading-relaxed border-l-2 italic"
-          style={{ 
+          style={{
             backgroundColor: isDark ? 'rgba(30,41,59,0.4)' : 'rgba(241,245,249,0.6)',
             borderColor: accentColor,
             color: isDark ? '#cbd5e1' : '#475569'

--- a/frontend/components/chat/task-progress.tsx
+++ b/frontend/components/chat/task-progress.tsx
@@ -77,6 +77,8 @@ export function TaskProgress({ task }: TaskProgressProps) {
       {/* 标题栏 */}
       <button
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-controls="task-progress-content"
         className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-card/60 transition-colors"
       >
         <div className="flex items-center gap-3 min-w-0">
@@ -107,7 +109,7 @@ export function TaskProgress({ task }: TaskProgressProps) {
       </button>
 
       {/* 内容区 */}
-      <div className={`transition-all duration-300 ease-in-out ${expanded ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'} overflow-hidden`}>
+      <div id="task-progress-content" className={`transition-all duration-300 ease-in-out ${expanded ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'} overflow-hidden`}>
         <div className="px-4 pb-4 pt-1 space-y-4">
           {/* 进度轨道 */}
           <div className="relative">

--- a/frontend/components/code-highlight/code-block.tsx
+++ b/frontend/components/code-highlight/code-block.tsx
@@ -75,7 +75,10 @@ export const CodeBlock = memo(function CodeBlock({
       </div>
 
       {/* Code Content */}
-      <pre className="p-3 overflow-x-auto text-sm font-mono leading-relaxed">
+      <pre
+        className="p-3 overflow-x-auto text-sm font-mono leading-relaxed"
+        aria-label={language ? `${language} 代码块` : '代码块'}
+      >
         <code className={langClass}>{code}</code>
       </pre>
     </div>

--- a/frontend/components/explorer/reasoning-panel.tsx
+++ b/frontend/components/explorer/reasoning-panel.tsx
@@ -44,6 +44,8 @@ function ReasoningStepCard({
     <div className="rounded-lg border border-white/10 bg-white/5">
       <button
         onClick={onToggle}
+        aria-expanded={isExpanded}
+        aria-controls={`reasoning-step-${step.step}-content`}
         className="flex w-full items-center justify-between p-3 text-left"
       >
         <div className="flex items-center gap-2">
@@ -59,7 +61,7 @@ function ReasoningStepCard({
         </span>
       </button>
       {isExpanded && (
-        <div className="border-t border-white/10 px-3 pb-3 pt-2">
+        <div id={`reasoning-step-${step.step}-content`} className="border-t border-white/10 px-3 pb-3 pt-2">
           <p className="text-sm text-white/80">{step.fact}</p>
           <p className="mt-1 text-xs text-white/50">来源：{step.source}</p>
         </div>

--- a/frontend/components/hud/agent-env-hud.tsx
+++ b/frontend/components/hud/agent-env-hud.tsx
@@ -54,6 +54,7 @@ export function AgentEnvHud({ open, onClose }: AgentEnvHudProps) {
         </div>
         <button
           onClick={onClose}
+          aria-label="关闭环境感知面板"
           className='w-6 h-6 flex items-center justify-center rounded hover:bg-slate-100 text-slate-400 hover:text-slate-600'
         >
           <X size={14} />

--- a/frontend/components/hud/layer-style-panel.tsx
+++ b/frontend/components/hud/layer-style-panel.tsx
@@ -87,6 +87,7 @@ export const LayerStylePanel = memo(function LayerStylePanel() {
                 ref={nameRef}
                 value={tempName}
                 onChange={(e) => setTempName(e.target.value)}
+                aria-label="重命名图层"
                 className="flex-1 text-[15px] bg-white/[0.06] border border-hud-cyan/30 rounded px-2 py-1 text-white/90 focus:outline-none focus:border-hud-cyan/60"
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
@@ -130,6 +131,7 @@ export const LayerStylePanel = memo(function LayerStylePanel() {
                 <div className="relative w-7 h-7 rounded-lg overflow-hidden border border-white/10">
                   <input type="color" value={color}
                     onChange={(e) => updateStyle({ color: e.target.value })}
+                    aria-label="填充颜色"
                     className="absolute inset-0 w-full h-full cursor-pointer" />
                 </div>
                 <span className="text-[14px] text-white/30 font-mono">{color}</span>
@@ -143,6 +145,7 @@ export const LayerStylePanel = memo(function LayerStylePanel() {
                 <div className="relative w-7 h-7 rounded-lg overflow-hidden border border-white/10">
                   <input type="color" value={strokeColor}
                     onChange={(e) => updateStyle({ strokeColor: e.target.value })}
+                    aria-label="描边颜色"
                     className="absolute inset-0 w-full h-full cursor-pointer" />
                 </div>
                 <span className="text-[14px] text-white/30 font-mono">{strokeColor}</span>

--- a/frontend/components/sidebar/assets-tab.tsx
+++ b/frontend/components/sidebar/assets-tab.tsx
@@ -86,7 +86,11 @@ export function AssetsTab() {
 
   if (analysisAssets.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-center px-6">
+      <div
+        className="flex flex-col items-center justify-center h-full text-center px-6"
+        role="status"
+        aria-live="polite"
+      >
         <div className="w-10 h-10 rounded-xl bg-slate-100 flex items-center justify-center mb-2">
           <FileText size={16} className="text-slate-300" />
         </div>

--- a/frontend/components/sidebar/left-sidebar.tsx
+++ b/frontend/components/sidebar/left-sidebar.tsx
@@ -58,6 +58,7 @@ export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#
 
   return (
     <aside
+      aria-label="左侧导航栏"
       className="fixed top-[42px] left-0 bottom-[24px] z-40 flex flex-col"
       style={{
         width: sidebarWidth,

--- a/frontend/components/sidebar/ops-log-tab.tsx
+++ b/frontend/components/sidebar/ops-log-tab.tsx
@@ -42,7 +42,7 @@ export function OpsLogTab() {
       </div>
 
       {/* Log list */}
-      <div className='flex-1 overflow-y-auto p-2'>
+      <div className='flex-1 overflow-y-auto p-2' aria-live='polite' aria-label='操作日志'>
         {opsLog.length === 0 ? (
           <div className='text-center py-8 text-xs text-slate-400'>
             暂无操作记录


### PR DESCRIPTION
## Summary

Mechanical accessibility improvements from the frontend component review (findings.md Low severity). Targets the three highest-impact a11y patterns across 9 components. All changes are **additive** — no behavior changes.

## Changes

### aria-expanded + aria-controls pairs (toggle components)
Screen readers need these to announce expand/collapse state:
- `collapsible-think.tsx` — 思考过程 toggle
- `task-progress.tsx` — task detail toggle
- `reasoning-panel.tsx` — reasoning step toggle

### aria-label on icon-only buttons / landmark elements
Screen readers can't name buttons that only contain an icon:
- `agent-env-hud.tsx` — close button (was unlabeled X icon)
- `left-sidebar.tsx` — `<aside>` landmark ("左侧导航栏")
- `layer-style-panel.tsx` — rename input + fill/stroke color inputs
- `code-block.tsx` — `<pre>` code block (describes language, e.g. "python 代码块")

### Live regions (status announcements for dynamic content)
- `assets-tab.tsx` — empty state (`role="status"`, `aria-live="polite"`)
- `ops-log-tab.tsx` — log container (`aria-live="polite"`, `aria-label="操作日志"`)

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 272 passed, 3 skipped
- [x] `npm run build` — succeeds

## Remaining Low findings (not in this PR)
These are lower-impact and need different approaches:
- Performance (style memoization, requestAnimationFrame pausing) — needs profiling
- `suggested-prompts.tsx` key collision — needs unique ID source
- `prefers-reduced-motion` support — global CSS change