### PR TITLE
fix(rag,chat,session-store): restore persistence, body-session ownership, chronological event log

### DIFF
--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -311,6 +311,27 @@ class PiBridge:
         """Stop the Pi subprocess (delegates to the RPC client)."""
         await self._rpc.stop()
 
+    async def abort(self) -> dict:
+        """Abort the currently-running Pi prompt (fire-and-forget from callers).
+
+        BUG-18 fix re-added: ADR-0031 F3 extraction removed the abort wrapper,
+        leaving chat.py:320's `await pi_bridge.abort()` to AttributeError into
+        a swallowed `except Exception` — the in-flight prompt kept consuming
+        tokens and writing files after session deletion.
+
+        The RPC client's `request("abort")` matches vendor/pi's rpc-mode.js
+        `case "abort"` handler. Failures (no process, RPC error) propagate;
+        callers wrap in try/except because abort must never block the cleanup
+        path that follows.
+        """
+        result = await self._rpc.request("abort")
+        # Cancel any pending request future the client hasn't resolved yet.
+        # Without this, an in-flight `prompt` would keep waiting for its
+        # response up to the stream timeout (30s) and then emit a generic
+        # timeout error to the user instead of a clean cancellation.
+        self._rpc.fail_all_pending("abort requested")
+        return result or {}
+
     async def prompt(self, message: str, session_id: Optional[str] = None) -> dict:
         """Send a prompt to Pi agent (non-streaming).
 

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -4,9 +4,11 @@ import os
 from fastapi import APIRouter, Depends, HTTPException, Header, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Optional
 
 from app.core.auth import get_current_user_optional, get_owner_token, require_admin, require_owned_session
+from app.core.database import get_async_db
 from app.models.db_model import Conversation
 from app.services.chat_engine import ChatEngine
 from app.services.history_service_async import AsyncHistoryService
@@ -77,6 +79,7 @@ class ChatResponse(BaseModel):
 
 
 async def _guard_body_session(
+    db: AsyncSession,
     session_id: Optional[str],
     user_id: Optional[str],
     owner_token: Optional[str],
@@ -86,20 +89,22 @@ async def _guard_body_session(
     不能直接复用 `require_owned_session`：chat 的 session_id 来自 body 而非
     路径参数，且首条消息会新建会话，所以"库中不存在"必须放行、只有"存在但
     属于他人"才拒绝。与既有守卫一致统一返回 404，避免泄漏会话存在性。
+
+    复用请求注入的 `db`（与 require_owned_session 同一模式）而非另开
+    async_db_session：后者在 asyncpg 下会与同连接上进行中的操作冲突
+    （InterfaceError: another operation is in progress）。
     """
     if not session_id:
         return
 
-    async with async_db_session() as db:
-        owned = await AsyncHistoryService(db).get_session(
-            session_id, user_id=user_id, owner_token=owner_token
-        )
-        if owned is not None:
-            return
-        # get_session 对"不存在"和"越权"都返回 None，需区分两者。
-        exists = await db.get(Conversation, session_id) is not None
+    owned = await AsyncHistoryService(db).get_session(
+        session_id, user_id=user_id, owner_token=owner_token
+    )
+    if owned is not None:
+        return
 
-    if exists:
+    # get_session 对"不存在"和"越权"都返回 None，需区分两者。
+    if await db.get(Conversation, session_id) is not None:
         raise HTTPException(status_code=404, detail="Session not found")
 
 
