### PR TITLE
chore: remove dead code left by ADR-0031/0038 extractions

### DIFF
--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -61,12 +61,6 @@ PI_EVENT_DRAIN_TIMEOUT = _env_float_drain("PI_EVENT_DRAIN_TIMEOUT", 2.0)    # pr
 PI_EVENT_STREAM_TIMEOUT = _env_float_drain("PI_EVENT_STREAM_TIMEOUT", 30.0)  # stream_prompt 等待下一个 event 的超时
 
 
-# SSE content strings for compaction events.
-# TODO: Replace with i18n-aware strings when the frontend supports localized SSE events.
-COMPACTION_START_MSG = "[压缩上下文...]\n"
-COMPACTION_END_MSG = "[上下文压缩完成]\n"
-
-
 # ── Pi tool dispatch models (owned by bridge, not pi_tools route) ──
 
 class PiToolRequest(BaseModel):
@@ -263,8 +257,7 @@ class PiBridge:
     Thin orchestrator: holds a :class:`PiRpcClient` (the deep RPC core),
     owns the prompt/stream_prompt turn lifecycle (including the ADR-0022 cache
     clearing), and delegates event->SSE mapping to the pure
-    :func:`map_event_to_sse` function (extracted in Commit 2; until then the
-    mapper methods stay on this class).
+    :func:`map_event_to_sse` function.
 
     The ADR-0022 dispatch-result cache + the two dispatch adapters
     (``dispatch_tool`` HTTP callback + ``_handle_tool_execution_end`` SSE

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 import numpy as np
 
-from app.services.rag.chunker import split_into_chunks, split_markdown_sections
+from app.services.rag.chunker import split_into_chunks
 from app.services.rag.faiss_store import FaissVectorStore
 
 logger = logging.getLogger(__name__)
@@ -31,21 +31,6 @@ def _get_embedding_model():
 def _load_metadata() -> dict:
     """Backward compatibility helper for metadata loading."""
     return _default_store.load_metadata()
-
-
-def _save_metadata(meta: dict) -> None:
-    """Backward compatibility helper for metadata saving."""
-    _default_store.save_metadata(meta)
-
-
-def _mark_deleted(doc_id: str) -> None:
-    """Backward compatibility helper for marking deleted docs."""
-    _default_store.mark_deleted(doc_id)
-
-
-def _split_markdown_section(text: str) -> list[str]:
-    """Backward compatibility helper for markdown splitting."""
-    return split_markdown_sections(text)
 
 
 async def add_document(


### PR DESCRIPTION
Three pieces flagged by the v0.1.3 deep-modules review's maintainability specialist. Each verified at HEAD to have **zero callers** before deletion. Pure deletion, no behavior change.

> Independent of #289 / #290 / #291 — touches lines none of them touch.

## `agent_pi_bridge.py`

- **`COMPACTION_START_MSG` / `COMPACTION_END_MSG`** (lines 66-67) — duplicates of the live constants in `app/services/chat/pi_event_mapper.py:18-19`, which is the only place they are read. The bridge copies were left behind by ADR-0031's F3 extraction; keeping two copies of the same string is a silent drift trap.
- **Stale `PiBridge` class docstring** — referenced `"(extracted in Commit 2; until then the mapper methods stay on this class)"`, describing a mid-extraction state that no longer exists.

## `rag_service.py`

- **`_save_metadata` / `_mark_deleted` / `_split_markdown_section`** (lines 36-48) — "backward compatibility helpers" that ADR-0038 left in place but that nothing imports or calls. The real implementations live in `FaissVectorStore` and `chunker`.
- Dropped the now-unused `split_markdown_sections` import.

## Deliberately NOT removed

`_get_faiss_index` / `_get_embedding_model` / `_load_metadata` are still referenced by the ignored `tests/test_core_features_sanity.py`, which patches them as seams.

That test is already broken (network-dependent SentenceTransformer load + patches a code path that no longer exists post-#289), and is ignored in `pytest.ini`, but deleting the symbols it patches would convert "test is ignored" into "test fails to import" — a sharper break for anyone who tries to revive it. The right fix for that test is its own PR.

## Verification

Backend: **1567 passed / 1 skipped** — unchanged from master, pure deletion.