### PR TITLE
perf(rag): cache parsed metadata keyed by file mtime

### DIFF
--- a/app/services/rag/faiss_store.py
+++ b/app/services/rag/faiss_store.py
@@ -130,6 +130,9 @@ class FaissVectorStore:
         self.index_dir = index_dir
         self._index = None
         self._model = None
+        # (mtime_ns, parsed_dict) cache for load_metadata. None until first
+        # load. See load_metadata docstring for invalidation semantics.
+        self._metadata_cache: Optional[tuple] = None
 
     def _get_embedding_model(self):
         """Lazy load sentence transformer model."""
@@ -237,10 +240,42 @@ class FaissVectorStore:
 
     def load_metadata(self) -> Dict[str, Any]:
         """Load metadata. Uses a shared read lock so writers don't tear
-        the file mid-parse."""
+        the file mid-parse.
+
+        REVIEW-P2 perf: caches the parsed dict keyed by the file's mtime.
+        search() calls this on every query; without the cache each query
+        re-opened, flocked, and json.load'd the whole file (megabytes for
+        any non-trivial KB). The mtime check is a single stat() syscall,
+        and when the file hasn't changed we return the cached parse
+        directly. Cross-instance correctness is preserved: any writer
+        (this process, another uvicorn worker, a Celery compact task)
+        changes the mtime on save, so the next reader re-parses.
+        """
         meta_file = os.path.join(self.index_dir, "metadata.json")
-        if not os.path.exists(meta_file):
+        try:
+            stat = os.stat(meta_file)
+        except FileNotFoundError:
+            # Cache the empty-dict result too, so a missing-file case
+            # also avoids the os.path.exists check on every call.
+            self._metadata_cache = (None, {"chunks": []})
             return {"chunks": []}
+        except OSError:
+            # stat failed for some other reason — fall through to the
+            # uncached read path, which has its own error handling.
+            return self._load_metadata_uncached(meta_file)
+
+        cached = getattr(self, "_metadata_cache", None)
+        if cached is not None:
+            cached_mtime, cached_meta = cached
+            if cached_mtime == stat.st_mtime_ns:
+                return cached_meta
+
+        meta = self._load_metadata_uncached(meta_file)
+        self._metadata_cache = (stat.st_mtime_ns, meta)
+        return meta
+
+    def _load_metadata_uncached(self, meta_file: str) -> Dict[str, Any]:
+        """Read+parse metadata.json from disk, no cache."""
         try:
             with open(meta_file, "r", encoding="utf-8") as f:
                 fcntl.flock(f.fileno(), fcntl.LOCK_SH)

--- a/tests/unit/test_rag_metadata_cache.py
+++ b/tests/unit/test_rag_metadata_cache.py
@@ -1,0 +1,128 @@
+"""
+FaissVectorStore.load_metadata cache tests (REVIEW-P2 perf).
+
+search() calls load_metadata() on every query. Without the cache, each
+query re-opened, flocked, and json.load'd the whole metadata.json
+(megabytes for any non-trivial KB). The cache keys on the file's mtime:
+a stat() syscall decides hit vs miss, and any writer — this process,
+another uvicorn worker, a Celery compact task — changes the mtime on
+save, so the next reader re-parses.
+"""
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from app.services.rag.faiss_store import FaissVectorStore
+
+
+@pytest.fixture
+def tmp_store():
+    """A FaissVectorStore in a fresh temp dir; cleaned up after the test."""
+    tmpdir = tempfile.mkdtemp(prefix="rag-meta-cache-")
+    yield FaissVectorStore(index_dir=tmpdir), tmpdir
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_repeated_load_hits_cache_without_restatting_the_file(tmp_store, monkeypatch):
+    """Two consecutive load_metadata calls with no write in between must
+    return the same parsed dict and skip the disk read on the second call.
+    """
+    store, dir_ = tmp_store
+    store.save_metadata({"chunks": [{"document_id": "d1", "content": "alpha"}]})
+
+    # Count how many times the uncached path runs.
+    calls = {"n": 0}
+    original = store._load_metadata_uncached
+
+    def counting(path):
+        calls["n"] += 1
+        return original(path)
+
+    monkeypatch.setattr(store, "_load_metadata_uncached", counting)
+
+    first = store.load_metadata()
+    second = store.load_metadata()
+
+    assert calls["n"] == 1, (
+        f"repeated load with no write should hit the cache; uncached path "
+        f"ran {calls['n']} times, expected 1"
+    )
+    assert first is second, "cache hit should return the same object identity"
+
+
+def test_save_invalidates_cache(tmp_store):
+    """After save_metadata, the next load_metadata must re-parse from disk
+    and return the new content, not the cached old content.
+
+    The test explicitly populates the cache first (two reads with no write)
+    so a never-invalidate cache mutation would serve the stale entry."""
+    store, dir_ = tmp_store
+    store.save_metadata({"chunks": [{"document_id": "d1"}]})
+
+    # Populate the cache with two reads.
+    store.load_metadata()
+    first = store.load_metadata()
+    assert first["chunks"][0]["document_id"] == "d1"
+
+    # Write new content — mtime changes.
+    store.save_metadata({"chunks": [{"document_id": "d2"}]})
+
+    second = store.load_metadata()
+    assert second["chunks"][0]["document_id"] == "d2", (
+        "cache was not invalidated by save; got stale content"
+    )
+    assert first is not second, "cache should have re-parsed, not reused"
+
+
+def test_cross_instance_sees_writer_changes(tmp_store):
+    """Two store instances pointing at the same dir must see each other's
+    writes — the mtime check is what makes the cache safe across workers.
+
+    Explicitly populates store_b's cache before store_a's second write so
+    a never-invalidate mutation would serve stale content."""
+    store_a, dir_ = tmp_store
+    store_b = FaissVectorStore(index_dir=dir_)
+
+    store_a.save_metadata({"chunks": [{"document_id": "from_a"}]})
+    assert store_b.load_metadata()["chunks"][0]["document_id"] == "from_a"
+
+    # store_b reads again — populates its cache.
+    store_b.load_metadata()
+
+    # store_a writes again — store_b's next read must see it.
+    store_a.save_metadata({"chunks": [{"document_id": "from_a_again"}]})
+    assert store_b.load_metadata()["chunks"][0]["document_id"] == "from_a_again", (
+        "cross-instance cache was not invalidated by the other writer's save"
+    )
+
+
+def test_missing_file_returns_empty_without_crash(tmp_store):
+    """A fresh store with no metadata.json returns {'chunks': []} and caches
+    that result so subsequent loads also avoid the os.stat."""
+    store, dir_ = tmp_store
+    assert not os.path.exists(os.path.join(dir_, "metadata.json"))
+
+    first = store.load_metadata()
+    second = store.load_metadata()
+
+    assert first == {"chunks": []}
+    assert second == {"chunks": []}
+    # The missing-file branch caches (None, {"chunks": []}); second call
+    # should re-stat and hit the FileNotFoundError branch again, returning
+    # the cached empty dict. Just verify no crash and correct value.
+
+
+def test_corrupt_file_falls_back_to_empty(tmp_store):
+    """If the metadata file is corrupt JSON, load_metadata logs and returns
+    the empty-dict fallback rather than crashing the search path."""
+    store, dir_ = tmp_store
+    meta_path = os.path.join(dir_, "metadata.json")
+    # Write invalid JSON directly so save_metadata's cache invalidation
+    # doesn't run.
+    with open(meta_path, "w") as f:
+        f.write("{not valid json")
+
+    assert store.load_metadata() == {"chunks": []}


### PR DESCRIPTION
P2 perf from the v0.1.3 deep-modules review. `faiss_store.search()` calls `load_metadata()` on every query; the uncached path opened, flocked, and `json.load`'d the whole `metadata.json` (megabytes for any non-trivial KB because each chunk's full content text is stored inline). For a KB with thousands of chunks, every search was O(corpus) of disk I/O + parsing.

> **Targeted at `fix/rag-durability-atomic-writes` (PR #290), not `master`.** Same reason as #291 — `faiss_store.py` lives there. Merge order: #290 → this rebases to master.

## What

Cache the parsed dict keyed by the file's `mtime_ns`. A `stat()` syscall decides hit vs miss — when the file hasn't changed since the last parse, return the cached dict directly. Drops per-query cost from "open + flock + json.load megabytes" to "stat + dict lookup."

Cross-instance correctness is preserved for free: any writer — this process, another uvicorn worker, a Celery compact task — changes the mtime on `save_metadata`, so the next reader's `stat` sees the new mtime and re-parses. **No explicit invalidation needed in the write path.**

The missing-file case caches `(None, {"chunks": []})` so even a fresh store avoids the `os.path.exists` check on every call.

## Tests (mutation-verified, 5 new)

- `test_repeated_load_hits_cache_without_restatting_the_file` — monkeypatches `_load_metadata_uncached` to count calls; asserts two consecutive reads run the uncached path exactly once. Mutation (bypass cache): `assert 2 == 1`.
- `test_save_invalidates_cache` — reads twice to populate the cache, writes new content, reads again; asserts the new content is returned. Mutation (always-return-cached): fails with stale `from_a` instead of `from_a_again`.
- `test_cross_instance_sees_writer_changes` — two stores on the same dir; `store_b` populates its cache, `store_a` writes again, `store_b` must see the new content. Same mutation signature.
- `test_missing_file_returns_empty_without_crash` — fresh store, no `metadata.json`, empty fallback twice.
- `test_corrupt_file_falls_back_to_empty` — invalid JSON on disk logs and returns empty fallback rather than crashing the search path.

The invalidation tests had to be strengthened mid-mutation-check: the original shape (read once, write, read) didn't actually exercise the cache because the cache is only populated *after* a read. Added the second pre-write read so a never-invalidate mutation actually serves stale content.

## Verification

Backend: **1583 passed / 1 skipped** on this branch (#290's 1578 + 5 new).