### PR TITLE
test(pi): fix cache_miss_with_is_error lambda to single-arg cache_lookup

### DIFF
--- a/tests/unit/test_pi_event_mapper.py
+++ b/tests/unit/test_pi_event_mapper.py
@@ -178,7 +178,9 @@ def test_map_tool_execution_end_cache_miss_with_is_error():
         "result": {"content": [{"type": "text", "text": "Buffer radius must be positive"}]},
         "isError": True,
     }
-    sse = map_event_to_sse(event, session_id="s1", cache_lookup=lambda s, t: None)
+    # cache_lookup is single-arg (tool_call_id) since #295 collapsed the
+    # dispatch-cache key; the two-arg form would TypeError on master.
+    sse = map_event_to_sse(event, session_id="s1", cache_lookup=lambda t: None)
     assert sse is not None
     assert "event: step_error" in sse
     assert "Buffer radius must be positive" in sse


### PR DESCRIPTION
## Summary

Fixes the master CI failure from merge-order interaction between #295 and #299.

- **#295** changed `map_event_to_sse`'s `cache_lookup` callable from `(session_id, tool_call_id)` to single-arg `(tool_call_id)` (dispatch-cache key collapse).
- **#299** added `test_map_tool_execution_end_cache_miss_with_is_error` using the old two-arg `lambda s, t: None` — passed CI in isolation (branched before #295), but fails on combined master with `TypeError: missing 1 required positional argument: 't'`.

**Fix:** use the single-arg `lambda t: None` matching the merged mapper.

## Verification
- `tests/unit/test_pi_event_mapper.py`: 12 passed.
- Full backend suite: **1644 passed / 1 skipped**.

🤖 Generated with [ZCode](https://zcode.ai)
