### PR TITLE
fix(pi): turn-scoped event attribution + serial turns on singleton bridge

### DIFF
--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -15,7 +15,7 @@ glues the RPC client + mapper together.
 
 ADR-0022 constraint: ``_dispatch_result_cache``, ``_session_executed_sets``,
 ``dispatch_tool``, ``cache_dispatch_result``, ``get_cached_dispatch_result``,
-and ``_clear_session_dispatch_cache`` stay here. The extracted modules have
+and ``_clear_dispatch_cache`` stay here. The extracted modules have
 zero knowledge of the cache.
 """
 from __future__ import annotations
@@ -103,36 +103,40 @@ def get_tool_registry() -> "ToolRegistry":
     return _tool_registry
 
 
-# ── Session-keyed dispatch result cache (unified-tool-dispatch 票据 02) ──
+# ── Dispatch result cache (unified-tool-dispatch 票据 02) ──
 #
-# dispatch_tool（HTTP 回调）调度一次后把 ToolDispatchResult 按 (session_id, toolCallId)
-# 缓存；_handle_tool_execution_end（SSE 适配器）随后按同一 toolCallId 读取，发 step_result
+# dispatch_tool（HTTP 回调）调度一次后把 ToolDispatchResult 按 toolCallId 缓存；
+# _handle_tool_execution_end（SSE 适配器）随后按同一 toolCallId 读取，发 step_result
 # 时携带 geojson_ref。这样两条适配器共享一次 dispatch，避免 Pi 回传的 result 与服务端
 # 视图（已 slim、已落 ref）不一致 -- 此前 Pi 路径从不产生 ref，前端图层挂载失效。
 #
 # 缓存短命（一个 turn 内）：dispatch 时写入，SSE 读取后即清除，杜绝跨任务泄漏。
+#
+# Keyed by tool_call_id only. The prior (session_id, tool_call_id) key was asymmetric:
+# the HTTP callback (`dispatch_tool`) receives sessionId=None (the Pi extension posts
+# no sessionId — see app/extensions/webgis-tools/index.mjs), so writes landed under
+# ("", tool_call_id); the SSE adapter read with the bridge's current session_id, which
+# is non-empty for any real chat turn -> guaranteed cache miss -> step_result lost its
+# geojson_ref. Turns are now strictly serial on the singleton bridge (whole-turn lock
+# in stream_prompt/prompt), so the session dimension is redundant for correlation.
 # ADR-0022: this cache + the two dispatch adapters stay here - they are the
 # deliberate rendezvous between the Pi HTTP-callback and SSE adapters.
-_dispatch_result_cache: dict[tuple[str, str], "ToolDispatchResult"] = {}
+_dispatch_result_cache: dict[str, "ToolDispatchResult"] = {}
 
 
-def cache_dispatch_result(session_id: Optional[str], tool_call_id: str, result: "ToolDispatchResult") -> None:
+def cache_dispatch_result(tool_call_id: str, result: "ToolDispatchResult") -> None:
     """缓存一次 dispatch 的结果，供 SSE 适配器按 toolCallId 读取。"""
-    key = (session_id or "", tool_call_id)
-    _dispatch_result_cache[key] = result
+    _dispatch_result_cache[tool_call_id] = result
 
 
-def get_cached_dispatch_result(session_id: Optional[str], tool_call_id: str) -> "Optional[ToolDispatchResult]":
+def get_cached_dispatch_result(tool_call_id: str) -> "Optional[ToolDispatchResult]":
     """读取并弹出缓存的 dispatch 结果（读后即清，单次消费）。"""
-    key = (session_id or "", tool_call_id)
-    return _dispatch_result_cache.pop(key, None)
+    return _dispatch_result_cache.pop(tool_call_id, None)
 
 
-def _clear_session_dispatch_cache(session_id: str) -> None:
-    """清空某 session 的所有缓存 dispatch 结果（新 turn 开始时调用）。"""
-    sid = session_id or ""
-    for key in [k for k in _dispatch_result_cache if k[0] == sid]:
-        del _dispatch_result_cache[key]
+def _clear_dispatch_cache() -> None:
+    """清空所有缓存的 dispatch 结果（新 turn 开始时调用）。"""
+    _dispatch_result_cache.clear()
 
 
 async def dispatch_tool(request: PiToolRequest) -> PiToolResponse:
@@ -206,8 +210,8 @@ async def dispatch_tool(request: PiToolRequest) -> PiToolResponse:
 
     duration_ms = int((time.monotonic() - t0) * 1000)
 
-    # 缓存供 SSE 适配器读取
-    cache_dispatch_result(request.sessionId, request.toolCallId, result)
+    # 缓存供 SSE 适配器读取（keyed by tool_call_id only — see cache docstring）
+    cache_dispatch_result(request.toolCallId, result)
 
     if _harness is not None:
         is_error = result.status == "error"
@@ -287,7 +291,6 @@ class PiBridge:
                 extension_paths=extension_paths or [],
             )
         self._lock = asyncio.Lock()
-        self._session_id: str = ""
 
     @property
     def _process_died(self) -> bool:
@@ -316,6 +319,13 @@ class PiBridge:
         `case "abort"` handler. Failures (no process, RPC error) propagate;
         callers wrap in try/except because abort must never block the cleanup
         path that follows.
+
+        Deliberately does NOT acquire ``self._lock``: ``prompt``/``stream_prompt``
+        hold the lock across the whole turn (send + drain) to serialize turns
+        on the singleton bridge, and an abort that blocked on the lock would
+        deadlock against the in-flight turn it is trying to cancel. The
+        ``request("abort")`` RPC + ``fail_all_pending`` below provide
+        cancellation without the lock.
         """
         result = await self._rpc.request("abort")
         # Cancel any pending request future the client hasn't resolved yet.
