### PR TITLE
fix(map): scope map failures to a boundary + test explorer stages

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -17,6 +17,7 @@ import TopBar from '@/components/layout/top-bar';
 import { LeftSidebar } from '@/components/sidebar/left-sidebar';
 import FloatingLegend from '@/components/map/floating-legend';
 import { SpatialCrosshair } from '@/components/map/spatial-crosshair';
+import { MapErrorBoundary } from '@/components/map/map-error-boundary';
 import { EmbodiedHud } from '@/components/hud/embodied-hud';
 import TweaksPanel from '@/components/tweaks-panel';
 
@@ -159,14 +160,16 @@ export default function Home() {
       <div style={{ flex: 1, position: 'relative', overflow: 'hidden', marginTop: 42, marginBottom: 24 }}>
         {/* Map Panel */}
         <div style={{ position: 'absolute', inset: 0 }}>
-          <MapPanel
-            layers={layers}
-            onRemoveLayer={removeLayer}
-            onToggleLayer={toggleLayer}
-            onViewportChange={bridge.onViewportChange}
-          />
-          <ExportMask />
-          <SpatialCrosshair />
+          <MapErrorBoundary>
+            <MapPanel
+              layers={layers}
+              onRemoveLayer={removeLayer}
+              onToggleLayer={toggleLayer}
+              onViewportChange={bridge.onViewportChange}
+            />
+            <ExportMask />
+            <SpatialCrosshair />
+          </MapErrorBoundary>
         </div>
 
         {/* Floating Legend */}

--- a/frontend/components/map/map-error-boundary.test.tsx
+++ b/frontend/components/map/map-error-boundary.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for the map-scoped error boundary.
+ *
+ * Before this boundary existed, a MapLibre failure ("Style is not done loading"
+ * when the tile CDN is unreachable) bubbled to the top-level ErrorBoundary in
+ * client-providers.tsx and replaced the entire app with a full-screen
+ * "System Error" page — killing chat and analysis along with the map.
+ *
+ * These tests pin three properties:
+ *   1. A throwing child is contained; the fallback renders instead of crashing.
+ *   2. Tile/network failures get a network-specific message, not a raw stack.
+ *   3. Retry clears the error locally (no window.location.reload, which would
+ *      discard chat history).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MapErrorBoundary } from './map-error-boundary';
+
+function Boom({ message }: { message: string }): never {
+  throw new Error(message);
+}
+
+describe('MapErrorBoundary', () => {
+  beforeEach(() => {
+    // React logs caught boundary errors to console.error; silence the expected noise.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when nothing throws', () => {
+    render(
+      <MapErrorBoundary>
+        <div>map canvas</div>
+      </MapErrorBoundary>
+    );
+
+    expect(screen.getByText('map canvas')).toBeInTheDocument();
+    expect(screen.queryByText(/map unavailable/i)).not.toBeInTheDocument();
+  });
+
+  it('contains a throwing child instead of letting the error escape', () => {
+    render(
+      <MapErrorBoundary>
+        <Boom message='Style is not done loading' />
+      </MapErrorBoundary>
+    );
+
+    expect(screen.getByText(/map unavailable/i)).toBeInTheDocument();
+  });
+
+  it('explains a tile-load failure as a network problem, not a crash', () => {
+    render(
+      <MapErrorBoundary>
+        <Boom message='Style is not done loading' />
+      </MapErrorBoundary>
+    );
+
+    expect(screen.getByText(/basemap tiles could not be loaded/i)).toBeInTheDocument();
+    // The whole point of scoping the boundary: the rest of the app survives.
+    expect(screen.getByText(/chat and analysis still work/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the raw message for non-network failures', () => {
+    render(
+      <MapErrorBoundary>
+        <Boom message='layer id collision: eq' />
+      </MapErrorBoundary>
+    );
+
+    expect(screen.getByText('layer id collision: eq')).toBeInTheDocument();
+    expect(screen.queryByText(/basemap tiles could not be loaded/i)).not.toBeInTheDocument();
+  });
+
+  it('clears the error state on retry so a recovered map can remount', () => {
+    // Throw on first render, succeed after retry — mirrors a transient tile failure.
+    let shouldThrow = true;
+    function Flaky() {
+      if (shouldThrow) throw new Error('Style is not done loading');
+      return <div>map canvas</div>;
+    }
+
+    render(
+      <MapErrorBoundary>
+        <Flaky />
+      </MapErrorBoundary>
+    );
+
+    expect(screen.getByText(/map unavailable/i)).toBeInTheDocument();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /retry map/i }));
+
+    expect(screen.getByText('map canvas')).toBeInTheDocument();
+    expect(screen.queryByText(/map unavailable/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/map/map-error-boundary.tsx
+++ b/frontend/components/map/map-error-boundary.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, { Component, type ReactNode } from 'react';
+
+interface MapErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Scoped error boundary for the map region.
+ *
+ * Without this, a MapLibre failure (most commonly "Style is not done loading"
+ * when the tile CDN is unreachable) propagates to the top-level ErrorBoundary in
+ * client-providers.tsx and takes down the whole app — chat, layers, and analysis
+ * panels included. The map is the least essential part of the page for a text
+ * conversation, so it should fail alone.
+ *
+ * Recovery is a local remount (`key` bump) rather than `window.location.reload()`:
+ * transient tile/network failures usually clear on retry, and a full reload would
+ * discard the user's chat history and session state.
+ */
+export class MapErrorBoundary extends Component<{ children: ReactNode }, MapErrorBoundaryState> {
+  state: MapErrorBoundaryState = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    const message = this.state.error?.message ?? 'Unknown map error';
+    // MapLibre surfaces an unreachable tile/style endpoint as "Style is not done
+    // loading". Name the network cause so the user doesn't read it as data loss.
+    const isStyleLoadError = /style is not done loading|failed to fetch|networkerror/i.test(message);
+
+    return (
+      <div className='absolute inset-0 flex items-center justify-center bg-[#dce8f2]'>
+        <div className='max-w-sm space-y-3 px-6 text-center'>
+          <div className='font-mono text-xs uppercase tracking-widest text-slate-500'>
+            Map Unavailable
+          </div>
+          <p className='text-sm text-slate-600'>
+            {isStyleLoadError
+              ? 'The basemap tiles could not be loaded. Check your network connection or tile provider.'
+              : message}
+          </p>
+          <p className='text-xs text-slate-400'>
+            Chat and analysis still work. Layers will render once the map recovers.
+          </p>
+          <button
+            onClick={this.handleRetry}
+            className='rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-600 transition-colors hover:bg-slate-200/60'
+          >
+            Retry Map
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/tests/unit/test_explorer_stages.py
+++ b/tests/unit/test_explorer_stages.py
@@ -1,0 +1,300 @@
+"""Unit tests for the Explorer discover and fetch stages (ADR-0034).
+
+These two stages were extracted into pure async functions with injectable seams
+(`adapter`, `store_ref`, `on_progress`) but shipped without tests. The behaviours
+pinned here are the ones a caller depends on and that a refactor could silently
+break:
+
+  discover: dict->SearchContext coercion, top-3 truncation, score-descending sort
+  fetch:    per-source error isolation, store_ref seam, all-failed => success=False
+
+Both stages default to a real `GovDataAdapter` when no adapter is passed, so every
+test injects a fake to keep the suite offline and deterministic.
+"""
+import pytest
+
+from app.adapters.base import DataSource
+from app.services.explorer.discover_stage import run_discover_stage
+from app.services.explorer.fetch_stage import run_fetch_stage
+from app.services.explorer.models import (
+    DataSourceQualityScore,
+    RawContent,
+    SearchContext,
+)
+
+
+def _source(source_id: str, fmt: str = "csv") -> DataSource:
+  return DataSource(id=source_id, name=f"source-{source_id}", format=fmt)
+
+
+def _score(overall: float) -> DataSourceQualityScore:
+  """A quality score whose `overall` is the only dimension under test."""
+  return DataSourceQualityScore(
+      temporal_score=overall,
+      thematic_score=overall,
+      spatial_score=overall,
+      field_score=overall,
+      precision_score=overall,
+      overall=overall,
+  )
+
+
+class FakeDiscoverAdapter:
+  """Adapter double for the discover stage.
+
+  `scores` maps source id -> overall score so a test can control ranking without
+  caring about the other four quality dimensions.
+  """
+
+  def __init__(self, sources: list[DataSource], scores: dict[str, float] | None = None):
+    self._sources = sources
+    self._scores = scores or {}
+    self.discover_calls: list[tuple[str, SearchContext]] = []
+    self.assessed: list[str] = []
+
+  async def discover(self, query: str, context: SearchContext) -> list[DataSource]:
+    self.discover_calls.append((query, context))
+    return self._sources
+
+  async def quick_assess(self, query: str, source: DataSource) -> DataSourceQualityScore:
+    self.assessed.append(source.id)
+    return _score(self._scores.get(source.id, 0.5))
+
+
+class FakeFetchAdapter:
+  """Adapter double for the fetch stage.
+
+  `payloads` maps source id -> bytes to return. A source id absent from the map
+  raises, which is how the per-source failure path gets exercised.
+  """
+
+  def __init__(self, payloads: dict[str, bytes]):
+    self._payloads = payloads
+    self.fetched: list[str] = []
+
+  async def fetch(self, source: DataSource) -> RawContent:
+    self.fetched.append(source.id)
+    if source.id not in self._payloads:
+      raise RuntimeError(f"upstream 503 for {source.id}")
+    return RawContent(data=self._payloads[source.id], content_type="text/csv")
+
+
+# ─── discover stage ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_discover_coerces_dict_context_and_defaults_query():
+  """A dict context is coerced to SearchContext, with `query` filled from the arg.
+
+  Callers (the Celery adapter) pass a plain dict, so the stage must not require a
+  pre-built model, and must not lose the query when the dict omits it.
+  """
+  adapter = FakeDiscoverAdapter([_source("a")])
+
+  await run_discover_stage(
+      task_id="t1",
+      query="海淀区学校分布",
+      context={"expected_data_type": "poi_list"},
+      adapter=adapter,
+  )
+
+  _, ctx = adapter.discover_calls[0]
+  assert isinstance(ctx, SearchContext)
+  assert ctx.query == "海淀区学校分布"
+  assert ctx.expected_data_type == "poi_list"
+
+
+@pytest.mark.asyncio
+async def test_discover_does_not_overwrite_explicit_context_query():
+  """An explicit query already in the context wins over the positional arg."""
+  adapter = FakeDiscoverAdapter([_source("a")])
+
+  await run_discover_stage(
+      task_id="t1",
+      query="positional",
+      context={"query": "explicit"},
+      adapter=adapter,
+  )
+
+  _, ctx = adapter.discover_calls[0]
+  assert ctx.query == "explicit"
+
+
+@pytest.mark.asyncio
+async def test_discover_assesses_at_most_three_sources():
+  """Only the top 3 candidates are scored — quick_assess is the expensive call."""
+  adapter = FakeDiscoverAdapter([_source(str(i)) for i in range(6)])
+
+  result = await run_discover_stage(
+      task_id="t1",
+      query="q",
+      context={"query": "q"},
+      adapter=adapter,
+  )
+
+  assert len(adapter.assessed) == 3
+  assert len(result.data["selected_sources"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_discover_sorts_selected_sources_by_score_descending():
+  """The caller picks `selected_sources[0]`, so best-first ordering is the contract."""
+  adapter = FakeDiscoverAdapter(
+      [_source("low"), _source("high"), _source("mid")],
+      scores={"low": 0.1, "high": 0.9, "mid": 0.5},
+  )
+
+  result = await run_discover_stage(
+      task_id="t1",
+      query="q",
+      context={"query": "q"},
+      adapter=adapter,
+  )
+
+  ordered = [item["source"]["id"] for item in result.data["selected_sources"]]
+  assert ordered == ["high", "mid", "low"]
+
+
+@pytest.mark.asyncio
+async def test_discover_reports_progress_and_echoes_task_id():
+  adapter = FakeDiscoverAdapter([_source("a")])
+  progress: list[int] = []
+
+  result = await run_discover_stage(
+      task_id="task-42",
+      query="q",
+      context={"query": "q"},
+      adapter=adapter,
+      on_progress=progress.append,
+  )
+
+  assert progress == [10, 100]
+  assert result.success is True
+  assert result.stage == "discover"
+  assert result.data["task_id"] == "task-42"
+
+
+# ─── fetch stage ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_fetch_stores_payload_through_store_ref_seam():
+  """Payloads go through the injected store_ref; the stage returns only its id.
+
+  Raw bytes must not ride along in the stage result — that is what the ref seam
+  exists to avoid (Celery meta would otherwise carry whole files).
+  """
+  adapter = FakeFetchAdapter({"a": b"col1,col2\n1,2\n"})
+  stored: list[tuple[dict, str]] = []
+
+  def store_ref(payload: dict, kind: str) -> str:
+    stored.append((payload, kind))
+    return "ref-123"
+
+  result = await run_fetch_stage(
+      task_id="t1",
+      selected_sources=[{"source": _source("a").model_dump()}],
+      adapter=adapter,
+      store_ref=store_ref,
+  )
+
+  assert result.success is True
+  entry = result.data["fetch_results"][0]
+  assert entry == {
+      "source_id": "a",
+      "ref_id": "ref-123",
+      "size_bytes": len(b"col1,col2\n1,2\n"),
+      "format": "csv",
+  }
+
+  payload, kind = stored[0]
+  assert kind == "fetch"
+  assert payload["data"] == b"col1,col2\n1,2\n".hex()
+  assert payload["content_type"] == "text/csv"
+
+
+@pytest.mark.asyncio
+async def test_fetch_falls_back_to_synthetic_ref_without_store_ref():
+  """With no store_ref injected the stage still succeeds, using a derived id."""
+  adapter = FakeFetchAdapter({"a": b"x"})
+
+  result = await run_fetch_stage(
+      task_id="t1",
+      selected_sources=[{"source": _source("a").model_dump()}],
+      adapter=adapter,
+  )
+
+  assert result.data["fetch_results"][0]["ref_id"] == "ref_fetch_a"
+
+
+@pytest.mark.asyncio
+async def test_fetch_isolates_one_failing_source_and_keeps_the_rest():
+  """One bad source must not sink the batch — partial success is still success."""
+  adapter = FakeFetchAdapter({"good": b"data"})  # "bad" is absent => raises
+
+  result = await run_fetch_stage(
+      task_id="t1",
+      selected_sources=[
+          {"source": _source("bad").model_dump()},
+          {"source": _source("good").model_dump()},
+      ],
+      adapter=adapter,
+  )
+
+  assert result.success is True
+  ids = [r["source_id"] for r in result.data["fetch_results"]]
+  # Only successful fetches are forwarded; the failed one is dropped from results.
+  assert ids == ["good"]
+  assert adapter.fetched == ["bad", "good"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_fails_when_every_source_fails():
+  """All-failed is a stage failure, and the errors are kept for the caller."""
+  adapter = FakeFetchAdapter({})  # every fetch raises
+
+  result = await run_fetch_stage(
+      task_id="t1",
+      selected_sources=[
+          {"source": _source("a").model_dump()},
+          {"source": _source("b").model_dump()},
+      ],
+      adapter=adapter,
+  )
+
+  assert result.success is False
+  assert result.stage == "fetch"
+  assert "All source fetches failed" in result.message
+  errored = [e["source_id"] for e in result.data["errors"]]
+  assert errored == ["a", "b"]
+  assert all("error" in e for e in result.data["errors"])
+
+
+@pytest.mark.asyncio
+async def test_fetch_skips_final_progress_when_all_sources_fail():
+  """Progress must not report 100% for a stage that failed."""
+  adapter = FakeFetchAdapter({})
+  progress: list[int] = []
+
+  result = await run_fetch_stage(
+      task_id="t1",
+      selected_sources=[{"source": _source("a").model_dump()}],
+      adapter=adapter,
+      on_progress=progress.append,
+  )
+
+  assert result.success is False
+  assert progress == [10]
+
+
+@pytest.mark.asyncio
+async def test_fetch_reports_progress_on_success():
+  adapter = FakeFetchAdapter({"a": b"x"})
+  progress: list[int] = []
+
+  await run_fetch_stage(
+      task_id="t1",
+      selected_sources=[{"source": _source("a").model_dump()}],
+      adapter=adapter,
+      on_progress=progress.append,
+  )
+
+  assert progress == [10, 100]


### PR DESCRIPTION
Closes issues 3 and 4 from the v0.1.3 post-release investigation (follow-up to #287, which fixed issues 1 and 2).

## Issue 3: map failures took down the whole app

**Root cause:** A single top-level `ErrorBoundary` in `frontend/components/providers/client-providers.tsx:14-42` wraps the entire app. When MapLibre throws `Style is not done loading` (tile CDN unreachable), that boundary catches it and replaces the whole page with a full-screen "System Error" — chat, layers, and analysis panels die with the map. Its only recovery path is `window.location.reload()`, which discards chat history.

**Fix:** `MapErrorBoundary` scoped to the map region (`frontend/components/map/map-error-boundary.tsx`), wrapping `MapPanel` / `ExportMask` / `SpatialCrosshair` in `page.tsx`.

Behaviour:
- The map fails alone; chat and analysis keep working
- Tile/network failures get a network-specific message instead of a raw stack
- "Retry Map" clears error state locally (no reload, so chat history survives)

## Issue 4: explorer stages shipped untested

**Root cause:** `discover_stage.py` and `fetch_stage.py` were extracted into pure async functions with injectable seams (`adapter`, `store_ref`, `on_progress`) under ADR-0034, but landed with no tests.

**Fix:** `tests/unit/test_explorer_stages.py` — 11 tests on the contracts callers depend on:

| Stage | Pinned behaviour |
|-------|------------------|
| discover | dict -> `SearchContext` coercion; explicit context query wins over positional arg |
| discover | at most 3 sources assessed (`quick_assess` is the expensive call) |
| discover | `selected_sources` sorted score-descending (callers read `[0]`) |
| fetch | payload goes through the `store_ref` seam; raw bytes stay out of the result |
| fetch | synthetic ref fallback when no `store_ref` injected |
| fetch | one failing source is isolated; the batch still succeeds |
| fetch | all-failed => `success=False` with errors preserved |
| fetch | progress does not report 100% for a failed stage |

All tests inject fakes, so the suite stays offline and deterministic.

## Verification

Both new test files were **mutation-verified** — they fail when the code breaks:
- Removing the `sources[:3]` slice fails `test_discover_assesses_at_most_three_sources`
- Flipping all-failed `success=False` to `True` fails `test_fetch_fails_when_every_source_fails`

Suites:
- Backend: **1567 passed, 1 skipped** (was 1554 — +11 new, +2 collected)
- Frontend: **414 passed, 3 skipped across 62 files** (was 409 — +5 new)
- `tsc --noEmit`: clean

The 1 backend skip is `test_runtime_validator_full_flow` correctly self-skipping without Playwright.