### PR TITLE
feat(provider-health): route OSM (Overpass/Nominatim) through ProviderHealthTracker

### DIFF
--- a/app/services/provider_health.py
+++ b/app/services/provider_health.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
-PROVIDER_NAMES = frozenset({"amap", "baidu", "tianditu"})
+PROVIDER_NAMES = frozenset({"amap", "baidu", "tianditu", "overpass", "nominatim"})
 
 
 @dataclass
@@ -164,18 +164,40 @@ def check_tianditu_status(data: dict) -> tuple[bool, str]:
     return True, ""
 
 
+def check_overpass_status(data: Any) -> tuple[bool, str]:
+    """Overpass 响应业务校验：应含 elements 数组（查询错误时可能只含 remark）。"""
+    if not isinstance(data, dict) or "elements" not in data:
+        return False, "Overpass 响应缺少 elements"
+    return True, ""
+
+
+def check_nominatim_status(data: Any) -> tuple[bool, str]:
+    """Nominatim 响应业务校验：search 返回 list，reverse 返回 dict（无 error 键）。"""
+    if isinstance(data, dict) and "error" in data:
+        return False, str(data["error"])
+    if isinstance(data, list) or isinstance(data, dict):
+        return True, ""
+    return False, "Nominatim 响应格式异常"
+
+
 async def tracked_provider_get(
     provider: str,
     url: str,
     params: dict,
     *,
+    method: str = "GET",
+    data: dict | None = None,
     business_checker: Callable[[dict], tuple[bool, str]] | None = None,
     tracker: ProviderHealthTracker | None = None,
     ssl_context: Any = None,
     proxy: str | None = None,
     timeout: float = 10.0,
 ) -> dict:
-    """Execute a tracked HTTP GET request using get_shared_client() with circuit breaker protection."""
+    """Execute a tracked HTTP request using get_shared_client() with circuit breaker protection.
+
+    `method` 支持 "GET"（默认，用 `params`）与 "POST"（用 `data`）——Overpass 走
+    POST 提交查询体，其余第三方 API 均为 GET。
+    """
     ht = tracker or health_tracker
     if not await ht.record_attempt(provider):
         return {"error": f"{provider.capitalize()} 暂时不可用（频率限制或服务故障），请稍后重试"}