@@ -324,6 +334,51 @@ class PiBridge:
         # timeout error to the user instead of a clean cancellation.
         self._rpc.fail_all_pending("abort requested")
         return result or {}
+
+    async def _drain_stale_events(self) -> int:
+        """Drop any events left in the shared queue from a prior turn.
+
+        Called at the start of each turn (under ``self._lock``) so that a
+        previous turn's residual events — left behind after a consumer timeout
+        or client disconnect — cannot be dequeued and attributed to this turn.
+        Returns the number of events dropped. Bounded by the queue maxsize so
+        a runaway producer can't make this loop unbounded.
+        """
+        dropped = 0
+        last_type = ""
+        events = self._rpc.events
+        for _ in range(events.maxsize or 1024):
+            try:
+                event = events.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            dropped += 1
+            last_type = event.get("type", "") if isinstance(event, dict) else ""
+        if dropped:
+            logger.warning(
+                "[PiBridge] drained %d stale event(s) from prior turn before "
+                "starting this one (last type=%s); they would otherwise have "
+                "been attributed to the new session",
+                dropped, last_type,
+            )
+        return dropped
+
+    async def _drain_remaining_turn_events(self) -> None:
+        """Best-effort drain of this turn's leftover events after timeout/disconnect.
+
+        Without this, a timed-out or cancelled stream leaves the turn's
+        remaining events (up to ``agent_end``) in the shared queue, where the
+        next turn's drain loop would pick them up. Bounded and non-blocking so
+        a stuck producer cannot block cleanup.
+        """
+        events = self._rpc.events
+        for _ in range(events.maxsize or 1024):
+            try:
+                event = events.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if isinstance(event, dict) and event.get("type") == "agent_end":
+                break
 
     async def prompt(self, message: str, session_id: Optional[str] = None) -> dict:
         """Send a prompt to Pi agent (non-streaming).
@@ -338,34 +393,50 @@ class PiBridge:
         Raises:
             PiRpcError: If the Pi agent returns an error or the request fails.
         """
+        # Turn-scoped session id: attribution uses this local, never the
+        # mutable self._session_id field (which a concurrent/preceding turn
+        # could overwrite). Pi events carry no session of their own.
+        turn_sid = session_id or ""
         data: dict[str, Any] = {"message": message}
-        if session_id:
-            data["sessionId"] = session_id
-            self._session_id = session_id
+        if turn_sid:
+            data["sessionId"] = turn_sid
 
-        # 新 turn 开始：清空该 session 的重复调用拦截集合与 dispatch 结果缓存。
-        _session_executed_sets.pop(self._session_id, None)
-        _clear_session_dispatch_cache(self._session_id)
+        # 新 turn 开始：清空重复调用拦截集合与 dispatch 结果缓存。
+        # 重复拦截语义是「同一 turn 内」-- 跨 turn 用户重发同一问题是合法的。
+        _session_executed_sets.pop(turn_sid, None)
+        _clear_dispatch_cache()
 
-        async with self._lock:
+        # Hold the lock across send + drain so turns are strictly serial on the
+        # singleton bridge. Pi processes one prompt at a time, so this matches
+        # the real execution model and prevents two turns' events interleaving
+        # in the shared queue. Abort bypasses the lock (see abort()).
+        await self._lock.acquire()
+        try:
+            # Drop any residual events from a prior turn before sending, so they
+            # cannot be attributed to this turn.
+            await self._drain_stale_events()
             await self._rpc.request("prompt", data)
 
