### PR TITLE
perf(explorer): concurrent fetch, offload sync parse, dedup geocode addresses

### DIFF
--- a/app/adapters/gov/gov_data_adapter.py
+++ b/app/adapters/gov/gov_data_adapter.py
@@ -1,4 +1,5 @@
 """政府开放数据适配器"""
+import asyncio
 import logging
 import aiohttp
 import csv
@@ -151,11 +152,18 @@ class GovDataAdapter(BaseDataAdapter):
         )
 
     async def parse(self, raw: RawContent) -> StructuredData:
-        """解析 CSV/Excel 为结构化数据"""
+        """解析 CSV/Excel 为结构化数据。
+
+        The underlying ``_parse_csv`` / ``_parse_excel`` are synchronous
+        (``csv.DictReader``, ``openpyxl.load_workbook``) and can block for the
+        full parse of a large file (up to the 50MB fetch cap). Offload them to
+        the default thread pool so the Celery worker's event loop stays
+        responsive - matches the house pattern (rag/engine.py, stac_client.py).
+        """
         if raw.content_type == "text/csv":
-            return self._parse_csv(raw)
+            return await asyncio.to_thread(self._parse_csv, raw)
         elif raw.content_type in ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "application/vnd.ms-excel"):
-            return self._parse_excel(raw)
+            return await asyncio.to_thread(self._parse_excel, raw)
         else:
             raise ValueError(f"Unsupported format: {raw.content_type}")
 

--- a/app/services/explorer/fetch_stage.py
+++ b/app/services/explorer/fetch_stage.py
@@ -1,6 +1,7 @@
 """
-Fetch Stage — Pure async stage runner for content fetching.
+Fetch Stage - Pure async stage runner for content fetching.
 """
