### PR TITLE
fix(pi): clear dead _process for respawn + atexit orphan cleanup

### DIFF
--- a/app/services/chat/pi_rpc_client.py
+++ b/app/services/chat/pi_rpc_client.py
@@ -18,6 +18,7 @@ The ADR-0022 dispatch-result cache and the two dispatch adapters stay in
 from __future__ import annotations
 
 import asyncio
+import atexit
 import json
 import logging
 import os
@@ -98,6 +99,33 @@ class PiRpcClient:
         self._stderr_task: Optional[asyncio.Task] = None
         # 审计 AGENT-05：Pi 进程死亡后标记为 True，让 _use_pi_bridge() 能回退
         self._process_died = False
+        # Register an atexit hook so that if the Python process exits for any
+        # catchable reason (SIGTERM, unhandled exception, normal shutdown) the
+        # Pi child is terminated rather than orphaned. The k8s entrypoint's
+        # `trap 'kill 0' TERM INT` covers graceful pod termination at the
+        # container level; this hook covers the application level. SIGKILL/OOM
+        # is uncatchable and remains a deployment-level concern (tini/init).
+        atexit.register(self._cleanup_on_exit)
+
+    def _cleanup_on_exit(self) -> None:
+        """Terminate the Pi subprocess if still alive (atexit safety net).
+
+        Runs on Python-level exit. Cannot await stop() (no running loop at
+        exit time), so does a best-effort synchronous terminate/kill. This is
+        not a substitute for stop() during graceful ASGI shutdown - it's the
+        safety net for paths that bypass lifespan teardown.
+        """
+        proc = self._process
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
 
     @property
     def events(self) -> asyncio.Queue:
@@ -269,7 +297,21 @@ class PiRpcClient:
             self._fail_all_pending("Pi process exited or reader stopped")
             # 标记为不可用
             self._process_died = True
-            logger.error("[PiRpcClient] Pi subprocess exited; bridge is now unavailable until restart")
+            # Clear the dead process reference so start() can respawn (its guard
+            # is `if self._process is not None: return`). Only clear when the
+            # process has actually exited (poll() returns a non-None exit code) -
+            # on the stop()-cancellation path the process may still be
+            # mid-terminate and stop()'s own finally handles the final clearing.
+            if self._process is not None and self._process.poll() is not None:
+                self._process = None
+                logger.error(
+                    "[PiRpcClient] Pi subprocess exited (poll=dead); "
+                    "_process cleared, bridge can respawn via start()"
+                )
+            else:
+                logger.error(
+                    "[PiRpcClient] Pi subprocess exited; bridge is now unavailable until restart"
+                )
 
     async def _handle_response(self, response: dict) -> None:
         """Handle a request response from Pi."""

--- a/tests/unit/test_pi_rpc_client.py
+++ b/tests/unit/test_pi_rpc_client.py
@@ -115,6 +115,78 @@ async def test_pi_rpc_client_process_died_flag():
     await client._read_responses()
 
     assert client.process_died is True