-        # Drain events from the queue (non-streaming mode)
-        content_parts: list[str] = []
-        while True:
-            try:
-                event = await asyncio.wait_for(self._rpc.events.get(), timeout=PI_EVENT_DRAIN_TIMEOUT)
-                if event.get("type") == "agent_end":
+            # Drain events from the queue (non-streaming mode)
+            content_parts: list[str] = []
+            while True:
+                try:
+                    event = await asyncio.wait_for(self._rpc.events.get(), timeout=PI_EVENT_DRAIN_TIMEOUT)
+                    if event.get("type") == "agent_end":
+                        break
+                    from app.services.chat.pi_event_mapper import _extract_text_from_event
+                    text = _extract_text_from_event(event)
+                    if text:
+                        content_parts.append(text)
+                except asyncio.TimeoutError:
                     break
-                from app.services.chat.pi_event_mapper import _extract_text_from_event
-                text = _extract_text_from_event(event)
-                if text:
-                    content_parts.append(text)
-            except asyncio.TimeoutError:
-                break
+            # Best-effort: drain any leftover events so the next turn starts clean.
+            await self._drain_remaining_turn_events()
+        finally:
+            self._lock.release()
 
         return {
-            "sessionId": self._session_id,
+            "sessionId": turn_sid,
             "content": "".join(content_parts),
         }
 
