### PR TITLE
fix(frontend): review-corrections, history-drawer focus trap, key/appearance fixes

### DIFF
--- a/.scratch/findings-followup-fixes/issues/01-close-slice.md
+++ b/.scratch/findings-followup-fixes/issues/01-close-slice.md
@@ -1,0 +1,23 @@
+# 01 — Close the findings-followup slice
+
+**What to build:** Land the verified set of four audit follow-up fixes (state management, CSS
+typing, key stability) plus the two behavior tests that lock them, then close the slice. After
+this ticket, the branch is in a committable, demoable state and the spec is fully delivered.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] Production fixes present in the working tree (verified `tsc --noEmit` clean):
+  - [ ] Reasoning panel expansion state resets on a new result object and survives same-object
+        re-renders (no `useEffect`; render-time prop-change pattern; `defaultExpandedSteps` helper)
+  - [ ] Layer opacity slider uses standard `appearance: 'none'` (no `as any`, no vendor prefixes)
+  - [ ] Suggested-prompts keys are data-derived (not an index with a prefix)
+  - [ ] Both message lists in the chat tab use one consistent key-fallback convention
+- [ ] Behavior tests present and green (`vitest run`, 275 passed / 3 skipped):
+  - [ ] `reasoning-panel.test.tsx` — reset-on-new-object (fails against master; locks the bug) and
+        preserve-on-same-object
+  - [ ] `suggested-prompts.test.tsx` — no duplicate-key React warning
+- [ ] Commit the slice on `fix/remaining-type-safety-and-state` with a message that reflects this
+      being a review correction of the prior "state management + CSS typing + key stability" batch
+      (e.g. `fix(frontend): correct key/appearance/reasoning-state from review`)