@@ -188,12 +210,14 @@ async def tracked_provider_get(
 
     try:
         session = await get_shared_client()
-        async with session.get(
+        request = session.post if method.upper() == "POST" else session.get
+        kwargs: dict = {"data": data} if method.upper() == "POST" else {"params": params}
+        async with request(
             url,
-            params=params,
             ssl=actual_ssl,
             proxy=actual_proxy,
             timeout=timeout,
+            **kwargs,
         ) as resp:
             if resp.status != 200:
                 await ht.record_error(provider)

--- a/app/services/viewport_naming.py
+++ b/app/services/viewport_naming.py
@@ -39,14 +39,6 @@ _RATE_LIMIT_MAX_PER_MINUTE = 30
 _RATE_WINDOW_SECONDS = 60.0
 _rate_window: "deque[float]" = deque()
 
-# Shared aiohttp.ClientSession (/review P2-3). The original code created a
-# fresh ClientSession per call (~200–500ms TLS handshake every time). Reuse
-# one process-level session: lazily created, never explicitly closed (Python
-# process exit reclaims fd's). If you wire app lifespan, call _close_session()
-# on shutdown.
-_aiohttp_session: Optional["aiohttp.ClientSession"] = None  # noqa: F821 (string-only forward ref)
-_aiohttp_session_lock: Optional[asyncio.Lock] = None
-
 
 def _rate_limit_check() -> bool:
     """Return True if the current call is allowed under the token bucket.
@@ -61,31 +53,6 @@ def _rate_limit_check() -> bool:
         return False
     _rate_window.append(now)
     return True
-
-
-async def _get_aiohttp_session():
-    """Lazily create or return the shared aiohttp.ClientSession."""
-    global _aiohttp_session, _aiohttp_session_lock
-    import aiohttp
-    from app.core.network import get_base_headers
-    if _aiohttp_session_lock is None:
-        _aiohttp_session_lock = asyncio.Lock()
-    async with _aiohttp_session_lock:
-        if _aiohttp_session is None or _aiohttp_session.closed:
-            timeout = aiohttp.ClientTimeout(total=_LOOKUP_TIMEOUT_SEC)
-            _aiohttp_session = aiohttp.ClientSession(
-                headers=get_base_headers(),
-                timeout=timeout,
-            )
-    return _aiohttp_session
-
-
-async def _close_session() -> None:
-    """Close the shared session. Call from FastAPI lifespan shutdown if wired."""
-    global _aiohttp_session
-    if _aiohttp_session is not None and not _aiohttp_session.closed:
-        await _aiohttp_session.close()
-    _aiohttp_session = None
 
 
 def _quantize(lng: float, lat: float) -> tuple[float, float]:
@@ -134,11 +101,12 @@ def _format_address(address: dict) -> str:
 async def _fetch_nominatim(lng: float, lat: float) -> Optional[str]:
     """实际调用 Nominatim 反查；失败返回 None。
 
-    /review P2-3: uses a shared ClientSession (reused across calls) to avoid
-    a fresh TCP/TLS handshake per lookup.
+    经 ProviderHealthTracker 统一执行缝（熔断/限流/SSL/代理/超时），复用
+    get_shared_client 的连接池（原共享 session 的等价物），故障快速降级返回 None。
+    超时沿用本模块的 3s（后台预热路径，绝不能阻塞主链路）。
     """
     from app.core.config import settings
-    from app.core.network import get_ssl_context
+    from app.services.provider_health import check_nominatim_status, tracked_provider_get
 
     url = settings.NOMINATIM_URL.replace("/search", "/reverse")
     params = {
@@ -149,18 +117,16 @@ async def _fetch_nominatim(lng: float, lat: float) -> Optional[str]:
         "zoom": 10,  # 城市/区县级精度足矣，不要返回门牌号
     }
     try:
-        session = await _get_aiohttp_session()
-        async with session.get(
+        result = await tracked_provider_get(
+            "nominatim",
             url,
-            params=params,
-            ssl=get_ssl_context(),
-            proxy=settings.HTTPS_PROXY or settings.HTTP_PROXY,
-        ) as resp:
-            if resp.status != 200:
-                return None
-            data = await resp.json()
-        if "error" in data:
+            params,
+            timeout=_LOOKUP_TIMEOUT_SEC,
+            business_checker=check_nominatim_status,
+        )
+        if "error" in result:
             return None
+        data = result
         address = data.get("address") or {}
         if isinstance(address, dict):
             label = _format_address(address)

--- a/app/tools/geocoding.py
+++ b/app/tools/geocoding.py
@@ -1,7 +1,6 @@
 """地理编码工具 - Nominatim"""
-import aiohttp
 from app.core.config import settings
-from app.core.network import get_ssl_context, get_base_headers
+from app.services.provider_health import check_nominatim_status, tracked_provider_get
 from app.tools.registry import ToolRegistry, tool
 
 
@@ -29,16 +28,16 @@ def register_geocoding_tools(registry: ToolRegistry):
             "limit": limit,
             "accept-language": "zh",
         }
-        async with aiohttp.ClientSession(headers=get_base_headers()) as session:
-            async with session.get(
-                settings.NOMINATIM_URL, 
-                params=params, 
-                ssl=get_ssl_context(),
-                proxy=settings.HTTPS_PROXY or settings.HTTP_PROXY
-            ) as resp:
-                if resp.status != 200:
-                    raise RuntimeError(f"Nominatim API error: {resp.status}")
-                results = await resp.json()
+        result = await tracked_provider_get(
+            "nominatim",
+            settings.NOMINATIM_URL,
+            params,
+            timeout=30,
+            business_checker=check_nominatim_status,
+        )
+        if "error" in result:
+            raise RuntimeError(f"Nominatim API error: {result['error']}")
+        results = result
 
         if not results:
             return {"results": [], "count": 0}
@@ -80,19 +79,16 @@ def register_geocoding_tools(registry: ToolRegistry):
             "format": "json",
             "accept-language": "zh",
         }
-        async with aiohttp.ClientSession(headers=get_base_headers()) as session:
-            async with session.get(
-                url, 
-                params=params, 
-                ssl=get_ssl_context(),
-                proxy=settings.HTTPS_PROXY or settings.HTTP_PROXY
-            ) as resp:
-                if resp.status != 200:
-                    raise RuntimeError(f"Nominatim API error: {resp.status}")
-                data = await resp.json()
-
-        if "error" in data:
-            raise ValueError(data["error"])
+        result = await tracked_provider_get(
+            "nominatim",
+            url,
+            params,
+            timeout=30,
+            business_checker=check_nominatim_status,
+        )
+        if "error" in result:
+            raise RuntimeError(f"Nominatim API error: {result['error']}")
+        data = result
 
         return {
             "name": data.get("display_name", ""),

--- a/app/tools/osm.py
+++ b/app/tools/osm.py
@@ -1,12 +1,11 @@
 """OSM 数据查询工具 - Overpass API (修复版)"""
 import json
 import logging
-import aiohttp
 from typing import Optional
 from pydantic import BaseModel, Field
 
 from app.core.config import settings
-from app.core.network import get_ssl_context, get_shared_client
+from app.services.provider_health import check_nominatim_status, check_overpass_status, tracked_provider_get
 from app.tools.registry import ToolRegistry, tool
 
 logger = logging.getLogger(__name__)
@@ -20,11 +19,11 @@ def _sanitize_overpass_value(value: str) -> str:
     return str(value).replace("\\", "").replace('"', "").replace("]", "").replace(";", "").replace("\n", "").replace("\r", "")
 
 
-def _overpass_to_geojson(data: str) -> dict:
-    """将 Overpass JSON 结果转为 GeoJSON"""
+def _overpass_to_geojson(data: str | dict) -> dict:
+    """将 Overpass JSON 结果转为 GeoJSON（接受原始字符串或已解析 dict）。"""
     try:
-        result = json.loads(data)
-    except json.JSONDecodeError:
+        result = json.loads(data) if isinstance(data, str) else data
+    except (json.JSONDecodeError, TypeError):
         return {"type": "FeatureCollection", "features": []}
 
     features = []
@@ -59,26 +58,23 @@ async def _query_overpass(query: str) -> dict:
     """执行 Overpass QL 查询，返回 GeoJSON"""
     full_query = f"[out:json][timeout:30];{query.rstrip(';')};out body geom;"
     logger.info("[OSM] Querying Overpass API...")
-    
-    try:
-        session = await get_shared_client()
-        async with session.post(
-            settings.OVERPASS_API_URL,
-            data={"data": full_query},
-            timeout=aiohttp.ClientTimeout(total=60),
-            ssl=get_ssl_context(),
-            proxy=settings.HTTPS_PROXY or settings.HTTP_PROXY
-        ) as resp:
-            if resp.status != 200:
-                text = await resp.text()
-                logger.error(f"[OSM] Overpass error {resp.status}: {text}")
-                return {"type": "FeatureCollection", "features": [], "error": f"Overpass error {resp.status}: {text}"}
-            data = await resp.text()
-            logger.info(f"[OSM] Overpass query successful, data size: {len(data)} bytes")
-    except aiohttp.ClientError as e:
-        logger.error(f"[OSM] Overpass network/timeout error: {e}")
-        return {"type": "FeatureCollection", "features": [], "error": str(e)}
 
+    # 经 ProviderHealthTracker 统一执行缝（熔断/限流/SSL/代理/超时），POST 提交查询体。
+    result = await tracked_provider_get(
+        "overpass",
+        settings.OVERPASS_API_URL,
+        {},
+        method="POST",
+        data={"data": full_query},
+        timeout=60,
+        business_checker=check_overpass_status,
+    )
+    if "error" in result:
+        logger.error(f"[OSM] Overpass error: {result['error']}")
+        return {"type": "FeatureCollection", "features": [], "error": result["error"]}
+
+    data = result
+    logger.info(f"[OSM] Overpass query successful, data size: {len(json.dumps(data))} bytes")
     return _overpass_to_geojson(data)
 
 
@@ -90,18 +86,17 @@ async def _geocode_bbox(query: str, expand_km: float = 0) -> Optional[str]:
         "limit": 5,
         "accept-language": "zh",
     }
-    session = await get_shared_client()
-    async with session.get(
+    result = await tracked_provider_get(
+        "nominatim",
         settings.NOMINATIM_URL,
-        params=params,
-        timeout=aiohttp.ClientTimeout(total=30),
-        ssl=get_ssl_context(),
-        proxy=settings.HTTPS_PROXY or settings.HTTP_PROXY
-    ) as resp:
-        if resp.status != 200:
-            logger.error(f"Nominatim error: {resp.status}")
-            return None
-        results = await resp.json()
+        params,
+        timeout=30,
+        business_checker=check_nominatim_status,
+    )
+    if "error" in result:
+        logger.error(f"Nominatim error: {result['error']}")
+        return None
+    results = result
 
     if not results:
         return None
@@ -147,17 +142,16 @@ async def _nominatim_search_poi(category: str, bbox: str, limit: int) -> dict:
         "bounded": "1",
     }
     features = []
-    session = await get_shared_client()
-    async with session.get(
+    result = await tracked_provider_get(
+        "nominatim",
         settings.NOMINATIM_URL,
-        params=params,
-        timeout=aiohttp.ClientTimeout(total=30),
-        ssl=get_ssl_context(),
-        proxy=settings.HTTPS_PROXY or settings.HTTP_PROXY
-    ) as resp:
-        if resp.status != 200:
-            return {"type": "FeatureCollection", "features": []}
-        results = await resp.json()
+        params,
+        timeout=30,
+        business_checker=check_nominatim_status,
+    )
+    if "error" in result:
+        return {"type": "FeatureCollection", "features": []}
+    results = result
 
     for r in results:
         lat = float(r.get("lat", 0))
@@ -410,17 +404,16 @@ def register_osm_tools(registry: ToolRegistry):
                 "accept-language": "zh",
                 "polygon_geojson": "1",
             }
-            session = await get_shared_client()
-            async with session.get(
-                settings.NOMINATIM_URL, 
-                params=params, 
-                timeout=aiohttp.ClientTimeout(total=30),
-                ssl=get_ssl_context(),
-                proxy=settings.HTTPS_PROXY or settings.HTTP_PROXY
-            ) as resp:
-                if resp.status == 200:
-                    results = await resp.json()
-                    if results:
+            result = await tracked_provider_get(
+                "nominatim",
+                settings.NOMINATIM_URL,
+                params,
+                timeout=30,
+                business_checker=check_nominatim_status,
+            )
+            if "error" not in result:
+                results = result
+                if results:
                         r = results[0]
                         geojson_poly = r.get("geojson")
                         if geojson_poly:

--- a/tests/unit/test_osm_provider_degradation.py
+++ b/tests/unit/test_osm_provider_degradation.py
@@ -1,0 +1,113 @@
+"""OSM 家族降级契约测试（issue #310）。
+
+执行缝（tracked_provider_get）返回 {"error": ...}（熔断/限流/故障）时，各调用方
+必须保持既有契约：osm 空 FC/None、geocoding RuntimeError、viewport None。
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.tools.osm import _query_overpass, _geocode_bbox, _nominatim_search_poi
+from app.tools.registry import ToolRegistry
+from app.tools.geocoding import register_geocoding_tools
+from app.services.viewport_naming import _fetch_nominatim
+
+# osm.py / geocoding.py 在模块级 import tracked_provider_get → patch 模块内引用；
+# viewport_naming 在函数内 import → patch provider_health 源。
+
+
+@pytest.mark.asyncio
+async def test_query_overpass_degraded():
+    """熔断时 _query_overpass 返回空 FeatureCollection + error（现有契约）。"""
+    with patch("app.tools.osm.tracked_provider_get", new=AsyncMock(return_value={"error": "Overpass 暂时不可用（频率限制或服务故障），请稍后重试"})):
+        res = await _query_overpass("node(1);")
+    assert res["type"] == "FeatureCollection"
+    assert res["features"] == []
+    assert "error" in res
+
+
+@pytest.mark.asyncio
+async def test_query_overpass_success_parses_dict():
+    """seam 返回已解析 dict 时，_overpass_to_geojson 正确转 GeoJSON。"""
+    with patch(
+        "app.tools.osm.tracked_provider_get",
+        new=AsyncMock(return_value={"elements": [{"type": "node", "lat": 1.0, "lon": 2.0, "tags": {"name": "X"}}]}),
+    ):
+        res = await _query_overpass("node(1);")
+    assert res["type"] == "FeatureCollection"
+    assert len(res["features"]) == 1
+    assert res["features"][0]["geometry"]["coordinates"] == [2.0, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_geocode_bbox_degraded_returns_none():
+    with patch("app.tools.osm.tracked_provider_get", new=AsyncMock(return_value={"error": "x"})):
+        assert await _geocode_bbox("Beijing") is None
+
+
+@pytest.mark.asyncio
+async def test_nominatim_search_poi_degraded_returns_empty_fc():
+    with patch("app.tools.osm.tracked_provider_get", new=AsyncMock(return_value={"error": "x"})):
+        res = await _nominatim_search_poi("restaurant", "10,20,30,40", 5)
+    assert res == {"type": "FeatureCollection", "features": []}
+
+
+def _geocoding_tools():
+    reg = ToolRegistry()
+    register_geocoding_tools(reg)
+    return reg._tools  # registry 存的是原始 callable（绕过 dispatch 的引用解析）
+
+
+@pytest.mark.asyncio
+async def test_geocode_degraded_raises_runtime_error():
+    tools = _geocoding_tools()
+    with patch("app.tools.geocoding.tracked_provider_get", new=AsyncMock(return_value={"error": "Nominatim 暂时不可用"})):
+        with pytest.raises(RuntimeError, match="Nominatim"):
+            await tools["geocode"]("Beijing")
+
+
+@pytest.mark.asyncio
+async def test_geocode_success():
+    tools = _geocoding_tools()
+    with patch(
+        "app.tools.geocoding.tracked_provider_get",
+        new=AsyncMock(return_value=[{"display_name": "Beijing, China", "lat": "39.9", "lon": "116.4", "type": "city", "importance": "0.8"}]),
+    ):
+        res = await tools["geocode"]("Beijing")
+    assert res["count"] == 1
+    assert res["results"][0]["name"] == "Beijing, China"
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_degraded_raises_runtime_error():
+    tools = _geocoding_tools()
+    with patch("app.tools.geocoding.tracked_provider_get", new=AsyncMock(return_value={"error": "Nominatim 暂时不可用"})):
+        with pytest.raises(RuntimeError, match="Nominatim"):
+            await tools["reverse_geocode"](39.9, 116.4)
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_success():
+    tools = _geocoding_tools()
+    with patch(
+        "app.tools.geocoding.tracked_provider_get",
+        new=AsyncMock(return_value={"display_name": "Beijing", "lat": "39.9", "lon": "116.4", "address": {"city": "Beijing"}}),
+    ):
+        res = await tools["reverse_geocode"](39.9, 116.4)
+    assert res["name"] == "Beijing"
+    assert res["address"]["city"] == "Beijing"
+
+
+@pytest.mark.asyncio
+async def test_viewport_fetch_nominatim_degraded_returns_none():
+    with patch("app.services.provider_health.tracked_provider_get", new=AsyncMock(return_value={"error": "x"})):
+        assert await _fetch_nominatim(116.4, 39.9) is None
+
+
+@pytest.mark.asyncio
+async def test_viewport_fetch_nominatim_success():
+    with patch(
+        "app.services.provider_health.tracked_provider_get",
+        new=AsyncMock(return_value={"display_name": "Beijing, China", "address": {}}),
+    ):
+        label = await _fetch_nominatim(116.4, 39.9)
+    assert label == "Beijing, China"

--- a/tests/unit/test_provider_health_tracked_get.py
+++ b/tests/unit/test_provider_health_tracked_get.py
@@ -2,11 +2,14 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from app.services.provider_health import (
+    PROVIDER_NAMES,
     ProviderHealthTracker,
     tracked_provider_get,
     check_amap_status,
     check_baidu_status,
     check_tianditu_status,
+    check_overpass_status,
+    check_nominatim_status,
 )
 
 
@@ -23,6 +26,22 @@ def test_business_status_checkers():
     # Tianditu success vs failure
     assert check_tianditu_status({"returncode": "100", "data": []})[0] is True
     assert check_tianditu_status({"error": "Token expired"})[0] is False
+
+    # Overpass success vs failure
+    assert check_overpass_status({"elements": []})[0] is True
+    assert check_overpass_status({"remark": "query error"})[0] is False
+    assert check_overpass_status("not-a-dict")[0] is False
+
+    # Nominatim: search 返回 list、reverse 返回 dict、错误 dict 拒绝
+    assert check_nominatim_status([])[0] is True
+    assert check_nominatim_status({"display_name": "X", "address": {}})[0] is True
+    assert check_nominatim_status({"error": "Unable to geocode"})[0] is False
+    assert check_nominatim_status("nope")[0] is False
+
+
+def test_provider_names_include_osm():
+    """OSM 家族已纳入 PROVIDER_NAMES（熔断日志友好显示）。"""
+    assert {"overpass", "nominatim"} <= PROVIDER_NAMES
 
 
 @pytest.mark.asyncio
@@ -83,3 +102,44 @@ async def test_tracked_provider_get_circuit_breaker(monkeypatch):
 
     assert "error" in res
     assert "暂时不可用" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_tracked_provider_get_post(monkeypatch):
+    """POST 分支：Overpass 风格查询体经 session.post 提交（issue #310）。"""
+    tracker = ProviderHealthTracker(calls_per_minute=10)
+
+    mock_resp = AsyncMock()
+    mock_resp.status = 200
+    mock_resp.json = AsyncMock(return_value={"elements": []})
+
+    mock_post = MagicMock()
+    mock_post.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_post.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.post = MagicMock(return_value=mock_post)
+
+    async def fake_get_shared_client():
+        return mock_session
+
+    monkeypatch.setattr("app.core.network.get_shared_client", fake_get_shared_client)
+
+    res = await tracked_provider_get(
+        "overpass",
+        "https://overpass-api.de/api/interpreter",
+        {},
+        method="POST",
+        data={"data": "[out:json];node(1);out;"},
+        timeout=60,
+        business_checker=check_overpass_status,
+        tracker=tracker,
+    )
+
+    assert "elements" in res
+    # POST 走 session.post 而非 session.get，且携带 data 与超时。
+    mock_session.post.assert_called_once()
+    call_kwargs = mock_session.post.call_args.kwargs
+    assert call_kwargs.get("data") == {"data": "[out:json];node(1);out;"}
+    assert call_kwargs.get("timeout") == 60
+    mock_session.get.assert_not_called()


### PR DESCRIPTION
Closes #310 — 评审方案阶段三(OSM 接入 ProviderHealthTracker + 遥感核实)。

## 改动
- **seam 扩展**:`tracked_provider_get` 增加 `method`/`data` 参数(POST 分支供 Overpass);新增 `check_overpass_status` / `check_nominatim_status` 业务校验器;`PROVIDER_NAMES` 纳入 overpass/nominatim(熔断日志友好)
- **osm.py 4 处**:`_query_overpass`(POST)、`_geocode_bbox`、`_nominatim_search_poi`、`query_osm_boundary` 的 Nominatim 兜底,全部接入 seam;`_overpass_to_geojson` 兼容已解析 dict
- **geocoding.py 2 处**:`geocode` / `reverse_geocode` 接入;失败保持 `RuntimeError`(Nominatim 业务错误原 ValueError 统一为 RuntimeError)
- **viewport_naming.py**:`_fetch_nominatim` 接入(保留 3s 后台预热超时);移除失效的共享 session 死代码
- **降级契约**:seam `{"error": ...}` → osm 空 FC/None、geocoding RuntimeError、viewport None

## 验证
- 新增测试 15 个(seam POST 分支、checkers、PROVIDER_NAMES、OSM/geocoding/viewport 降级与成功契约),相关回归 57 过
- 遥感链路核实已确认实现(4 个计算入口均串联 STAC→Band Math),见 #310 评论
- 按约定未等待 CI