@@ -381,56 +452,77 @@ class PiBridge:
         Yields:
             SSE-formatted event strings
         """
+        # Turn-scoped session id: every SSE payload is stamped with this local
+        # value, not the mutable self._session_id field. Pi events carry no
+        # session of their own, so attribution must come from the request that
+        # owns this turn — not bridge instance state a prior turn could have
+        # overwritten.
+        turn_sid = session_id or ""
         data: dict[str, Any] = {"message": message}
-        if session_id:
-            data["sessionId"] = session_id
-            self._session_id = session_id
+        if turn_sid:
+            data["sessionId"] = turn_sid
 
-        # 新 turn 开始：清空该 session 的重复调用拦截集合与 dispatch 结果缓存。
+        # 新 turn 开始：清空重复调用拦截集合与 dispatch 结果缓存。
         # 重复拦截语义是「同一 turn 内」-- 跨 turn 用户重发同一问题是合法的。
-        _session_executed_sets.pop(self._session_id, None)
-        _clear_session_dispatch_cache(self._session_id)
+        _session_executed_sets.pop(turn_sid, None)
+        _clear_dispatch_cache()
 
-        # Send prompt command
+        # Hold the lock across send + drain + cleanup so turns are strictly
+        # serial on the singleton bridge (Pi processes one prompt at a time).
+        # try/finally ensures a client-disconnect GeneratorExit/CancelledError
+        # at the yield still releases the lock and drains residual events.
+        # Abort deliberately bypasses this lock (see abort()).
+        await self._lock.acquire()
         try:
-            async with self._lock:
-                await self._rpc.request("prompt", data)
-        except PiRpcError as e:
-            logger.error(f"[PiBridge] stream_prompt send failed: {e}")
-            yield sse_event("task_error", {
-                "task_id": session_id or "",
-                "session_id": self._session_id,
-                "error": str(e),
-            })
-            yield sse_event("done", {"session_id": self._session_id})
-            return
+            # Drop residual events from a prior turn so they can't be dequeued
+            # and attributed to this session.
+            await self._drain_stale_events()
 
-        # Stream events from Pi
-        yield sse_event("task_start", {"task_id": session_id or "", "session_id": self._session_id})
-
-        from app.services.chat.pi_event_mapper import map_event_to_sse
-        timed_out = False
-        while True:
+            # Send prompt command
             try:
-                event = await asyncio.wait_for(self._rpc.events.get(), timeout=PI_EVENT_STREAM_TIMEOUT)
-                sse = map_event_to_sse(event, self._session_id, cache_lookup=get_cached_dispatch_result)
-                if _harness is not None:
-                    _harness.record_sse_event(event)
-                if sse:
-                    yield sse
-                if event.get("type") == "agent_end":
+                await self._rpc.request("prompt", data)
+            except PiRpcError as e:
+                logger.error(f"[PiBridge] stream_prompt send failed: {e}")
+                yield sse_event("task_error", {
+                    "task_id": turn_sid,
+                    "session_id": turn_sid,
+                    "error": str(e),
+                })
+                yield sse_event("done", {"session_id": turn_sid})
+                return
+
+            # Stream events from Pi
+            yield sse_event("task_start", {"task_id": turn_sid, "session_id": turn_sid})
+
+            from app.services.chat.pi_event_mapper import map_event_to_sse
+            timed_out = False
+            while True:
+                try:
+                    event = await asyncio.wait_for(self._rpc.events.get(), timeout=PI_EVENT_STREAM_TIMEOUT)
+                    sse = map_event_to_sse(event, turn_sid, cache_lookup=get_cached_dispatch_result)
+                    if _harness is not None:
+                        _harness.record_sse_event(event)
+                    if sse:
+                        yield sse
+                    if event.get("type") == "agent_end":
+                        break
+                except asyncio.TimeoutError:
+                    timed_out = True
                     break
-            except asyncio.TimeoutError:
-                timed_out = True
-                break
 
-        if timed_out:
-            yield sse_event("error", {
-                "session_id": self._session_id,
-                "error": f"Pi agent response timed out ({int(PI_EVENT_STREAM_TIMEOUT)}s). The agent may be processing or stalled.",
-            })
+            if timed_out:
+                yield sse_event("error", {
+                    "session_id": turn_sid,
+                    "error": f"Pi agent response timed out ({int(PI_EVENT_STREAM_TIMEOUT)}s). The agent may be processing or stalled.",
+                })
 
-        yield sse_event("done", {"session_id": self._session_id})
+            yield sse_event("done", {"session_id": turn_sid})
+        finally:
+            # Drain any leftover events so a timeout/disconnect doesn't poison
+            # the next turn. (On a normal agent_end the queue is already empty;
+            # this is a no-op there.)
+            await self._drain_remaining_turn_events()
+            self._lock.release()
 
 
 # Global bridge instance

--- a/app/services/chat/pi_event_mapper.py
+++ b/app/services/chat/pi_event_mapper.py
@@ -108,10 +108,15 @@ def _handle_tool_execution_start(event: dict, session_id: str, cache_lookup: Opt
 
 
 def _handle_tool_execution_end(event: dict, session_id: str, cache_lookup: Optional[Callable]) -> Optional[str]:
-    """SSE 适配器：读缓存的 dispatch 结果发 step_result / step_error."""
+    """SSE 适配器：读缓存的 dispatch 结果发 step_result / step_error.
+
+    cache_lookup is keyed by tool_call_id only (the dispatch cache collapsed its
+    session dimension — see app.agent_pi_bridge._dispatch_result_cache). session_id
+    here is still used to stamp the SSE payload's session_id field.
+    """
     tool_name = event.get("toolName", "")
     tool_call_id = event.get("toolCallId", "")
-    cached = cache_lookup(session_id, tool_call_id) if cache_lookup else None
+    cached = cache_lookup(tool_call_id) if cache_lookup else None
 
     if cached is not None:
         if getattr(cached, "status", None) == "error":
@@ -187,15 +192,19 @@ _EVENT_HANDLERS: dict[str, Callable[[dict, str, Optional[Callable]], Optional[st
 def map_event_to_sse(
     event: dict,
     session_id: str = "",
-    cache_lookup: Optional[Callable[[str, str], Optional[Any]]] = None,
+    cache_lookup: Optional[Callable[[str], Optional[Any]]] = None,
 ) -> Optional[str]:
     """Map a Pi AgentSessionEvent to an SSE-formatted string.
 
     Args:
         event: Pi event dictionary
-        session_id: Session ID
-        cache_lookup: Optional callable (session_id, tool_call_id) -> ToolDispatchResult
-                      injected by PiBridge (ADR-0022 rendezvous)
+        session_id: Session ID — used to stamp the SSE payload's session_id field.
+                    Caller must pass the turn-scoped id (not a stale bridge field),
+                    since Pi events carry no session of their own.
+        cache_lookup: Optional callable (tool_call_id,) -> ToolDispatchResult
+                      injected by PiBridge (ADR-0022 rendezvous). Keyed by
+                      tool_call_id only; the session dimension was collapsed
+                      because the HTTP callback never receives a real session_id.
 
     Returns:
         SSE-formatted string or None if unhandled

--- a/tests/test_pi_integration.py
+++ b/tests/test_pi_integration.py
@@ -158,6 +158,187 @@ class TestPiBridgeSubprocessFlow:
         assert "connection refused" in error_ev
         assert event_types[-1] == "done"
 