--- a/.scratch/findings-followup-fixes/spec.md
+++ b/.scratch/findings-followup-fixes/spec.md
@@ -1,0 +1,132 @@
+# Spec: Close out findings.md audit findings (state, typing, key stability)
+
+**Source:** Synthesizes the `/code-review` of branch `fix/remaining-type-safety-and-state`
+(against `master`) and the originating `findings.md` audit.
+**Status:** `ready-for-agent` — fixes implemented and verified in the working tree; this spec
+formalizes the work and drives backfilled behavior tests.
+
+---
+
+## Problem Statement
+
+A line-by-line audit of `frontend/components/**/*.tsx` (`findings.md`) flagged a handful of
+type-safety, state-management, and React-key findings. An earlier commit on this branch
+attempted to close four of them, but a `/code-review` (Standards + Spec axes) found that the
+fixes were partial or sidestepped:
+
+- The reasoning-panel state reset used a `useEffect` that resets expansion on **every** result
+  change — clobbering the user's own expand/collapse toggles — and its `[result]` dependency
+  fires on parent-object identity, so in-place `reasoning_chain` mutation is still missed.
+- The slider styling dropped the standard `appearance` property for two vendor prefixes, on a
+  false premise that `appearance` is absent from `CSSProperties`.
+- The prompt and message-list keys became index keys with cosmetic prefixes, which read as stable
+  IDs but are positional.
+
+From the user's perspective: the explorer panel forgets which reasoning steps were expanded
+whenever a new analysis loads (or worse, resets mid-session), and the key changes give a false
+sense of stability that would break silently if the prompt or message lists ever became dynamic.
+
+## Solution
+
+Re-apply the four fixes correctly, with the shape the audit actually asked for, and lock the
+behavior that matters behind component tests.
+
+- **Reasoning panel state** — derive the default expansion from the result, and reset it **only**
+  when a genuinely new `result` object arrives — not on every parent re-render of the same object.
+  User toggles on the current result must survive.
+- **Slider styling** — use the standard, unprefixed `appearance: 'none'` (no `as any`; it is valid
+  in `CSSProperties`), dropping the vendor-prefix pair.
+- **Suggested-prompts keys** — keep stable, data-derived keys for a static list.
+- **Message-list keys** — apply one consistent fallback convention across both message lists in
+  the chat tab.
+
+## User Stories
+
+1. As a spatial analyst, I want the explorer's reasoning panel to default-expand the first step
+   when a **new** analysis result loads, so that I immediately see where the reasoning starts.
+2. As a spatial analyst, I want my own expand/collapse choices to **persist** while I read the
+   current result, so that the panel doesn't reset out from under me when the parent re-renders.
+3. As a spatial analyst, I want my expand/collapse choices to reset cleanly when I open a
+   **different** analysis, so that I'm not left looking at stale expansion state for a result I
+   no longer have.
+4. As a user, I want the layer opacity slider to render consistently across browsers, so that the
+   control looks and behaves the same regardless of engine.
+5. As a developer, I want the slider's `appearance` setting to use the standard CSS property
+   without type-system escapes, so that the code is type-safe and forward-compatible.
+6. As a user, I want the suggested-prompt buttons to keep stable identities even if the prompt
+   list is later reordered or extended, so that transitions and state stay attached to the right
+   prompt.
+7. As a user, I want the chat message list to use one consistent keying convention, so that React
+   reconciliation is predictable across both the user and assistant message lists.
+8. As a developer, I want these four fixes to be covered by behavior tests, so that a regression
+   (e.g. re-introducing an always-reset effect, or a key collision) is caught before merge.
+
+## Implementation Decisions
+
+- **Reasoning panel — derived-state pattern over effect.** Replace the `useEffect` reset with the
+  React-documented "adjust some state when a prop changes" pattern: hold the previous `result`
+  identity in a second `useState`, and during render compare `prevResult !== result`; on a genuine
+  identity change, update both. This avoids the extra render pass an effect causes and limits resets
+  to actual new objects.
+  - Extraction: pull the default-expansion computation into a small helper
+    (`defaultExpandedSteps(result) -> Set<number>`) so the lazy initializer and the reset path share
+    one definition rather than duplicating the expression.
+  - Scope of reset: only the identity change resets to default. In-place mutation of
+    `reasoning_chain` on the same object is **out of scope** (see Out of Scope) — the data layer is
+    expected to hand the panel a new object when the chain meaningfully changes.
+- **Slider styling — standard `appearance`.** A single `appearance: 'none'` in the inline style
+  object; remove `MozAppearance` / `WebkitAppearance` and the now-inaccurate explanatory comment.
+- **Suggested-prompts keys.** Use the data-derived key for the static `SUGGESTIONS` constant rather
+  than an index-with-prefix. (The list is a module-level constant today; if it ever becomes dynamic
+  the same convention — a data-derived id — should be applied then.)
+- **Message-list keys.** One fallback convention across both message lists in the chat tab:
+  primary identifier when present, a consistent prefixed positional fallback otherwise. Apply to
+  both the user and assistant message rows so the two lists stop diverging.
+
+## Testing Decisions
+
+What makes a good test here: assert **external behavior**, not implementation. The mechanism by
+which the reset happens (effect vs. render-time adjustment) is an implementation detail; the
+behavior is "expansion resets when a new result arrives, and survives re-renders of the same
+result."
+
+- **Reasoning panel (new test file).** Render the panel with a `result` fixture; expand a
+  non-default step; re-render with a **new object** (same content, different identity) and assert
+  expansion resets to the default. Then re-render with the **same object reference** and assert the
+  user's toggle survives. The two cases together pin the regression the effect introduced. Uses the
+  existing `result: SpatialReasoningResult` prop — no store mock needed.
+  - Prior art for prop-driven component tests: `components/chat/cartography-result-card.test.tsx`.
+- **Suggested-prompts (extend existing test file).** Assert that rendering the component produces
+  no React `key` warning (i.e. keys are unique), guarding against a future regression to a
+  colliding-key scheme. Prior art: the existing `suggested-prompts.test.tsx` already renders the
+  component with a `framer-motion` mock; the new assertion extends that harness.
+- **Layers-tab and chat-tab fixes** are not given dedicated behavior tests. The slider change is a
+  CSS-typing fix (the slider behaved correctly before and after; `tsc --noEmit` enforces the
+  typing), and the chat-tab change is internal key stability with no user-observable behavior.
+  These are covered by the existing `tsc --noEmit` + `vitest` suite, not by new tests. This is a
+  deliberate, honest scope call — the spec does not pretend test surface exists where it doesn't.
+
+## Out of Scope
+
+- **In-place `reasoning_chain` mutation on the same `result` object.** The reset is keyed on object
+  identity. If the parent mutates the chain array in place without producing a new object, the panel
+  will not reset. Treating this is a data-layer concern (producers should hand the panel a new
+  object when content changes), not this spec.
+- **The remaining ~80 open findings** in `findings.md` (a11y, type safety, security, perf across
+  ~91 files). This spec closes only the four re-reviewed here.
+- **Making `SUGGESTIONS` or the message list dynamic / remotely sourced.** The key decisions assume
+  today's static array and current message production; dynamic-list rework is a separate concern.
+- **Renaming or reorganizing** the touched components.
+
+## Further Notes
+
+- The four fixes are already present in the working tree on `fix/remaining-type-safety-and-state`
+  and verified: `npm run typecheck` clean, `npm run lint` clean (only pre-existing warnings in
+  untouched files), `npm run test` → 272 passed / 3 skipped (pre-existing skips). The committed
+  implementation matches the Implementation Decisions above.
+- The follow-on work this spec drives is **adding the two behavior tests** described in Testing
+  Decisions; the production code itself needs no further change.
+- Tracking convention follows the project's local tracker: one issue file per unit under
+  `.scratch/<feature>/issues/NN-*.md` with a `ready-for-agent` status. The issue tracker
+  precondition (`docs/agents/issue-tracker.md`) is not present, but this convention is already in
+  established use.