+import asyncio
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -21,38 +22,61 @@ async def run_fetch_stage(
     """
     Execute the content fetch stage.
     Fetches raw content from data sources and stores payloads via injected store_ref seam.
+
+    Sources are fetched concurrently via ``asyncio.gather`` (with per-source
+    error isolation via ``return_exceptions=True``) rather than serially, so
+    the stage stays within the Celery ``soft_time_limit`` when multiple sources
+    each have a multi-second HTTP timeout.
     """
     if on_progress:
         on_progress(10)
 
     data_adapter = adapter or GovDataAdapter()
-    results: List[Dict[str, Any]] = []
 
-    for item in selected_sources:
+    async def _fetch_one(item: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch one source, store its payload, return the result dict.
+
+        Raises on fetch failure so ``gather(return_exceptions=True)`` captures
+        it as an exception alongside the successful results - per-source
+        isolation without cancelling sibling fetches.
+        """
         source_dict = item.get("source", {})
         source = DataSource(**source_dict)
+        raw = await data_adapter.fetch(source)
+        payload = {
+            "data": raw.data.hex(),
+            "content_type": raw.content_type,
+            "encoding": raw.encoding,
+        }
+        ref_id = store_ref(payload, "fetch") if store_ref else f"ref_fetch_{source.id}"
+        return {
+            "source_id": source.id,
+            "ref_id": ref_id,
+            "size_bytes": len(raw.data),
+            "format": source.format,
+        }
 
-        try:
-            raw = await data_adapter.fetch(source)
-            payload = {
-                "data": raw.data.hex(),
-                "content_type": raw.content_type,
-                "encoding": raw.encoding,
-            }
-            ref_id = store_ref(payload, "fetch") if store_ref else f"ref_fetch_{source.id}"
+    # Concurrent fetch with per-source isolation: a failing source becomes an
+    # exception in the results list, not a cancellation of the others.
+    # Input order is preserved by gather's positional result alignment.
+    gather_results = await asyncio.gather(
+        *(_fetch_one(item) for item in selected_sources),
+        return_exceptions=True,
+    )
 
+    # Build the results list in input order, discriminating success vs failure.
+    results: List[Dict[str, Any]] = []
+    for item, outcome in zip(selected_sources, gather_results):
+        source_dict = item.get("source", {})
+        source = DataSource(**source_dict)
+        if isinstance(outcome, BaseException):
+            logger.warning(f"[Explorer:{task_id}] Fetch failed for {source.id}: {outcome}")
             results.append({
                 "source_id": source.id,
-                "ref_id": ref_id,
-                "size_bytes": len(raw.data),
-                "format": source.format,
+                "error": str(outcome),
             })
-        except Exception as e:
-            logger.warning(f"[Explorer:{task_id}] Fetch failed for {source.id}: {e}")
-            results.append({
-                "source_id": source.id,
-                "error": str(e),
-            })
+        else:
+            results.append(outcome)
 
     successful = [r for r in results if "ref_id" in r]
     if not successful:

--- a/app/services/explorer/geocode_stage.py
+++ b/app/services/explorer/geocode_stage.py
@@ -221,11 +221,20 @@ async def _geocode_chunk(
     failure rate exceeds the threshold and another provider remains, the
     failed addresses are retried against the next provider, and ``flag`` is
     set to signal that a rotation occurred.
+
+    Deduplicates addresses before geocoding: each unique address is geocoded
+    once, then the result is fanned out to every row that shares it. This
+    avoids re-billing quota-limited/paid provider calls for duplicate
+    addresses (common in real datasets - e.g. multiple rows in the same
+    district).
     """
     addresses = [address for _, address in chunk]
+    # Dedup preserving first-occurrence order so the strategy sees each unique
+    # address exactly once. dict.fromkeys is insertion-ordered (3.7+).
+    unique_addrs: list[str] = list(dict.fromkeys(addresses))
     strategy = GeocodeProviderStrategy()
     results, hit = await strategy.geocode_addresses(
-        addresses,
+        unique_addrs,
         batch_geocode=batch_geocode,
         providers=providers,
         failure_threshold=PROVIDER_FAILURE_THRESHOLD,
@@ -233,8 +242,11 @@ async def _geocode_chunk(
     )
     if hit:
         flag.hit = True
-        
-    for (row_idx, _), res in zip(chunk, results):
+
+    # Fan out unique-address results to every row_idx that shares the address.
+    addr_to_result = dict(zip(unique_addrs, results))
+    for row_idx, addr in chunk:
+        res = addr_to_result[addr]
         row = rows[row_idx]
         row["_lat"] = res.lat
         row["_lon"] = res.lon

--- a/app/tasks/explorer/task_chain.py
+++ b/app/tasks/explorer/task_chain.py
@@ -72,9 +72,9 @@ def explorer_discover_task(self, task_id: str, query: str, context: dict):
         raise self.retry(exc=e, countdown=2 ** self.request.retries)
 
 
-@celery_app.task(bind=True, max_retries=1, soft_time_limit=55, time_limit=60)
+@celery_app.task(bind=True, soft_time_limit=55, time_limit=60)
 def explorer_fetch_task(self, prev_result: dict):
-    """内容抓取阶段 — thin Celery adapter."""
+    """内容抓取阶段 - thin Celery adapter."""
     from app.services.explorer.fetch_stage import run_fetch_stage
     task_id = prev_result["task_id"]
     logger.info(f"[Explorer:{task_id}] Starting fetch stage")
@@ -114,9 +114,13 @@ def explorer_parse_task(self, prev_result: dict):
     return res.data
 
 
-@celery_app.task(bind=True, max_retries=2, soft_time_limit=290, time_limit=300)
+# No max_retries: this task never calls self.retry(), so a retry budget would
+# be misleading (implying retries are configured when they aren't). If retries
+# are added later, set max_retries alongside the self.retry() call + an
+# idempotency guard.
+@celery_app.task(bind=True, soft_time_limit=290, time_limit=300)
 def explorer_geocode_task(self, prev_result: dict):
-    """地理编码阶段 — thin Celery adapter over the pure :func:`geocode_stage`."""
+    """地理编码阶段 - thin Celery adapter over the pure :func:`geocode_stage`."""
     from app.tools.chinese_maps import batch_geocode_cn
     from app.services.explorer.geocode_stage import geocode_stage
 

--- a/tests/test_geocode_stage.py
+++ b/tests/test_geocode_stage.py
@@ -293,3 +293,110 @@ def test_geocode_stage_all_providers_failed():
 
     # Both rows in one batch → all 3 providers tried once each
     assert call_count["n"] == 3
+
+
+def test_geocode_stage_dedupes_duplicate_addresses():
+    """Duplicate addresses are geocoded once, not N times.
+
+    Regression for the no-dedup defect: every row with a non-empty address
+    went into the geocode chunk verbatim, so duplicate addresses (common in
+    real datasets - e.g. multiple rows in the same district) were billed
+    N times against quota-limited/paid providers.
+    """
+    parsed_sources = [
+        {"ref_id": "ref_1", "row_count": 4, "mapping": {"address": "addr"}},
+    ]
+
+    # Four rows, but only two unique addresses.
+    rows = [
+        {"name": "A", "addr": "北京"},
+        {"name": "B", "addr": "上海"},
+        {"name": "C", "addr": "北京"},  # dup of A
+        {"name": "D", "addr": "上海"},  # dup of B
+    ]
+
+    def load_ref(ref_id):
+        return {"rows": rows, "mapping": {"address": "addr"}}
+
+    geocoded_addresses: list[str] = []
+
+    async def batch_geocode(addresses, provider="amap", max_concurrency=3):
+        geocoded_addresses.extend(addresses)
+        locs = {"北京": [116.4, 39.9], "上海": [121.5, 31.2]}
+        return {
+            "total": len(addresses),
+            "success_count": len(addresses),
+            "error_count": 0,
+            "results": [
+                {"index": i, "status": "ok", "address": a, "results": [{"location": locs[a]}]}
+                for i, a in enumerate(addresses)
+            ],
+            "errors": [],
+            "provider": "amap",
+        }
+
+    result = _run(geocode_stage(
+        parsed_sources,
+        load_ref=load_ref,
+        batch_geocode=batch_geocode,
+    ))
+
+    # Each unique address geocoded exactly once (2 calls, not 4).
+    assert geocoded_addresses == ["北京", "上海"], (
+        f"expected deduped geocode of 2 unique addresses, got {geocoded_addresses}"
+    )
+    # All four rows got results (fan-out from the deduped set).
+    assert result.summary.total == 4
+    assert result.summary.success == 4
+    # Duplicate-address rows share the same coordinates.
+    assert result.rows[0]["_lat"] == result.rows[2]["_lat"]  # both 北京
+    assert result.rows[1]["_lat"] == result.rows[3]["_lat"]  # both 上海
+    assert result.rows[0]["_lat"] != result.rows[1]["_lat"]   # 北京 != 上海
+
+
+def test_geocode_stage_dedup_preserves_result_mapping():
+    """Rows with the same address both get the correct lat/lon.
+
+    Pins the fan-out: the dedup must map the unique-address result back to
+    every row_idx that shares it, not just the first.
+    """
+    parsed_sources = [
+        {"ref_id": "ref_1", "row_count": 2, "mapping": {"address": "addr"}},
+    ]
+
+    rows = [
+        {"name": "A", "addr": "同一地址"},
+        {"name": "B", "addr": "同一地址"},
+    ]
+
+    def load_ref(ref_id):
+        return {"rows": rows, "mapping": {"address": "addr"}}
+
+    async def batch_geocode(addresses, provider="amap", max_concurrency=3):
+        assert addresses == ["同一地址"]
+        return {
+            "total": 1,
+            "success_count": 1,
+            "error_count": 0,
+            "results": [
+                {"index": 0, "status": "ok", "address": "同一地址", "results": [{"location": [116.4, 39.9]}]},
+            ],
+            "errors": [],
+            "provider": "amap",
+        }
+
+    result = _run(geocode_stage(
+        parsed_sources,
+        load_ref=load_ref,
+        batch_geocode=batch_geocode,
+    ))
+
+    assert result.summary.total == 2
+    assert result.summary.success == 2
+    # Both rows got the same coordinates from the single geocode call.
+    # location=[116.4, 39.9] is [lon, lat] (geocoding API convention), so
+    # _lat=39.9, _lon=116.4 (see extract_lat_lon in geocode_strategy.py).
+    assert result.rows[0]["_lat"] == 39.9
+    assert result.rows[0]["_lon"] == 116.4
+    assert result.rows[1]["_lat"] == 39.9
+    assert result.rows[1]["_lon"] == 116.4

--- a/tests/unit/test_explorer_stages.py
+++ b/tests/unit/test_explorer_stages.py
@@ -298,3 +298,51 @@ async def test_fetch_reports_progress_on_success():
   )
 
   assert progress == [10, 100]
+
+
+# ─── Fetch concurrency (review §3 item 3c) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_runs_sources_concurrently():
+  """Sources are fetched concurrently, not serially.
+
+  Regression for the serial-await defect: the loop previously did one
+  ``await data_adapter.fetch(source)`` at a time, so N sources × 30s timeout
+  blew the Celery soft_time_limit=55. Now uses asyncio.gather. This test
+  proves concurrency by having two fetches that each block on an asyncio.Event
+  until the other has started - impossible to satisfy serially.
+  """
+  import asyncio as _asyncio
+
+  a_started = _asyncio.Event()
+  b_started = _asyncio.Event()
+
+  class ConcurrencyProbeAdapter:
+    """Adapter whose fetch gates on the sibling starting."""
+
+    async def fetch(self, source):
+      if source.id == "a":
+        a_started.set()
+        # Wait until B has started (proves they overlap).
+        await _asyncio.wait_for(b_started.wait(), timeout=2.0)
+        return RawContent(data=b"a", content_type="text/csv")
+      else:
+        b_started.set()
+        await _asyncio.wait_for(a_started.wait(), timeout=2.0)
+        return RawContent(data=b"b", content_type="text/csv")
+
+  adapter = ConcurrencyProbeAdapter()
+  result = await run_fetch_stage(
+      task_id="t1",
+      selected_sources=[
+          {"source": _source("a").model_dump()},
+          {"source": _source("b").model_dump()},
+      ],
+      adapter=adapter,
+  )
+
+  # If fetches were serial, A would wait for B (which never starts) -> timeout
+  # -> the stage would fail or error. Both succeeded -> they ran concurrently.
+  assert result.success is True
+  assert len(result.data["fetch_results"]) == 2


### PR DESCRIPTION
## Summary

Completes the explorer pipeline reliability cluster (review §3 item 3) - the resource-leak half. The silent-failure half is PR #296. These three fixes are independent of #296 and of each other, but live in the same surface area.

### 1. Concurrent fetch (`fetch_stage.py`)
Serial `await data_adapter.fetch(source)` over up to 3 sources, each with a 30s HTTP timeout, against a Celery `soft_time_limit=55` (3×30=90s blows the limit). Replaced with `asyncio.gather(return_exceptions=True)` - concurrent fetches with per-source error isolation (`isinstance(outcome, BaseException)` discrimination, matching the house pattern in `layer_schema.py`/`execution_engine.py`). Input order preserved.

### 2. Offload sync parse (`gov_data_adapter.py`)
`async def parse` contained zero awaits and delegated to blocking `csv.DictReader` / `openpyxl.load_workbook`, stalling the Celery worker's event loop for the full parse of up to 50MB files. Wrapped the sync `_parse_csv`/`_parse_excel` dispatch in `asyncio.to_thread` inside the adapter impl (not the call site, so the async test-fake seam stays intact). Matches the house pattern (`rag/engine.py`, `stac_client.py`).

### 3. Dedup geocode addresses (`geocode_stage.py`)
Duplicate addresses (common in real datasets) were geocoded N times, re-billing quota-limited/paid providers. `_geocode_chunk` now deduplicates addresses before `batch_geocode` and fans out the result to every row sharing it.

Also removed inert `max_retries` from `explorer_fetch_task` (`max_retries=1`) and `explorer_geocode_task` (`max_retries=2`) - neither calls `self.retry()`, so the retry budget was misleading. `explorer_discover_task` keeps its `max_retries=2` (it does call `self.retry()`).

## Verification
- Full backend suite: **1618 passed / 1 skipped** (was 1615 on master; +3 net new tests).
- **Mutation-verified** 2 guards: reverting the gather -> serial loop makes the concurrency test fail (one fetch times out); reverting the dedup makes the dedup test fail (4 addresses geocoded instead of 2).
- The `asyncio.to_thread` offload is covered behaviorally by the existing `test_gov_adapter.py` parse tests (they call `await adapter.parse(raw)` and assert row/field correctness - transparent to the offload).

## Relationship to #296
Both PRs touch `geocode_stage.py` but in different functions (this one: `_geocode_chunk` at ~line 211; #296: the main loop's `missing_refs` at ~line 147). No conflict expected on merge.

🤖 Generated with [ZCode](https://zcode.ai)