+    # ─── Session attribution regression tests (review §3 item 1) ────────────
+
+    @pytest.mark.asyncio
+    async def test_stream_prompt_drains_stale_events_from_prior_turn(self):
+        """Residual events from a prior turn must not bleed into this turn's SSE.
+
+        Regression for the singleton-bridge attribution bug: one shared queue
+        served all sessions, a prior turn's leftover events (after timeout or
+        client disconnect) were dequeued by the next turn and stamped with the
+        new session_id. stream_prompt must drain stale events at turn start.
+        """
+        rpc = MagicMock()
+        rpc.events = asyncio.Queue(maxsize=1024)
+        rpc.start = AsyncMock()
+        rpc.stop = AsyncMock()
+        bridge = PiBridge(rpc=rpc)
+
+        # Seed the queue with a stale event from a *prior* turn (e.g. one whose
+        # consumer timed out before reaching agent_end).
+        stale_event = {
+            "type": "message_update",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "STALE FROM PRIOR TURN"}]},
+            "assistantMessageEvent": {"type": "text_delta", "content": "STALE FROM PRIOR TURN"},
+        }
+        await rpc.events.put(stale_event)
+
+        async def fake_request(cmd, data=None):
+            if cmd == "prompt":
+                # This turn's own events arrive only AFTER the prompt is sent.
+                await rpc.events.put({
+                    "type": "message_update",
+                    "message": {"role": "assistant", "content": []},
+                    "assistantMessageEvent": {"type": "text_delta", "content": "fresh"},
+                })
+                await rpc.events.put({"type": "agent_end"})
+
+        rpc.request = AsyncMock(side_effect=fake_request)
+
+        events = []
+        async for ev in bridge.stream_prompt("next turn", session_id="sess-B"):
+            events.append(ev)
+
+        # The stale event's content must NOT appear in this turn's SSE stream.
+        joined = "\n".join(events)
+        assert "STALE FROM PRIOR TURN" not in joined, (
+            "stale event from prior turn leaked into this turn's SSE stream"
+        )
+        # The fresh event's content must still flow.
+        assert "fresh" in joined
+
+    @pytest.mark.asyncio
+    async def test_stream_prompt_attributes_events_to_request_session(self):
+        """Every emitted SSE carries the request's session_id, not bridge state.
+
+        Locks turn-scoped attribution: the session_id stamped on SSE payloads
+        comes from the request argument, not a mutable instance field a prior
+        turn could have overwritten.
+        """
+        rpc = MagicMock()
+        rpc.events = asyncio.Queue(maxsize=1024)
+        rpc.start = AsyncMock()
+        rpc.stop = AsyncMock()
+        bridge = PiBridge(rpc=rpc)
+
+        async def fake_request(cmd, data=None):
+            if cmd == "prompt":
+                await rpc.events.put({
+                    "type": "message_update",
+                    "message": {"role": "assistant", "content": []},
+                    "assistantMessageEvent": {"type": "text_delta", "content": "hello"},
+                })
+                await rpc.events.put({"type": "agent_end"})
+
+        rpc.request = AsyncMock(side_effect=fake_request)
+
+        events = []
+        async for ev in bridge.stream_prompt("hi", session_id="sess-attrib-target"):
+            events.append(ev)
+
+        # Every SSE payload that carries a session_id must carry THIS turn's id.
+        for ev in events:
+            if "session_id" in ev:
+                assert '"session_id": "sess-attrib-target"' in ev, (
+                    f"SSE payload attributed to wrong session: {ev!r}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_stream_prompt_lock_serializes_concurrent_turns(self):
+        """The whole-turn lock serializes turns: turn B cannot send its prompt
+        until turn A has fully drained and emitted its final ``done``.
+
+        Without the lock (old behavior: lock only around the send RPC), turn B's
+        ``request("prompt")`` would run while turn A is still draining the shared
+        queue, so both turns' events interleave in the queue and get attributed
+        to whichever session drains them. This test pins the invariant directly:
+        while turn A is parked mid-drain (waiting on ``events.get()`` for its
+        agent_end), turn B must still be blocked on the lock and must NOT have
+        sent its prompt yet.
+        """
+        rpc = MagicMock()
+        rpc.events = asyncio.Queue(maxsize=1024)
+        rpc.start = AsyncMock()
+        rpc.stop = AsyncMock()
+        bridge = PiBridge(rpc=rpc)
+
+        # Turn A's send returns immediately after emitting one non-terminal
+        # event; its drain loop then parks on events.get() waiting for
+        # agent_end, which a feeder task supplies only after `a_release`.
+        a_drained_first_event = asyncio.Event()
+        a_release = asyncio.Event()
+        b_prompt_sent = asyncio.Event()
+
+        async def fake_request_a(cmd, data=None):
+            if cmd == "prompt":
+                await rpc.events.put({
+                    "type": "message_update",
+                    "message": {"role": "assistant", "content": []},
+                    "assistantMessageEvent": {"type": "text_delta", "content": "AAA"},
+                })
+
+        async def fake_request_b(cmd, data=None):
+            if cmd == "prompt":
+                b_prompt_sent.set()
+                await rpc.events.put({
+                    "type": "message_update",
+                    "message": {"role": "assistant", "content": []},
+                    "assistantMessageEvent": {"type": "text_delta", "content": "BBB"},
+                })
+                await rpc.events.put({"type": "agent_end"})
+
+        async def feed_a_agent_end():
+            """Wait until turn A has drained its first event, then hold for release."""
+            await a_drained_first_event.wait()
+            await a_release.wait()
+            await rpc.events.put({"type": "agent_end"})
+
+        a_events: list[str] = []
+        b_events: list[str] = []
+
+        async def run_a():
+            rpc.request = AsyncMock(side_effect=fake_request_a)
+            async for ev in bridge.stream_prompt("A", session_id="sess-A"):
+                if "AAA" in ev:
+                    a_drained_first_event.set()
+                a_events.append(ev)
+
+        async def run_b():
+            rpc.request = AsyncMock(side_effect=fake_request_b)
+            async for ev in bridge.stream_prompt("B", session_id="sess-B"):
+                b_events.append(ev)
+
+        feeder = asyncio.ensure_future(feed_a_agent_end())
+        task_a = asyncio.ensure_future(run_a())
+        # Let turn A drain its first event and park in events.get().
+        await asyncio.wait_for(a_drained_first_event.wait(), timeout=2.0)
+        # Ensure turn A is actually parked waiting for the next event.
+        await asyncio.sleep(0.02)
+
+        # Now start turn B. Under the whole-turn lock it must block on
+        # self._lock.acquire() (turn A holds it across its drain) and NOT send
+        # its prompt yet. Give the scheduler a chance to run B if it could.
+        task_b = asyncio.ensure_future(run_b())
+        await asyncio.sleep(0.05)
+        assert not b_prompt_sent.is_set(), (
+            "turn B sent its prompt while turn A was still parked mid-drain — "
+            "the whole-turn lock is not serializing turns (B should block on "
+            "self._lock until A's drain + done completes)"
+        )
+
+        # Release turn A's agent_end; it drains to completion and releases the
+        # lock, then turn B can proceed.
+        a_release.set()
+        await asyncio.wait_for(asyncio.gather(task_a, task_b, feeder), timeout=5.0)
+
+        assert a_events, "turn A produced no SSE events"
+        assert b_events, "turn B produced no SSE events"
+        assert b_prompt_sent.is_set(), "turn B never sent its prompt after A released"
+        # Turn A's events must all be attributed to sess-A, B's to sess-B.
+        assert all('"session_id": "sess-A"' in e or "session_id" not in e for e in a_events)
+        assert all('"session_id": "sess-B"' in e or "session_id" not in e for e in b_events)
+
 
 # ============================================================================
 # /pi-tools/execute endpoint tests

--- a/tests/unit/test_pi_dispatch_adapters.py
+++ b/tests/unit/test_pi_dispatch_adapters.py
@@ -1,12 +1,17 @@
 """Pi-path dispatch 适配器契约测试（unified-tool-dispatch 票据 02）。
 
-锁定的契约：Pi 路径经 ToolDispatchService 调度一次，结果按 session+toolCallId 缓存；
+锁定的契约：Pi 路径经 ToolDispatchService 调度一次，结果按 toolCallId 缓存；
 HTTP 回调适配器把 llm_payload 翻成 PiToolResponse.content，SSE 适配器读缓存结果
 发 step_result 并携带 geojson_ref。两条适配器共享一次 dispatch。
 
 这是整个 unified-tool-dispatch 工作修复的静默回归的契约锁：此前 Pi 路径从不产生
 ref_id，前端图层挂载逻辑（键 off geojson_ref）找不到图层可挂。本测试确保
 geojson_ref 从 dispatch 一路 round-trip 到 SSE payload。
+
+缓存键只取 toolCallId：HTTP 回调从不带真实 sessionId（Pi 扩展不 post sessionId），
+而此前按 (session_id, tool_call_id) 键时，写入落 ("", toolCallId)、SSE 读时用
+bridge 的 session_id -> 必然 miss -> step_result 丢失 geojson_ref。turn 现已严格
+串行（whole-turn lock），session 维度对关联是冗余的。
 """
 import pytest
 from app.tools.registry import ToolRegistry
@@ -29,13 +34,11 @@ async def clean_session():
     await session_data_manager.clear_session(sid)
     # 隔离：清空该 session 的重复拦截集合与 dispatch 缓存（真实流程由 turn 边界清）。
     _session_executed_sets.pop(sid, None)
-    for key in [k for k in _dispatch_result_cache if k[0] == sid]:
-        del _dispatch_result_cache[key]
+    _dispatch_result_cache.clear()
     yield sid
     await session_data_manager.clear_session(sid)
     _session_executed_sets.pop(sid, None)
-    for key in [k for k in _dispatch_result_cache if k[0] == sid]:
-        del _dispatch_result_cache[key]
+    _dispatch_result_cache.clear()
 
 
 def _geojson_tool_registry() -> ToolRegistry:
@@ -81,7 +84,7 @@ async def test_http_callback_translates_llm_payload_to_content(clean_session):
 
 @pytest.mark.asyncio
 async def test_http_callback_caches_result_for_sse_adapter(clean_session):
-    """dispatch 后结果按 session+toolCallId 缓存，供 SSE 适配器读取。"""
+    """dispatch 后结果按 toolCallId 缓存，供 SSE 适配器读取。"""
     set_tool_registry(_geojson_tool_registry())
     req = PiToolRequest(
         toolCallId="tc-geo-2",
@@ -91,7 +94,7 @@ async def test_http_callback_caches_result_for_sse_adapter(clean_session):
     )
     await dispatch_tool(req)
 
-    cached = get_cached_dispatch_result(clean_session, "tc-geo-2")
+    cached = get_cached_dispatch_result("tc-geo-2")
     assert cached is not None
     assert cached.status == "ok"
     assert cached.geojson_ref is not None  # 关键：ref 被存储了
@@ -117,7 +120,11 @@ async def test_sse_adapter_round_trips_geojson_ref(clean_session):
         sessionId=clean_session,
     ))
 
