### PR TITLE
feat(map): integrate RenderDebouncer + worker diff into MapSpecRuntime

### DIFF
--- a/.scratch/js-bundle-optimization/issues/01-next-package-tree-shaking.md
+++ b/.scratch/js-bundle-optimization/issues/01-next-package-tree-shaking.md
@@ -4,7 +4,7 @@
 
 **Blocked by:** None — can start immediately
 
-**Status:** ready-for-agent
+**Status:** done — verified 2026-08-05 (code + tests)
 
 - [x] frontend/next.config.mjs 中配置 optimizePackageImports 白名单
 - [x] npm run build 编译成功且无配置警告

--- a/.scratch/js-bundle-optimization/issues/02-dynamic-component-code-splitting.md
+++ b/.scratch/js-bundle-optimization/issues/02-dynamic-component-code-splitting.md
@@ -4,7 +4,7 @@
 
 **Blocked by:** 01 — Next.js 模块级树摇（Tree-Shaking）优化
 
-**Status:** ready-for-agent
+**Status:** done — verified 2026-08-05 (code + tests)
 
 - [x] 地图与二次抽屉组件通过 next/dynamic 异步懒加载
 - [x] Zustand useHudStore 状态水化保持 100% 一致

--- a/.scratch/js-bundle-optimization/issues/03-pdf-exporter-lazy-loading.md
+++ b/.scratch/js-bundle-optimization/issues/03-pdf-exporter-lazy-loading.md
@@ -4,7 +4,7 @@
 
 **Blocked by:** 01 — Next.js 模块级树摇（Tree-Shaking）优化
 
-**Status:** ready-for-agent
+**Status:** done — verified 2026-08-05 (code + tests)
 
 - [x] jsPDF 使用动态 await import('jspdf') 异步加载
 - [x] 地图与报告 PDF 导出功能正常运行

--- a/.scratch/js-bundle-optimization/issues/04-performance-benchmark-baseline.md
+++ b/.scratch/js-bundle-optimization/issues/04-performance-benchmark-baseline.md
@@ -4,7 +4,7 @@
 
 **Blocked by:** 02 — 重型组件代码拆分与 Dynamic Import, 03 — 客户端 PDF 导出器按需延迟加载
 
-**Status:** ready-for-agent
+**Status:** done — verified 2026-08-05 (code + tests)
 
 - [x] .gstack/benchmark-reports/baselines/baseline.json 保存存盘
 - [x] /benchmark 检测通过并评级为 Grade A (A+)

--- a/docs/research/raf_render_debouncer_worker_design.md
+++ b/docs/research/raf_render_debouncer_worker_design.md
@@ -75,3 +75,17 @@ To prevent AST diffing from blocking UI interaction, `diffSpecs` is wrapped in a
 | **Frame Rate (FPS) during continuous slider drag** | Drops to 18-24 FPS | Maintains 58-60 FPS | **Zero micro-stuttering** |
 | **AST Diffing CPU Impact (150-layer Spec)** | 12ms on UI main thread | 0ms main thread (runs in Worker) | **100% main thread offload** |
 | **Redundant MapLibre GL API Calls** | N operations executed | 1 coalesced operation per property | **Up to 80% operation savings** |
+
+---
+
+## 6. 实现状态 (2026-08-05)
+
+按本设计完成集成,模块先建、接线补齐:
+
+- **`frontend/lib/mapspec-compiler/worker-bridge.ts`**(新增):`diffSpecsAsync(prev, next)` — 有 Worker 时经 `reconciler.worker` 异步 diff,不可用时(SSR/Node/测试)回退主线程同步 diff。独立模块,避免 worker 入口在主线程 import 时覆写 `window.onmessage`。
+- **`frontend/lib/mapspec-runtime/runtime.ts`**:
+  - 新增 `reconcileAsync(nextSpec)` — 样式未就绪重试 → worker diff → `RenderDebouncer` 帧预算调度应用(操作按严格顺序入队:layer 移除 → source → layer 添加 → z-order,全部 high 优先级,保证同帧内顺序)。
+  - 新增 `flush()` 同步排空(测试/截图用)。
+  - 原 `reconcile()` 同步路径保留为正确性参考(扩展开-收缩风格,与 unified-tool-dispatch 一致)。
+- **`frontend/components/map/map-panel.tsx`**:渲染路径切换到 `void reconcileAsync(spec)`。
+- **测试**:`worker-bridge.test.ts`(3 例:回退/worker 往返/worker 错误空补丁)、`runtime.test.ts` 新增 `reconcileAsync` 块(3 例:flush 后应用/同 spec 无操作/样式未就绪延迟)。全套 vitest 435 过、`tsc --noEmit` 0 错。

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -169,12 +169,13 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
   }, [currentMapStyle])
 
   // Reconcile whenever the inputs to the derived MapSpec change. The runtime's
