### PR TITLE
fix(rag): offload compact() re-embed off the event loop

### DIFF
--- a/app/services/rag/engine.py
+++ b/app/services/rag/engine.py
@@ -2,6 +2,7 @@
 KnowledgeEngine - Deep RAG Knowledge Retrieval & Vector Indexing Engine.
 Enforces TenantContext multi-tenant security isolation and index compaction.
 """
+import asyncio
 import logging
 import uuid
 from dataclasses import dataclass
@@ -144,14 +145,21 @@ class KnowledgeEngine:
 
         if total_vectors > 0 and (deleted_count / total_vectors) >= 0.20:
             logger.info("KnowledgeEngine: deleted ratio exceeds 20%, executing compact()")
-            self.compact_index()
+            await self.compact_index()
 
         return True
 
-    def compact_index(self) -> Dict[str, Any]:
-        """Compact underlying vector index."""
+    async def compact_index(self) -> Dict[str, Any]:
+        """Compact underlying vector index.
+
+        Offloaded to a worker thread: compact() re-embeds the entire active
+        corpus via SentenceTransformer (seconds for any non-trivial KB),
+        which would otherwise stall the uvicorn event loop on a single
+        DELETE /knowledge/document request. Mirrors the asyncio.to_thread
+        treatment PR #289 applied to index_document/search.
+        """
         if hasattr(self._store, "compact"):
-            return self._store.compact()
+            return await asyncio.to_thread(self._store.compact)
         return {}
 
 

--- a/tests/unit/test_knowledge_engine.py
+++ b/tests/unit/test_knowledge_engine.py
@@ -97,5 +97,5 @@ async def test_soft_delete_and_compaction(knowledge_engine):
     assert len(results) == 0
 
     # Manual compaction
-    compact_res = knowledge_engine.compact_index()
+    compact_res = await knowledge_engine.compact_index()
     assert "purged" in compact_res

--- a/tests/unit/test_rag_compact_offloop.py
+++ b/tests/unit/test_rag_compact_offloop.py
@@ -1,0 +1,92 @@
+"""
+KnowledgeEngine.compact_index must run compact() off the event loop.
+
+compact() re-embeds every active chunk via SentenceTransformer when the
+deleted-ratio crosses 20%. That is seconds-of-CPU work; if it runs on
+the uvicorn event loop it stalls every concurrent request until it
+finishes. PR #289 already moved index_document and search off the loop
+via asyncio.to_thread; this test pins the same contract for the
+compaction path triggered by delete_document.
+"""
+import asyncio
+import threading
+from typing import Any, Dict, List
+
+import pytest
+
+
+class _RecordingStore:
+    """Minimal VectorStoreProtocol whose compact records its thread."""
+
+    def __init__(self, ntotal: int = 100, deleted: int = 30) -> None:
+        self._ntotal = ntotal
+        self._deleted = deleted
+        self.compact_thread: threading.Thread | None = None
+        self.compact_calls = 0
+
+    def compact(self) -> Dict[str, Any]:
+        self.compact_calls += 1
+        self.compact_thread = threading.current_thread()
+        return {"purged": self._deleted, "total": self._ntotal - self._deleted}
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {"total_vectors": self._ntotal, "deleted_count": self._deleted}
+
+    def mark_deleted(self, doc_id: str) -> None:
+        self._deleted += 1
+
+    # The other Protocol methods aren't exercised here.
+    def embed_texts(self, texts: List[str]) -> Any: raise NotImplementedError
+    def add_vectors(self, vectors, chunks_metadata) -> None: raise NotImplementedError
+    def search(self, query_vector, top_k=5, user_id=None, org_id=None, is_admin=False):
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_compact_index_runs_off_loop():
+    """compact_index must call self._store.compact in a worker thread,
+    not on the asyncio loop's main thread."""
+    from app.services.rag.engine import KnowledgeEngine
+
+    store = _RecordingStore()
+    engine = KnowledgeEngine(vector_store=store)
+
+    await engine.compact_index()
+
+    assert store.compact_calls == 1
+    assert store.compact_thread is not None
+    assert store.compact_thread is not threading.current_thread(), (
+        "compact ran on the event loop's main thread; "
+        "asyncio.to_thread wrapping is missing or bypassed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_document_runs_compact_off_loop():
+    """delete_document triggers compact when the deleted ratio crosses 20%.
+    That compaction must also run off the loop — same thread-identity
+    contract as compact_index itself."""
+    from app.services.rag.engine import KnowledgeEngine, TenantContext
+
+    # ntotal=10, deleted=2 → ratio=0.20 → compact triggers.
+    store = _RecordingStore(ntotal=10, deleted=2)
+    engine = KnowledgeEngine(vector_store=store)
+
+    await engine.delete_document("doc_x", tenant=TenantContext(user_id="alice"))
+
+    assert store.compact_calls == 1
+    assert store.compact_thread is not threading.current_thread()
+
+
+@pytest.mark.asyncio
+async def test_delete_document_below_threshold_does_not_compact():
+    """Sanity: below 20% ratio, no compaction is triggered (and therefore
+    no extra thread hop)."""
+    from app.services.rag.engine import KnowledgeEngine, TenantContext
+
+    store = _RecordingStore(ntotal=100, deleted=1)  # ratio 0.01
+    engine = KnowledgeEngine(vector_store=store)
+
+    await engine.delete_document("doc_x", tenant=TenantContext(user_id="alice"))
+
+    assert store.compact_calls == 0


### PR DESCRIPTION
P2 from the v0.1.3 deep-modules review. Completes the trio PR #289 started: `index_document`, `search`, and now `compact_index` all run their CPU-bound SentenceTransformer work in a worker thread instead of blocking the uvicorn event loop.

> **Targeted at `fix/rag-durability-atomic-writes` (PR #290), not `master`.** The `compact()` body lives in #290; basing here avoids a textual conflict. Merge order: #290 first, then this rebases cleanly onto master. Independent of #289 — `engine.py` touches are disjoint.

## What

`KnowledgeEngine.delete_document` triggers compaction when the deleted ratio crosses 20%; the compaction re-embeds every active chunk via SentenceTransformer (seconds of CPU for any non-trivial KB). On the event loop, a single `DELETE /knowledge/document` request stalls every other request until that finishes.

```python
async def compact_index(self) -> Dict[str, Any]:
    if hasattr(self._store, "compact"):
        return await asyncio.to_thread(self._store.compact)
    return {}
```

## API contract change

`compact_index` is now `async`. Verified all callers:
- `delete_document` (engine.py) → `await self.compact_index()` ✅
- `tests/unit/test_knowledge_engine.py::test_soft_delete_and_compaction` → was already `async`, just needed `await` ✅
- No production code outside the engine references `compact_index` (grep-verified).

## Tests (mutation-verified)

`_RecordingStore` captures the thread that `compact()` runs on.

- `test_compact_index_runs_off_loop` — asserts `compact_thread` is not the loop's main thread. Fails against sync code: thread identity matches.
- `test_delete_document_runs_compact_off_loop` — seeds stats at exactly the 20% threshold, calls `delete_document`, asserts the triggered compaction also ran off the loop.
- `test_delete_document_below_threshold_does_not_compact` — sanity: below 20%, no compaction.

Against the unfixed (sync) version, the first two fail with the same `AssertionError: <_MainThread>` signature as PR #289's embed offload tests.

## Verification

Backend: **1581 passed / 1 skipped** on this branch (#290's 1578 + 3 new).