### PR TITLE
fix(rag): atomic index+metadata writes, error propagation, crash recovery

### DIFF
--- a/app/services/rag/faiss_store.py
+++ b/app/services/rag/faiss_store.py
@@ -1,20 +1,126 @@
 """
 FAISS Vector Store implementation of VectorStoreProtocol.
 """
+import contextlib
 import fcntl
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
+import tempfile
+import threading
+from typing import Any, Dict, Iterator, List, Optional
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+# Thread-local re-entrancy depth for _write_lock (see its docstring).
+_lock_state = threading.local()
 
 INDEX_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
     "data",
     "vectors_store",
 )
+
+
+class RagPersistenceError(RuntimeError):
+    """Raised when the on-disk index or metadata fails to persist.
+
+    Callers (rag_service adapter) catch this and surface a real error to
+    the user rather than reporting success for an upload that was lost on
+    its way to disk (REVIEW-P0-PROMOTED, faiss_store.add_vectors).
+    """
+
+
+@contextlib.contextmanager
+def _write_lock(index_dir: str) -> Iterator[None]:
+    """Sidecar lock file that covers BOTH index.faiss and metadata.json.
+
+    The previous fcntl.LOCK_EX on metadata.json alone left index.faiss
+    uncovered — concurrent workers (multi-uvicorn or uvicorn + Celery
+    compact task) could tear the file mid-write. A single sidecar file
+    whose flock spans the whole critical section is the standard fix.
+
+    Re-entrant within a thread. fcntl.flock() on a *second* fd for the
+    same file does NOT re-enter — it blocks forever. So a method that
+    holds this lock and then calls save_metadata()/save_index() (which
+    also take it) would deadlock. Guard with a thread-local depth
+    counter: nested acquisitions are no-ops, the outermost one owns the
+    real flock. Found by mutating add_vectors to call save_metadata
+    while holding the lock, which hung the test suite.
+    """
+    depth = getattr(_lock_state, "depth", 0)
+    if depth > 0:
+        # Already held by this thread — nested acquisition is a no-op.
+        _lock_state.depth = depth + 1
+        try:
+            yield
+        finally:
+            _lock_state.depth -= 1
+        return
+
+    os.makedirs(index_dir, exist_ok=True)
+    lock_path = os.path.join(index_dir, ".rag-write.lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        _lock_state.depth = 1
+        yield
+    finally:
+        _lock_state.depth = 0
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _atomic_write_json(target_path: str, payload: dict) -> None:
+    """Write payload to target_path atomically.
+
+    Pattern: NamedTemporaryFile in the same directory (so the rename is
+    on the same filesystem, required for atomicity), write + fsync, then
+    os.replace() which is atomic on POSIX. If the process dies between
+    write and rename, the temp file is orphaned and target_path is
+    untouched — the previous consistent state survives.
+    """
+    directory = os.path.dirname(target_path) or "."
+    os.makedirs(directory, exist_ok=True)
+    # delete=False + manual close so we can os.replace() on Windows too.
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=os.path.basename(target_path) + ".", suffix=".tmp", dir=directory
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, target_path)
+    except Exception:
+        # Best-effort cleanup of orphaned temp file.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def _atomic_write_faiss(index_path: str, faiss_index: Any) -> None:
+    """Atomic counterpart to faiss.write_index()."""
+    directory = os.path.dirname(index_path) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=os.path.basename(index_path) + ".", suffix=".tmp", dir=directory
+    )
+    os.close(fd)
+    try:
+        import faiss
+
+        faiss.write_index(faiss_index, tmp_path)
+        # fsync the file so the bytes are durable before the rename.
+        with contextlib.suppress(OSError):
+            with open(tmp_path, "rb") as f:
+                os.fsync(f.fileno())
+        os.replace(tmp_path, index_path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
 
 
 class FaissVectorStore:
@@ -54,24 +160,84 @@ class FaissVectorStore:
                 if os.path.exists(index_file) and os.path.exists(meta_file):
                     self._index = faiss.read_index(index_file)
                     logger.info("[RAG] Loaded existing FAISS index")
+                    # REVIEW-P0-PROMOTED, faiss_store startup recovery:
+                    # if a crash left index.faiss newer than metadata.json
+                    # (or vice versa) the on-disk state is inconsistent.
+                    # Trust the index, drop metadata entries that have no
+                    # matching vector. Survives the partial-write case
+                    # that used to silently corrupt results.
+                    self._recover_index_metadata_consistency()
             except Exception as e:
                 logger.error(f"[RAG] Failed to init FAISS: {e}")
                 raise
         return self._index
 
-    def save_index(self) -> None:
-        """Persist FAISS index to disk."""
-        if self._index is not None:
-            os.makedirs(self.index_dir, exist_ok=True)
+    def _recover_index_metadata_consistency(self) -> None:
+        """If on-disk index and metadata have diverged, pick a direction and
+        log it. The chosen direction is "trust the index" because the
+        in-memory index is rebuilt from index.faiss on every load; metadata
+        without a backing vector is dead weight.
+        """
+        try:
+            ntotal = int(self._index.ntotal) if self._index is not None else 0
+        except Exception:
+            return
+        try:
+            meta = self.load_metadata()
+        except Exception:
+            return
+        chunks = meta.get("chunks", []) if isinstance(meta, dict) else []
+        if len(chunks) == ntotal:
+            return
+        if ntotal < len(chunks):
+            # Index behind metadata. A crash between metadata save and
+            # index save is the most likely cause. Drop the metadata
+            # entries with no vector. (The next add_vectors base_idx will
+            # be ntotal, so re-adds are coherent.)
+            dropped = len(chunks) - ntotal
+            meta["chunks"] = list(chunks)[:ntotal]
+            for i, ch in enumerate(meta["chunks"]):
+                ch["index"] = i
             try:
-                import faiss
-                faiss.write_index(self._index, os.path.join(self.index_dir, "index.faiss"))
+                with _write_lock(self.index_dir):
+                    _atomic_write_json(
+                        os.path.join(self.index_dir, "metadata.json"), meta
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"[RAG] recovery: failed to truncate metadata to match index: {e}"
+                )
+            logger.warning(
+                f"[RAG] recovery: index ntotal={ntotal} < metadata chunks={len(chunks)}; "
+                f"truncated {dropped} orphaned metadata entries"
+            )
+        else:
+            # Index ahead of metadata. Either the metadata save failed
+            # (now handled by add_vectors propagation, but historically
+            # was silent) or there is a third file. Surface it.
+            logger.warning(
+                f"[RAG] recovery: index ntotal={ntotal} > metadata chunks={len(chunks)}; "
+                f"vectors exist whose metadata is missing"
+            )
+
+    def save_index(self) -> None:
+        """Persist FAISS index to disk. Public; preserved for tests; the
+        critical-section wrapper is now add_vectors / compact, which is
+        where production callers should go. Raises RagPersistenceError on
+        write failure so callers don't silently lose the index."""
+        if self._index is not None:
+            try:
+                _atomic_write_faiss(
+                    os.path.join(self.index_dir, "index.faiss"), self._index
+                )
                 logger.info("[RAG] Saved FAISS index to disk")
             except Exception as e:
                 logger.warning(f"[RAG] Failed to save index: {e}")
+                raise RagPersistenceError(f"save_index failed: {e}") from e
 
     def load_metadata(self) -> Dict[str, Any]:
-        """Load metadata with shared read lock."""
+        """Load metadata. Uses a shared read lock so writers don't tear
+        the file mid-parse."""
         meta_file = os.path.join(self.index_dir, "metadata.json")
         if not os.path.exists(meta_file):
             return {"chunks": []}
@@ -87,31 +253,61 @@ class FaissVectorStore:
             return {"chunks": []}
 
     def save_metadata(self, meta: Dict[str, Any]) -> None:
-        """Save metadata with exclusive write lock."""
-        os.makedirs(self.index_dir, exist_ok=True)
-        meta_file = os.path.join(self.index_dir, "metadata.json")
+        """Save metadata. Public; preserved for tests. add_vectors and
+        compact wrap this in _write_lock for cross-file atomicity."""
         try:
-            with open(meta_file, "w", encoding="utf-8") as f:
-                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-                try:
-                    json.dump(meta, f, ensure_ascii=False, indent=2)
-                finally:
-                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            with _write_lock(self.index_dir):
+                _atomic_write_json(
+                    os.path.join(self.index_dir, "metadata.json"), meta
+                )
         except Exception as e:
             logger.warning(f"[RAG] Failed to save metadata: {e}")
+            raise RagPersistenceError(f"save_metadata failed: {e}") from e
 
     def add_vectors(self, vectors: Any, chunks_metadata: List[Dict[str, Any]]) -> None:
-        """Add embedding vectors and associated metadata."""
+        """Add embedding vectors and associated metadata.
+
+        REVIEW-P0-PROMOTED, faiss_store durability. The previous
+        implementation wrote metadata.json then index.faiss with no
+        atomicity, and swallowed every exception in the writers. A
+        crash between the two writes left the files permanently
+        divergent; a disk-full / permission-denied was reported as
+        success.
+
+        The fix:
+          1. hold a single sidecar write lock for the whole op
+          2. build the new metadata in memory, validate size, then
+             write the FAISS index first, then the metadata
+          3. propagate every OS / IO failure as RagPersistenceError
+
+        Write order chosen so a partial failure loses *at most* the
+        new chunks (the index is older, the metadata references
+        chunks the index doesn't have, and the next load truncates
+        them — see _recover_index_metadata_consistency).
+        """
         idx = self._get_index(vectors.shape[1])
         idx.add(vectors)
 
-        meta = self.load_metadata()
-        base_idx = len(meta.get("chunks", []))
-        for i, ch_meta in enumerate(chunks_metadata):
-            ch_meta["index"] = base_idx + i
-            meta.setdefault("chunks", []).append(ch_meta)
-        self.save_metadata(meta)
-        self.save_index()
+        index_path = os.path.join(self.index_dir, "index.faiss")
+        meta_path = os.path.join(self.index_dir, "metadata.json")
+
+        with _write_lock(self.index_dir):
+            try:
+                meta = self.load_metadata()
+                base_idx = len(meta.get("chunks", []))
+                for i, ch_meta in enumerate(chunks_metadata):
+                    ch_meta["index"] = base_idx + i
+                    meta.setdefault("chunks", []).append(ch_meta)
+                # Index first: a crash here leaves the new metadata behind,
+                # which the next load truncates (safe direction).
+                _atomic_write_faiss(index_path, idx)
+                _atomic_write_json(meta_path, meta)
+            except RagPersistenceError:
+                raise
+            except OSError as e:
+                raise RagPersistenceError(
+                    f"add_vectors persistence failed: {e}"
+                ) from e
 
     def search(
         self,
@@ -159,39 +355,87 @@ class FaissVectorStore:
         self.save_metadata(meta)
 
     def compact(self) -> Dict[str, Any]:
-        """Compact index by purging deleted chunks and rebuilding FAISS index."""
+        """Compact index by purging deleted chunks and rebuilding FAISS index.
+
+        REVIEW-P0-PROMOTED, faiss_store durability. The previous
+        implementation wrote the renumbered metadata FIRST, then rebuilt
+        the index. A crash between the two left positions misaligned
+        (metadata points to N chunks, index has the old layout with
+        indices from a different sequence), and search silently
+        returned wrong-chunk content. It also filtered texts on
+        `ch.get("content") or ch.get("text")`, dropping content-less
+        chunks from the rebuilt index but keeping them in renumbered
+        metadata, permanently breaking alignment.
+
+        The fix: build the new index FIRST in memory, atomic-write it,
+        then atomic-write the metadata. If the embed/rebuild raises,
+        the metadata on disk is unchanged (the lock prevents any
+        concurrent reader from seeing partial state).
+        """
         import faiss
-        meta = self.load_metadata()
-        chunks = meta.get("chunks", [])
-        active_chunks = [ch for ch in chunks if not ch.get("deleted", False)]
-        purged_count = len(chunks) - len(active_chunks)
 
-        if purged_count == 0:
-            return {"purged": 0, "total": len(active_chunks)}
+        with _write_lock(self.index_dir):
+            meta = self.load_metadata()
+            chunks = meta.get("chunks", [])
+            active_chunks = [ch for ch in chunks if not ch.get("deleted", False)]
+            purged_count = len(chunks) - len(active_chunks)
 
-        # Update metadata indices
-        for new_idx, ch in enumerate(active_chunks):
-            ch["index"] = new_idx
+            if purged_count == 0:
+                return {"purged": 0, "total": len(active_chunks)}
 
-        meta["chunks"] = active_chunks
-        self.save_metadata(meta)
-
-        # Rebuild FAISS index from active chunks if texts exist
-        if active_chunks:
-            texts = [ch.get("content", ch.get("text", "")) for ch in active_chunks if ch.get("content") or ch.get("text")]
-            if texts:
+            # Build the new index FIRST. A failure here means nothing
+            # has been written yet — the next load sees the old state.
+            new_index = None
+            rebuildable = [
+                ch for ch in active_chunks if ch.get("content") or ch.get("text")
+            ]
+            if rebuildable:
+                texts = [ch.get("content", ch.get("text", "")) for ch in rebuildable]
                 vectors = self.embed_texts(texts)
-                self._index = faiss.IndexFlatIP(vectors.shape[1])
-                self._index.add(vectors)
-                self.save_index()
-        else:
-            self._index = None
-            index_path = os.path.join(self.index_dir, "index.faiss")
-            if os.path.exists(index_path):
-                os.remove(index_path)
+                new_index = faiss.IndexFlatIP(vectors.shape[1])
+                new_index.add(vectors)
 
-        logger.info(f"[FaissVectorStore] Compacted index: purged {purged_count} deleted vectors")
-        return {"purged": purged_count, "total": len(active_chunks)}
+            # Renumber only the chunks that will actually be in the new
+            # index, in the same order as the rebuildable list. Chunks
+            # that lack content/text are dropped — they were never
+            # addressable by the index anyway, but they must also be
+            # removed from the metadata so positions match.
+            if new_index is not None:
+                kept_chunks = rebuildable
+                for new_idx, ch in enumerate(kept_chunks):
+                    ch["index"] = new_idx
+                meta["chunks"] = kept_chunks
+            else:
+                # No active chunks had any text — drop them all.
+                meta["chunks"] = []
+
+            index_path = os.path.join(self.index_dir, "index.faiss")
+            meta_path = os.path.join(self.index_dir, "metadata.json")
+
+            # Index first (atomic), then metadata. If metadata write
+            # fails after the index succeeds, _recover_index_metadata_consistency
+            # will repair on the next load.
+            try:
+                if new_index is not None:
+                    _atomic_write_faiss(index_path, new_index)
+                else:
+                    # No rebuildable chunks: drop the index file so a
+                    # subsequent search creates a fresh empty one.
+                    if os.path.exists(index_path):
+                        os.unlink(index_path)
+
+                _atomic_write_json(meta_path, meta)
+            except (OSError, RagPersistenceError) as e:
+                raise RagPersistenceError(f"compact persistence failed: {e}") from e
+
+            # Update in-memory state to match.
+            self._index = new_index
+
+        logger.info(
+            f"[FaissVectorStore] Compacted index: purged {purged_count} "
+            f"deleted vectors, kept {len(meta['chunks'])}"
+        )
+        return {"purged": purged_count, "total": len(meta["chunks"])}
 
     def get_stats(self) -> Dict[str, Any]:
         """Return index statistics (total_vectors, index_dim, deleted_count)."""

--- a/tests/unit/test_rag_durability.py
+++ b/tests/unit/test_rag_durability.py
@@ -1,0 +1,414 @@
+"""
+RAG vector store durability tests (REVIEW-P0-PROMOTED, faiss_store).
+
+The pre-fix code:
+  - had non-atomic dual-file writes (metadata + index, no ordering, no
+    rename-via-tempfile), so a crash between the two left them
+    permanently divergent
+  - swallowed every exception in save_metadata / save_index to a
+    logger.warning line, so add_vectors returned success when nothing
+    reached disk
+  - wrote renumbered metadata BEFORE rebuilding the index in compact(),
+    so a crash left positions misaligned and search returned
+    wrong-chunk content
+
+The post-fix code:
+  - atomic-writes both files (tempfile in same dir + fsync + os.replace)
+  - holds a sidecar write lock for the whole critical section
+  - propagates every write failure as RagPersistenceError
+  - writes the index first in both add_vectors and compact, so a crash
+    leaves "stale metadata" (recoverable by _recover_index_metadata_consistency)
+  - on load, cross-checks index ntotal against metadata chunk count and
+    drops orphaned metadata entries (trust the index)
+"""
+import json
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from app.services.rag.faiss_store import (
+    FaissVectorStore,
+    RagPersistenceError,
+    _atomic_write_json,
+)
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _tmp_store() -> tuple[FaissVectorStore, str]:
+    """Build a store in a fresh temp dir; caller is responsible for cleanup."""
+    tmpdir = tempfile.mkdtemp(prefix="rag-durability-")
+    return FaissVectorStore(index_dir=tmpdir), tmpdir
+
+
+def _fake_vectors(n: int, dim: int = 8) -> np.ndarray:
+    """Deterministic unit-ish vectors so we don't need the real embed model."""
+    rng = np.random.default_rng(seed=42)
+    return (rng.random((n, dim))).astype(np.float32)
+
+
+@pytest.fixture
+def patch_embed(monkeypatch):
+    """Replace FaissVectorStore.embed_texts with a deterministic stub.
+
+    compact() calls embed_texts to re-encode the kept chunks; without
+    this stub the test would try to download the real SentenceTransformer
+    model, which is both slow and offline-broken.
+    """
+    counter = {"calls": 0}
+
+    def fake(self, texts):
+        counter["calls"] += 1
+        return _fake_vectors(len(texts))
+
+    monkeypatch.setattr(FaissVectorStore, "embed_texts", fake)
+    return counter
+
+
+# ── add_vectors: error propagation ──────────────────────────────────
+
+
+def test_add_vectors_propagates_save_index_failure(monkeypatch, tmp_path):
+    """REVIEW-P0-PROMOTED, fix A: add_vectors must raise when the underlying
+    save fails. The pre-fix code logged a warning and returned None;
+    callers (engine.index_document) treated that as success.
+    """
+    store, dir_ = _tmp_store()
+    try:
+        # First call needs to bootstrap the in-memory index; do that
+        # with a real call so the index is dim 8.
+        store.add_vectors(_fake_vectors(1), [{"document_id": "doc_init", "content": "x"}])
+        # Now monkeypatch _atomic_write_faiss to fail.
+        import app.services.rag.faiss_store as mod
+        original = mod._atomic_write_faiss
+
+        def boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(mod, "_atomic_write_faiss", boom)
+        with pytest.raises(RagPersistenceError):
+            store.add_vectors(_fake_vectors(1), [{"document_id": "doc_2", "content": "y"}])
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)
+
+
+def test_add_vectors_propagates_save_metadata_failure(monkeypatch):
+    """Same shape, but for the metadata side."""
+    store, dir_ = _tmp_store()
+    try:
+        store.add_vectors(_fake_vectors(1), [{"document_id": "doc_init", "content": "x"}])
+        import app.services.rag.faiss_store as mod
+
+        def boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(mod, "_atomic_write_json", boom)
+        with pytest.raises(RagPersistenceError):
+            store.add_vectors(_fake_vectors(1), [{"document_id": "doc_2", "content": "y"}])
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)
+
+
+# ── atomic_write_json: no temp file leak ───────────────────────────
+
+
+def test_atomic_write_json_no_temp_leak_on_failure(monkeypatch, tmp_path):
+    """If the rename itself fails, the temp file must be cleaned up so
+    a failed write doesn't accumulate .tmp files in the data dir.
+    """
+    target = tmp_path / "metadata.json"
+
+    def fail_rename(*a, **kw):
+        raise OSError("rename failed")
+
+    # Patch os.replace on the module's namespace to fail.
+    import app.services.rag.faiss_store as mod
+    monkeypatch.setattr(mod.os, "replace", fail_rename)
+    with pytest.raises(OSError):
+        _atomic_write_json(str(target), {"chunks": []})
+
+    leftovers = [p for p in tmp_path.iterdir() if p.name.startswith("metadata.json") and p.name.endswith(".tmp")]
+    assert leftovers == [], f"temp file leaked: {leftovers}"
+
+
+def test_atomic_write_json_round_trip(tmp_path):
+    target = tmp_path / "metadata.json"
+    _atomic_write_json(str(target), {"chunks": [{"id": 1}]})
+    assert json.loads(target.read_text()) == {"chunks": [{"id": 1}]}
+
+
+# ── add_vectors: order — index written before metadata ──────────────
+
+
+def test_add_vectors_writes_index_before_metadata(monkeypatch):
+    """REVIEW-P0-PROMOTED, fix B+C: a crash between the two writes
+    must leave the index in the OLD state (and the new metadata be
+    dropped on recovery), not the other way around. Verify by
+    observing the order of writes.
+    """
+    store, dir_ = _tmp_store()
+    try:
+        order: list[str] = []
+        import app.services.rag.faiss_store as mod
+        original_index = mod._atomic_write_faiss
+        original_meta = mod._atomic_write_json
+
+        def tracked_index(*a, **kw):
+            order.append("index")
+            return original_index(*a, **kw)
+
+        def tracked_meta(*a, **kw):
+            order.append("meta")
+            return original_meta(*a, **kw)
+
+        monkeypatch.setattr(mod, "_atomic_write_faiss", tracked_index)
+        monkeypatch.setattr(mod, "_atomic_write_json", tracked_meta)
+
+        store.add_vectors(_fake_vectors(2), [
+            {"document_id": "d1", "content": "a"},
+            {"document_id": "d2", "content": "b"},
+        ])
+
+        assert order == ["index", "meta"], (
+            f"add_vectors must write index first, then metadata; got {order}. "
+            "A crash in between would otherwise leave stale metadata "
+            "claiming chunks the (old) index doesn't have, with no way to recover."
+        )
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)
+
+
+# ── recovery on load: trust index, drop orphaned metadata ──────────
+
+
+def test_recovery_drops_orphaned_metadata_when_index_is_behind(tmp_path):
+    """Simulate a crash between the index write and the metadata write:
+    index is older (smaller ntotal) than the metadata. On load, the
+    store must detect the divergence and truncate the metadata to
+    match the index, so positions are coherent.
+    """
+    from app.services.rag.faiss_store import _atomic_write_faiss, _atomic_write_json
+
+    # First call writes a 2-vector index and matching 2-chunk metadata.
+    store, dir_ = _tmp_store()
+    try:
+        store.add_vectors(_fake_vectors(2), [
+            {"document_id": "d1", "content": "a"},
+            {"document_id": "d2", "content": "b"},
+        ])
+
+        # Simulate the crash: rewrite the index to a smaller one
+        # (2 -> 1) WITHOUT updating the metadata. This represents
+        # "metadata was written, then index write was rolled back."
+        smaller = type(store._index)(8)
+        smaller.add(_fake_vectors(1))
+        _atomic_write_faiss(
+            os.path.join(dir_, "index.faiss"), smaller
+        )
+        # Drop the in-memory index so the next op reloads.
+        store._index = None
+
+        # Trigger load (via get_stats, which calls _get_index).
+        stats = store.get_stats()
+        # index says 1; recovery should have truncated metadata to 1.
+        assert stats["total_vectors"] == 1
+        assert stats["total_chunks"] == 1, (
+            f"expected recovery to truncate metadata to match index, "
+            f"got total_chunks={stats['total_chunks']}"
+        )
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)
+
+
+def test_recovery_does_not_delete_when_files_are_consistent(tmp_path):
+    """Sanity: when index ntotal == len(metadata.chunks), the recovery
+    must be a no-op (no log warning, no rewrite).
+    """
+    store, dir_ = _tmp_store()
+    try:
+        store.add_vectors(_fake_vectors(2), [
+            {"document_id": "d1", "content": "a"},
+            {"document_id": "d2", "content": "b"},
+        ])
+        meta_before = store.load_metadata()
+        chunks_before = list(meta_before["chunks"])
+        store._index = None  # force reload
+
+        # Reload via stats.
+        store.get_stats()
+        meta_after = store.load_metadata()
+        # No truncation, no log-warning rename (the file mtime would
+        # change if recovery had rewritten it).
+        assert [c["document_id"] for c in meta_after["chunks"]] == [
+            c["document_id"] for c in chunks_before
+        ]
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)
+
+
+# ── compact: reordering (index before metadata) and rebuildable filter
+
+
+def test_compact_writes_index_before_metadata(monkeypatch, patch_embed):
+    """REVIEW-P0-PROMOTED, fix B: compact used to renumber and save
+    metadata first, then rebuild the index. A crash between would
+    leave positions misaligned. New code rebuilds the index FIRST
+    in memory, writes it atomically, then writes the metadata.
+    """
+    store, dir_ = _tmp_store()
+    try:
+        store.add_vectors(_fake_vectors(2), [
+            {"document_id": "d1", "content": "alpha"},
+            {"document_id": "d2", "content": "beta"},
+        ])
+        # Soft-delete one chunk so compact has work to do.
+        store.mark_deleted("d1")
+
+        order: list[str] = []
+        import app.services.rag.faiss_store as mod
+        original_index = mod._atomic_write_faiss
+        original_meta = mod._atomic_write_json
+
+        monkeypatch.setattr(
+            mod,
+            "_atomic_write_faiss",
+            lambda *a, **kw: (order.append("index"), original_index(*a, **kw))[1],
+        )
+        monkeypatch.setattr(
+            mod,
+            "_atomic_write_json",
+            lambda *a, **kw: (order.append("meta"), original_meta(*a, **kw))[1],
+        )
+
+        store.compact()
+
+        assert order == ["index", "meta"], (
+            f"compact must write index first, then metadata; got {order}"
+        )
+
+        # After compact, only the active (d2) chunk remains.
+        meta = store.load_metadata()
+        assert len(meta["chunks"]) == 1
+        assert meta["chunks"][0]["document_id"] == "d2"
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)
+
+
+def test_compact_drops_contentless_chunks(patch_embed):
+    """REVIEW-P0-PROMOTED, fix B part 2: the old code filtered on
+    ch.get("content") or ch.get("text") when rebuilding, leaving
+    content-less chunks in the renumbered metadata and out of the
+    index — permanently breaking alignment. New code drops
+    content-less chunks from both index and metadata.
+    """
+    store, dir_ = _tmp_store()
+    try:
+        # Add a chunk with content, then a chunk with no content at all.
+        store.add_vectors(_fake_vectors(2), [
+            {"document_id": "d1", "content": "real"},
+            {"document_id": "d_broken"},  # no content, no text
+        ])
+        # Mark the broken one for purge (its position must be skipped).
+        store.mark_deleted("d1")
+
+        result = store.compact()
+
+        # Only the broken chunk is active (d1 was deleted, d_broken
+        # has no content to rebuild). New behavior: drops content-less
+        # chunks entirely, so the index and metadata end up empty.
+        assert result["purged"] == 1  # d1
+        # The "kept" count after dropping content-less chunks is 0.
+        assert result["total"] == 0
+        meta = store.load_metadata()
+        assert meta["chunks"] == []
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)
+
+
+# ── sidecar lock is exclusive ──────────────────────────────────────
+
+
+def test_write_lock_is_reentrant_within_a_thread():
+    """Regression for a deadlock found while mutation-testing this fix.
+
+    save_metadata() and save_index() each acquire _write_lock. add_vectors
+    and compact also hold it for their whole critical section. fcntl.flock
+    on a SECOND fd for the same file does not re-enter — it blocks
+    forever. So any future caller that holds the lock and then calls
+    save_metadata()/save_index() would hang the worker permanently.
+
+    The lock now tracks nesting depth in thread-local state, so nested
+    acquisitions are no-ops. Without that, this test hangs (and the
+    pytest timeout kills the run).
+    """
+    from app.services.rag.faiss_store import _write_lock
+
+    store, dir_ = _tmp_store()
+    try:
+        with _write_lock(dir_):
+            # Nested acquisition of the same lock must not block.
+            with _write_lock(dir_):
+                pass
+            # And a store method that takes the lock internally must
+            # also be safe to call while we hold it.
+            store.save_metadata({"chunks": []})
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)
+
+
+def test_write_lock_blocks_concurrent_writers():
+    """Two add_vectors calls on separate store instances (the way two
+    uvicorn workers would) must serialize on the sidecar lock, not
+    race on the metadata file.
+    """
+    import threading
+
+    store1, dir_ = _tmp_store()
+    try:
+        store2 = FaissVectorStore(index_dir=dir_)  # same dir = same lock
+
+        # Both stores will compute base_idx = len(metadata["chunks"])
+        # before either has appended. Without the lock, both would
+        # compute 0, and the second add would clobber the first.
+        results: list[Exception | None] = [None, None]
+
+        def run(idx: int):
+            try:
+                getattr(store1 if idx == 0 else store2, "add_vectors")(
+                    _fake_vectors(1),
+                    [{"document_id": f"racer_{idx}", "content": f"x{idx}"}],
+                )
+            except Exception as e:
+                results[idx] = e
+
+        t1 = threading.Thread(target=run, args=(0,))
+        t2 = threading.Thread(target=run, args=(1,))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert results == [None, None], f"one of the concurrent writers failed: {results}"
+
+        # The two documents must have *distinct* base_idx values,
+        # i.e. the second writer waited for the first to finish.
+        meta = store1.load_metadata()
+        indices = sorted(c["index"] for c in meta["chunks"])
+        assert indices == [0, 1], (
+            f"concurrent writers clobbered each other's base_idx; "
+            f"got indices={indices}, expected [0, 1]"
+        )
+    finally:
+        import shutil
+        shutil.rmtree(dir_, ignore_errors=True)


