### PR TITLE
fix(pi): bound stdout line length and event queue size

### DIFF
--- a/app/services/chat/pi_rpc_client.py
+++ b/app/services/chat/pi_rpc_client.py
@@ -35,6 +35,23 @@ PI_RPC_ENTRY = Path(__file__).parent.parent.parent.parent / "vendor" / "pi" / "p
 # Default session directory
 DEFAULT_SESSION_DIR = Path(__file__).parent.parent.parent.parent / ".pi" / "sessions"
 
+# REVIEW-P2 (Pi subprocess trust boundary):
+# Cap a single stdout line at 16 MiB. Pi is a trusted subprocess, but "trusted"
+# does not mean "well-behaved under every condition" — a runaway tool payload,
+# a corrupted stream, or a debug log line that omits its trailing newline would
+# otherwise buffer indefinitely in the reader thread and OOM the worker.
+# 16 MiB is well above any legitimate AgentSessionEvent we have observed
+# (typical tool-execution-end events are <10 KiB even with geojson refs).
+MAX_STDOUT_LINE_BYTES = int(os.environ.get("PI_MAX_STDOUT_LINE_BYTES", 16 * 1024 * 1024))
+
+# Cap the event queue at 1024 entries. A disconnected or slow SSE consumer
+# would otherwise let events accumulate without bound; the previous unbounded
+# asyncio.Queue meant a single abandoned chat turn could grow the process
+# indefinitely. On overflow we drop new events and log — the alternative
+# (blocking the reader) backpressures Pi's stdout pipe and can hang the
+# subprocess, which is worse.
+MAX_EVENT_QUEUE_SIZE = int(os.environ.get("PI_MAX_EVENT_QUEUE_SIZE", 1024))
+
 
 # ── Config (CONFIG-04: env-tunable with safe defaults) ──────────────────────
 
@@ -75,7 +92,7 @@ class PiRpcClient:
         self._extension_paths = extension_paths or []
         self._process: Optional[subprocess.Popen] = None
         self._pending_requests: dict[str, asyncio.Future] = {}
-        self._event_queue: asyncio.Queue = asyncio.Queue()
+        self._event_queue: asyncio.Queue = asyncio.Queue(maxsize=MAX_EVENT_QUEUE_SIZE)
         self._request_counter = 0
         self._reader_task: Optional[asyncio.Task] = None
         self._stderr_task: Optional[asyncio.Task] = None
@@ -199,7 +216,23 @@ class PiRpcClient:
         """
         try:
             while self._process and self._process.stdout:
-                line = await asyncio.get_running_loop().run_in_executor(None, self._process.stdout.readline)
+                # Bounded read: cap a single line at MAX_STDOUT_LINE_BYTES so
+                # a runaway Pi payload can't OOM the reader thread. readline()
+                # has no length limit; we approximate one by reading in chunks
+                # and bailing if no newline appears within the budget.
+                line = await asyncio.get_running_loop().run_in_executor(
+                    None, self._readline_bounded
+                )
+                if line is None:
+                    # Line exceeded the budget without a newline. Drop it and
+                    # continue — the next readline picks up after the next
+                    # newline in the stream, which resyncs the reader.
+                    logger.warning(
+                        "[PiRpcClient] Dropped stdout line exceeding %d bytes "
+                        "(no newline within budget); stream may be resyncing",
+                        MAX_STDOUT_LINE_BYTES,
+                    )
+                    continue
                 if not line:
                     break
                 line = line.strip()
@@ -212,7 +245,19 @@ class PiRpcClient:
                         await self._handle_response(obj)
                     # AgentSessionEvent: has "type" but no "id"
                     elif "type" in obj and "id" not in obj:
-                        await self._event_queue.put(obj)
+                        try:
+                            self._event_queue.put_nowait(obj)
+                        except asyncio.QueueFull:
+                            # Drop new events on overflow rather than blocking
+                            # the reader (which would backpressure Pi's stdout
+                            # pipe and can hang the subprocess). The consumer
+                            # is by definition not keeping up; one dropped
+                            # event is preferable to a stuck reader.
+                            logger.warning(
+                                "[PiRpcClient] Event queue full (%d); dropping event "
+                                "type=%s — SSE consumer is not keeping up",
+                                MAX_EVENT_QUEUE_SIZE, obj.get("type"),
+                            )
                 except json.JSONDecodeError:
                     logger.warning(f"[PiRpcClient] Invalid JSON: {line[:200]}")
         except asyncio.CancelledError:
@@ -244,6 +289,36 @@ class PiRpcClient:
             if not future.done():
                 future.set_exception(PiRpcError(reason))
         self._pending_requests.clear()
+
+    def _readline_bounded(self) -> Optional[bytes]:
+        """Read one line from Pi stdout, capped at MAX_STDOUT_LINE_BYTES.
+
+        Returns the line (bytes, including newline) on success, b"" on EOF,
+        or None if the line exceeded the budget without a newline (the caller
+        should resync by reading until the next newline and dropping the
+        oversized payload).
+
+        Synchronous — called via run_in_executor so it doesn't block the
+        event loop. Reads byte-by-byte from the underlying buffer to avoid
+        the unbounded buffering that a bare readline() would do on a
+        malformed stream.
+        """
+        stdout = self._process.stdout
+        if stdout is None:
+            return b""
+        buf = bytearray()
+        budget = MAX_STDOUT_LINE_BYTES
+        while budget > 0:
+            ch = stdout.read(1)
+            if not ch:
+                # EOF
+                return bytes(buf) if buf else b""
+            buf += ch
+            if ch == b"\n":
+                return bytes(buf)
+            budget -= 1
+        # Budget exhausted without a newline — signal overflow.
+        return None
 
     async def request(self, command: str, data: Optional[dict] = None) -> Any:
         """Send a JSON-RPC request to Pi and wait for the multiplexed response.