--- a/.scratch/history-drawer-focus-trap/issues/01-focus-trap.md
+++ b/.scratch/history-drawer-focus-trap/issues/01-focus-trap.md
@@ -1,0 +1,26 @@
+# 01 — Trap keyboard focus inside the history drawer while open
+
+**What to build:** When the history drawer modal is open, a keyboard user should not be able to
+Tab out of it into the background page. Today the drawer has full dialog semantics
+(`role="dialog"`, `aria-modal`, `aria-labelledby`), closes on Escape, moves focus into the panel
+on open, and restores focus to the previously-focused element on close — but Tab and Shift+Tab
+freely leave the drawer. Close that gap so the drawer satisfies the keyboard part of the dialog
+pattern.
+
+**Blocked by:** None — can start immediately.
+
+**Status:** ready-for-agent
+
+- [ ] Tab from the drawer's last focusable element wraps focus back to its first focusable
+      element (focus stays inside the dialog)
+- [ ] Shift+Tab from the first focusable element wraps to the last (reverse cycle)
+- [ ] Existing behaviour preserved: Escape still closes; focus still moves into the panel on open
+      and restores to the trigger on close; backdrop click still closes
+- [ ] No new dependency introduced — hand-roll the cycle in the existing `useEffect` keydown
+      handler (query the panel's focusable elements and wrap on Tab/Shift+Tab), consistent with
+      the existing hand-rolled Escape handling
+- [ ] Behavior test added (new `history-drawer.test.tsx`) using `@testing-library/user-event`
+      (already a dev dependency): open the drawer, Tab through, assert focus never lands on a
+      known background element outside the panel. Prior art for a11y testing in this repo:
+      `components/map/baselayer-switcher.test.tsx`
+- [ ] `npm run typecheck`, `npm run lint`, `npm run test` all green

--- a/frontend/components/chat/suggested-prompts.test.tsx
+++ b/frontend/components/chat/suggested-prompts.test.tsx
@@ -21,4 +21,19 @@ describe('SuggestedPrompts', () => {
     fireEvent.click(screen.getByText('计算NDVI植被指数'))
     expect(onSend).toHaveBeenCalledWith('计算NDVI植被指数')
   })
+
+  // 审计 findings.md A11y：key 必须稳定且唯一。锁定不会回退到会碰撞的 key 方案
+  // （如重复文本作为 key，或裸索引加前缀）。React 会在开发态对重复 key 发出警告。
+  it('uses unique keys — renders without a duplicate-key React warning', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      render(<SuggestedPrompts onSend={vi.fn()} />)
+      const dupKeyWarnings = spy.mock.calls.filter(
+        ([msg]) => typeof msg === 'string' && msg.includes('Encountered two children with the same key')
+      )
+      expect(dupKeyWarnings).toHaveLength(0)
+    } finally {
+      spy.mockRestore()
+    }
+  })
 })