+    # The dead process reference must be cleared so start() can respawn
+    # (its guard is `if self._process is not None: return`). Previously
+    # _process_died was set but _process kept pointing at the dead Popen,
+    # permanently blocking respawn.
+    assert client._process is None
+
+
+@pytest.mark.asyncio
+async def test_process_not_cleared_when_still_alive_on_cancellation():
+    """On the stop()-cancellation path, the process may still be alive
+    (mid-terminate). The reader's finally must NOT clear _process in that
+    case - stop()'s own finally handles the final clearing. The poll() guard
+    prevents a premature clear.
+    """
+    client = PiRpcClient()
+
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+    mock_proc.stdout = DummyPipe(["x"])  # not empty, but we cancel before reading
+    mock_proc.stderr = DummyPipe([])
+    mock_proc.poll.return_value = None  # still alive
+
+    client._process = mock_proc
+    # Simulate the reader being cancelled (as stop() does).
+    client._reader_task = asyncio.create_task(client._read_responses())
+    await asyncio.sleep(0)  # let it start
+    client._reader_task.cancel()
+    try:
+        await client._reader_task
+    except asyncio.CancelledError:
+        pass
+
+    # _process should still be the mock (not cleared) because poll() is None.
+    # stop()'s finally would handle clearing it.
+    assert client._process is mock_proc
+
+
+@pytest.mark.asyncio
+async def test_start_can_respawn_after_natural_death():
+    """After the process dies naturally (EOF + poll=dead), start() must not
+    early-return on the `if self._process is not None: return` guard.
+
+    Previously _process was never cleared, so start() silently no-opped and
+    the bridge could never respawn without a full app restart.
+
+    We verify the guard passes by pre-importing pi_tools (so start()'s inline
+    import doesn't re-trigger numpy's subprocess chain) and mocking Popen.
+    """
+    # Pre-import so start()'s `from app.api.routes.pi_tools import ...` hits
+    # the cached module rather than triggering a fresh import chain.
+    import app.api.routes.pi_tools  # noqa: F401
+
+    client = PiRpcClient()
+
+    # Simulate a process that already died: _process cleared by the reader's
+    # finally (as tested above), _process_died set.
+    client._process = None
+    client._process_died = True
+
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = None
+    mock_proc.stdin = MagicMock()
+
+    with patch.object(PiRpcClient, "_read_responses", new_callable=AsyncMock), \
+         patch.object(PiRpcClient, "_read_stderr", new_callable=AsyncMock), \
+         patch("app.services.chat.pi_rpc_client.subprocess.Popen", return_value=mock_proc), \
+         patch("app.api.routes.pi_tools.get_bridge_secret", return_value="test-secret"), \
+         patch.object(PiRpcClient, "_wait_for_ready", new_callable=AsyncMock):
+        await client.start()
+
+    # start() did NOT early-return - it assigned the spawned process.
+    assert client._process is mock_proc, "start() should have spawned a new process, not early-returned"
 
 
 async def test_pi_rpc_client_fail_all_pending_resolves_futures():


### PR DESCRIPTION
## Summary

Fixes two Pi subprocess lifecycle bugs in `pi_rpc_client.py` (review §3 item 2).

### 1. Dead `_process` blocks respawn
`_read_responses`' `finally` set `_process_died = True` but left `_process` pointing at the dead `Popen`. Combined with `start()`'s guard (`if self._process is not None: return`), a dead process permanently blocked respawn on the same client instance - the bridge could never recover without a full app restart.

**Fix:** clear `_process = None` in the `finally` when `poll()` confirms the process has actually exited. The `poll()` guard avoids clearing on the `stop()`-cancellation path (where the process may still be mid-terminate; `stop()`'s own `finally` handles that).

### 2. No parent-death cleanup
The `subprocess.Popen` has no process-group isolation and no `atexit` hook. A hard parent crash (SIGTERM, unhandled exception) orphans the node child.

**Fix:** register an `atexit` cleanup hook that terminates the child if still alive. Covers Python-level exit paths that bypass the ASGI lifespan teardown. SIGKILL/OOM remains deployment-level (k8s `trap 'kill 0'`).

**Note:** `start_new_session=True` was deliberately NOT used - it would isolate the child in its own session, breaking the k8s `trap 'kill 0'` which relies on the child sharing the parent's process group.

## Verification
- Full backend suite: **1617 passed / 1 skipped** (+2 net new tests).
- **Mutation-verified:** reverting the `_process` clearing makes `test_pi_rpc_client_process_died_flag` fail (stale mock remains instead of `None`).
- The cancellation-safety test (`test_process_not_cleared_when_still_alive_on_cancellation`) pins the `poll()` guard.

## Out of scope
- Auto-respawn-on-death watchdog (needs retry/backoff policy, separate PR).
- Wiring `process_died` into `_use_pi_bridge()` for fallback (behavior change, needs its own spec).

🤖 Generated with [ZCode](https://zcode.ai)