-    # Pi 随后流式回传 tool_execution_end 事件 —— SSE 适配器读缓存
+    # Pi 随后流式回传 tool_execution_end 事件 —— SSE 适配器读缓存。
+    # NOTE: dispatch 写入时 sessionId 来自 HTTP 回调（Pi 扩展不 post sessionId，
+    # 故为 None -> 键为 toolCallId）。这里 mapper 用一个 *不同的* session_id
+    # (clean_session) 调用，正是此前 (session_id, tool_call_id) 键时必然 miss 的
+    # 场景。键坍缩为 toolCallId-only 后必须命中。
     event = {
         "type": "tool_execution_end",
         "toolCallId": "tc-geo-3",
@@ -178,3 +185,35 @@ async def test_sse_adapter_error_uses_cached_error_status(clean_session):
     sse = map_event_to_sse(event, clean_session, cache_lookup=get_cached_dispatch_result)
     assert sse is not None
     assert "step_error" in sse
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_survives_session_mismatch(clean_session):
+    """【cache-key 坍缩回归】dispatch 写入 sessionId=None（HTTP 回调真实情况），
+    SSE 适配器用一个 *非空、不同* 的 session_id 读取必须命中。
+
+    此前键为 (session_id, tool_call_id)：写入落 ("", toolCallId)，读取用 bridge 的
+    非空 self._session_id -> 必然 miss -> step_result 丢失 geojson_ref，退化到
+    Pi-echoed result。键坍缩为 tool_call_id-only 后此 asymmetry 必须消除。
+    """
+    set_tool_registry(_geojson_tool_registry())
+    # 模拟真实 HTTP 回调：PiToolRequest.sessionId 为 None（扩展不 post sessionId）。
+    await dispatch_tool(PiToolRequest(
+        toolCallId="tc-asym",
+        name="pi_geo_tool",
+        arguments={},
+        sessionId=None,
+    ))
+
+    # SSE 适配器在一个拥有真实 session_id 的 turn 中读取。
+    event = {
+        "type": "tool_execution_end",
+        "toolCallId": "tc-asym",
+        "toolName": "pi_geo_tool",
+        "result": {},
+        "isError": False,
+    }
+    sse = map_event_to_sse(event, "a-real-nonempty-session-id", cache_lookup=get_cached_dispatch_result)
+    assert sse is not None
+    assert "geojson_ref" in sse, "cache miss under session mismatch — key asymmetry regression"
+    assert "ref:geojson-" in sse

--- a/tests/unit/test_pi_event_mapper.py
+++ b/tests/unit/test_pi_event_mapper.py
@@ -89,8 +89,8 @@ def test_map_tool_execution_end_with_cache_hit():
         geojson_ref="ref:buffer/1",
     )
 