-  // internal diff is the no-op fast path for unchanged specs, so no debounce is
-  // needed (the F31 source-ref cache makes repeated setData cheap).
+  // internal diff is the no-op fast path for unchanged specs, and the async
+  // path offloads the diff to a worker and applies the patch through a
+  // frame-budgeted RenderDebouncer (ADR-0036 / issue #227).
   useEffect(() => {
     if (!runtimeRef.current) return
     const spec = hudStateToMapSpec({ layers, processLayers, activeFilters, is3D })
-    runtimeRef.current.reconcile(spec)
+    void runtimeRef.current.reconcileAsync(spec)
   }, [layers, processLayers, activeFilters, is3D, mapReady, currentMapStyle])
 
 

--- a/frontend/lib/mapspec-compiler/worker-bridge.test.ts
+++ b/frontend/lib/mapspec-compiler/worker-bridge.test.ts
@@ -1,30 +1,73 @@
-import { describe, expect, it } from "vitest";
-import { WorkerReconcilerBridge } from "./worker-bridge";
-import { MapSpec } from "./types";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { diffSpecsAsync, _resetWorkerBridgeForTests } from "./worker-bridge";
+import { diffSpecs } from "./reconciler";
+import type { MapSpec } from "./types";
 
-describe("WorkerReconcilerBridge", () => {
-  it("should perform diffing via sync fallback when Worker is undefined", async () => {
-    const bridge = new WorkerReconcilerBridge();
+// diffSpecsAsync: worker-offloaded diff with a main-thread fallback.
 
-    const prev = {
-      version: "1.0",
-      view: { center: [0, 0], zoom: 2 },
-      sources: {},
-      layers: [],
-    } as unknown as MapSpec;
+const spec: MapSpec = {
+  version: "1.0",
+  sources: {
+    A: { type: "geojson", inlineData: { type: "FeatureCollection", features: [] } },
+  },
+  layers: [{ id: "A__point", source: "A", type: "circle", paint: { "circle-radius": 6 } }],
+};
 
-    const next = {
-      version: "1.0",
-      view: { center: [116.4, 39.9], zoom: 10 },
-      sources: {},
-      layers: [],
-    } as unknown as MapSpec;
+describe("diffSpecsAsync", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    _resetWorkerBridgeForTests();
+  });
 
-    const patch = await bridge.diffSpecsAsync(prev, next);
+  it("falls back to a synchronous diff when Worker is unavailable", async () => {
+    vi.stubGlobal("Worker", undefined);
+    const patch = await diffSpecsAsync(null, spec);
+    expect(patch.layers).toHaveLength(1);
+    expect(patch.layers[0].kind).toBe("add");
+    expect(patch.sources[0].kind).toBe("add");
+  });
 
-    expect(patch.sources).toBeDefined();
-    expect(patch.layers).toBeDefined();
+  it("round-trips through a worker when one is available", async () => {
+    let listener: ((event: { data: { id: string; patch: ReturnType<typeof diffSpecs> } }) => void) | null = null;
+    class FakeWorker {
+      constructor(_url: URL, _opts?: { type?: string }) {}
+      postMessage(msg: { id: string; prev: MapSpec | null; next: MapSpec }) {
+        const { id, prev, next } = msg;
+        queueMicrotask(() => {
+          const patch = diffSpecs(prev, next);
+          listener?.({ data: { id, patch } });
+        });
+      }
+      addEventListener(_type: string, cb: typeof listener) {
+        listener = cb;
+      }
+      removeEventListener() {}
+    }
+    vi.stubGlobal("Worker", FakeWorker as unknown as typeof Worker);
 
-    bridge.destroy();
+    const patch = await diffSpecsAsync(null, spec);
+    expect(patch.layers[0].kind).toBe("add");
+    // The worker path must produce the same patch as the sync diff.
+    expect(patch).toEqual(diffSpecs(null, spec));
+  });
+
+  it("resolves an empty patch on worker error, matching the no-op contract", async () => {
+    let listener: ((event: { data: { id: string; patch: ReturnType<typeof diffSpecs>; error?: string } }) => void) | null = null;
+    class ErrorWorker {
+      constructor(_url: URL, _opts?: { type?: string }) {}
+      postMessage(msg: { id: string }) {
+        queueMicrotask(() => {
+          listener?.({ data: { id: msg.id, patch: { sources: [], layers: [] }, error: "boom" } });
+        });
+      }
+      addEventListener(_type: string, cb: typeof listener) {
+        listener = cb;
+      }
+      removeEventListener() {}
+    }
+    vi.stubGlobal("Worker", ErrorWorker as unknown as typeof Worker);
+
+    const patch = await diffSpecsAsync(null, spec);
+    expect(patch).toEqual({ sources: [], layers: [] });
   });
 });

--- a/frontend/lib/mapspec-compiler/worker-bridge.ts
+++ b/frontend/lib/mapspec-compiler/worker-bridge.ts
@@ -1,48 +1,82 @@
 import { diffSpecs, SpecPatch } from "./reconciler";
-import { MapSpec } from "./types";
+import type { MapSpec } from "./types";
 
-export class WorkerReconcilerBridge {
-  private worker: Worker | null = null;
-  private pending = new Map<string, (patch: SpecPatch) => void>();
-  private reqId = 0;
+/**
+ * WorkerReconcilerBridge — offload `diffSpecs` to a Web Worker so large-spec
+ * tree comparison never blocks the UI thread (ADR-0036 / raf_render_debouncer
+ * design, issue #227).
+ *
+ * Falls back to running `diffSpecs` synchronously on the main thread when a
+ * Worker is unavailable (SSR, Node, test environments, bundler without worker
+ * support). The fallback is transparent: callers always `await` the same shape.
+ *
+ * NOTE: this module deliberately does NOT import `./reconciler.worker` at the
+ * top level. Importing the worker entry on the main thread would clobber
+ * `window.onmessage` (its `self.onmessage` registration is guarded only by
+ * `typeof self !== "undefined"`, which is true on the browser main thread).
+ * The worker is referenced by URL only.
+ */
 
-  constructor() {
-    if (typeof window !== "undefined" && typeof Worker !== "undefined") {
-      try {
-        this.worker = new Worker(new URL("./reconciler.worker.ts", import.meta.url), {
-          type: "module",
-        });
-        this.worker.onmessage = (e: MessageEvent) => {
-          const { id, patch } = e.data || {};
-          const resolver = this.pending.get(id);
-          if (resolver) {
-            this.pending.delete(id);
-            resolver(patch);
-          }
-        };
-      } catch (err) {
-        console.warn("Failed to initialize reconciler worker, falling back to sync main thread diffing:", err);
-        this.worker = null;
-      }
-    }
-  }
+interface DiffRequest {
+  id: string;
+  prev: MapSpec | null;
+  next: MapSpec;
+}
 
-  public async diffSpecsAsync(prev: MapSpec | null, next: MapSpec): Promise<SpecPatch> {
-    if (!this.worker) {
-      return diffSpecs(prev, next);
-    }
-    return new Promise((resolve) => {
-      const id = `diff_${++this.reqId}`;
-      this.pending.set(id, resolve);
-      this.worker!.postMessage({ id, prev, next });
+interface DiffResponse {
+  id: string;
+  patch: SpecPatch;
+  error?: string;
+}
+
+let sharedWorker: Worker | null = null;
+let nextRequestId = 0;
+
+/**
+ * Test-only: drop the cached worker so the next call re-evaluates the
+ * environment (e.g. to exercise the fallback path after a worker test).
+ */
+export function _resetWorkerBridgeForTests(): void {
+  sharedWorker = null;
+  nextRequestId = 0;
+}
+
+function createWorker(): Worker | null {
+  if (sharedWorker) return sharedWorker;
+  try {
+    if (typeof Worker === "undefined" || typeof URL === "undefined") return null;
+    sharedWorker = new Worker(new URL("./reconciler.worker", import.meta.url), {
+      type: "module",
     });
+    return sharedWorker;
+  } catch {
+    // Bundler / environment without worker support — fall back to sync diff.
+    return null;
+  }
+}
+
+/**
+ * Diff two specs, off the main thread when a Worker is available.
+ * Resolves with the SpecPatch (or an empty patch on worker error — the caller
+ * treats that as "nothing to apply", same as diffSpecs' no-op contract).
+ */
+export function diffSpecsAsync(prev: MapSpec | null, next: MapSpec): Promise<SpecPatch> {
+  const worker = createWorker();
+  if (!worker) {
+    return Promise.resolve(diffSpecs(prev, next));
   }
 
-  public destroy(): void {
-    if (this.worker) {
-      this.worker.terminate();
-      this.worker = null;
-    }
-    this.pending.clear();
-  }
+  return new Promise<SpecPatch>((resolve) => {
+    const id = `diff-${++nextRequestId}`;
+
+    const onMessage = (event: MessageEvent<DiffResponse>) => {
+      if (event.data?.id !== id) return;
+      worker.removeEventListener("message", onMessage);
+      resolve(event.data.patch);
+    };
+
+    worker.addEventListener("message", onMessage);
+    const request: DiffRequest = { id, prev, next };
+    worker.postMessage(request);
+  });
 }

--- a/frontend/lib/mapspec-runtime/runtime.test.ts
+++ b/frontend/lib/mapspec-runtime/runtime.test.ts
@@ -247,4 +247,59 @@ describe("MapSpecRuntime (ADR-0036)", () => {
       expect(map._calls.addLayer.map((c: any) => c.def.id)).toEqual(["L1__point"]);
     });
   });
+
+  describe("reconcileAsync — worker fallback + debounced apply", () => {
+    beforeEach(() => {
+      // No Worker in the test env → the bridge falls back to a sync diff.
+      vi.stubGlobal("Worker", undefined);
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("applies the spec once flushed (fallback diff path)", async () => {
+      const rt = new MapSpecRuntime(map);
+      await rt.reconcileAsync(pointSpec());
+      // appliedSpec is set when the patch is computed; map mutations are
+      // queued on the debouncer until a frame runs (or flush() drains).
+      expect(rt.getAppliedSpec()).toEqual(pointSpec());
+      rt.flush();
+      expect(map._calls.addSource.map((c: any) => c.id)).toEqual(["L1"]);
+      expect(map._calls.addLayer.map((c: any) => c.def.id)).toEqual(["L1__point"]);
+    });
+
+    it("is a no-op for an identical spec (nothing applied after flush)", async () => {
+      const rt = new MapSpecRuntime(map);
+      await rt.reconcileAsync(pointSpec());
+      rt.flush();
+      map._calls.addSource.length = 0;
+      map._calls.addLayer.length = 0;
+
+      await rt.reconcileAsync(pointSpec());
+      rt.flush();
+
+      expect(map._calls.addSource).toEqual([]);
+      expect(map._calls.addLayer).toEqual([]);
+      expect(map._calls.removeLayer).toEqual([]);
+    });
+
+    it("defers until the style is loaded, then applies once", async () => {
+      vi.useFakeTimers();
+      let loaded = false;
+      map.isStyleLoaded = () => loaded;
+      const rt = new MapSpecRuntime(map);
+
+      const pending = rt.reconcileAsync(pointSpec());
+      expect(map._calls.addSource).toEqual([]);
+
+      loaded = true;
+      await vi.advanceTimersByTimeAsync(150);
+      await pending;
+      rt.flush();
+
+      expect(map._calls.addSource.map((c: any) => c.id)).toEqual(["L1"]);
+      expect(map._calls.addLayer.map((c: any) => c.def.id)).toEqual(["L1__point"]);
+      vi.useRealTimers();
+    });
+  });
 });

--- a/frontend/lib/mapspec-runtime/runtime.ts
+++ b/frontend/lib/mapspec-runtime/runtime.ts
@@ -1,5 +1,7 @@
-import { diffSpecs } from "@/lib/mapspec-compiler/reconciler";
+import { diffSpecs, type SpecPatch } from "@/lib/mapspec-compiler/reconciler";
+import { diffSpecsAsync } from "@/lib/mapspec-compiler/worker-bridge";
 import type { MapSpec, MapSpecSource, MapSpecLayer } from "@/lib/mapspec-compiler/types";
+import { RenderDebouncer, type RenderOperation } from "@/lib/map-kit/render-debouncer";
 import * as renderer from "@/lib/map-kit/renderer";
 
 /**
@@ -30,9 +32,11 @@ export class MapSpecRuntime {
   private appliedSpec: MapSpec | null = null;
   private pendingTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
+  private debouncer: RenderDebouncer | null;
 
   constructor(map: any) {
     this.map = map;
+    this.debouncer = new RenderDebouncer(map);
   }
 
   /**
@@ -63,15 +67,51 @@ export class MapSpecRuntime {
     }
 
     const patch = diffSpecs(this.appliedSpec, nextSpec);
+    this.applyPatchDirect(patch, nextSpec);
+  }
 
-    // --- sources ---
-    // Removes must come before layer removes that reference them; the patch
-    // already orders sources arbitrarily, so we remove dependent layers first
-    // (below) — but MapLibre requires a source's layers gone before removeSource.
-    // We handle that by removing layers first (patch.layers), then sources.
-    // To be safe, we also remove layers whose source is being removed.
-    const removedSourceIds = new Set(patch.sources.filter((s) => s.kind === "remove").map((s) => s.id));
+  /**
+   * Async reconcile — worker-offloaded diff + frame-budgeted application.
+   *
+   * Same contract as `reconcile` (diff against last-applied → minimal patch),
+   * but: the diff runs in a Web Worker when available (falling back to the
+   * main thread), and the patch is applied through a RenderDebouncer so
+   * MapLibre mutations are coalesced and time-sliced per rAF frame instead of
+   * blocking the UI thread (ADR-0036 / issue #227).
+   *
+   * Fire-and-forget from callers: `void rt.reconcileAsync(spec)`.
+   * `flush()` drains pending operations synchronously (tests / screenshots).
+   */
+  async reconcileAsync(nextSpec: MapSpec): Promise<void> {
+    if (this.disposed || !this.map) return;
 
+    // Defer until the base style is loaded (mirrors the sync retry loop).
+    if (!this.map.isStyleLoaded()) {
+      await new Promise((resolve) => setTimeout(resolve, STYLE_RETRY_MS));
+      if (this.disposed || !this.map) return;
+      return this.reconcileAsync(nextSpec);
+    }
+
+    const patch = await diffSpecsAsync(this.appliedSpec, nextSpec);
+    if (this.disposed || !this.map) return;
+    this.applyPatchDebounced(patch, nextSpec);
+  }
+
+  /**
+   * Synchronously drain all pending debounced operations (e.g. before unmount
+   * or taking a screenshot). No-op when nothing is queued.
+   */
+  flush(): void {
+    this.debouncer?.flush();
+  }
+
+  /**
+   * Apply a SpecPatch immediately (synchronous path). Kept as the
+   * correctness-preserving reference used by `reconcile()` and the sync
+   * test suite; the debounced path enqueues the same operations in the same
+   * strict order.
+   */
+  private applyPatchDirect(patch: SpecPatch, nextSpec: MapSpec): void {
     // --- layers (remove + recompile may free sources) ---
     for (const change of patch.layers) {
       if (change.kind === "remove") {
@@ -108,7 +148,71 @@ export class MapSpecRuntime {
     renderer.syncLayerZOrder(this.map, "", orderedIds);
 
     this.appliedSpec = nextSpec;
-    void removedSourceIds; // (kept for clarity; removes already handled above)
+  }
+
+  /**
+   * Enqueue a SpecPatch as coalesced, frame-budgeted render operations.
+   * Ordering mirrors applyPatchDirect exactly (layers-remove → sources →
+   * layers-add → z-order), all high priority so the sequence within a frame
+   * is preserved — MapLibre requires a layer's source to exist first.
+   */
+  private applyPatchDebounced(patch: SpecPatch, nextSpec: MapSpec): void {
+    const ops: RenderOperation[] = [];
+
+    for (const change of patch.layers) {
+      if (change.kind === "remove" || change.kind === "recompile") {
+        ops.push({
+          id: `layer:remove:${change.id}`,
+          type: "REMOVE_LAYER",
+          priority: "high",
+          execute: () => this.removeLayerSafe(change.id),
+        });
+      }
+    }
+
+    for (const change of patch.sources) {
+      if (change.kind === "remove") {
+        ops.push({
+          id: `source:remove:${change.id}`,
+          type: "REMOVE_LAYER",
+          priority: "high",
+          execute: () => this.removeSourceSafe(change.id),
+        });
+      } else if ((change.kind === "add" || change.kind === "update") && change.next) {
+        const next = change.next;
+        ops.push({
+          id: `source:apply:${change.id}`,
+          type: "UPDATE_GEOJSON",
+          priority: "high",
+          execute: () => this.applySource(change.id, next),
+        });
+      }
+    }
+
+    for (const change of patch.layers) {
+      if ((change.kind === "add" || change.kind === "recompile") && change.next) {
+        const next = change.next;
+        ops.push({
+          id: `layer:add:${change.id}`,
+          type: "ADD_LAYER",
+          priority: "high",
+          execute: () => this.addLayerSafe(next),
+        });
+      }
+    }
+
+    const orderedIds = nextSpec.layers.map((l) => l.id);
+    ops.push({
+      id: "zorder:sync",
+      type: "SET_STYLE",
+      priority: "high",
+      execute: () => renderer.syncLayerZOrder(this.map, "", orderedIds),
+    });
+
+    for (const op of ops) {
+      this.debouncer?.enqueue(op);
+    }
+    this.appliedSpec = nextSpec;
   }
 
   getAppliedSpec(): MapSpec | null {
@@ -121,6 +225,8 @@ export class MapSpecRuntime {
       clearTimeout(this.pendingTimer);
       this.pendingTimer = null;
     }
+    this.debouncer?.dispose();
+    this.debouncer = null;
     this.map = null;
     this.appliedSpec = null;
   }


### PR DESCRIPTION
评审方案阶段二(前端渲染)的核实+补缺口。

## 核实结论
`.scratch/js-bundle-optimization` 4 项已全部实现(树摇白名单、next/dynamic、`await import('jspdf')`、baseline.json 存档),均标注 `done`。
真实缺口:**Reconciler 集成未做**——`reconciler.worker.ts`/`render-debouncer.ts` 模块与测试存在,但渲染管线(map-panel)仍同步 diff + 阻塞应用。

## 集成实现(按 raf_render_debouncer_worker_design.md)
1. **`worker-bridge.ts`**(新):`diffSpecsAsync` — Web Worker 异步 diff,SSR/Node/测试环境回退主线程同步。独立模块避免 worker 入口覆写 `window.onmessage`。
2. **`runtime.ts`**:新增 `reconcileAsync(nextSpec)` — 样式就绪重试 → worker diff → `RenderDebouncer` 帧预算调度(严格操作顺序:layer 移除→source→layer 添加→z-order,均 high 优先级);`flush()` 同步排空;同步 `reconcile()` 保留为正确性参考(expand-contract,仓库先例)。
3. **`map-panel.tsx`**:渲染路径切换到 `void reconcileAsync(spec)`。
4. **测试**:worker-bridge 3 例 + runtime reconcileAsync 3 例;全套 **vitest 435 passed**(63 文件)、`tsc --noEmit` 0 错误。
5. **文档**:设计文档追加"实现状态"节;js-bundle 4 issue 标注 verified。

## 说明
- 合并到 master 会触发一次 CI(按约定未等待)。
- 真实地图行为需浏览器验证(browse/qa 技能可做,如有需要另行执行)。