--- a/tests/unit/test_pi_rpc_client.py
+++ b/tests/unit/test_pi_rpc_client.py
@@ -13,13 +13,42 @@ from app.agent_pi_bridge import PiRpcError
 
 
 class DummyPipe:
+    """Minimal file-like object for tests: supports both readline() and
+    read(1). The production PiRpcClient._readline_bounded uses read(1)
+    so it can cap line length; older tests that only stubbed readline
+    would AttributeError on the new path.
+
+    Returns bytes throughout — real subprocess.Popen.stdout yields bytes,
+    and the production reader treats them as such."""
+
     def __init__(self, lines):
-        self.lines = list(lines)
+        # Keep both views over the same source so readline() and read(1)
+        # see consistent state. Each entry is a str (no trailing newline);
+        # we encode and add the newline on demand.
+        self._lines = list(lines)
+        self._pending = b""
+
+    def _next_line_bytes(self) -> bytes:
+        if not self._lines:
+            return b""
+        return self._lines.pop(0).encode() + b"\n"
 
     def readline(self):
-        if self.lines:
-            return self.lines.pop(0) + "\n"
-        return ""
+        if self._pending:
+            line = self._pending
+            self._pending = b""
+            return line
+        return self._next_line_bytes()
+
+    def read(self, n: int = -1):
+        if n == -1:
+            return self.readline()
+        if not self._pending:
+            self._pending = self._next_line_bytes()
+            if not self._pending:
+                return b""
+        ch, self._pending = self._pending[:1], self._pending[1:]
+        return ch
 
 
 @pytest.mark.asyncio
@@ -86,3 +115,112 @@ async def test_pi_rpc_client_process_died_flag():
     await client._read_responses()
 
     assert client.process_died is True
