### PR TITLE
fix(telemetry): separate rates from counts so UI stops showing counts as %

### DIFF
--- a/app/lib/harness/pi_agent_harness.py
+++ b/app/lib/harness/pi_agent_harness.py
@@ -209,14 +209,23 @@ class PiAgentHarness:
         rate = (self.recovered_exceptions_count / total_exceptions) * 100.0
         return min(100.0, max(0.0, rate))
 
-    def get_telemetry_summary(self) -> Dict[str, float]:
-        """Return instant in-memory telemetry metrics summary."""
+    def get_telemetry_summary(self) -> Dict[str, Dict[str, float]]:
+        """Return instant in-memory telemetry metrics summary.
+
+        Rates (0-100) and raw counts are separated so consumers can format
+        them correctly - previously both shared one flat Dict[str, float] and
+        the UI rendered counts (e.g. ToolCallsCount=42) with a ``%`` suffix.
+        """
         return {
-            "MapSpecValidity": round(self.compute_mapspec_validity(), 2),
-            "CursorResolutionRate": round(self.compute_cursor_resolution_rate(), 2),
-            "ErrorRecoveryRate": round(self.compute_error_recovery_rate(), 2),
-            "ToolCallsCount": float(len(self.tool_calls)),
-            "ExceptionsCount": float(len(self.exceptions)),
+            "rates": {
+                "MapSpecValidity": round(self.compute_mapspec_validity(), 2),
+                "CursorResolutionRate": round(self.compute_cursor_resolution_rate(), 2),
+                "ErrorRecoveryRate": round(self.compute_error_recovery_rate(), 2),
+            },
+            "counts": {
+                "ToolCallsCount": float(len(self.tool_calls)),
+                "ExceptionsCount": float(len(self.exceptions)),
+            },
         }
 
     def evaluate_all(

--- a/frontend/components/drawers/telemetry-status-card.test.tsx
+++ b/frontend/components/drawers/telemetry-status-card.test.tsx
@@ -23,8 +23,14 @@ describe("TelemetryStatusCard", () => {
     },
     harness_enabled: true,
     harness_metrics: {
-      ToolChoiceAccuracy: 95.0,
-      MapSpecValidity: 100.0,
+      rates: {
+        ToolChoiceAccuracy: 95.0,
+        MapSpecValidity: 100.0,
+      },
+      counts: {
+        ToolCallsCount: 42,
+        ExceptionsCount: 3,
+      },
     },
   };
 
@@ -34,7 +40,7 @@ describe("TelemetryStatusCard", () => {
     expect(screen.getByText("暂无遥测数据，请点击刷新加载。")).toBeDefined();
   });
 
-  it("renders metrics, spatial cache hit ratio, and harness metrics", () => {
+  it("renders metrics, spatial cache hit ratio, and harness rates with %", () => {
     render(<TelemetryStatusCard digest={sampleDigest} />);
     expect(screen.getByText("生产端性能与评估遥测")).toBeDefined();
     expect(screen.getByText("83%")).toBeDefined(); // 10 hits / 12 total = 83%
@@ -42,6 +48,18 @@ describe("TelemetryStatusCard", () => {
     expect(screen.getByText("30 ms")).toBeDefined(); // 150ms / 5 = 30ms
     expect(screen.getByText("ToolChoiceAccuracy")).toBeDefined();
     expect(screen.getByText("95%")).toBeDefined();
+  });
+
+  it("renders raw counts WITHOUT a % suffix (U5 regression)", () => {
+    // Previously ToolCallsCount (42) and ExceptionsCount (3) were rendered
+    // as "42%" / "3%" because the card applied % to every harness_metrics
+    // value. Counts must now render as plain numbers.
+    render(<TelemetryStatusCard digest={sampleDigest} />);
+    expect(screen.getByText("42")).toBeDefined();
+    expect(screen.getByText("3")).toBeDefined();
+    // The counts must NOT carry a % - "42%" must not exist in the document.
+    expect(screen.queryByText("42%")).toBeNull();
+    expect(screen.queryByText("3%")).toBeNull();
   });
 
   it("triggers onRefresh callback when refresh button clicked", () => {

--- a/frontend/components/drawers/telemetry-status-card.tsx
+++ b/frontend/components/drawers/telemetry-status-card.tsx
@@ -18,12 +18,19 @@ export interface SpatialCacheInfo {
   maxsize: number;
 }
 
+export interface HarnessTelemetryMetrics {
+  /** 0-100 percentage metrics. Rendered with a ``%`` suffix. */
+  rates: Record<string, number>;
+  /** Raw integer counts. Rendered without a ``%`` suffix. */
+  counts: Record<string, number>;
+}
+
 export interface TelemetryDigest {
   success: boolean;
   tool_metrics: Record<string, ToolMetricSnapshot>;
   spatial_cache: SpatialCacheInfo;
   harness_enabled: boolean;
-  harness_metrics?: Record<string, number> | null;
+  harness_metrics?: HarnessTelemetryMetrics | null;
 }
 
 export interface TelemetryStatusCardProps {
@@ -137,13 +144,24 @@ export function TelemetryStatusCard({
             5-维 GIS 评估质量指标
           </span>
           <div className="grid grid-cols-2 gap-2 text-xs">
-            {Object.entries(harness_metrics).map(([name, score]) => (
+            {Object.entries(harness_metrics.rates || {}).map(([name, score]) => (
               <div key={name} className="flex justify-between items-center bg-slate-900/60 p-1.5 rounded">
                 <span className="text-slate-400 text-[11px] truncate">{name}</span>
                 <span className="font-mono font-semibold text-emerald-400">{score}%</span>
               </div>
             ))}
           </div>
+          {/* Raw counts - rendered WITHOUT % (U5 fix: previously shown as percentages). */}
+          {Object.entries(harness_metrics.counts || {}).length > 0 && (
+            <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1 border-t border-slate-800/60">
+              {Object.entries(harness_metrics.counts || {}).map(([name, count]) => (
+                <span key={name} className="text-[11px] text-slate-400">
+                  <span className="text-slate-500">{name}: </span>
+                  <span className="font-mono text-slate-200">{Math.round(count)}</span>
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/tests/unit/test_harness_dispatch_hook.py
+++ b/tests/unit/test_harness_dispatch_hook.py
@@ -135,6 +135,37 @@ def test_harness_caps_accumulated_events():
     assert len(harness.exceptions) <= PiAgentHarness.MAX_EVENTS
 
 
+def test_telemetry_summary_separates_rates_from_counts():
+    """U5 fix: get_telemetry_summary must separate rates (0-100, rendered with
+    %) from raw counts (rendered without %). Previously both shared one flat
+    Dict[str, float], so the UI showed ToolCallsCount=42 as "42%"."""
+    harness = PiAgentHarness(session_id="u5_test")
+    # Record 2 tool calls + 1 error so counts are non-zero.
+    harness.record_event(ToolCallEvent(
+        tool_call_id="ok_1", tool_name="noop", arguments={}, result={},
+    ))
+    harness.record_event(ToolCallEvent(
+        tool_call_id="ok_2", tool_name="noop", arguments={}, result={},
+    ))
+    harness.record_event(ToolCallEvent(
+        tool_call_id="err_1", tool_name="noop", arguments={}, is_error=True,
+        error_msg="boom",
+    ))
+
+    summary = harness.get_telemetry_summary()
+    assert "rates" in summary
+    assert "counts" in summary
+    # Rates are 0-100 percentages.
+    assert "MapSpecValidity" in summary["rates"]
+    assert "ErrorRecoveryRate" in summary["rates"]
+    for v in summary["rates"].values():
+        assert 0.0 <= v <= 100.0
+    # Counts are raw integers-as-floats, NOT in rates.
+    assert summary["counts"]["ToolCallsCount"] == 3.0
+    assert summary["counts"]["ExceptionsCount"] == 1.0
+    assert "ToolCallsCount" not in summary["rates"]
+
+
 def test_tool_metrics_record_event():
     """Verify tool_metrics.record_event delegates to record_tool_call."""
     from app.lib.harness.tool_call_event import ToolCallEvent


### PR DESCRIPTION
## Summary
Fixes #269. `PiAgentHarness.get_telemetry_summary()` returned one flat `Dict[str, float]` mixing 0-100 rates with raw counts. `TelemetryStatusCard` rendered every value with a `%` suffix, so `ToolCallsCount=42` displayed as "42%" - a user-visible display bug.

## Fix
- Split `get_telemetry_summary()` into `{rates: {...}, counts: {...}}`.
- `TelemetryStatusCard` renders rates with `%` (in the metric grid) and counts as plain numbers (in a separate row below).

## Tests
- Backend: `test_telemetry_summary_separates_rates_from_counts` - asserts structure + that counts are not in rates.
- Frontend: `renders raw counts WITHOUT a % suffix (U5 regression)` - asserts "42" renders but "42%" does not.
- `tsc --noEmit` clean (no type errors).

## Out of scope
The other 4 unfixed review findings are tracked in:
- #267 - compiler emits no `<text>` labels
- #268 - raster basemap oversampling missing
- #271 - no E2E tests for export pipelines
- #272 - visualJudge dead code