### PR TITLE
fix(ci): review follow-ups - shared env-priv script, load prometheus alert rules

### DIFF
--- a/.env.Priv.example
+++ b/.env.Priv.example
@@ -15,9 +15,10 @@ REDIS_PASSWORD=change_me_to_a_strong_password_32chars_min
 # 生成命令: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
 JWT_SECRET_KEY=change_me_to_a_very_strong_random_secret_key_at_least_32_chars
 
-# LLM API 密钥 — 生产环境必须设置（config.py 生产模式强制校验：缺失或
-# 占位符 "your-api-key-here" 都会让 api 启动失败）。
-LLM_API_KEY=change_me_to_your_real_llm_api_key
+# LLM API 密钥 — 生产环境必须设置。占位符值固定为 "your-api-key-here"：
+# 这正是 config.py 生产模式校验器拒绝的字面量——照抄模板不改会快速失败，
+# 而不是带着死 key 启动（其余模板占位符为 change_me_*，不被该校验器拦截）。
+LLM_API_KEY=your-api-key-here
 
 # CORS 允许来源（生产环境禁止 ["*"]）。settings.CORS_ORIGINS 是 List[str]，
 # 环境变量必须是 JSON 数组格式（逗号分隔的纯字符串无法通过 pydantic 解析，

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -308,6 +308,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      actions: read
     steps:
       - name: Checkout Code
         # Start Preview Stack needs repo files that the image artifact
@@ -487,18 +488,18 @@ jobs:
       - name: Deploy to Server via SSH
         if: vars.SSH_HOST != ''
         # 前置要求：SSH_HOST var + SSH_PRIVATE_KEY / DB_PWD / REDIS_PASSWORD /