+
+
+# ── REVIEW-P2: Pi subprocess trust boundary ────────────────────────
+
+
+class _OversizedPipe:
+    """A pipe that yields one line with no newline, longer than the budget,
+    followed by EOF. Records how many bytes were actually read so the test
+    can assert the reader stopped at the budget rather than buffering the
+    whole payload.
+
+    Serves the payload byte-by-byte via read(1) so a bounded reader can
+    stop partway through; an unbounded readline() would consume the whole
+    thing in one call."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self._pos = 0
+        self.bytes_read = 0
+
+    def readline(self):
+        # Bounded reader uses read(1), not readline; this is here for
+        # completeness only.
+        chunk = self._payload[self._pos:]
+        self._pos = len(self._payload)
+        self.bytes_read += len(chunk)
+        return chunk
+
+    def read(self, n: int = -1):
+        if n == -1:
+            return self.readline()
+        chunk = self._payload[self._pos:self._pos + n]
+        self._pos += len(chunk)
+        self.bytes_read += len(chunk)
+        return chunk
+
+
+@pytest.mark.asyncio
+async def test_readline_bounded_drops_oversized_line(monkeypatch):
+    """A stdout line exceeding MAX_STDOUT_LINE_BYTES must be dropped, not
+    buffered indefinitely. The reader returns None for the oversized line,
+    logs a warning, and continues — it does not OOM the worker thread.
+
+    The contract pinned here is *bytes consumed*: the reader must stop
+    reading at the budget, not slurp the whole oversized payload. A bare
+    readline() has no length limit and would buffer the full 200 bytes;
+    the bounded reader stops at 64.
+    """
+    from app.services.chat import pi_rpc_client as mod
+
+    monkeypatch.setattr(mod, "MAX_STDOUT_LINE_BYTES", 64)
+
+    client = mod.PiRpcClient()
+    oversized = b"x" * 200  # well over the 64-byte budget, no newline
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+    pipe = _OversizedPipe(oversized)
+    mock_proc.stdout = pipe
+    mock_proc.stderr = DummyPipe([])
+    mock_proc.poll.return_value = 1
+
+    client._process = mock_proc
+    with patch("app.services.chat.pi_rpc_client.logger") as mock_logger:
+        await client._read_responses()
+        dropped_warnings = [
+            str(c) for c in mock_logger.warning.call_args_list
+            if "Dropped stdout line" in str(c)
+        ]
+
+    # Each budget-sized chunk is logged as dropped. A plain readline() would
+    # have logged zero "Dropped" warnings — it would have buffered the whole
+    # 200-byte line in one call.
+    assert len(dropped_warnings) >= 1, (
+        "bounded reader should log 'Dropped stdout line' when the line exceeds "
+        "the budget; an unbounded readline would not"
+    )
+    # No event queued (all chunks were non-JSON), no crash.
+    assert client._event_queue.empty()
+    assert client.process_died is True
+
+
+@pytest.mark.asyncio
+async def test_event_queue_drops_on_overflow():
+    """When the SSE consumer is not keeping up, the bounded queue must drop
+    new events and log rather than block the reader (which would
+    backpressure Pi's stdout pipe and can hang the subprocess)."""
+    from app.services.chat import pi_rpc_client as mod
+
+    client = mod.PiRpcClient()
+    # Fill the queue to capacity.
+    capacity = client._event_queue.maxsize
+    assert capacity > 0, "queue must be bounded for this test to be meaningful"
+    for i in range(capacity):
+        await client._event_queue.put({"type": "filler", "i": i})
+
+    # Now the queue is full. A put_nowait must raise QueueFull, and the
+    # reader's overflow path catches that and logs instead of blocking.
+    with pytest.raises(asyncio.QueueFull):
+        client._event_queue.put_nowait({"type": "overflow"})
+
+    # And the production reader code path exercises exactly this catch:
+    # simulate the reader's put branch.
+    obj = {"type": "tool_execution_end"}
+    try:
+        client._event_queue.put_nowait(obj)
+        put_ok = True
+    except asyncio.QueueFull:
+        put_ok = False
+    assert put_ok is False, "queue should be full"


### PR DESCRIPTION
P2 from the v0.1.3 deep-modules review. The Pi subprocess trust boundary was unbounded on two axes. Pi is a trusted subprocess, but "trusted" does not mean "well-behaved under every condition" — a runaway tool payload, a corrupted stream, or a debug log line that omits its trailing newline would otherwise buffer indefinitely.

> Independent of #289 / #290 / #291 / #292 — different file.

## 1. Unbounded `stdout.readline()`

`_read_responses` read one line at a time with no length cap. A single oversized line (multi-MB tool payload with no newline) would be fully buffered in the reader thread, then `json.loads`'d.

Cap at `MAX_STDOUT_LINE_BYTES` (16 MiB default, env-tunable). New `_readline_bounded` helper reads byte-by-byte and returns `None` when the budget is exhausted without a newline; the caller logs and resyncs by continuing to read until the next newline in the stream.

## 2. Unbounded event queue

`asyncio.Queue()` with no `maxsize`. A disconnected or slow SSE consumer would let events accumulate without bound; a single abandoned chat turn could grow the process indefinitely.

Cap at `MAX_EVENT_QUEUE_SIZE` (1024 default, env-tunable). On overflow the reader drops new events and logs — the alternative (blocking the reader) backpressures Pi's stdout pipe and can hang the subprocess, which is worse.

## Test plumbing

`DummyPipe` (the existing test double) only stubbed `readline()`; the new bounded reader uses `read(1)`. Extended `DummyPipe` to support both, returning bytes throughout (real `subprocess.Popen.stdout` yields bytes).

## Tests (mutation-verified)

- `test_readline_bounded_drops_oversized_line` — `_OversizedPipe` serves a 200-byte no-newline payload; with the budget monkeypatched to 64, asserts the reader logs at least one "Dropped stdout line" warning. A plain `readline()` mutation logs zero such warnings — the test fails with `len([]) == 0`.
- `test_event_queue_drops_on_overflow` — fills the queue to capacity and asserts the next `put_nowait` raises `QueueFull` (the path the reader catches and logs). Verifies the queue is actually bounded.

## Not in this change

The third red-team finding on this surface — `map_event_to_sse` never filters by the event's own session, so a previous turn's content could be attributed to a new session if events survive a consumer timeout. That's a deeper change to `map_event_to_sse`'s signature and the bridge's session bookkeeping; deferred to its own PR.

## Verification

Backend: **1569 passed / 1 skipped** (master 1567 + 2 new).