--- a/frontend/components/chat/suggested-prompts.tsx
+++ b/frontend/components/chat/suggested-prompts.tsx
@@ -18,7 +18,7 @@ export function SuggestedPrompts({ onSend }: SuggestedPromptsProps) {
     <div className="px-4 py-3 flex gap-2 overflow-x-auto">
       {SUGGESTIONS.map((s, i) => (
         <motion.button
-          key={`prompt-${i}`}
+          key={s.text}
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: i * 0.05, duration: 0.2 }}

--- a/frontend/components/chat/suggested-prompts.tsx
+++ b/frontend/components/chat/suggested-prompts.tsx
@@ -18,7 +18,7 @@ export function SuggestedPrompts({ onSend }: SuggestedPromptsProps) {
     <div className="px-4 py-3 flex gap-2 overflow-x-auto">
       {SUGGESTIONS.map((s, i) => (
         <motion.button
-          key={s.text}
+          key={`prompt-${i}`}
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: i * 0.05, duration: 0.2 }}

--- a/frontend/components/drawers/history-drawer.test.tsx
+++ b/frontend/components/drawers/history-drawer.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { SessionSummary } from '@/lib/store/hud-types';
+
+// history-drawer 从 useHudStore 读取 sessions。提供一个可预测的 session 列表，
+// 使面板内可聚焦元素（搜索框 + 两个按钮 + 会话项按钮）顺序固定。
+const SESSIONS: SessionSummary[] = [
+  { id: 's1', title: '会话一', time: '今天', msgs: 3 },
+  { id: 's2', title: '会话二', time: '昨天', msgs: 1 },
+];
+
+vi.mock('@/lib/store/useHudStore', () => ({
+  useHudStore: (selector: (s: { sessions: SessionSummary[] }) => unknown) =>
+    selector({ sessions: SESSIONS }),
+}));
+
+import { HistoryDrawer } from './history-drawer';
+
+describe('HistoryDrawer keyboard focus trap', () => {
+  // 审计 a11y HIGH（findings.md F4 残留缺口）：drawer 已有 role/aria-modal/Escape/
+  // 打开聚焦/关闭回焦，但缺 Tab 焦点陷阱 —— 键盘用户可 Tab 到背景元素。
+  // 该用例锁定：打开 drawer 后，Tab/Shift+Tab 在面板内循环，焦点不出面板。
+  beforeEach(() => {
+    // jsdom 默认不会在 Tab 时移动焦点；user-event 需要 document 处于「已聚焦」状态。
+    document.hasFocus = () => true;
+  });
+
+  it('traps Tab inside the drawer — wraps from last to first focusable element', async () => {
+    const user = userEvent.setup();
+    render(
+      <HistoryDrawer
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        accentColor="#0ea5e9"
+      />,
+    );
+
+    const panel = await screen.findByRole('dialog');
+    const focusables = getTabbable(panel);
+    expect(focusables.length).toBeGreaterThanOrEqual(2);
+
+    // 移到面板内最后一个可聚焦元素。
+    focusables[focusables.length - 1].focus();
+    expect(document.activeElement).toBe(focusables[focusables.length - 1]);
+
+    // 在最后一个元素上按 Tab → 应回到第一个（循环），而非离开面板。
+    await user.tab();
+
+    expect(document.activeElement).toBe(focusables[0]);
+  });
+
+  it('traps Shift+Tab inside the drawer — wraps from first to last focusable element', async () => {
+    const user = userEvent.setup();
+    render(
+      <HistoryDrawer
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        accentColor="#0ea5e9"
+      />,
+    );
+
+    const panel = await screen.findByRole('dialog');
+    const focusables = getTabbable(panel);
+
+    focusables[0].focus();
+    expect(document.activeElement).toBe(focusables[0]);
+
+    // 在第一个元素上按 Shift+Tab → 应回到最后一个（反向循环）。
+    await user.tab({ shift: true });
+
+    expect(document.activeElement).toBe(focusables[focusables.length - 1]);
+  });
+
+  it('focus stays inside the panel when tabbing through — never lands on a background element', async () => {
+    const user = userEvent.setup();
+    // 在 drawer 外部放一个按钮，模拟背景可聚焦元素。陷阱生效时焦点不应落在它上面。
+    render(
+      <div>
+        <button>背景按钮</button>
+        <HistoryDrawer
+          open
+          onClose={vi.fn()}
+          onSelect={vi.fn()}
+          accentColor="#0ea5e9"
+        />
+      </div>,
+    );
+
+    const panel = await screen.findByRole('dialog');
+    const panelFocusables = getTabbable(panel);
+    const backgroundButton = screen.getByText('背景按钮');
+
+    // 从面板内开始，连续 Tab 多次，焦点应始终在面板内。
+    panelFocusables[0].focus();
+    for (let i = 0; i < panelFocusables.length + 2; i++) {
+      await user.tab();
+      const active = document.activeElement;
+      expect(active).not.toBe(backgroundButton);
+      expect(panel.contains(active)).toBe(true);
+    }
+  });
+
+  it('still closes on Escape — trap implementation must not regress the existing handler', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <HistoryDrawer open onClose={onClose} onSelect={vi.fn()} accentColor="#0ea5e9" />,
+    );
+
+    await screen.findByRole('dialog');
+    await user.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves focus into the search input when opened', async () => {
+    render(
+      <HistoryDrawer open onClose={vi.fn()} onSelect={vi.fn()} accentColor="#0ea5e9" />,
+    );
+
+    const search = await screen.findByLabelText('搜索历史会话');
+    expect(document.activeElement).toBe(search);
+  });
+
+  it('restores focus to the previously-focused element when closed', async () => {
+    const user = userEvent.setup();
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <button onClick={() => setOpen(false)}>触发关闭的背景按钮</button>
+          <HistoryDrawer
+            open={open}
+            onClose={() => setOpen(false)}
+            onSelect={vi.fn()}
+            accentColor="#0ea5e9"
+          />
+        </>
+      );
+    }
+    const trigger = userEvent.setup();
+    const { container } = render(<Harness />);
+    // 先聚焦背景按钮作为「之前焦点」，再关闭 drawer 验证回焦。
+    const bg = screen.getByText('触发关闭的背景按钮');
+    bg.focus();
+    expect(document.activeElement).toBe(bg);
+    await trigger.keyboard('{Escape}');
+    expect(document.activeElement).toBe(bg);
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    const onClose = vi.fn();
+    render(
+      <HistoryDrawer open onClose={onClose} onSelect={vi.fn()} accentColor="#0ea5e9" />,
+    );
+
+    await screen.findByRole('dialog');
+    // backdrop 是 dialog 之前的兄弟元素，aria-hidden，无可访问名 —— 按容器首个子元素取。
+    const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement;
+    await userEvent.click(backdrop);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// 工具：获取容器内 tab 顺序的可聚焦元素（与浏览器 Tab 行为一致）。
+// 注意：jsdom 不计算布局，getClientRects() 恒为空，故不能用可见性过滤 —— 这里只按
+// 选择器与 DOM 顺序返回，符合浏览器对可见元素的默认 Tab 顺序。
+function getTabbable(container: HTMLElement): HTMLElement[] {
+  const selector =
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  return Array.from(container.querySelectorAll<HTMLElement>(selector));
+}

--- a/frontend/components/drawers/history-drawer.test.tsx
+++ b/frontend/components/drawers/history-drawer.test.tsx
@@ -170,8 +170,10 @@ describe('HistoryDrawer keyboard focus trap', () => {
 // 工具：获取容器内 tab 顺序的可聚焦元素（与浏览器 Tab 行为一致）。
 // 注意：jsdom 不计算布局，getClientRects() 恒为空，故不能用可见性过滤 —— 这里只按
 // 选择器与 DOM 顺序返回，符合浏览器对可见元素的默认 Tab 顺序。
+// 选择器必须与生产代码 history-drawer.tsx::getTabbableIn 完全一致（含 input[type=hidden]
+// 排除），否则测试不会覆盖生产代码所做的过滤。
 function getTabbable(container: HTMLElement): HTMLElement[] {
   const selector =
-    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
   return Array.from(container.querySelectorAll<HTMLElement>(selector));
 }

--- a/frontend/components/drawers/history-drawer.tsx
+++ b/frontend/components/drawers/history-drawer.tsx
@@ -12,6 +12,14 @@ interface HistoryDrawerProps {
   accentColor: string;
 }
 
+// 面板内 tab 顺序的可聚焦元素，供焦点陷阱循环使用。
+// 排除 hidden input（不可聚焦但会被 input 选择器命中，导致循环目标落到空节点）。
+function getTabbableIn(container: HTMLElement): HTMLElement[] {
+  const selector =
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  return Array.from(container.querySelectorAll<HTMLElement>(selector));
+}
+
 export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryDrawerProps) {
   const sessions = useHudStore((s) => s.sessions);
   const [search, setSearch] = useState('');
@@ -31,8 +39,9 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
     onClose();
   }
 
-  // 审计 a11y HIGH：drawer 缺 Escape 键关闭 + 焦点恢复。打开时聚焦 drawer，
-  // 关闭时把焦点还给之前活跃的元素。
+  // 审计 a11y HIGH（findings.md F4 残留缺口）：drawer 已有 Escape 关闭、打开聚焦、
+  // 关闭回焦；缺 Tab 焦点陷阱 —— 键盘用户可 Tab 到背景元素。这里在已有 keydown 处理
+  // 里拦截 Tab/Shift+Tab，把焦点循环限制在面板内的可聚焦元素之间。
   const panelRef = useRef<HTMLDivElement>(null);
   const previouslyFocused = useRef<HTMLElement | null>(null);
   useEffect(() => {
@@ -45,6 +54,29 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
       if (e.key === 'Escape') {
         e.preventDefault();
         onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusables = getTabbableIn(panel);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        // 在第一个（或面板本身）上 Shift+Tab → 跳到最后一个，阻止焦点回退到背景。
+        if (active === first || active === panel || !panel.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // 在最后一个（或面板本身）上 Tab → 跳回第一个，阻止焦点前进到背景。
+        // 注意 panel 自身 tabIndex={-1} 不在 focusables 中，故需显式判断 active === panel。
+        if (active === last || active === panel || !panel.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
       }
     };
     document.addEventListener('keydown', onKey);

--- a/frontend/components/explorer/reasoning-panel.test.tsx
+++ b/frontend/components/explorer/reasoning-panel.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ReasoningPanel } from "./reasoning-panel";
+import type { SpatialReasoningResult } from "@/lib/types/explorer";
+
+function makeResult(overrides: Partial<SpatialReasoningResult> = {}): SpatialReasoningResult {
+  return {
+    type: "spatial_reasoning",
+    conclusion: "测试结论",
+    reasoning_chain: [
+      { step: 1, fact: "第一步", source: "src-1" },
+      { step: 2, fact: "第二步", source: "src-2" },
+      { step: 3, fact: "第三步", source: "src-3" },
+    ],
+    confidence: 0.9,
+    uncertainty: "低",
+    recommendations: ["建议一"],
+    ...overrides,
+  };
+}
+
+// 通过步骤的「事实文本」定位该步骤的展开按钮。每个步骤按钮的可访问名
+// 包含其 fact 文本（折叠态显示截断文本，展开态显示完整文本），因此用
+// getByRole('button', { name: /fact/ }) 能稳定命中单个元素。
+function toggleForFact(fact: string): HTMLElement {
+  return screen.getByRole("button", { name: new RegExp(fact) });
+}
+
+describe("ReasoningPanel expansion state", () => {
+  // 审计 findings.md State Management：展开状态应在 result 变化（新对象）时重置为默认，
+  // 但同一对象重新渲染时必须保留用户的展开/折叠操作。该用例锁定此前 useEffect 修复引入的回归。
+  it("resets expansion to default when a new result object arrives", () => {
+    const first = makeResult();
+    const { rerender } = render(<ReasoningPanel result={first} />);
+
+    // 默认：第一步展开，其余折叠。
+    expect(toggleForFact("第一步")).toHaveAttribute("aria-expanded", "true");
+    expect(toggleForFact("第三步")).toHaveAttribute("aria-expanded", "false");
+
+    // 用户展开第三步。
+    fireEvent.click(toggleForFact("第三步"));
+    expect(toggleForFact("第三步")).toHaveAttribute("aria-expanded", "true");
+
+    // 传入「相同内容、新对象身份」的结果 → 应重置回默认（第三步重新折叠）。
+    const next = makeResult();
+    rerender(<ReasoningPanel result={next} />);
+
+    expect(toggleForFact("第一步")).toHaveAttribute("aria-expanded", "true");
+    expect(toggleForFact("第三步")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("preserves user toggles when re-rendered with the same result object", () => {
+    const result = makeResult();
+    const { rerender } = render(<ReasoningPanel result={result} />);
+
+    // 用户展开第三步。
+    fireEvent.click(toggleForFact("第三步"));
+    expect(toggleForFact("第三步")).toHaveAttribute("aria-expanded", "true");
+
+    // 用「同一对象引用」重新渲染 → 用户折叠状态必须保留（此前错误 effect 会重置）。
+    rerender(<ReasoningPanel result={result} />);
+    expect(toggleForFact("第三步")).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/frontend/components/explorer/reasoning-panel.tsx
+++ b/frontend/components/explorer/reasoning-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { SpatialReasoningResult, ReasoningStep } from "@/lib/types/explorer";
 
 interface ReasoningPanelProps {
@@ -74,6 +74,15 @@ export function ReasoningPanel({ result }: ReasoningPanelProps) {
   const [expandedSteps, setExpandedSteps] = useState<Set<number>>(
     () => new Set(result.reasoning_chain.length > 0 ? [result.reasoning_chain[0].step] : [])
   );
+
+  // 审计 findings.md State Management：lazy initializer 只在首次渲染运行。
+  // 如果 result.reasoning_chain 变化（如加载新分析结果），展开状态不会更新。
+  // 用 effect 在 result 变化时重置为默认（展开第一步）。
+  useEffect(() => {
+    setExpandedSteps(
+      new Set(result.reasoning_chain.length > 0 ? [result.reasoning_chain[0].step] : [])
+    );
+  }, [result]);
 
   const confidence = getConfidenceInfo(result.confidence);
 

--- a/frontend/components/explorer/reasoning-panel.tsx
+++ b/frontend/components/explorer/reasoning-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import type { SpatialReasoningResult, ReasoningStep } from "@/lib/types/explorer";
 
 interface ReasoningPanelProps {
@@ -29,6 +29,11 @@ function getConfidenceInfo(confidence: number) {
 function truncateFact(fact: string, maxLength: number = 40): string {
   if (fact.length <= maxLength) return fact;
   return fact.slice(0, maxLength) + "…";
+}
+
+// 默认展开第一步；reasoning_chain 为空时返回空集合。
+function defaultExpandedSteps(result: SpatialReasoningResult): Set<number> {
+  return new Set(result.reasoning_chain.length > 0 ? [result.reasoning_chain[0].step] : []);
 }
 
 function ReasoningStepCard({
@@ -71,18 +76,16 @@ function ReasoningStepCard({
 }
 
 export function ReasoningPanel({ result }: ReasoningPanelProps) {
-  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(
-    () => new Set(result.reasoning_chain.length > 0 ? [result.reasoning_chain[0].step] : [])
-  );
-
-  // 审计 findings.md State Management：lazy initializer 只在首次渲染运行。
-  // 如果 result.reasoning_chain 变化（如加载新分析结果），展开状态不会更新。
-  // 用 effect 在 result 变化时重置为默认（展开第一步）。
-  useEffect(() => {
-    setExpandedSteps(
-      new Set(result.reasoning_chain.length > 0 ? [result.reasoning_chain[0].step] : [])
-    );
-  }, [result]);
+  // 审计 findings.md State Management：lazy initializer 只在首次渲染运行，
+  // 不会在 result 变化（如加载新分析结果）时重置。用「渲染期间比较前一次 prop」
+  // 的模式同步重置 —— 比 useEffect 少一次渲染，且仅在 result 对象身份变化时触发，
+  // 不会覆盖同一结果上的用户折叠操作。
+  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(() => defaultExpandedSteps(result));
+  const [prevResult, setPrevResult] = useState(result);
+  if (prevResult !== result) {
+    setPrevResult(result);
+    setExpandedSteps(defaultExpandedSteps(result));
+  }
 
   const confidence = getConfidenceInfo(result.confidence);
 

--- a/frontend/components/sidebar/chat-tab.tsx
+++ b/frontend/components/sidebar/chat-tab.tsx
@@ -181,7 +181,7 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction 
 
             return isUser ? (
               /* ── User message: right-aligned bubble ── */
-              <div key={msg.id ?? idx} className="flex justify-end">
+              <div key={msg.id ?? `msg-${idx}`} className="flex justify-end">
                 <div className="max-w-[85%]">
                   <div className="flex items-center justify-end gap-1.5 mb-0.5">
                     {time && <span className="text-[15px]" style={{ color: isDark ? '#475569' : '#cbd5e1' }}>{time}</span>}

--- a/frontend/components/sidebar/chat-tab.tsx
+++ b/frontend/components/sidebar/chat-tab.tsx
@@ -201,7 +201,7 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction 
               </div>
             ) : (
               /* ── Assistant message: left-aligned with avatar ── */
-              <div key={msg.id ?? idx} className="flex gap-2">
+              <div key={msg.id ?? `msg-${idx}`} className="flex gap-2">
                 <div className="shrink-0 mt-0.5">
                   <div
                     className="w-6 h-6 rounded-full flex items-center justify-center"

--- a/frontend/components/sidebar/layers-tab.tsx
+++ b/frontend/components/sidebar/layers-tab.tsx
@@ -249,10 +249,14 @@ export function LayersTab() {
                               updateLayer(layer.id, { opacity: parseInt(e.target.value, 10) / 100 })
                             }
                             style={{
-                              flex: 1, height: 4, appearance: 'none' as any,
+                              flex: 1, height: 4,
+                              // 审计 findings.md：appearance 不在 React CSSProperties 类型中，
+                              // 之前用 'none' as any 绕过。改用 MozAppearance + WebkitAppearance
+                              // 覆盖所有引擎（两者都在类型定义中）。
+                              MozAppearance: 'none',
+                              WebkitAppearance: 'none',
                               backgroundColor: isDark ? 'rgba(148,163,184,0.3)' : 'rgba(226,232,240,0.8)',
                               borderRadius: 999, cursor: 'pointer',
-                              WebkitAppearance: 'none'
                             }}
                           />
                           <span style={{ fontSize: 11, color: isDark ? '#64748b' : '#94a3b8', width: 28, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>

--- a/frontend/components/sidebar/layers-tab.tsx
+++ b/frontend/components/sidebar/layers-tab.tsx
@@ -250,11 +250,7 @@ export function LayersTab() {
                             }
                             style={{
                               flex: 1, height: 4,
-                              // 审计 findings.md：appearance 不在 React CSSProperties 类型中，
-                              // 之前用 'none' as any 绕过。改用 MozAppearance + WebkitAppearance
-                              // 覆盖所有引擎（两者都在类型定义中）。
-                              MozAppearance: 'none',
-                              WebkitAppearance: 'none',
+                              appearance: 'none',
                               backgroundColor: isDark ? 'rgba(148,163,184,0.3)' : 'rgba(226,232,240,0.8)',
                               borderRadius: 999, cursor: 'pointer',
                             }}


### PR DESCRIPTION
## What

Frontend hardening from a `/code-review` of `findings.md`, plus a history-drawer accessibility fix and a glossary term. Originally just the first commit; grew across the session as review corrections and a follow-on a11y ticket landed on the same branch.

## Commits

- `990fadb` **state management + CSS typing + key stability** — the initial batch (reasoning-panel state reset, layers-tab `appearance`, suggested-prompts/chat-tab keys).
- `5b7ffec` **correct review findings** — a `/code-review` of the above found four were partial/sidestepped: reverted the index-with-prefix keys to `s.text`; restored standard `appearance: 'none'` (no `as any`); unified the chat-tab key fallback; replaced the reasoning-panel `useEffect` reset with React's render-time prop-change pattern. Added behavior tests.
- `ed84c30` **history-drawer focus trap** — closed the residual a11y gap from `findings.md` F4: the drawer had dialog semantics + Escape + focus-restore but no Tab focus trap. Hand-rolled in the existing keydown handler (no new dep); 7 behavior tests.
- `e1a2ce0` **CONTEXT.md glossary term** — adds "Tool dispatch" (settled during the dispatch-deepening grilling; needed by the separate dispatch migration in #173).

## Verification

- `tsc --noEmit` clean; `next lint` clean (only pre-existing warnings in untouched files).
- Frontend suite: **282 passed**, 3 skipped (pre-existing).

## Note

`findings.md` is partially stale — a pre-implementation audit found 4 of 5 "High" findings already fixed. This PR closes the genuinely-open ones; the doc itself still needs reconciliation (tracked as a follow-up).