-        # JWT_SECRET_KEY secrets 均已配置。任一凭据缺失时 printf 写出空行，
-        # compose 的 ${DB_PWD:?...} 等插值会在 up 时快速失败——绝不部署弱口令
-        # 或模板占位符。用 printf（而非 sed 替换模板）生成 .env.Priv，避免
-        # secret 值含 | / & 等字符时破坏文件。
+        # JWT_SECRET_KEY secrets 均已配置。.env.Priv 由共享脚本
+        # deploy/ci-generate-env-priv.sh 从这些 secret 生成：任一凭据缺失时
+        # 写出空行，compose 的 ${DB_PWD:?...} 等插值会在 up 时快速失败——
+        # 绝不部署弱口令或模板占位符。
+        env:
+          DB_PWD: ${{ secrets.DB_PWD }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
         run: |
-          printf 'DB_PWD=%s\nREDIS_PASSWORD=%s\nJWT_SECRET_KEY=%s\nLLM_API_KEY=%s\nCORS_ORIGINS=%s\n' \
-            "${{ secrets.DB_PWD }}" \
-            "${{ secrets.REDIS_PASSWORD }}" \
-            "${{ secrets.JWT_SECRET_KEY }}" \
-            "${{ secrets.LLM_API_KEY }}" \
-            "${{ secrets.CORS_ORIGINS || '["https://your-domain.com"]' }}" \
-            > .env.Priv
+          sh deploy/ci-generate-env-priv.sh
           # redis 服务挂载 deploy/redis.conf + deploy/redis-entrypoint.sh，
           # 必须随 compose 一起推送到主机（否则 bind mount 指向不存在路径，
           # redis 启动失败）。
@@ -638,16 +639,24 @@ jobs:
 
       - name: Deploy Rollback via SSH
         if: vars.SSH_HOST != ''
+        # 与 deploy-prod 一致：把 compose + .env.Priv + redis 配置 + 镜像推到生产主机再 up。
+        # .env.Priv 由共享脚本从 secrets 生成（缺失时留空行，compose 的
+        # ${VAR:?...} 快速失败）。回退构建路径检出 PREV_SHA，可能早于脚本
+        # 存在——此时用等价的 printf 兜底。
+        env:
+          DB_PWD: ${{ secrets.DB_PWD }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
         run: |
-          # 与 deploy-prod 一致：把 compose + .env.Priv + redis 配置 + 镜像推到生产主机再 up。
-          # 生产凭据来自 GitHub secrets（缺失时留空行，compose 的 ${VAR:?...} 快速失败）。
-          printf 'DB_PWD=%s\nREDIS_PASSWORD=%s\nJWT_SECRET_KEY=%s\nLLM_API_KEY=%s\nCORS_ORIGINS=%s\n' \
-            "${{ secrets.DB_PWD }}" \
-            "${{ secrets.REDIS_PASSWORD }}" \
-            "${{ secrets.JWT_SECRET_KEY }}" \
-            "${{ secrets.LLM_API_KEY }}" \
-            "${{ secrets.CORS_ORIGINS || '["https://your-domain.com"]' }}" \
-            > .env.Priv
+          if [ -f deploy/ci-generate-env-priv.sh ]; then
+            sh deploy/ci-generate-env-priv.sh
+          else
+            printf 'DB_PWD=%s\nREDIS_PASSWORD=%s\nJWT_SECRET_KEY=%s\nLLM_API_KEY=%s\nCORS_ORIGINS=%s\n' \
+              "$DB_PWD" "$REDIS_PASSWORD" "$JWT_SECRET_KEY" "$LLM_API_KEY" \
+              "${CORS_ORIGINS:-[\"https://your-domain.com\"]}" > .env.Priv
+          fi
           docker save ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rollback > /tmp/rollback-image.tar
           ssh ${{ vars.SSH_HOST }} 'mkdir -p ~/deploy'
           scp docker-compose.prod.secure.yml ${{ vars.SSH_HOST }}:~/

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ Thumbs.db
 **/.env.*.local
 # Exception: the placeholder credential template IS tracked. CI's Deploy
 # Preview job (production.yml) copies .env.Priv.example → .env.Priv and fills
-# it with random secrets; the workflow asserts this file is committed, so it
+# it with random secrets; the job fails when the template is missing, so it
 # must not be ignored. .env.Priv itself (real secrets) stays ignored above.
 !.env.Priv.example
 # Frontend test artifacts

--- a/deploy/ci-generate-env-priv.sh
+++ b/deploy/ci-generate-env-priv.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Generate .env.Priv from the environment. Used by the deploy-prod and
+# rollback SSH steps in production.yml so the credential mapping lives in one
+# place instead of being duplicated per job.
+#
+# Credentials arrive as env vars fed from GitHub secrets by the caller step.
+# A missing/empty value writes an empty line, and compose's ${VAR:?...}
+# interpolation fails fast at `up` — never deploy a weak placeholder.
+#
+# Prefer this over sed-replacing .env.Priv.example: secret values may contain
+# | / & etc., which would corrupt a sed replacement.
+set -eu
+
+printf 'DB_PWD=%s\nREDIS_PASSWORD=%s\nJWT_SECRET_KEY=%s\nLLM_API_KEY=%s\nCORS_ORIGINS=%s\n' \
+  "$DB_PWD" "$REDIS_PASSWORD" "$JWT_SECRET_KEY" "$LLM_API_KEY" \
+  "${CORS_ORIGINS:-[\"https://your-domain.com\"]}" > .env.Priv

--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -5,9 +5,13 @@ global:
 alerting:
   alertmanagers:
     - static_configs:
+        # 告警投递需要 alertmanager 服务（尚未部署）；规则仍会被加载并在
+        # Prometheus UI 中可见。
         - targets: []
 
-rule_files: []
+# 加载仓库内已跟踪的告警规则（deploy/alerts-rules.json，compose 中挂载）。
+rule_files:
+  - /etc/prometheus/alerts-rules.json
 
 scrape_configs:
   # Prometheus 自身监控

--- a/docker-compose.prod.secure.yml
+++ b/docker-compose.prod.secure.yml
@@ -204,6 +204,7 @@ services:
       - "127.0.0.1:9090:9090"
     volumes:
       - ./deploy/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./deploy/alerts-rules.json:/etc/prometheus/alerts-rules.json:ro
       - prometheus_data_secure:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'


### PR DESCRIPTION
对 `3ba28f4...HEAD` code-review 发现的修复:

## Standards 轴
- **Duplicated Code**:`.env.Priv` 生成提取为共享脚本 `deploy/ci-generate-env-priv.sh`,deploy-prod / rollback 两个 SSH 步骤统一调用(rollback 保留 PREV_SHA 回退兼容:回退检出可能早于脚本,用等价 printf 兜底)。
- **prometheus**:`deploy/alerts-rules.json`(仓库已跟踪 164 行真实规则)之前从未被加载(`rule_files: []`)。现接入 `rule_files` + compose 挂载;alertmanager 投递仍需独立服务(栈中尚无,配置内注明)。
- **.gitignore 注释**:改为准确表述("job 在模板缺失时失败"),不再声称 workflow "asserts it is committed"。

## Spec 轴
- **模板占位符绕过校验**:`LLM_API_KEY` 占位符改为 `your-api-key-here`——这正是 config.py 生产模式校验器拒绝的字面量,照抄模板不改会快速失败,而非带着死 key 启动。
- **actions: read**:preview job permissions 补上,download-artifact@v4 更稳。

## 验证
- workflow YAML / prometheus YAML 解析通过;`sh -n` 通过。
- 脚本实测:全变量正常输出;缺失时写出空行(CORS 回退 `["https://your-domain.com"]`),compose `:?` 快速失败语义保持。
- compose config 渲染通过,两个挂载(prometheus.yml + alerts-rules.json)就位。