-    def fake_lookup(sid, tcid):
-        if sid == "s1" and tcid == "tc-123":
+    def fake_lookup(tcid):
+        if tcid == "tc-123":
             return fake_result
         return None
 
@@ -112,7 +112,7 @@ def test_map_tool_execution_end_with_cache_error():
         error_msg="Buffer radius must be positive",
     )
 
-    def fake_lookup(sid, tcid):
+    def fake_lookup(tcid):
         return fake_result
 
     sse = map_event_to_sse(event, session_id="s1", cache_lookup=fake_lookup)
@@ -129,7 +129,7 @@ def test_map_tool_execution_end_cache_miss_fallback():
         "result": {"summary": "fallback result"},
         "isError": False,
     }
-    sse = map_event_to_sse(event, session_id="s1", cache_lookup=lambda s, t: None)
+    sse = map_event_to_sse(event, session_id="s1", cache_lookup=lambda t: None)
     assert sse is not None
     assert "event: step_result" in sse
     assert '"fallback result"' in sse


### PR DESCRIPTION
## Summary

Fixes two active bugs in the Pi event pipeline, both in the `map_event_to_sse` / `PiBridge` surface area (v0.1.3 deep-modules review §3 item 1, plus a second bug surfaced during exploration).

### 1. Cross-session event attribution
The singleton `PiBridge` (one subprocess, one shared `asyncio.Queue`) stamped every dequeued Pi event with a mutable `self._session_id` field that each incoming request overwrote. A prior turn's residual events — left in the queue after a consumer timeout or client disconnect — were then dequeued by the next turn and attributed to the new session. Pi events carry no session field of their own (`AgentEvent` has no `sessionId`; `rpc-mode` emits raw events), so attribution had to be fixed bridge-side.