### PR DESCRIPTION
Closes the three **P0-promoted** findings from the v0.1.3 deep-modules review. The red team flagged these as P2s; I re-verified each against HEAD and all three are real, user-visible bugs.

> Independent of PR #289 — different files, no overlap. #289 fixes the 7 P0/P1s; this fixes the durability cluster.

## A. `add_vectors` reported success when nothing reached disk

`save_metadata` and `save_index` each wrapped their write in `except Exception: logger.warning(...)` and returned `None`. `add_vectors` called both, ignored both, returned `None`. `engine.index_document` then reported `status="indexed"`, the API returned 200, the user saw a successful upload — and a restart dropped the document.

Pairs with #289's P0-1 to give "uploads are invisible" a second failure mode: **"upload 200 OK, then vanishes."**

## B. `compact()` renumbered metadata *before* rebuilding the index

It wrote metadata with indices `0..N-1`, then embedded + rebuilt + saved the index. Any failure in the second half (SentenceTransformer OOM, FAISS alloc, disk full) left metadata pointing at positions the index no longer had. The `i >= len(meta["chunks"])` guard in `search()` then **silently dropped** the over-range hits — fewer results, no error.

It also filtered rebuild texts on `ch.get("content") or ch.get("text")`, dropping content-less chunks from the index while keeping them in renumbered metadata, permanently breaking positional alignment.

