### PR TITLE
fix(frontend): type safety + null guard + rAF perf

### DIFF
--- a/frontend/components/chat/chat-panel.tsx
+++ b/frontend/components/chat/chat-panel.tsx
@@ -45,7 +45,7 @@ export function ChatHud({
   void _isLoading;
   void _setShowUploadZone;
   const scrollRef = useRef<HTMLDivElement>(null)
-  const currentTask = useHudStore((s: any) => s.currentTask)
+  const currentTask = useHudStore((s) => s.currentTask)
 
   const scrollToBottom = useCallback(() => {
     if (scrollRef.current) {

--- a/frontend/components/explorer/what-if-panel.tsx
+++ b/frontend/components/explorer/what-if-panel.tsx
@@ -134,13 +134,14 @@ export function WhatIfPanel({ result, onViewModeChange }: WhatIfPanelProps) {
           <div className="rounded-lg border border-white/10 bg-white/5 p-3">
             <div className="text-xs text-white/50">直接影响面积</div>
             <div className="mt-1 text-lg font-semibold text-white/90">
-              {result.impact_summary.direct_area_km2.toFixed(2)} km²
+              {/* 审计 findings.md：toFixed 无 null 守卫，后端缺字段时崩溃 */}
+              {(result.impact_summary.direct_area_km2 ?? 0).toFixed(2)} km²
             </div>
           </div>
           <div className="rounded-lg border border-white/10 bg-white/5 p-3">
             <div className="text-xs text-white/50">间接影响面积</div>
             <div className="mt-1 text-lg font-semibold text-white/90">
-              {result.impact_summary.indirect_area_km2.toFixed(2)} km²
+              {(result.impact_summary.indirect_area_km2 ?? 0).toFixed(2)} km²
             </div>
           </div>
         </div>

--- a/frontend/components/hud/agent-env-hud.tsx
+++ b/frontend/components/hud/agent-env-hud.tsx
@@ -100,7 +100,7 @@ export function AgentEnvHud({ open, onClose }: AgentEnvHudProps) {
               <div key={layer.id} className='flex items-center gap-2 text-xs'>
                 <div
                   className='w-2 h-2 rounded-full'
-                  style={{ backgroundColor: layer.visible ? ((layer as any).color || layer.style?.color || '#16a34a') : '#cbd5e1', opacity: layer.visible ? 1 : 0.3 }}
+                  style={{ backgroundColor: layer.visible ? (layer.style?.color || '#16a34a') : '#cbd5e1', opacity: layer.visible ? 1 : 0.3 }}
                 />
                 <span className={layer.visible ? 'text-slate-700' : 'text-slate-400'}>
                   {layer.name}

--- a/frontend/components/hud/embodied-hud.tsx
+++ b/frontend/components/hud/embodied-hud.tsx
@@ -82,6 +82,9 @@ export function EmbodiedHud() {
   // Waveform phase animation
   const [phase, setPhase] = useState(0);
   useEffect(() => {
+    // 审计 findings.md Perf Medium：HUD 关闭时（仅显示 24px 条）无需动画，
+    // 暂停 rAF 循环避免空转的 60fps 状态更新 + 重渲染。
+    if (!hudOpen) return;
     let frame: number;
     const tick = () => {
       setPhase((p) => (p + (isThinking ? 0.25 : 0.08)) % (Math.PI * 2));
@@ -89,7 +92,7 @@ export function EmbodiedHud() {
     };
     frame = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(frame);
-  }, [isThinking]);
+  }, [isThinking, hudOpen]);
 
   // Render CPU Cognitive Waveform
   const renderWaveform = () => {

--- a/frontend/components/hud/layer-style-panel.tsx
+++ b/frontend/components/hud/layer-style-panel.tsx
@@ -16,12 +16,12 @@ const PALETTES: Record<string, { label: string; colors: string[] }> = {
 const MODE_LABELS: Record<string, string> = { vector: '矢量', heatmap: '热力', grid: '格网' };
 
 export const LayerStylePanel = memo(function LayerStylePanel() {
-  const editingLayerId = useHudStore((s: any) => s.editingLayerId);
-  const layers = useHudStore((s: any) => s.layers);
-  const updateLayer = useHudStore((s: any) => s.updateLayer);
-  const setEditingLayerId = useHudStore((s: any) => s.setEditingLayerId);
+  const editingLayerId = useHudStore((s) => s.editingLayerId);
+  const layers = useHudStore((s) => s.layers);
+  const updateLayer = useHudStore((s) => s.updateLayer);
+  const setEditingLayerId = useHudStore((s) => s.setEditingLayerId);
 
-  const layer = layers.find((l: any) => l.id === editingLayerId);
+  const layer = layers.find((l) => l.id === editingLayerId);
 
   const updateStyle = (patch: Partial<LayerStyle>) => {
     if (!layer) return;

--- a/frontend/components/sidebar/map-studio-tab.tsx
+++ b/frontend/components/sidebar/map-studio-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useHudStore } from '@/lib/store/useHudStore';
+import type { ExportItem } from '@/lib/store/hud-types';
 import { useMapAction } from '@/lib/contexts/map-action-context';
 import { Download, Trash2, Printer, History } from 'lucide-react';
 import { API_BASE } from '@/lib/api/config';
@@ -50,7 +51,7 @@ export function MapStudioTab() {
     };
   }, [activeSubTab, updateExportSettings]);
 
-  const handleDownload = (item: any) => {
+  const handleDownload = (item: ExportItem) => {
     // 审计 F37：downloadName 来自后端响应，但防御性校验路径穿越/特殊字符。
     // 只允许字母数字 + . _ -，拒绝 ../ ? # 等。
     const downloadName = item.filename || item.name;


### PR DESCRIPTION
## Summary

Six findings from the frontend component review (findings.md Medium) across type safety, crash prevention, and performance.

## Type Safety (4 fixes)
- `chat-panel.tsx` — remove `(s: any)` store selector (HudState infers correctly)
- `layer-style-panel.tsx` — remove 4× `(s: any)` selectors + `(l: any)` find
- `map-studio-tab.tsx` — `handleDownload(item: any)` → `ExportItem` (type already exists in hud-types)
- `agent-env-hud.tsx` — remove `(layer as any).color` — Layer type has no top-level `color` field (only `style.color`); the cast accessed a non-existent property

## Null guard (crash prevention)
- `what-if-panel.tsx` — `direct_area_km2.toFixed(2)` + `indirect_area_km2` had no null guard. Would crash `TypeError: Cannot read properties of undefined` if backend omits the field. Added `?? 0` fallback.

## Performance
- `embodied-hud.tsx` — `requestAnimationFrame` loop ran continuously even when HUD collapsed (24px bar). The waveform animation updated state at ~60fps for an invisible element. Skip rAF when `!hudOpen`.

## Verification
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 272 passed, 3 skipped
- [x] `npm run build` — succeeds