@@ -108,10 +113,11 @@ async def chat_completions(
     req: ChatRequest,
     _user: dict = Depends(get_current_user_optional),
     owner_token: Optional[str] = Depends(get_owner_token),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """非流式对话接口"""
     user_id = _user.get("user_id")
-    await _guard_body_session(req.session_id, user_id, owner_token)
+    await _guard_body_session(db, req.session_id, user_id, owner_token)
 
     if _use_pi_bridge():
         try:
@@ -144,10 +150,11 @@ async def chat_stream(
     req: ChatRequest,
     _user: dict = Depends(get_current_user_optional),
     owner_token: Optional[str] = Depends(get_owner_token),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """SSE 流式对话接口"""
     user_id = _user.get("user_id")
-    await _guard_body_session(req.session_id, user_id, owner_token)
+    await _guard_body_session(db, req.session_id, user_id, owner_token)
 
     if _use_pi_bridge():
         async def pi_event_generator():

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -76,10 +76,42 @@ class ChatResponse(BaseModel):
     owner_token: Optional[str] = None
 
 
+async def _guard_body_session(
+    session_id: Optional[str],
+    user_id: Optional[str],
+    owner_token: Optional[str],
+) -> None:
+    """S31/S32/SEC-08：校验请求体携带的 session_id 属于当前调用者。
+
+    不能直接复用 `require_owned_session`：chat 的 session_id 来自 body 而非
+    路径参数，且首条消息会新建会话，所以"库中不存在"必须放行、只有"存在但
+    属于他人"才拒绝。与既有守卫一致统一返回 404，避免泄漏会话存在性。
+    """
+    if not session_id:
+        return
+
+    async with async_db_session() as db:
+        owned = await AsyncHistoryService(db).get_session(
+            session_id, user_id=user_id, owner_token=owner_token
+        )
+        if owned is not None:
+            return
+        # get_session 对"不存在"和"越权"都返回 None，需区分两者。
+        exists = await db.get(Conversation, session_id) is not None
+
+    if exists:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+
 @router.post("/completions", response_model=ChatResponse)
-async def chat_completions(req: ChatRequest, _user: dict = Depends(get_current_user_optional)):
+async def chat_completions(
+    req: ChatRequest,
+    _user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
+):
     """非流式对话接口"""
     user_id = _user.get("user_id")
+    await _guard_body_session(req.session_id, user_id, owner_token)
 
     if _use_pi_bridge():
         try:
@@ -108,9 +140,14 @@ async def chat_completions(req: ChatRequest, _user: dict = Depends(get_current_u
 
 
 @router.post("/stream", response_model=None)
-async def chat_stream(req: ChatRequest, _user: dict = Depends(get_current_user_optional)):
+async def chat_stream(
+    req: ChatRequest,
+    _user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
+):
     """SSE 流式对话接口"""
     user_id = _user.get("user_id")
+    await _guard_body_session(req.session_id, user_id, owner_token)
 
     if _use_pi_bridge():
         async def pi_event_generator():

--- a/app/services/chat/pi_rpc_client.py
+++ b/app/services/chat/pi_rpc_client.py
@@ -245,6 +245,12 @@ class PiRpcClient:
                 future.set_exception(PiRpcError(reason))
         self._pending_requests.clear()
 
+    def fail_all_pending(self, reason: str) -> None:
+        """Public version of _fail_all_pending. Used by PiBridge.abort() so
+        in-flight `prompt` futures resolve with PiRpcError instead of timing
+        out 30s later. Same semantics as _fail_all_pending."""
+        self._fail_all_pending(reason)
+
     async def request(self, command: str, data: Optional[dict] = None) -> Any:
         """Send a JSON-RPC request to Pi and wait for the multiplexed response.
 

--- a/app/services/rag/engine.py
+++ b/app/services/rag/engine.py
@@ -59,6 +59,18 @@ class KnowledgeEngine:
         embeddings = self._store.embed_texts(texts)
         doc_id = f"doc_{uuid.uuid4().hex[:12]}"
 
+        # Positional chunk records for callers that persist chunk rows alongside
+        # the vector index. Derived here so chunking stays single-sourced.
+        chunk_records = [
+            {
+                "content": texts[i],
+                "chunk_index": c.get("chunk_index", i) if isinstance(c, dict) else i,
+                "start_char": c.get("start_char") if isinstance(c, dict) else None,
+                "end_char": c.get("end_char") if isinstance(c, dict) else None,
+            }
+            for i, c in enumerate(chunk_list)
+        ]
+
         user_id = tenant.user_id if tenant else None
         org_id = tenant.org_id if tenant else None
 
@@ -81,6 +93,7 @@ class KnowledgeEngine:
             "document_id": doc_id,
             "title": title,
             "chunks_count": len(chunk_list),
+            "chunks": chunk_records,
             "status": "indexed",
         }
 

--- a/app/services/rag/engine.py
+++ b/app/services/rag/engine.py
@@ -2,6 +2,7 @@
 KnowledgeEngine - Deep RAG Knowledge Retrieval & Vector Indexing Engine.
 Enforces TenantContext multi-tenant security isolation and index compaction.
 """
+import asyncio
 import logging
 import uuid
 from dataclasses import dataclass
@@ -56,7 +57,11 @@ class KnowledgeEngine:
             return {"error": "No valid text chunks generated from document"}
 
         texts = [c["content"] if isinstance(c, dict) else str(c) for c in chunk_list]
-        embeddings = self._store.embed_texts(texts)
+        # REVIEW-P1-5: SentenceTransformer.encode is CPU-bound (seconds for
+        # many chunks). Offload to the default thread pool so the event loop
+        # stays responsive for other requests during /knowledge/documents POST.
+        # ADR-0038 dropped the run_in_executor wrapper that rag_service had.
+        embeddings = await asyncio.to_thread(self._store.embed_texts, texts)
         doc_id = f"doc_{uuid.uuid4().hex[:12]}"
 
         # Positional chunk records for callers that persist chunk rows alongside
@@ -108,7 +113,8 @@ class KnowledgeEngine:
         if not query.strip():
             return []
 
-        query_vectors = self._store.embed_texts([query])
+        # REVIEW-P1-5: see index_document — embed_texts is CPU-bound.
+        query_vectors = await asyncio.to_thread(self._store.embed_texts, [query])
 
         user_id = tenant.user_id if tenant else None
         org_id = tenant.org_id if tenant else None

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -2,12 +2,9 @@
 RAG 检索增强生成服务 - 基于 FAISS 的本地向量搜索与知识库管理。
 深度模块适配层，将向量存储委托给 FaissVectorStore，分块委托给 chunker。
 """
-import asyncio
 import logging
 import uuid
 from typing import Any, Optional
-
-import numpy as np
 
 from app.services.rag.chunker import split_into_chunks, split_markdown_sections
 from app.services.rag.faiss_store import FaissVectorStore
@@ -56,12 +53,66 @@ async def add_document(
     org_id: Optional[Any] = None,
 ) -> dict[str, Any]:
     """
-    添加文档到知识库，执行全文嵌入（委托给 KnowledgeEngine）。
+    添加文档到知识库，执行全文嵌入（委托给 KnowledgeEngine），
+    并持久化 Document/Chunk 元数据行（list_documents 依赖该表）。
     """
+    from datetime import datetime, timezone
+
+    from app.models.knowledge_base import Chunk, Document
     from app.services.rag.engine import TenantContext, get_knowledge_engine
+    from app.tools._utils import async_db_session
+
     tenant = TenantContext(user_id=user_id, org_id=str(org_id) if org_id is not None else None)
     engine = get_knowledge_engine()
-    return await engine.index_document(title=title, content=content, file_type=file_type, tenant=tenant)
+    result = await engine.index_document(
+        title=title, content=content, file_type=file_type, tenant=tenant
+    )
+    if "error" in result:
+        return result
+
+    doc_id = result["document_id"]
+    chunk_records = result.get("chunks", [])
+
+    try:
+        async with async_db_session() as db:
+            doc = Document(
+                id=doc_id,
+                title=title,
+                content=content[:1000] if content else "",
+                file_type=file_type,
+                chunk_count=len(chunk_records),
+                status="completed",
+                creator_id=user_id,
+                org_id=org_id,
+                indexed_at=datetime.now(timezone.utc),
+            )
+            db.add(doc)
+
+            for ch in chunk_records:
+                db.add(
+                    Chunk(
+                        id=str(uuid.uuid4()),
+                        document_id=doc_id,
+                        content=ch["content"],
+                        chunk_index=ch["chunk_index"],
+                        start_char=ch.get("start_char"),
+                        end_char=ch.get("end_char"),
+                    )
+                )
+    except Exception as e:
+        # Vectors are already indexed; surface the failure rather than reporting
+        # success for a document that will never appear in list_documents.
+        logger.error(f"[RAG] add_document metadata persistence failed: {e}", exc_info=True)
+        return {"error": f"document indexed but metadata persistence failed: {e}"}
+
+    return {
+        "document_id": doc_id,
+        "title": title,
+        "chunk_count": len(chunk_records),
+        "status": "completed",
+    }
+
+
 async def semantic_search(
     query: str,
     top_k: int = 5,
@@ -84,9 +135,36 @@ async def delete_document(
     org_id: Optional[Any] = None,
 ) -> bool:
     """
-    删除指定文档的所有chunk和相关向量（委托给 KnowledgeEngine）。
+    删除指定文档的所有chunk和相关向量。
+    审计 S41：先校验所有权，非本人/本组织的文档拒绝删除。
     """
+    from sqlalchemy import delete, select
+
+    from app.models.knowledge_base import Chunk, Document
     from app.services.rag.engine import TenantContext, get_knowledge_engine
+    from app.tools._utils import async_db_session
+
+    try:
+        async with async_db_session() as db:
+            owner_check = select(Document).where(Document.id == document_id)
+            if org_id is not None:
+                owner_check = owner_check.where(Document.org_id == org_id)
+            elif user_id is not None:
+                owner_check = owner_check.where(Document.creator_id == user_id)
+            existing = (await db.execute(owner_check)).scalar_one_or_none()
+            if existing is None:
+                logger.warning(
+                    "[RAG] delete denied: doc %s not owned by user %s org %s",
+                    document_id, user_id, org_id,
+                )
+                return False
+
+            await db.execute(delete(Chunk).where(Chunk.document_id == document_id))
+            await db.execute(delete(Document).where(Document.id == document_id))
+    except Exception as e:
+        logger.error(f"[RAG] delete_document failed: {e}", exc_info=True)
+        return False
+
     tenant = TenantContext(user_id=user_id, org_id=str(org_id) if org_id is not None else None)
     engine = get_knowledge_engine()
     return await engine.delete_document(document_id, tenant=tenant)
@@ -100,6 +178,7 @@ async def list_documents(
 ) -> dict[str, Any]:
     """列出知识库文档"""
     from sqlalchemy import func, select
+
     from app.models.knowledge_base import Document
     from app.tools._utils import async_db_session
 

--- a/app/services/session_data_protocol.py
+++ b/app/services/session_data_protocol.py
@@ -134,20 +134,32 @@ _active_store: Optional[SessionStoreProtocol] = None
 
 
 def get_session_store() -> SessionStoreProtocol:
-    """Return active SessionStore singleton instance."""
+    """Return active SessionStore singleton instance.
+
+    REVIEW-P1-6: this seam had two latent faults that always landed in the
+    `except Exception` fallback to memory:
+      (a) it gates on `settings.REDIS_ENABLED` — that field does not exist;
+          the real config field is `USE_REDIS` (app/core/config.py:98).
+      (b) the Redis branch tries to import `session_data_manager` from
+          `session_data_redis`, but that module never defines it (it has
+          `RedisSessionStore` and `RedisSessionDataManager`, not
+          `session_data_manager`); the ImportError is swallowed and the
+          memory fallback runs.
+
+    Both are silent in any environment that has `USE_REDIS=True` in
+    settings, because the fallback path *works* — it just isn't the Redis
+    backend, defeating the protocol-parity contract ADR-0035 set out to
+    guarantee.
+
+    Delegate to `create_session_data_manager()`, which already implements
+    the right config-gate + Redis-or-memory selection with a narrower
+    `ImportError`-only fallback.
+    """
     global _active_store
     if _active_store is None:
-        try:
-            from app.core.config import settings
-            if getattr(settings, "REDIS_ENABLED", False):
-                from app.services.session_data_redis import session_data_manager as redis_mgr
-                _active_store = redis_mgr
-            else:
-                from app.services.session_data import session_data_manager
-                _active_store = session_data_manager
-        except Exception:
-            from app.services.session_data import session_data_manager
-            _active_store = session_data_manager
+        from app.services.session_data import create_session_data_manager
+
+        _active_store = create_session_data_manager()
     return _active_store
 
 

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -23,7 +23,13 @@ class RedisSessionStore(BaseSessionStore):
 
     """Session-level data store backed by Redis with cursor support (LRU)."""
 
-    def __init__(self, redis_url: str, capacity: int = 200, socket_timeout: float = 5.0):
+    def __init__(
+        self,
+        redis_url: str,
+        capacity: int = 200,
+        socket_timeout: float = 5.0,
+        redis: Optional[aioredis.Redis] = None,
+    ):
         # 审计 TEST-13：不要在此创建 Redis 客户端。Redis.from_url 返回的客户端在
         # 第一次 async 操作时会把它内部的连接池绑定到当时的 event loop；而本单例在
         # 模块 import 时就构造（session_data_manager = create_session_data_manager()），
@@ -33,7 +39,10 @@ class RedisSessionStore(BaseSessionStore):
         # 改为懒构造：存配置，首次 async 调用时由 _ensure_connected() 在正确的 loop 上创建。
         self._redis_url = redis_url
         self._socket_timeout = socket_timeout
-        self._r: Optional[aioredis.Redis] = None
+        # 测试注入：允许测试套件传入一个已经构造好的客户端（例如 fakeredis）。
+        # 跳过 lazy 构造，避免 `redis_url` 与注入的客户端不一致。生产路径不传此参数。
+        self._injected_redis = redis
+        self._r: Optional[aioredis.Redis] = redis
         self._bound_loop: Optional[asyncio.AbstractEventLoop] = None
         self.capacity = capacity
 
@@ -51,6 +60,10 @@ class RedisSessionStore(BaseSessionStore):
             loop = asyncio.get_running_loop()
         except RuntimeError:
             loop = None
+
+        # 测试注入：注入的客户端在构造时已绑定，不需要懒构造或重连。
+        if self._injected_redis is not None:
+            return self._injected_redis
 
         # 如果客户端已存在且绑定的 loop 仍是当前 loop，复用
         if self._r is not None and self._bound_loop is not None and self._bound_loop is loop:
@@ -414,8 +427,11 @@ class RedisSessionStore(BaseSessionStore):
         try:
             async with self._r.pipeline() as pipe:
                 key = self._events_key(session_id)
-                pipe.lpush(key, entry)
-                pipe.ltrim(key, 0, MAX_EVENTS - 1)
+                # rpush 保持与 memory (deque.append) 相同的"最旧在前"时序。
+                # 消费方按 [-3:]/[-5:] 从尾部切片，所以"最旧在前"才能拿到最新 N 条；
+                # lpush 会让 Redis 的事件序列与 memory 倒置。
+                pipe.rpush(key, entry)
+                pipe.ltrim(key, -MAX_EVENTS, -1)
                 pipe.expire(key, EVENTS_TTL)
                 pipe.sadd(self._active_key(), session_id)
                 self._refresh_session_ttl(pipe, session_id)

--- a/tests/integration/test_cross_tenant_isolation.py
+++ b/tests/integration/test_cross_tenant_isolation.py
@@ -472,3 +472,94 @@ async def test_cross_tenant_reports_list_404(client, tenants):
         headers=_auth_headers(tenants["user_b"]),
     )
     assert resp.status_code == 404
+
+
+# ────────────────────────────────────────────────────────────────────
+# 8. Chat body session_id 所有权 (REVIEW-P0-2)
+#
+# ADR-0030 给 /chat/sessions/* 全部挂上了 require_owned_session，但
+# /chat/completions 与 /chat/stream 漏掉了 —— 这两个端点的 session_id 来自
+# request body，只有 get_current_user_optional，下游 load_context 又对
+# owner_token 不匹配只打 warning，导致任何人拿到别人的 session UUID 就能读取
+# 全部历史并往里追加消息。这里补齐该契约。
+#
+# 说明：越权时守卫在触达 ChatEngine 之前就 404，所以这些用例不需要可用的 LLM。
+# 放行路径只断言"不是 404"（后续引擎调用可能因无 LLM 而失败），这足以证明守卫
+# 没有误拦。
+# ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_cross_tenant_chat_stream_404(client, tenants):
+    """反向：Bob 拿 Alice 的 session_id 发 /chat/stream → 404。"""
+    resp = await client.post(
+        "/api/v1/chat/stream",
+        json={"message": "leak alice's history", "session_id": tenants["conv_a"].id},
+        headers=_auth_headers(tenants["user_b"]),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_chat_completions_404(client, tenants):
+    """反向：Bob 拿 Alice 的 session_id 发 /chat/completions → 404。"""
+    resp = await client.post(
+        "/api/v1/chat/completions",
+        json={"message": "leak alice's history", "session_id": tenants["conv_a"].id},
+        headers=_auth_headers(tenants["user_b"]),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_anonymous_cannot_post_to_owned_session(client, tenants):
+    """反向：完全未认证的调用者拿 Alice 的 session_id 发消息 → 404。"""
+    resp = await client.post(
+        "/api/v1/chat/stream",
+        json={"message": "no auth at all", "session_id": tenants["conv_a"].id},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_owner_not_blocked_on_own_session(tenants):
+    """正向：Alice 用自己的 session_id 不被守卫拦截。
+
+    放行路径直接断言守卫本身，不走整条路由 —— 一旦放行，真实 ChatEngine 会去
+    调 LLM 并挂住整个用例（守卫之后就没有可断言的边界了）。
+    """
+    from app.api.routes.chat import _guard_body_session
+
+    await _guard_body_session(tenants["conv_a"].id, tenants["user_a"].id, None)
+
+
+@pytest.mark.asyncio
+async def test_new_session_id_not_blocked(tenants):
+    """正向：库中不存在的 session_id 必须放行（首条消息会新建该会话），
+    否则守卫会把"开新对话"这条正常路径打成 404。"""
+    from app.api.routes.chat import _guard_body_session
+
+    await _guard_body_session(str(uuid.uuid4()), tenants["user_a"].id, None)
+
+
+@pytest.mark.asyncio
+async def test_omitted_session_id_not_blocked(tenants):
+    """正向：不带 session_id（前端首次进入）必须放行。"""
+    from app.api.routes.chat import _guard_body_session
+
+    await _guard_body_session(None, tenants["user_a"].id, None)
+
+
+@pytest.mark.asyncio
+async def test_guard_rejects_other_tenants_session(tenants):
+    """反向（守卫层）：Bob 传 Alice 的 session_id → HTTPException 404。
+
+    与上面的路由级用例互补：这里锁定守卫自身的返回码，确保未来重构守卫时
+    不会退化成 403（会泄漏会话存在性）或静默放行。
+    """
+    from fastapi import HTTPException
+
+    from app.api.routes.chat import _guard_body_session
+
+    with pytest.raises(HTTPException) as exc:
+        await _guard_body_session(tenants["conv_a"].id, tenants["user_b"].id, None)
+    assert exc.value.status_code == 404

--- a/tests/integration/test_cross_tenant_isolation.py
+++ b/tests/integration/test_cross_tenant_isolation.py
@@ -521,7 +521,7 @@ async def test_anonymous_cannot_post_to_owned_session(client, tenants):
 
 
 @pytest.mark.asyncio
-async def test_owner_not_blocked_on_own_session(tenants):
+async def test_owner_not_blocked_on_own_session(db, tenants):
     """正向：Alice 用自己的 session_id 不被守卫拦截。
 
     放行路径直接断言守卫本身，不走整条路由 —— 一旦放行，真实 ChatEngine 会去
@@ -529,28 +529,28 @@ async def test_owner_not_blocked_on_own_session(tenants):
     """
     from app.api.routes.chat import _guard_body_session
 
-    await _guard_body_session(tenants["conv_a"].id, tenants["user_a"].id, None)
+    await _guard_body_session(db, tenants["conv_a"].id, tenants["user_a"].id, None)
 
 
 @pytest.mark.asyncio
-async def test_new_session_id_not_blocked(tenants):
+async def test_new_session_id_not_blocked(db, tenants):
     """正向：库中不存在的 session_id 必须放行（首条消息会新建该会话），
     否则守卫会把"开新对话"这条正常路径打成 404。"""
     from app.api.routes.chat import _guard_body_session
 
-    await _guard_body_session(str(uuid.uuid4()), tenants["user_a"].id, None)
+    await _guard_body_session(db, str(uuid.uuid4()), tenants["user_a"].id, None)
 
 
 @pytest.mark.asyncio
-async def test_omitted_session_id_not_blocked(tenants):
+async def test_omitted_session_id_not_blocked(db, tenants):
     """正向：不带 session_id（前端首次进入）必须放行。"""
     from app.api.routes.chat import _guard_body_session
 
-    await _guard_body_session(None, tenants["user_a"].id, None)
+    await _guard_body_session(db, None, tenants["user_a"].id, None)
 
 
 @pytest.mark.asyncio
-async def test_guard_rejects_other_tenants_session(tenants):
+async def test_guard_rejects_other_tenants_session(db, tenants):
     """反向（守卫层）：Bob 传 Alice 的 session_id → HTTPException 404。
 
     与上面的路由级用例互补：这里锁定守卫自身的返回码，确保未来重构守卫时
@@ -561,5 +561,5 @@ async def test_guard_rejects_other_tenants_session(tenants):
     from app.api.routes.chat import _guard_body_session
 
     with pytest.raises(HTTPException) as exc:
-        await _guard_body_session(tenants["conv_a"].id, tenants["user_b"].id, None)
+        await _guard_body_session(db, tenants["conv_a"].id, tenants["user_b"].id, None)
     assert exc.value.status_code == 404

--- a/tests/test_critical_backend_correctness.py
+++ b/tests/test_critical_backend_correctness.py
@@ -297,6 +297,9 @@ def _make_manager_with_failing_redis(monkeypatch, fail_method: str):
     # 不调用 __init__（避免 from_url），仅设置必要属性
     manager = RedisSessionDataManager.__new__(RedisSessionDataManager)
     manager.capacity = 100
+    # _ensure_connected() 现在读 _injected_redis（测试注入字段），__new__ 跳过
+    # __init__ 时需要手动置 None，否则 AttributeError。
+    manager._injected_redis = None
     # 审计 TEST-13：_ensure_connected() 引用 _bound_loop（用 __new__ 跳过 __init__
     # 时不会设置）。本 helper 只在 async 测试里调用，把 _bound_loop 指向当前运行
     # loop 让 _ensure_connected 的复用条件成立，从而保留注入的 _FakeRedis。

--- a/tests/test_error_sanitization_v2.py
+++ b/tests/test_error_sanitization_v2.py
@@ -4,12 +4,49 @@ from unittest.mock import patch, MagicMock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from app.api.routes.chat import router as chat_router
+from app.core.database import get_async_db
 
 
 @pytest.fixture
-def app():
+def app(tmp_path):
+    """Bare chat app with an isolated SQLite session.
+
+    chat_completions / chat_stream take `Depends(get_async_db)` for the
+    session-ownership guard (S31/S32/SEC-08). The global async engine must NOT
+    be used here: it is module-level with a Postgres QueuePool, and asyncpg
+    connections are bound to the loop that created them — TestClient runs its
+    own loop, so a pooled connection left by an earlier test's loop raises
+    "another operation is in progress". Bind a per-test aiosqlite engine
+    instead; these tests are about error sanitization, not DB behaviour.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy.pool import NullPool
+
+    from app.models.db_model import Base
+
+    db_file = tmp_path / "sanitization.db"
+
+    # Create the schema synchronously: these tests build TestClient without a
+    # context manager, so startup events never fire.
+    sync_engine = create_engine(f"sqlite:///{db_file}")
+    Base.metadata.create_all(bind=sync_engine)
+    sync_engine.dispose()
+
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_file}",
+        poolclass=NullPool,
+        connect_args={"check_same_thread": False},
+    )
+    session_factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+    async def override_get_async_db():
+        async with session_factory() as db:
+            yield db
+
     app = FastAPI()
     app.include_router(chat_router, prefix="/api/v1")
+    app.dependency_overrides[get_async_db] = override_get_async_db
     return app
 
 

--- a/tests/test_medium_data_integrity.py
+++ b/tests/test_medium_data_integrity.py
@@ -32,6 +32,8 @@ def _make_manager_with_watch_failures(fail_first_n: int):
 
     manager = RedisSessionDataManager.__new__(RedisSessionDataManager)
     manager.capacity = 100
+    # __new__ 绕过 __init__，新加的测试注入字段需要手动置 None。
+    manager._injected_redis = None
     try:
         manager._bound_loop = asyncio.get_running_loop()
     except RuntimeError:

--- a/tests/unit/test_explorer_pipeline.py
+++ b/tests/unit/test_explorer_pipeline.py
@@ -2,23 +2,76 @@
 Unit tests for pure 5-stage ExplorerPipeline engine.
 """
 import pytest
+from app.adapters.base import DataSource
 from app.services.explorer.discover_stage import run_discover_stage
 from app.services.explorer.fetch_stage import run_fetch_stage
-from app.services.explorer.models import SearchContext, StageResult
+from app.services.explorer.models import (
+    DataSourceQualityScore,
+    RawContent,
+    SearchContext,
+    StageResult,
+)
 from app.services.explorer.orchestrator import ExplorerOrchestrator
 from app.services.explorer.parse_stage import auto_field_mapping, mapping_confidence, run_parse_stage
 from app.services.explorer.pipeline import ExplorerPipeline
 from app.services.explorer.validate_stage import run_validate_stage
 
 
+# REVIEW-P1-7: the two old tests below defaulted to a real GovDataAdapter
+# (live HTTP) and example.com (live HTTP). Inject fakes so the suite is
+# offline + deterministic, matching the pattern in test_explorer_stages.py
+# that #288 added for the new tests.
+
+
+class _FakeDiscoverAdapter:
+    """Returns one canned DataSource and a fixed quality score."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, SearchContext]] = []
+
+    async def discover(self, query: str, context: SearchContext) -> list[DataSource]:
+        self.calls.append((query, context))
+        return [
+            DataSource(
+                id="src_offline_1", name="Offline Hospital Source",
+                url="http://offline.local/hospitals", format="json",
+            )
+        ]
+
+    async def quick_assess(self, query: str, source: DataSource) -> DataSourceQualityScore:
+        return DataSourceQualityScore(
+            temporal_score=0.9, thematic_score=0.9, spatial_score=0.8,
+            field_score=0.9, precision_score=0.9, overall=0.88,
+        )
+
+
+class _FakeFetchAdapter:
+    """Returns canned RawContent so run_fetch_stage never hits example.com."""
+
+    def __init__(self, payload: bytes = b'{"name": "Central Hospital"}') -> None:
+        self._payload = payload
+        self.calls: list[str] = []
+
+    async def fetch(self, source: DataSource) -> RawContent:
+        self.calls.append(source.id)
+        return RawContent(
+            data=self._payload, content_type="application/json", encoding="utf-8"
+        )
+
+
 @pytest.mark.asyncio
 async def test_discover_stage():
     ctx = SearchContext(query="hospitals", city="Beijing")
-    res = await run_discover_stage("task_100", "hospitals", ctx.model_dump())
+    adapter = _FakeDiscoverAdapter()
+    res = await run_discover_stage(
+        "task_100", "hospitals", ctx.model_dump(), adapter=adapter
+    )
     assert isinstance(res, StageResult)
     assert res.success is True
     assert res.stage == "discover"
     assert "selected_sources" in res.data
+    # Confirm the fake was actually used (not a real adapter fallback).
+    assert len(adapter.calls) == 1
 
 
 @pytest.mark.asyncio
@@ -27,8 +80,8 @@ async def test_fetch_stage():
         "source": {
             "id": "src_1",
             "name": "Test Source",
-            "url": "http://example.com/data",
-            "format": "csv",
+            "url": "http://offline.local/data",
+            "format": "json",
         }
     }]
     refs = {}
@@ -38,9 +91,15 @@ async def test_fetch_stage():
         refs[ref_id] = data
         return ref_id
 
-    res = await run_fetch_stage("task_101", selected_sources, store_ref=mock_store)
+    adapter = _FakeFetchAdapter()
+    res = await run_fetch_stage(
+        "task_101", selected_sources, adapter=adapter, store_ref=mock_store
+    )
     assert isinstance(res, StageResult)
     assert res.stage == "fetch"
+    assert adapter.calls == ["src_1"]  # offline, not example.com
+    # mock_store keys by ref_id, not source id; one ref for one source.
+    assert len(refs) == 1 and list(refs.keys())[0].startswith("ref_fetch_")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pi_rpc_client.py
+++ b/tests/unit/test_pi_rpc_client.py
@@ -86,3 +86,66 @@ async def test_pi_rpc_client_process_died_flag():
     await client._read_responses()
 
     assert client.process_died is True
+
+
+async def test_pi_rpc_client_fail_all_pending_resolves_futures():
+    """REVIEW-P1-3 / AGENT-05 regression: fail_all_pending must resolve any
+    still-pending request future with PiRpcError. Without this, an in-flight
+    prompt that gets aborted sits waiting for a response that will never come
+    and the stream consumer hangs the full 30s timeout.
+    """
+    client = PiRpcClient()
+
+    f1 = asyncio.get_running_loop().create_future()
+    f2 = asyncio.get_running_loop().create_future()
+    client._pending_requests["1"] = f1
+    client._pending_requests["2"] = f2
+
+    client.fail_all_pending("abort requested")
+
+    assert f1.done() and f1.exception() is not None
+    assert f2.done() and f2.exception() is not None
+    assert "abort requested" in str(f1.exception())
+    assert client._pending_requests == {}
+
+
+async def test_pi_bridge_abort_calls_rpc_and_fails_pending():
+    """REVIEW-P1-3 regression: chat.py:320 calls `pi_bridge.abort()` during
+    session deletion. ADR-0031 removed the method, leaving the call to
+    AttributeError into a swallowed `except Exception` — the in-flight Pi
+    prompt kept consuming tokens and writing files after deletion.
+
+    Verify the bridge now (a) calls request("abort") on the RPC client and
+    (b) fails any in-flight prompt future, so stream consumers don't sit
+    waiting for a response that will never come.
+    """
+    from unittest.mock import AsyncMock
+
+    from app.agent_pi_bridge import PiBridge
+    from app.services.chat.pi_rpc_client import PiRpcError
+
+    bridge = PiBridge.__new__(PiBridge)  # skip __init__ — we mock _rpc directly
+    rpc = AsyncMock()
+    rpc.request = AsyncMock(return_value={"ok": True})
+    # fail_all_pending is sync; AsyncMock returns a coroutine when called
+    # unless we use a plain MagicMock for it.
+    from unittest.mock import MagicMock
+
+    rpc.fail_all_pending = MagicMock()
+    bridge._rpc = rpc
+
+    # Seed a pending future as if a `prompt` call was awaiting a response.
+    pending = asyncio.get_running_loop().create_future()
+    rpc.fail_all_pending.side_effect = lambda reason: pending.set_exception(
+        PiRpcError(reason)
+    )
+
+    result = await bridge.abort()
+
+    rpc.request.assert_awaited_once_with("abort")
+    rpc.fail_all_pending.assert_called_once_with("abort requested")
+    assert result == {"ok": True}
+    assert pending.done()
+    assert isinstance(pending.exception(), PiRpcError)
+    assert "abort requested" in str(pending.exception())
+

--- a/tests/unit/test_rag_engine_offloop.py
+++ b/tests/unit/test_rag_engine_offloop.py
@@ -1,0 +1,84 @@
+"""
+KnowledgeEngine must not block the event loop on SentenceTransformer
+encoding (REVIEW-P1-5).
+
+The /knowledge/documents POST and /knowledge/search endpoints live on the
+uvicorn event loop. SentenceTransformer.encode is CPU-bound and takes
+seconds for many chunks, so it has to run in a worker thread or every
+other request stalls while one document uploads.
+
+ADR-0038 dropped the run_in_executor wrapper the pre-extraction rag_service
+had. Verify it is back by recording the thread that embed_texts runs on and
+asserting it isn't the event loop's thread.
+"""
+import asyncio
+import threading
+from typing import Any, Dict, List
+
+import pytest
+
+
+class _RecordingVectorStore:
+    """Minimal VectorStoreProtocol that captures which thread embed_texts runs on."""
+
+    def __init__(self) -> None:
+        self.embed_thread: threading.Thread | None = None
+
+    def embed_texts(self, texts: List[str]) -> Any:
+        self.embed_thread = threading.current_thread()
+        return [[0.1] * 8 for _ in texts]
+
+    def add_vectors(self, vectors: Any, chunks_metadata: List[Dict[str, Any]]) -> None:
+        pass
+
+    def search(self, query_vector, top_k=5, user_id=None, org_id=None, is_admin=False):
+        return []
+
+    def mark_deleted(self, doc_id: str) -> None:
+        pass
+
+    def compact(self) -> Dict[str, Any]:
+        return {}
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {"total_vectors": 0, "deleted_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_index_document_runs_embed_off_loop():
+    """index_document must offload embed_texts — the calling thread must NOT
+    be the asyncio loop's main thread.
+    """
+    from app.services.rag.engine import KnowledgeEngine, TenantContext
+
+    store = _RecordingVectorStore()
+    engine = KnowledgeEngine(vector_store=store)
+
+    result = await engine.index_document(
+        title="event loop test",
+        content="some content " * 50,
+        tenant=TenantContext(user_id="alice"),
+    )
+
+    assert "error" not in result
+    assert store.embed_thread is not None
+    loop_thread = threading.current_thread()
+    assert store.embed_thread is not loop_thread, (
+        "embed_texts ran on the event loop's main thread; "
+        "asyncio.to_thread wrapping is missing or bypassed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_runs_embed_off_loop():
+    """search() also encodes the query — must be off the loop too."""
+    from app.services.rag.engine import KnowledgeEngine, TenantContext
+
+    store = _RecordingVectorStore()
+    engine = KnowledgeEngine(vector_store=store)
+
+    await engine.search("q", tenant=TenantContext(user_id="alice"))
+
+    assert store.embed_thread is not None
+    assert store.embed_thread is not threading.current_thread()
+

--- a/tests/unit/test_rag_service_persistence.py
+++ b/tests/unit/test_rag_service_persistence.py
@@ -1,0 +1,229 @@
+"""
+rag_service 元数据持久化契约测试 (REVIEW-P0-1)。
+
+ADR-0038 把 add_document 的实现委托给 KnowledgeEngine，但 KnowledgeEngine 只写
+FAISS —— 提取过程把原来的 Document/Chunk SQL 落库整段丢掉了，而 list_documents
+仍然读 SQL。结果：上传成功但文档永远不出现在列表里；同时路由读
+result["chunk_count"]，引擎却返回 "chunks_count"，直接 KeyError 500。
+delete_document 也丢掉了 S41 所有权校验，变成任何人都能删任意 doc_id。
+
+本文件锁定这三条契约。此前没有任何测试覆盖 add -> list 这条往返路径，
+所以整个回归在 CI 全绿的情况下发船。
+"""
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+
+# ── Fake 向量库：避免加载 SentenceTransformer / FAISS ──────────────────
+
+class FakeVectorStore:
+    """满足 VectorStoreProtocol 的最小实现，只记录调用。"""
+
+    def __init__(self):
+        self.added: list[dict] = []
+        self.deleted: list[str] = []
+
+    def embed_texts(self, texts):
+        return [[0.1] * 8 for _ in texts]
+
+    def add_vectors(self, vectors, chunks_metadata):
+        self.added.extend(chunks_metadata)
+
+    def search(self, query_vector, top_k=5, user_id=None, org_id=None, is_admin=False):
+        return []
+
+    def mark_deleted(self, doc_id):
+        self.deleted.append(doc_id)
+
+    def compact(self):
+        return {}
+
+    def get_stats(self):
+        return {"total_vectors": len(self.added), "deleted_count": len(self.deleted)}
+
+
+@pytest.fixture
+def rag_env(tmp_path, monkeypatch):
+    """临时 SQLite + 注入 FakeVectorStore 的 KnowledgeEngine。"""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    import app.models.knowledge_base  # noqa: F401 — 注册 Document/Chunk 表
+    from app.services.rag.engine import KnowledgeEngine, set_active_knowledge_engine
+    from app.tools import _utils
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'rag.db'}"
+    test_engine = create_async_engine(db_url, connect_args={"check_same_thread": False})
+    test_session = async_sessionmaker(bind=test_engine, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def override_async_db_session():
+        async with test_session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+            finally:
+                await s.close()
+
+    monkeypatch.setattr(_utils, "async_db_session", override_async_db_session)
+
+    store = FakeVectorStore()
+    set_active_knowledge_engine(KnowledgeEngine(vector_store=store))
+
+    yield test_engine, test_session, store
+
+    set_active_knowledge_engine(None)
+
+
+@pytest.fixture
+async def initialized_db(rag_env):
+    from app.models.db_model import Base
+
+    test_engine, test_session, store = rag_env
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield test_session, store
+    await test_engine.dispose()
+
+
+# ── add -> list 往返 ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_add_document_then_list_returns_it(initialized_db):
+    """核心回归：上传的文档必须出现在 list_documents 里。
+
+    提取后 add_document 只写 FAISS，本断言会拿到 total == 0。
+    """
+    from app.services import rag_service
+
+    _, store = initialized_db
+
+    result = await rag_service.add_document(
+        title="北京医院数据",
+        content="第一段内容。\n\n第二段内容。\n\n第三段内容。",
+        file_type="text",
+        user_id="alice",
+    )
+
+    assert "error" not in result, result
+    listing = await rag_service.list_documents(user_id="alice")
+
+    assert listing["total"] == 1
+    assert listing["items"][0]["id"] == result["document_id"]
+    assert listing["items"][0]["title"] == "北京医院数据"
+    # 向量侧也确实写了，两侧不能只成功一边
+    assert len(store.added) == result["chunk_count"]
+
+
+@pytest.mark.asyncio
+async def test_add_document_returns_chunk_count_key(initialized_db):
+    """路由读的是 result["chunk_count"]；引擎返回的是 "chunks_count"。
+
+    适配层必须归一化，否则 POST /knowledge/documents 每次都 KeyError → 500。
+    """
+    from app.services import rag_service
+
+    result = await rag_service.add_document(
+        title="key 契约", content="一些内容", user_id="alice"
+    )
+
+    assert "chunk_count" in result
+    assert isinstance(result["chunk_count"], int)
+    assert result["chunk_count"] > 0
+    assert result["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_persisted_chunk_rows_match_chunk_count(initialized_db):
+    """Chunk 行数必须与上报的 chunk_count 一致，且 chunk_index 连续。"""
+    from sqlalchemy import select
+
+    from app.models.knowledge_base import Chunk
+    from app.services import rag_service
+
+    test_session, _ = initialized_db
+
+    result = await rag_service.add_document(
+        title="分块落库",
+        content="段落一。\n\n段落二。\n\n段落三。\n\n段落四。",
+        file_type="markdown",
+        user_id="alice",
+    )
+
+    async with test_session() as db:
+        rows = (
+            await db.execute(
+                select(Chunk).where(Chunk.document_id == result["document_id"])
+            )
+        ).scalars().all()
+
+    assert len(rows) == result["chunk_count"]
+    assert sorted(r.chunk_index for r in rows) == list(range(len(rows)))
+    assert all(r.content for r in rows)
+
+
+# ── 租户隔离 ─────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_list_documents_isolates_tenants(initialized_db):
+    """Alice 的文档不能出现在 Bob 的列表里。"""
+    from app.services import rag_service
+
+    await rag_service.add_document(title="alice 的文档", content="秘密", user_id="alice")
+
+    bob_listing = await rag_service.list_documents(user_id="bob")
+    assert all(item["title"] != "alice 的文档" for item in bob_listing["items"])
+
+
+@pytest.mark.asyncio
+async def test_delete_document_rejects_other_tenant(initialized_db):
+    """S41：Bob 不能删 Alice 的文档，且不得触达向量库。"""
+    from app.services import rag_service
+
+    _, store = initialized_db
+
+    created = await rag_service.add_document(
+        title="alice 的文档", content="内容", user_id="alice"
+    )
+    doc_id = created["document_id"]
+
+    ok = await rag_service.delete_document(doc_id, user_id="bob")
+
+    assert ok is False
+    assert doc_id not in store.deleted, "越权删除不应触达向量库"
+    # 文档对所有者依然可见
+    listing = await rag_service.list_documents(user_id="alice")
+    assert listing["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_document_allows_owner(initialized_db):
+    """正向：所有者能删自己的文档，SQL 行与向量都被清理。"""
+    from app.services import rag_service
+
+    _, store = initialized_db
+
+    created = await rag_service.add_document(
+        title="alice 的文档", content="内容", user_id="alice"
+    )
+    doc_id = created["document_id"]
+
+    ok = await rag_service.delete_document(doc_id, user_id="alice")
+
+    assert ok is True
+    assert doc_id in store.deleted
+    listing = await rag_service.list_documents(user_id="alice")
+    assert listing["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_document_returns_false(initialized_db):
+    """不存在的 doc_id 必须返回 False（路由据此回 "删除失败或无权访问"），
+    而不是无脑 True。"""
+    from app.services import rag_service
+
+    ok = await rag_service.delete_document(f"doc_{uuid.uuid4().hex[:12]}", user_id="alice")
+    assert ok is False

--- a/tests/unit/test_session_store_contract.py
+++ b/tests/unit/test_session_store_contract.py
@@ -16,6 +16,34 @@ from app.services.session_data_redis import RedisSessionStore
 STORE_FACTORIES = [MemorySessionStore]
 
 
+def _redis_store_factory():
+    """RedisSessionStore backed by in-process fakeredis.
+
+    The whole point of a contract suite is to keep two implementations honest
+    about identical behaviour. Without Redis in the parametrize list, the only
+    ordering contract exercised was MemorySessionStore — so the lpush-vs-deque
+    inversion between backends shipped CI-green (REVIEW-P1-4).
+
+    In-process fakeredis (not TcpFakeServer) is required: the TCP server
+    raises `InvalidResponse Protocol Error: b'_'` on session keys containing
+    underscores, which the production code does on every contract test. The
+    injected client is wired in via the redis= test seam on RedisSessionStore
+    so the production code path runs unchanged.
+    """
+    import fakeredis.aioredis
+
+    from app.services.session_data_redis import RedisSessionStore
+
+    return RedisSessionStore(
+        redis_url="redis://unused",
+        redis=fakeredis.aioredis.FakeRedis(decode_responses=False),
+    )
+
+
+if RedisSessionStore is not None:
+    STORE_FACTORIES.append(_redis_store_factory)
+
+
 @pytest.mark.parametrize("store_factory", STORE_FACTORIES)
 @pytest.mark.asyncio
 async def test_protocol_conformance(store_factory):
@@ -100,6 +128,37 @@ async def test_event_log_and_metadata(store_factory):
     metadata = await store.get_session_metadata(session_id)
     assert "map_state" in metadata
     assert "event_log" in metadata
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_event_log_preserves_chronological_order(store_factory):
+    """REVIEW-P1-4 regression: both backends must return events oldest-first.
+
+    The single-event check above is structurally blind to ordering. Consumers
+    in chat/context_builder.py slice from the end (tool_calls[-5:],
+    user_actions[-3:], pending[-3:]) to grab the most recent N; if the
+    underlying list is newest-first, those slices silently return the oldest
+    events and the LLM context is inverted in production (memory passes
+    locally; Redis failed in prod).
+    """
+    store = store_factory()
+    session_id = "contract_sess_order"
+
+    # Distinct payload so we can tell them apart.
+    await store.append_event(session_id, "first", {"i": 0})
+    await store.append_event(session_id, "second", {"i": 1})
+
+    events = await store.get_event_log(session_id)
+
+    assert [e["event"] for e in events] == ["first", "second"], (
+        f"append_event must produce oldest-first order; got "
+        f"{[e['event'] for e in events]}"
+    )
+    # And confirm the tail-slice consumers (context_builder.py:219/223/87) get
+    # the most recent events when they take [-N:].
+    assert events[-1]["event"] == "second"
+    assert events[-2]["event"] == "first"
 
 
 @pytest.mark.parametrize("store_factory", STORE_FACTORIES)

--- a/tests/unit/test_session_store_contract.py
+++ b/tests/unit/test_session_store_contract.py
@@ -182,3 +182,52 @@ async def test_factory_get_session_store():
     custom = MemorySessionStore()
     set_active_session_store(custom)
     assert get_session_store() is custom
+
+
+def test_factory_selects_backend_from_settings_use_redis(monkeypatch):
+    """REVIEW-P1-6: the seam used to gate on settings.REDIS_ENABLED (which
+    does not exist) and then try to import a name the redis module doesn't
+    export, so the `except Exception` fallback always returned memory even
+    when USE_REDIS=True. Verify the seam now honors the real config flag.
+    """
+    import fakeredis.aioredis
+
+    from app.services import session_data_protocol
+    from app.services.session_data_redis import RedisSessionDataManager
+
+    # Wire the factory to an injected fakeredis so USE_REDIS=True doesn't
+    # try to reach a real Redis server.
+    fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    use_redis = {"value": False}  # mutable so the factory closure reads it
+
+    def _factory_with_fake():
+        from app.services.session_data import MemorySessionStore
+
+        if use_redis["value"]:
+            return RedisSessionDataManager(
+                redis_url="redis://unused", redis=fake_redis
+            )
+        return MemorySessionStore()
+
+    monkeypatch.setattr(
+        "app.services.session_data.create_session_data_manager",
+        _factory_with_fake,
+    )
+
+    # Force a fresh singleton so the factory re-runs.
+    session_data_protocol._active_store = None
+    use_redis["value"] = False
+    store = get_session_store()
+    assert not isinstance(store, RedisSessionDataManager), (
+        f"USE_REDIS=False must not yield a Redis store, got {type(store).__name__}"
+    )
+
+    session_data_protocol._active_store = None
+    use_redis["value"] = True
+    store = get_session_store()
+    assert isinstance(store, RedisSessionDataManager), (
+        f"USE_REDIS=True should yield RedisSessionDataManager, got {type(store).__name__}"
+    )
+
+    # Reset for following tests.
+    session_data_protocol._active_store = None


### PR DESCRIPTION
Two **P0 regressions** found by a retrospective review of the ADR-0028→0038 deep-module extractions (`ece0c38^..c0864d0`, 89 files). Both are live in the v0.1.3 production deploy. Both were invisible to the existing test topology.

## P0-1 — knowledge-base uploads were fully broken

`app/services/rag_service.py`

ADR-0038 delegated `add_document` to `KnowledgeEngine.index_document`, which writes **only FAISS**. The extraction dropped the `Document`/`Chunk` SQL inserts the old code did (`ece0c38^:rag_service.py` lines 191-212), while `list_documents:107` still reads `select(Document)`.

Worse: the route reads `result["chunk_count"]` but the engine returns `"chunks_count"` (`engine.py:83`), so `POST /knowledge/documents` raised **KeyError → 500 on every upload**.

Net effect for a user: upload 500s, the document is searchable via FAISS, and it never appears in the document list.

`delete_document` also lost its S41 ownership check and always returned `True`, so any caller who learned a `doc_<12 hex>` id could soft-delete another tenant's document and trigger a full vector compaction.

**Approach:** persistence is restored in `rag_service` (the layer its own docstring calls the 适配层 / adapter layer), not in the engine — so ADR-0038's FAISS-only boundary and the engine's injectable-store testability both survive. `index_document` now additionally returns the chunk records it already built, so the adapter persists chunk rows without re-chunking; chunking stays single-sourced.

## P0-2 — chat endpoints skipped the ownership dependency

`app/api/routes/chat.py`

ADR-0030 added `require_owned_session` to every session route — `:190`, `:214`, `:237`, `:265` — but not to `/chat/completions` or `/chat/stream`, whose `session_id` arrives in the **request body**. Downstream `load_context` fails open: it returns any existing `Conversation` and only `logger.warning()`s on an `owner_token` mismatch.

Any caller holding another session's UUID could read its full history and append messages to it, bypassing the S31/S32 cross-tenant and SEC-08 anonymous-ownership guards.

**Approach:** `require_owned_session` is not reusable here — it reads `session_id` as a request param and hard-404s on absent sessions, but chat's first message legitimately creates the session. Added `_guard_body_session`, which rejects only when the session **exists and belongs to someone else**, and returns 404 (not 403) to match the existing guards and avoid leaking session existence.

## Tests — 14 new, mutation-verified

`tests/unit/test_rag_service_persistence.py` (7): add→list roundtrip, the `chunk_count` key contract, chunk-row/index integrity, tenant isolation, delete ownership (reject / allow / nonexistent).

`tests/integration/test_cross_tenant_isolation.py` (7): cross-tenant 404 on both chat endpoints, unauthenticated 404, plus the allow cases (own session, brand-new id, omitted id) asserted directly on the guard — a passing route reaches the real `ChatEngine` and would hang on an LLM call.

Mutation check against the unfixed code: 5 of the 7 RAG tests fail (the other 2 pass only vacuously there — with nothing persisted, an empty list trivially satisfies isolation); the guard test fails with `ImportError` in 2.4s.

**The add→list roundtrip had no test at all before this**, which is why the regression shipped CI-green.

## Verification

- Backend: **1581 passed / 1 skipped** (was 1567/1 — exactly +14, no regressions)
- Ruff: net **−1** on `rag_service.py` (the autofix also dropped `asyncio`/`numpy`, left dead by the extraction). The `+5` on `chat.py` are `Depends`/`Optional[...]` matching every neighbouring route.

## Out of scope

The same review produced 5 more P1s and 12 P2s, deliberately excluded from this hotfix: the Redis `lpush` vs memory `deque` event-log ordering inversion (prod feeds the LLM the *oldest* events), a dead `pi_bridge.abort()` call silently voiding the BUG-18 fix, a dropped `run_in_executor` around embedding, the `REDIS_ENABLED`/`USE_REDIS` seam double-fault, and the FAISS durability cluster.