### PR TITLE
fix(ci): document heavy marker contract + set master branch protection

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,10 +8,15 @@ timeout_method = thread
 ; 覆盖率闸由 CI 命令行控制（--cov-fail-under）。
 ; smoke-test-* 是脚本不是 pytest 用例，保留 --ignore。
 ; 其余被 --ignore 的测试待后续修复后逐一恢复。
+;
+; heavy marker contract: CI runs ALL tests including heavy ones (their deps
+; are in requirements.txt). Tests that need external toolchains beyond pip
+; (Node/Playwright/CDN) self-skip via shutil.which/env guards inside the test.
+; Run heavy-only locally: pytest -m heavy
 addopts = --ignore=tests/test_core_features_sanity.py --ignore=tests/smoke-test-buffer.py --ignore=tests/smoke_deep_enhancement.py --cov=app --cov-report=term-missing
 filterwarnings =
     ignore::PendingDeprecationWarning:starlette.*
     ignore:Please use `import python_multipart`:PendingDeprecationWarning
     ignore:Glyph .* missing from font:UserWarning
 markers =
-    heavy: tests that import geopandas/numpy/rasterio (run with: pytest -m heavy)
+    heavy: tests that need heavy deps (geopandas/numpy/rasterio). CI runs them; tests needing Node/Playwright self-skip.


### PR DESCRIPTION
## Root Cause Investigation: 4 Post-Release Issues

Investigated four issues identified during v0.1.3 post-release review.

### Issue 1: heavy marker contract broken (FIXED - documentation)
**Root cause:** The `heavy` marker in `pytest.ini` was documented as opt-in (`run with: pytest -m heavy`), implying CI excludes heavy tests. But CI ran all tests with no `-m` filter.

**Why not add `-m "not heavy"` to CI:** 4 of 5 heavy test files pass in CI because their deps (numpy, rasterio, shapely) are in `requirements.txt`. Only `test_runtime_validator_full_flow` fails (needs Node/Playwright/CDN). Adding `-m "not heavy"` would skip 4 passing tests, reducing coverage.

**Fix:** Document the actual contract accurately in `pytest.ini` comments and marker description. CI runs heavy tests; tests needing external toolchains beyond pip self-skip via env guards (already implemented in `test_runtime_validator.py`).

### Issue 2: CI red undetected for 4 days (FIXED - branch protection)
**Root cause:** Master CI was red for 4 consecutive days (21 failed runs from Jul 31 to Aug 3) since `test_runtime_validator_full_flow` was added. No branch protection existed (`404 Branch not protected`), so nothing prevented merging to a red master.

**Evidence:**
- Jul 31 05:31 to Aug 3 14:20: every CI run on master was `failure`
- Only the v0.1.3 fix (commit `f24a085`, merged this session) turned it green
- `gh api branches/master/protection` returned `404 Branch not protected`

**Fix:** Set branch protection on master requiring 4 CI checks:
- Backend Tests
- Frontend Tests
- Code Quality Check
- Security Scan

Set via `gh api repos/.../branches/master/protection` (already applied).

### Issue 3: MapLibre tile-load error handling (DOCUMENTED - feature scope)
**Root cause:** A single top-level `ErrorBoundary` in `frontend/components/providers/client-providers.tsx:14-42` wraps the entire app. When MapLibre throws "Style is not done loading" (tile CDN unreachable), this boundary catches it and renders a full-screen "System Error" overlay. No map-specific error boundary or graceful fallback exists.

**Recommendation:** Add a map-specific error boundary around `MapPanel` with a fallback UI ("Map unavailable, chat still works"). Separate scope from this PR.

### Issue 4: Test ratio at 15% (DOCUMENTED - feature scope)
**Root cause:** 201 Python source files in `app/`, 226 test files in `tests/`, but test-to-source ratio is ~15% by LOC. Key gaps: explorer pipeline modules (`discover_stage.py`, `fetch_stage.py`, `intent_detector.py`) are untested. The ADR-extracted geo modules (`density.py`, `geometry_ops.py`) do have tests.

**Recommendation:** Pair each future ADR with a test file. Prioritize explorer pipeline coverage next sprint. Separate scope from this PR.

### Changes
- `pytest.ini`: Documented heavy marker contract (comments + marker description)
- Branch protection on master (applied via gh api, not a file change)