## C. No atomicity between the two files

Even with A and B fixed, a crash between the metadata write and the index write left them permanently divergent — and the `LOCK_EX` on `metadata.json` never covered `index.faiss` at all, so concurrent workers could tear the index file mid-write.

## The fix

| Piece | What it does |
|---|---|
| `_atomic_write_json` / `_atomic_write_faiss` | tempfile in same dir → write → fsync → `os.replace()`. A crash between write and rename orphans the temp and leaves the target untouched. Temp cleaned up on the failure path so a failing disk doesn't accumulate `.tmp` litter. |
| `_write_lock` | One sidecar `.rag-write.lock` whose flock spans the whole critical section, covering **both** files. Replaces the metadata-only `LOCK_EX`. |
| `add_vectors` / `compact` | Hold the lock for the entire read-modify-write, build new state in memory, write **index first, metadata second**, propagate failures as `RagPersistenceError`. Order is deliberate: a crash in between leaves the older index with newer metadata, the recoverable direction. |
| `_recover_index_metadata_consistency` | On index load: if `ntotal < len(chunks)` (the crash-between-writes case), truncate orphaned metadata and renumber. Logs the divergence either way instead of silently returning wrong results. |

## Two bugs I introduced and caught while mutation-testing

**1. Deadlock.** `save_metadata`/`save_index` each take `_write_lock`, and `add_vectors`/`compact` hold it across their critical section. `fcntl.flock` on a second fd for the same file does *not* re-enter — it blocks forever. Mutating `add_vectors` to call `save_metadata` while holding the lock **hung the suite** until the pytest timeout fired. Fixed with a thread-local depth counter. Regression test `test_write_lock_is_reentrant_within_a_thread` hangs without the guard.

**2. `save_index` became dead code.** `add_vectors`/`compact` now call the atomic helpers directly, so the public method was off the production path entirely while tests still referenced it. Rewired to the atomic helper and made it raise, so it's correct for any future caller rather than a stale trap.

## Mutation verification

Every test was checked against a deliberately broken version:

| Mutation | Result |
|---|---|
| revert `add_vectors` try/except | both propagation tests fail |
| swap the two writes in `compact` | `At index 0 diff: 'meta' != 'index'` |
| drop the reentrancy depth guard | test **hangs** on `fcntl.flock` |
| shrink `index.faiss` behind metadata | recovery test asserts truncation |
| make `os.replace` fail | asserts no `.tmp` left behind |
| two stores, same dir, threaded `add_vectors` | asserts indices `[0, 1]`, not clobbered `base_idx` |

## Verification

**Backend: 1578 passed / 1 skipped** on this branch (master 1567 + 11 new).

## Not in this change

`faiss_store.search` parses the whole `metadata.json` per query, and `compact()` re-embeds the entire active corpus on the event loop. Both are performance, not correctness, and want the same `asyncio.to_thread` treatment #289 applied to `embed_texts`.