**Fix:** thread the request's `session_id` as a local `turn_sid`; hold `self._lock` across the whole turn (send + drain + cleanup) so turns are strictly serial on the singleton bridge; drain stale queue events at turn start and leftover turn events on exit.

### 2. Dispatch-cache key asymmetry (geojson_ref lost)
The dispatch-cache rendezvous keyed writes under `("", toolCallId)` (the HTTP callback receives `sessionId=None` — the Pi extension posts no sessionId) but reads under `(self._session_id, toolCallId)`. Every turn with a real session_id cache-missed → `step_result` lost its `geojson_ref` → frontend layer mounting broke.

**Fix:** collapse `_dispatch_result_cache` to a `tool_call_id`-only key. The session dimension was redundant (turns are now serial) and was the source of the asymmetry.

## Changes
- `app/agent_pi_bridge.py` — `turn_sid` local in `prompt`/`stream_prompt`; whole-turn lock with `try/finally`; new `_drain_stale_events` / `_drain_remaining_turn_events` helpers; removed mutable `self._session_id` field; `abort()` docstring notes it bypasses the lock to avoid deadlock; cache helpers collapsed to single-key.
- `app/services/chat/pi_event_mapper.py` — `cache_lookup` callable drops the session argument; docstring updated.
- Tests: 3 new integration regression tests (drain-stale, session attribution, whole-turn-lock serialization) + 1 dispatch-adapter asymmetry regression test + updated fakes for the new cache signature.

## Verification
- Full Pi suite (42 tests) + broad chat/session/auth subset (519 tests) green.
- Full backend suite: **1619 passed / 1 skipped** (was 1615/1 pre-change — 4 net new tests).
- **Mutation-verified** each guard: reverting the drain-stale line → `test_stream_prompt_drains_stale_events_from_prior_turn` fails; reverting the cache-key collapse → `test_cache_hit_survives_session_mismatch` fails; reverting the whole-turn lock → `test_stream_prompt_lock_serializes_concurrent_turns` fails.

## Out of scope (separate findings, deferred)
- Pi subprocess parent-death watchdog + `_process_died`/`_process=None` respawn bug (`pi_rpc_client.py`) — separate PR.
- Explorer pipeline cluster, `context_assembler` mutual import, `density.py` palette inversion, `test_core_features_sanity.py` rewrite.

## Risk
The whole-turn lock changes the concurrency model from "concurrent sends, interleaved drains" to "strictly serial turns." This matches Pi's own single-prompt-at-a-time execution model (`pi_rpc_client.py:78-79`), so it reflects reality. A slow turn blocks the next turn's send until `PI_EVENT_STREAM_TIMEOUT` (30s, already the bound). The abort-deadlock hazard (abort must not take `self._lock`) is called out explicitly in code and docstring.

🤖 Generated with [ZCode](https://zcode.ai)
