### PR TITLE
Performance & Reliability Convergence V2 + Harness–Cartography Closed Loop

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -232,6 +232,44 @@ jobs:
         # 完整 Playwright runtime + 5~6 类 E2E 场景在 nightly cartography-matrix。
         run: pytest -m cartography --no-cov --timeout=120 --timeout-method=thread -q
 
+  # ============ Nightly 重矩阵（schedule / 手动；非 PR-blocking）============
+  # 审计 REL-01：PR 路径只跑确定性 fast gate（cartography-smoke）。更重的矩阵
+  # （全量 cartography + perf + event-loop lag + 并发负载 + 未来 Playwright runtime）
+  # 放到 nightly，不阻塞 PR，但能在 schedule 暴露慢漂移 / 间歇性故障。
+  nightly-matrix:
+    name: Nightly Heavy Matrix
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    services:
+      redis:
+        image: redis:7-alpine
+        ports: [6379:6379]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+      - run: pip install -r requirements-dev.txt
+      - name: Set Environment Variables
+        run: |
+          echo "REDIS_URL=redis://localhost:6379/0" >> $GITHUB_ENV
+          echo "JWT_SECRET_KEY=ci-test-secret-key-32-chars-ok" >> $GITHUB_ENV
+          echo "ENV=development" >> $GITHUB_ENV
+          echo "LLM_API_KEY=test-key-not-real" >> $GITHUB_ENV
+      - name: Full cartography + perf + event-loop matrix
+        # Nightly 跑完整确定性矩阵：cartography（含并发 + 故障注入）+ perf
+        # （11 microbenchmarks + 3 e2e）+ perf_harness_v2 event-loop lag。无 Node
+        # 依赖部分全跑；需要 Node/Playwright 的 runtime 验证 self-skip（待 future）。
+        run: pytest -m "cartography or perf" --no-cov --timeout=180 --timeout-method=thread -q
+      - name: Event-loop lag & data-plane v2
+        run: pytest tests/benchmarks/test_perf_harness_v2.py --no-cov --timeout=120 -q
+
   test-frontend:
     name: Frontend Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -139,7 +139,11 @@ jobs:
         # （PR #319 首次 CI 暴露：h3_binning_10k 在 --cov 下 173.9ms vs 无 cov
         # 40ms，被误判为 HARD REGRESSION）。perf 门控由独立 test-perf job 在无
         # coverage 环境下执行（见下）。
-        run: pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=10 --timeout=60 --timeout-method=thread -m "not perf" -v
+        #
+        # 审计 REL-01：cartography marker（@pytest.mark.cartography）同样排除 ——
+        # 该集合由独立 cartography-smoke job（确定性 release-blocking gate）拥有，
+        # 避免双重执行 + 让 gate scope 显式。
+        run: pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=10 --timeout=60 --timeout-method=thread -m "not perf and not cartography" -v
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v5.5.5
@@ -180,6 +184,53 @@ jobs:
         # 让真实回归在 CI 可见；基线刷新需显式 PERF_UPDATE_BASELINES=1。
         # 与主测试 job 的 `-m "not perf"` 互斥，避免双重执行 + 覆盖率失真。
         run: pytest tests/benchmarks/test_perf_harness.py -m perf --no-cov --timeout=180 --timeout-method=thread -q
+
+  # ============ Stage 2c: 制图 / Harness 闭环 smoke（确定性，release-blocking）============
+  cartography-smoke:
+    name: Cartography & Harness Closed-Loop Gate
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install Dependencies
+        # 仅装核心依赖 + 测试工具（无需 Postgres service）。cartography smoke
+        # 走纯 Python 语义校验 + Harness V2 evidence model + ref 真实解析，
+        # 不依赖 Node / Chromium（那部分在 nightly cartography-matrix）。
+        run: pip install -r requirements-dev.txt
+
+      - name: Set Environment Variables
+        run: |
+          echo "REDIS_URL=redis://localhost:6379/0" >> $GITHUB_ENV
+          echo "JWT_SECRET_KEY=ci-test-secret-key-32-chars-ok" >> $GITHUB_ENV
+          echo "ENV=development" >> $GITHUB_ENV
+          echo "LLM_API_KEY=test-key-not-real" >> $GITHUB_ENV
+
+      - name: Run Cartography & Harness Closed-Loop Smoke
+        # 确定性 release-blocking gate（无 Node / 无 Chromium / 无 LLM / 无外网）：
+        #   - MapSpec transaction 语义（invalid mutation 不污染 last-known-good）
+        #   - ref cursor 真实解析（跨 session / 不存在 → fail，而非 100%）
+        #   - MapSpecValidity evidence ladder（no evidence ≠ success）
+        #   - 制图语义 deterministic checks（bbox overlap / geom-type / field-stops / legend）
+        #   - 故障注入子集（Redis/compiler/checkpoint failure 不产生 false-success）
+        # 完整 Playwright runtime + 5~6 类 E2E 场景在 nightly cartography-matrix。
+        run: pytest -m cartography --no-cov --timeout=120 --timeout-method=thread -q
 
   test-frontend:
     name: Frontend Tests
@@ -244,31 +295,73 @@ jobs:
         # bandit 跑，等效。
         # -ll = MEDIUM severity 及以上；-ii = MEDIUM confidence 及以上。
         # exit code 0 = 无 MEDIUM+ 告警；CI 不被 LOW 噪声阻断。
+        #
+        # 审计 REL-02：bandit 是 release-blocking security gate，必须真正阻断 ——
+        # 此 job 处于 build→deploy 依赖链上，不能 || true。依赖 CVE 扫描
+        # (pip-audit / npm audit) 现已拆到独立 dependency-audit job（见下），
+        # 该 job 诚实标注为 informational / 非 release-blocking，而不是在
+        # blocking 的 security job 内用 || true 把失败伪装成成功。
         run: |
           pip install bandit
           bandit -r app/ -ll -ii
 
+  # ============ Stage 3b: 依赖 CVE 扫描（informational，非 release-blocking）============
+  # 审计 REL-02：此前 pip-audit / npm audit 用 `|| true` 兜底在 blocking 的
+  # security job 内，使"required job 失败被伪装成成功"。已知 starlette / ecdsa
+  # 等传递依赖 CVE 需 FastAPI / PyJWT 上游升级，无法在任意 PR 内即时修复，
+  # 故无法作为 blocking gate。将其拆为独立 job 并明确标注非阻塞：信号可见、
+  # 诚实，且不再污染 blocking 的 security gate。major-version 依赖升级 PR
+  # 仍需通过下方完整的 blocking 链（backend/frontend/perf/cartography/build）。
+  dependency-audit:
+    name: Dependency CVE Audit (non-blocking)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
       - name: Dependency Audit (Backend)
         # pip-audit 抓到多个传递依赖 CVE（starlette 0.38.6 的 PYSEC-2026-161/1941/
         # 1943/2280/2281/248/249 + ecdsa 0.19.2 的 PYSEC-2026-1325）。这些需要升级
-        # FastAPI / PyJWT 上游依赖，是独立工作。
-        # 审计 P1：去掉 --fix 防止 CI 自动修改依赖版本（未经 review 的变更可能引入回归）。
-        # || true 兜底因为 pip-audit 不像 ruff 没有 --exit-zero 选项。
+        # FastAPI / PyJWT 上游依赖，是独立工作。本 job 非 release-blocking，
+        # 仅输出告警；无需 || true —— 它本身不在 build/release 依赖链上。
+        continue-on-error: true
         run: |
           pip install pip-audit
-          pip-audit -r requirements.txt --desc --progress-spinner off || true
+          pip-audit -r requirements.txt --desc --progress-spinner off
 
       - name: Dependency Audit (Frontend)
-        # npm audit 在 JS 生态经常有 moderate 级传递依赖告警。
-        # --audit-level=moderate 阻断 moderate+；|| true 兜底防止 npm 自身 bug 阻断。
+        # npm audit 在 JS 生态经常有 moderate 级传递依赖告警。同上：本 job
+        # 整体非 release-blocking（continue-on-error 在 step 级，job 不在依赖链）。
+        continue-on-error: true
         working-directory: ./frontend
-        run: npm audit --audit-level=moderate || true
+        run: npm audit --audit-level=moderate
+
+  # ============ Stage 3c: Release Gate 聚合（显式 release DAG）============
+  # 审计 REL-01：此前 build 直接 needs [lint, test-backend, test-frontend, security]，
+  # 而 test-perf（"Performance Regression Gate"）与任何 cartography smoke 均不在
+  # 依赖链上 —— 性能 HARD REGRESSION 与制图回归可直达 build→deploy-prod。
+  # 现以单一聚合 job 把 release-blocking 检查收敛为显式 DAG：
+  #   quality + backend + frontend + security + perf + cartography → release-gate → build → deploy
+  # 该 job 无 step（只做 needs 聚合），任何被依赖 job 失败即整体失败，
+  # 杜绝 continue-on-error / || true / skip 把 required 失败伪装成成功。
+  release-gate:
+    name: Release Gate
+    runs-on: ubuntu-latest
+    needs: [lint, test-backend, test-frontend, security, test-perf, cartography-smoke]
+    steps:
+      - name: Release gate passed
+        run: echo "All release-blocking checks (quality, backend, frontend, security, perf, cartography) passed."
 
   # ============ Stage 4: 构建镜像 ============
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
-    needs: [lint, test-backend, test-frontend, security]
+    needs: [release-gate]
     permissions:
       contents: read
       packages: write

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -250,7 +250,22 @@ Two sources with distinct responsibilities — **currently connected headless-on
 
 ### MapSpecLifecycleEngine
 The deep cartographic intent engine (`app/services/mapspec/lifecycle_engine.py`).
-Consolidates MapSpec document mutations (`InitProjectIntent`, `SetViewIntent`, `UpsertLayerIntent`, `RemoveLayerIntent`), source profiling, compiler coordination, and checkpoint generation behind an atomic `apply_mutation(session_id, intent)` seam.
+Consolidates MapSpec document mutations (`InitProjectIntent`, `SetViewIntent`, `UpsertLayerIntent`, `RemoveLayerIntent`, `SetLayoutIntent`, `SetTimeIntent`, `CheckpointIntent`, `RollbackIntent`) behind an atomic `apply_mutation(session_id, intent)` seam. Transaction semantics (ADR-0051): build candidate in memory → semantic-validate → reject mutations that introduce NEW blocking errors (`INVALID_SOURCE_REF`, `INVALID_STOPS_COUNT`, `NON_INCREASING_STOPS`) → checkpoint → save (atomic temp+replace, disk-before-Redis) → sync Redis layers, with rollback-to-snapshot on any failure. Per-session mutual exclusion via `SessionLockRegistry` (Redis cross-pod; in-process fallback). Heavy work (`process_layer_ingestion`, deepcopy, content-hash, file IO) offloaded via `asyncio.to_thread`.
+
+### SessionLockRegistry
+The distributed per-session lock registry (`app/services/distributed_lock.py`, ADR-0051). Provides `session_lock_registry.lock(session_id)` — a Redis-backed lock (`SET NX` + TTL + token-checked Lua release + best-effort renewal) for cross-pod mutual exclusion, with a resilient fallback to an in-process `asyncio.Lock` when Redis is unavailable or errors at acquire time (never blocks the request). Bounded fallback table with waiter-aware eviction.
+
+### PiAgentHarness (V2)
+The evidence-driven evaluation harness (`app/lib/harness/pi_agent_harness.py`, ADR-0051). Records tool calls with `run_id`/`session_id`/`turn_id`/`tool_call_id` correlation and computes metrics from REAL evidence, not "didn't error": `MapSpecValidity` is a tiered ladder (`NOT_EVALUATED → MUTATION_REJECTED → MUTATION_ACCEPTED → SEMANTIC_VALID → COMPILE_VALID → RUNTIME_VALID`); `CursorResolutionRate` resolves refs against the real `SessionStore`. Missing evidence → 0.0, never 100.0. `evaluate_with_evidence()` is the async seam that does real ref resolution; `evaluate_evidence()` is the gate policy (unevaluated dimensions fail under `require_evaluated=True`).
+
+### EvaluationEvidence
+The unified evidence model (`app/lib/harness/evidence.py`) connecting the Harness ↔ GIS ↔ MapSpec ↔ Cartography loop: `RefResolution` (status: malformed/syntactically_valid/not_found/wrong_session/type_mismatch/resolved), `MapSpecValidityEvidence` (the validity ladder), `ToolCallEvidence` (per-call correlation + refs + validity + runtime path), `EvaluationRun`.
+
+### CartographySemanticChecks
+Deterministic cartographic semantic checks (`app/lib/cartography/semantic_checks.py`, ADR-0051) connecting the GIS data profile ↔ MapSpec: `SOURCE_LAYER_REF`/`EMPTY_DATA` (errors), `GEOMETRY_LAYER_TYPE`/`STOPS_DATA_RANGE`/`INTERPOLATE_NUMERIC_FIELD`/`LEGEND_FIELD_CONSISTENCY` (warnings). Missing profile → `not_evaluated`, never a fake pass. Empty-data (zero features) is an error, not a silent map success.
+
+### MapSpec Checkpoint Store
+The content-addressed checkpoint store (`app/services/mapspec/checkpoint.py`, ADR-0051). Each ref payload is stored once as a content-addressed blob (`blobs/<sha>.json`); a checkpoint descriptor maps `ref_id → blob_hash`. Auto checkpoints (no explicit id) dedup on whole-checkpoint content hash (a repeated identical checkpoint writes 0 new bytes). Explicit checkpoint ids always materialize (rollback-by-name contract). Backward-compatible rollback handles both the new descriptor+blob layout and the legacy `materialized_refs.json` layout.
 
 ### MapSpec Compiler
 Deterministic, framework-agnostic TS module (`frontend/lib/mapspec-compiler/`) that turns a

--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -262,10 +262,24 @@ _session_executed_sets: dict[str, set[tuple[str, str]]] = {}
 
 
 # ── Optional evaluation harness (opt-in via PI_HARNESS_ENABLED=true) ──
+# V2（HARNESS-V2）：注入真实证据 resolver —— ref 解析走 SessionStore，
+# MapSpec 校验走真实 validate()，杜绝"没报错=100%有效"的假成功。
 _harness: Optional[PiAgentHarness] = None
 if os.getenv("PI_HARNESS_ENABLED", "").lower() in ("true", "1", "yes"):
-    _harness = PiAgentHarness(session_id="production")
-    logger.info("[PiBridge] Evaluation harness enabled for production telemetry")
+    try:
+        from app.services.session_data import session_data_manager as _sdm
+        from app.services.mapspec.coordinator import validate as _validate_mapspec
+        from app.lib.harness.ref_resolver import make_session_store_resolver
+
+        _harness = PiAgentHarness(
+            session_id="production",
+            ref_resolver=make_session_store_resolver(_sdm),
+            mapspec_validator=_validate_mapspec,
+        )
+        logger.info("[PiBridge] Evaluation harness V2 enabled (real SessionStore ref resolver)")
+    except Exception as _harness_err:  # noqa: BLE001 - never block startup on telemetry
+        logger.warning(f"[PiBridge] Harness V2 wiring failed, degrading to no harness: {_harness_err}")
+        _harness = None
 
 
 def get_harness() -> Optional[PiAgentHarness]:

--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -236,6 +236,15 @@ async def dispatch_tool(request: PiToolRequest) -> PiToolResponse:
 
     if _harness is not None:
         is_error = result.status == "error"
+        # HARNESS-V2: forward real MapSpec mutation evidence (is_compiled /
+        # success / warnings / checkpoint_id) from raw_result so the validity
+        # ladder isn't starved in production. Slim to evidence fields only — the
+        # full mapspec is fetched via fetch-on-demand, never logged wholesale.
+        ev = {"status": result.status, "llm_payload_len": len(result.llm_payload)}
+        raw = result.raw_result if isinstance(result.raw_result, dict) else {}
+        for k in ("success", "is_compiled", "warnings", "checkpoint_id", "message", "correction_hint"):
+            if k in raw:
+                ev[k] = raw[k]
         event = ToolCallEvent(
             tool_call_id=request.toolCallId,
             tool_name=request.name,
@@ -244,7 +253,7 @@ async def dispatch_tool(request: PiToolRequest) -> PiToolResponse:
             is_error=is_error,
             # P1 fix: truncate to a short message rather than the full payload.
             error_msg=(result.llm_payload[:200] if is_error else ""),
-            result={"status": result.status, "llm_payload_len": len(result.llm_payload)},
+            result=ev,
             session_id=request.sessionId,
         )
         _harness.record_event(event)

--- a/app/lib/cartography/semantic_checks.py
+++ b/app/lib/cartography/semantic_checks.py
@@ -1,0 +1,220 @@
+"""Deterministic cartographic semantic checks (closed loop: GIS profile ↔ MapSpec).
+
+These are deterministic, evidence-based checks that connect the spatial data
+profile (produced by GIS analysis / profile_geojson_source) to the MapSpec's
+layer/paint/legend/view configuration. They catch cartographic defects that
+"the tool didn't error" cannot: a layer painting a non-existent field, stops
+that don't cover the data range, a geometry/layer-type mismatch, an empty-data
+source presented as a successful map, etc.
+
+Contract: where evidence is unavailable (no profile), a check is reported as
+``not_evaluated`` rather than ``passed`` — never fake success.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# Layer "type" expected for a given geometry type. A Point layer painted as
+# "fill" is almost certainly a configuration defect.
+_GEOM_LAYER_TYPE = {
+    "Point": {"circle", "symbol"},
+    "MultiPoint": {"circle", "symbol"},
+    "LineString": {"line"},
+    "MultiLineString": {"line"},
+    "Polygon": {"fill"},
+    "MultiPolygon": {"fill"},
+}
+
+
+@dataclass
+class CartographyFinding:
+    check: str
+    severity: str  # "error" | "warning" | "info"
+    message: str
+    layer_id: Optional[str] = None
+    source_id: Optional[str] = None
+    evaluated: bool = True  # False when evidence was unavailable
+
+
+@dataclass
+class CartographyReport:
+    findings: List[CartographyFinding] = field(default_factory=list)
+
+    @property
+    def errors(self) -> List[CartographyFinding]:
+        return [f for f in self.findings if f.severity == "error" and f.evaluated]
+
+    @property
+    def warnings(self) -> List[CartographyFinding]:
+        return [f for f in self.findings if f.severity == "warning" and f.evaluated]
+
+    @property
+    def ok(self) -> bool:
+        """No error-severity findings. Warnings do not fail (cartographic taste)."""
+        return len(self.errors) == 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "error_count": len(self.errors),
+            "warning_count": len(self.warnings),
+            "findings": [
+                {
+                    "check": f.check,
+                    "severity": f.severity,
+                    "message": f.message,
+                    "layer_id": f.layer_id,
+                    "source_id": f.source_id,
+                    "evaluated": f.evaluated,
+                }
+                for f in self.findings
+            ],
+        }
+
+
+def _paint_methods(paint: Dict[str, Any]):
+    """Yield (prop_name, method_dict) for every data-driven paint property."""
+    if not isinstance(paint, dict):
+        return
+    for prop, spec in paint.items():
+        if isinstance(spec, dict) and spec.get("method") in ("interpolate", "step", "match"):
+            yield prop, spec
+
+
+def evaluate_cartography_semantics(
+    mapspec: Dict[str, Any],
+    source_profiles: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> CartographyReport:
+    """Run deterministic cartographic semantic checks.
+
+    ``source_profiles`` maps source_id -> profile (from profile_geojson_source).
+    When a profile is absent for a source, geometry/field/stops checks for that
+    source are reported as ``not_evaluated`` (info), never as a fake pass.
+    """
+    report = CartographyReport()
+    source_profiles = source_profiles or {}
+    sources = mapspec.get("sources", {}) or {}
+    layers = mapspec.get("layers", []) or []
+
+    source_keys = set(sources.keys())
+
+    for layer in layers:
+        lid = layer.get("id")
+        sid = layer.get("source")
+        profile = source_profiles.get(sid) if sid else None
+
+        # 1. Source/layer reference consistency (error).
+        if sid not in source_keys:
+            report.findings.append(CartographyFinding(
+                check="SOURCE_LAYER_REF", severity="error",
+                message=f"Layer '{lid}' references missing source '{sid}'",
+                layer_id=lid, source_id=sid,
+            ))
+            continue  # no point checking further against a missing source
+
+        # 2. Empty-data not success (error): a zero-feature source is no data.
+        if profile is not None and profile.get("featureCount", 1) == 0:
+            report.findings.append(CartographyFinding(
+                check="EMPTY_DATA", severity="error",
+                message=f"Layer '{lid}' source '{sid}' has zero features (no data)",
+                layer_id=lid, source_id=sid,
+            ))
+
+        # 3. Geometry type vs layer type (warning).
+        ltype = layer.get("type")
+        if profile is not None:
+            geom_types = profile.get("geometryTypes") or []
+            mismatched = [
+                g for g in geom_types
+                if g in _GEOM_LAYER_TYPE and ltype not in _GEOM_LAYER_TYPE[g]
+            ]
+            if mismatched and ltype:
+                report.findings.append(CartographyFinding(
+                    check="GEOMETRY_LAYER_TYPE", severity="warning",
+                    message=(
+                        f"Layer '{lid}' type '{ltype}' mismatches geometry "
+                        f"{mismatched} from source '{sid}'"
+                    ),
+                    layer_id=lid, source_id=sid,
+                ))
+        elif ltype:
+            report.findings.append(CartographyFinding(
+                check="GEOMETRY_LAYER_TYPE", severity="info",
+                message=f"Layer '{lid}' geometry/layer-type not evaluable (no profile for '{sid}')",
+                layer_id=lid, source_id=sid, evaluated=False,
+            ))
+
+        # 4-6. Paint field existence / numeric / stops-range checks.
+        fields_profile = (profile or {}).get("fields") or {}
+        for prop, spec in _paint_methods(layer.get("paint") or {}):
+            fname = spec.get("field")
+            method = spec.get("method")
+            if not fname:
+                continue
+            if profile is None:
+                report.findings.append(CartographyFinding(
+                    check="PAINT_FIELD_EXISTS", severity="info",
+                    message=f"Layer '{lid}' paint '{prop}' field '{fname}' not evaluable (no profile)",
+                    layer_id=lid, source_id=sid, evaluated=False,
+                ))
+                continue
+            field_info = fields_profile.get(fname)
+            if field_info is None:
+                report.findings.append(CartographyFinding(
+                    check="PAINT_FIELD_EXISTS", severity="error",
+                    message=(
+                        f"Layer '{lid}' paint '{prop}' references field '{fname}' "
+                        f"absent from source '{sid}'"
+                    ),
+                    layer_id=lid, source_id=sid,
+                ))
+                continue
+            # interpolate/step require a numeric field.
+            if method in ("interpolate", "step") and field_info.get("type") != "number":
+                report.findings.append(CartographyFinding(
+                    check="INTERPOLATE_NUMERIC_FIELD", severity="warning",
+                    message=(
+                        f"Layer '{lid}' paint '{prop}' uses {method} on non-numeric "
+                        f"field '{fname}' (type {field_info.get('type')})"
+                    ),
+                    layer_id=lid, source_id=sid,
+                ))
+            # stops domain should overlap the field's [min, max].
+            if method in ("interpolate", "step") and field_info.get("type") == "number":
+                stops = spec.get("stops") or []
+                fmin, fmax = field_info.get("min"), field_info.get("max")
+                if stops and fmin is not None and fmax is not None:
+                    stop_inputs = [s[0] for s in stops if isinstance(s, (list, tuple)) and s]
+                    if stop_inputs:
+                        s_lo, s_hi = min(stop_inputs), max(stop_inputs)
+                        # No overlap between [s_lo,s_hi] and [fmin,fmax] → out of range.
+                        if s_hi < fmin or s_lo > fmax:
+                            report.findings.append(CartographyFinding(
+                                check="STOPS_DATA_RANGE", severity="warning",
+                                message=(
+                                    f"Layer '{lid}' paint '{prop}' stops [{s_lo}, {s_hi}] "
+                                    f"do not overlap field '{fname}' data range [{fmin}, {fmax}]"
+                                ),
+                                layer_id=lid, source_id=sid,
+                            ))
+
+    # 7. Legend / style field consistency (warning).
+    legend = (mapspec.get("layout") or {}).get("legend") or {}
+    legend_field = legend.get("field") if isinstance(legend, dict) else None
+    if legend_field:
+        paint_fields = set()
+        for layer in layers:
+            for _prop, spec in _paint_methods(layer.get("paint") or {}):
+                if spec.get("field"):
+                    paint_fields.add(spec.get("field"))
+        if paint_fields and legend_field not in paint_fields:
+            report.findings.append(CartographyFinding(
+                check="LEGEND_FIELD_CONSISTENCY", severity="warning",
+                message=(
+                    f"Legend field '{legend_field}' not used by any layer paint "
+                    f"(used: {sorted(paint_fields)})"
+                ),
+            ))
+
+    return report

--- a/app/lib/harness/evaluator.py
+++ b/app/lib/harness/evaluator.py
@@ -1,5 +1,11 @@
 """
-HarnessEvaluator - 5-Dimensional Evaluation Metric Calculator & Quality Gate
+HarnessEvaluator - 5-Dimensional Evaluation Metric Calculator & Quality Gate.
+
+V2 gate policy（HARNESS-V2）：缺失证据不等于成功。
+- MapSpecValidity / CursorResolutionRate 在 V2 harness 下从真实证据计算；无证据
+  返回 0.0 而非 100.0，因此缺证据的 run 会真正 fail gate（除非显式豁免）。
+- 新增 evaluate_evidence()：消费 evaluate_with_evidence() 的结构化结果，对每个
+  维度给出 score / target / passed / evaluated（区分"未评估"与"失败"）。
 """
 import logging
 from typing import Any, Dict
@@ -17,7 +23,7 @@ DEFAULT_THRESHOLDS = {
 
 
 class HarnessEvaluator:
-    """Evaluates telemetry from PiAgentHarness against 5 quality gate thresholds."""
+    """Evaluates telemetry from PiAgentHarness against quality gate thresholds."""
 
     def __init__(self, thresholds: Dict[str, float] | None = None):
         self.thresholds = {**DEFAULT_THRESHOLDS, **(thresholds or {})}
@@ -54,6 +60,69 @@ class HarnessEvaluator:
             "checks": checks,
         }
 
+    def evaluate_evidence(
+        self,
+        evidence_result: Dict[str, Any],
+        *,
+        require_evaluated: bool = True,
+    ) -> Dict[str, Any]:
+        """Evaluate a structured ``evaluate_with_evidence`` result.
+
+        Per gate policy, unevaluated dimensions are treated as FAILURE rather than
+        success: ``require_evaluated=True`` (default) makes a dimension with no
+        evidence (e.g. zero mutations for MapSpecValidity, zero refs for
+        CursorResolutionRate) fail its check. Set ``require_evaluated=False`` to
+        instead exempt dimensions that had nothing to evaluate (useful for runs
+        that legitimately perform no cartography).
+        """
+        metrics: Dict[str, float] = evidence_result.get("metrics", {})
+        evidence = evidence_result.get("evidence", [])
+
+        had_mutation = any(e.get("mapspec_validity") for e in evidence)
+        had_ref = any(len(e.get("refs", [])) > 0 for e in evidence)
+        dims_evaluated = {
+            "MapSpecValidity": had_mutation,
+            "CursorResolutionRate": had_ref,
+            "ToolChoiceAccuracy": True,
+            "StepEfficiency": True,
+            "ErrorRecoveryRate": True,
+        }
+
+        checks: Dict[str, Dict[str, Any]] = {}
+        all_passed = True
+        for metric_name, target in self.thresholds.items():
+            evaluated = dims_evaluated[metric_name]
+            score = metrics.get(metric_name, 0.0)
+            if not evaluated and require_evaluated:
+                # No evidence to evaluate → policy: FAIL (not success).
+                passed = False
+                reason = "not_evaluated_policy_fail"
+            elif not evaluated and not require_evaluated:
+                # Legitimately nothing to evaluate → exempt.
+                passed = True
+                reason = "not_applicable_exempt"
+            else:
+                passed = score >= target
+                reason = "evaluated"
+            if not passed:
+                all_passed = False
+            checks[metric_name] = {
+                "score": score,
+                "target": target,
+                "passed": passed,
+                "evaluated": evaluated,
+                "reason": reason,
+            }
+
+        return {
+            "overall_passed": all_passed,
+            "metrics": metrics,
+            "thresholds": self.thresholds,
+            "checks": checks,
+            "run_id": evidence_result.get("run_id"),
+            "session_id": evidence_result.get("session_id"),
+        }
+
     def generate_markdown_report(
         self,
         session_id: str,
@@ -73,7 +142,12 @@ class HarnessEvaluator:
         ]
 
         for name, chk in evaluation_result["checks"].items():
-            status_icon = "🟢 PASS" if chk["passed"] else "🔴 FAIL"
+            if chk.get("passed"):
+                status_icon = "🟢 PASS"
+            elif chk.get("reason") == "not_evaluated_policy_fail":
+                status_icon = "⚫ NOT EVALUATED"
+            else:
+                status_icon = "🔴 FAIL"
             lines.append(
                 f"| {name} | {chk['score']}% | {chk['target']}% | {status_icon} |"
             )

--- a/app/lib/harness/evidence.py
+++ b/app/lib/harness/evidence.py
@@ -1,0 +1,121 @@
+"""Unified evaluation evidence model for the Harness ↔ GIS ↔ MapSpec ↔ Cartography loop.
+
+This module defines the structured evidence that flows across the whole chain.
+It replaces the legacy "didn't-error = success" booleans with a tiered,
+evidence-backed model where MISSING EVIDENCE IS NEVER SUCCESS.
+
+核心不变量：
+- 缺失证据 → ``NOT_EVALUATED`` / ``UNKNOWN``，绝不被当作 success。
+- MapSpecValidity 是分层证据（mutation accepted → semantic valid → compile valid
+  → runtime valid），不压成一个假 boolean。
+- CursorResolution 来自真实 SessionStore 解析（存在 + 归属 session + 类型匹配），
+  不是 ref 字符串前缀检查。
+- 每条证据携带完整 correlation（run/session/turn/tool_call/mapspec revision/
+  checkpoint/compile/runtime），并发 session 不互相污染。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class RefResolutionStatus(str, Enum):
+    """Ref cursor 解析的真实状态（非布尔）。"""
+    MALFORMED = "malformed"                 # 不符合 ref:<type>:<id> 语法
+    SYNTACTICALLY_VALID = "syntactically_valid"  # 语法合法但未解析
+    NOT_FOUND = "not_found"                 # 解析过，session 内不存在
+    WRONG_SESSION = "wrong_session"         # 存在但归属其它 session
+    TYPE_MISMATCH = "type_mismatch"         # 存在但 payload 类型与 ref 前缀不符
+    RESOLVED = "resolved"                   # 存在 + 归属正确 session + 类型匹配
+
+    @property
+    def is_resolved(self) -> bool:
+        return self is RefResolutionStatus.RESOLVED
+
+
+class MapSpecValidityTier(int, Enum):
+    """MapSpec 有效性的分层证据（值越大证据越强）。
+
+    缺失证据为 NOT_EVALUATED（0），绝不为 success。
+    """
+    NOT_EVALUATED = 0       # 未采集到任何证据
+    MUTATION_REJECTED = 1   # mutation 被校验拒绝（transaction 回滚）
+    MUTATION_ACCEPTED = 2   # 工具未报错（最弱证据——"没崩"≠"有效"）
+    SEMANTIC_VALID = 3      # 通过纯 Python 结构校验 validate()
+    COMPILE_VALID = 4       # 通过 TS 编译器（compile-report success）
+    RUNTIME_VALID = 5       # 通过 headless 运行时（mapLoaded + 无错误 + 非空 canvas）
+
+
+@dataclass
+class RefResolution:
+    """单次 ref cursor 解析的真实结果。"""
+    ref: str
+    session_id: Optional[str]
+    status: RefResolutionStatus = RefResolutionStatus.SYNTACTICALLY_VALID
+    expected_type: Optional[str] = None   # ref 前缀声明的类型 (geojson/raster/table)
+    actual_type: Optional[str] = None     # payload 实际类型
+    detail: str = ""
+
+    @property
+    def is_resolved(self) -> bool:
+        return self.status.is_resolved
+
+
+@dataclass
+class MapSpecValidityEvidence:
+    """一次 MapSpec mutation 的分层有效性证据。"""
+    tier: MapSpecValidityTier = MapSpecValidityTier.NOT_EVALUATED
+    # 各层原始证据（可观察，不静默）
+    mutation_accepted: Optional[bool] = None
+    semantic_errors: List[Dict[str, Any]] = field(default_factory=list)
+    compile_success: Optional[bool] = None
+    compile_errors: List[Dict[str, Any]] = field(default_factory=list)
+    runtime_valid: Optional[bool] = None
+    runtime_fatal_error: Optional[str] = None
+    mapspec_revision: Optional[str] = None
+    checkpoint_id: Optional[str] = None
+
+    @property
+    def is_valid(self) -> bool:
+        """有效 = 至少达到 SEMANTIC_VALID（真实证据），MUTATION_ACCEPTED 不算有效。"""
+        return self.tier >= MapSpecValidityTier.SEMANTIC_VALID
+
+    @property
+    def evaluated(self) -> bool:
+        return self.tier is not MapSpecValidityTier.NOT_EVALUATED
+
+
+@dataclass
+class ToolCallEvidence:
+    """单次工具调用的完整 correlation + 证据记录。
+
+    每条记录独立携带 run/session/turn/tool_call 标识，避免并发 session 互相污染。
+    """
+    run_id: str
+    session_id: str
+    turn_id: str
+    tool_call_id: str
+    tool_name: str
+    duration_ms: int = 0
+    is_error: bool = False
+    error_msg: str = ""
+    # ref 解析证据（真实 SessionStore 解析）
+    ref_resolutions: List[RefResolution] = field(default_factory=list)
+    # MapSpec 有效性分层证据（仅 mutation 工具）
+    mapspec_validity: Optional[MapSpecValidityEvidence] = None
+    # 运行时制图证据路径（screenshot/trace/report，可选）
+    runtime_evidence_path: Optional[str] = None
+
+
+@dataclass
+class EvaluationRun:
+    """一次评估 run 的 session-scoped 证据集合。"""
+    run_id: str
+    session_id: str
+    expected_tools: List[str] = field(default_factory=list)
+    ideal_step_count: int = 0
+    evidence: List[ToolCallEvidence] = field(default_factory=list)
+
+    def add(self, ev: ToolCallEvidence) -> None:
+        self.evidence.append(ev)

--- a/app/lib/harness/pi_agent_harness.py
+++ b/app/lib/harness/pi_agent_harness.py
@@ -28,7 +28,10 @@ from app.lib.harness.tool_call_event import ToolCallEvent
 
 logger = logging.getLogger(__name__)
 
-REF_CURSOR_PATTERN = re.compile(r"ref:(?:geojson|raster|table):[a-zA-Z0-9_-]+")
+# Real ref format produced by SessionStore is ``ref:<prefix>-<id>`` (DASH), e.g.
+# ``ref:geojson-abc123``. The legacy colon pattern never matched real refs, so
+# CursorResolutionRate was structurally always 100 (no refs ever detected).
+REF_CURSOR_PATTERN = re.compile(r"ref:(?:geojson|raster|table|data)-[a-zA-Z0-9_-]+")
 
 MAPSPEC_MUTATION_TOOLS = {
     "webgis_project_init",

--- a/app/lib/harness/pi_agent_harness.py
+++ b/app/lib/harness/pi_agent_harness.py
@@ -1,24 +1,34 @@
-"""PiAgentHarness - Simulation Seam & 5-Dimensional Metric Evaluator for Pi Agent Bridge.
+"""PiAgentHarness V2 — evidence-driven evaluation for the Pi Agent Bridge.
 
-Intercepts SSE events and tool call payloads during Pi RPC / Chat execution,
-tracking session execution telemetry and calculating evaluation metrics:
-1. ToolChoiceAccuracy
-2. MapSpecValidity
-3. CursorResolutionRate
-4. StepEfficiency
-5. ErrorRecoveryRate
+V2 闭环契约（HARNESS-V2）：
+- MapSpecValidity 来自分层真实证据（mutation accepted → semantic valid →
+  compile valid → runtime valid），而非"工具没报错"。缺失证据 = NOT_EVALUATED，
+  绝不是 success。
+- CursorResolutionRate 来自真实 SessionStore 解析（ref 存在 + 归属正确 session
+  + 类型匹配），而非 ref 字符串前缀检查。跨 session / 不存在的 ref 不计为 resolved。
+- 每条证据独立携带 run/session/turn/tool_call correlation，并发 session 不互染。
+- 兼容：旧浮点 metric 接口（compute_*、evaluate_all、get_telemetry_summary）保留，
+  但语义改为"真实证据"；无证据时返回 0.0（诚实），而非 100.0（假成功）。
 """
-
 from __future__ import annotations
 
 import logging
 import re
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from app.lib.harness.evidence import (
+    EvaluationRun,
+    MapSpecValidityEvidence,
+    MapSpecValidityTier,
+    RefResolution,
+    RefResolutionStatus,
+    ToolCallEvidence,
+)
 from app.lib.harness.tool_call_event import ToolCallEvent
 
 logger = logging.getLogger(__name__)
 
-REF_CURSOR_PATTERN = re.compile(r"ref:(geojson|raster|table):[a-zA-Z0-9_-]+")
+REF_CURSOR_PATTERN = re.compile(r"ref:(?:geojson|raster|table):[a-zA-Z0-9_-]+")
 
 MAPSPEC_MUTATION_TOOLS = {
     "webgis_project_init",
@@ -29,17 +39,37 @@ MAPSPEC_MUTATION_TOOLS = {
     "webgis_layout_set",
 }
 
+# Type injected by callers that can do real (async) SessionStore-backed resolution.
+RefResolver = Callable[[str, str], Awaitable[RefResolution]]
+# Sync pure-Python mapspec structural validator (app.services.mapspec.coordinator.validate).
+MapSpecValidator = Callable[[Dict[str, Any]], Dict[str, Any]]
+
 
 class PiAgentHarness:
-    """Simulation seam & evaluation harness for PiAgentBridge execution sessions."""
+    """Evidence-driven evaluation harness for PiAgentBridge execution sessions.
 
-    # P1 fix: the production harness is a module-level singleton, so its
-    # accumulator lists would grow without bound over a long-lived process.
-    # Each list is trimmed to this cap (FIFO eviction) to bound memory.
-    MAX_EVENTS: ClassVar[int] = 1000
+    The legacy float-metric surface (compute_*, evaluate_all, get_telemetry_summary)
+    is preserved for existing consumers, but every metric is now derived from real
+    evidence. Where evidence is missing the metric degrades to 0.0, never 100.0.
 
-    def __init__(self, session_id: str = ""):
+    Call ``evaluate_with_evidence`` to perform real (async) ref resolution and
+    build the structured ToolCallEvidence trail that powers the closed loop.
+    """
+
+    MAX_EVENTS: int = 1000
+
+    def __init__(
+        self,
+        session_id: str = "",
+        *,
+        ref_resolver: Optional[RefResolver] = None,
+        mapspec_validator: Optional[MapSpecValidator] = None,
+    ):
         self.session_id = session_id
+        self.ref_resolver = ref_resolver
+        self.mapspec_validator = mapspec_validator
+
+        # Raw event buffers (legacy-compatible shape), FIFO-capped.
         self.tool_calls: List[Dict[str, Any]] = []
         self.tool_results: List[Dict[str, Any]] = []
         self.sse_events: List[Dict[str, Any]] = []
@@ -49,32 +79,56 @@ class PiAgentHarness:
         self.recovered_exceptions_count: int = 0
         self._in_error_state: bool = False
 
+        # V2 correlation: every recorded event is stamped with the active
+        # run/turn so concurrent sessions cannot pool into one accumulator.
+        self._active_run_id: str = session_id or "default-run"
+        self._active_turn_id: str = ""
+        # Cached real resolutions from the last evaluate_with_evidence() pass;
+        # lets the sync compute_* surface reflect real data instead of faking.
+        self._resolved_refs: Dict[str, RefResolution] = {}
+        self._validity_cache: Dict[str, MapSpecValidityEvidence] = {}
+
+    # ── FIFO cap + correlation stamping ──────────────────────────────────
+
     def _append_capped(self, lst: List[Dict[str, Any]], item: Dict[str, Any]) -> None:
-        """Append and enforce the MAX_EVENTS FIFO cap."""
         lst.append(item)
         if len(lst) > self.MAX_EVENTS:
             del lst[: len(lst) - self.MAX_EVENTS]
 
+    def set_correlation(self, run_id: str = "", turn_id: str = "") -> None:
+        """Stamp subsequent records with run/turn correlation ids."""
+        if run_id:
+            self._active_run_id = run_id
+        if turn_id:
+            self._active_turn_id = turn_id
+
     def reset(self, session_id: str = "") -> None:
-        """Reset the harness state for a new test session."""
         self.session_id = session_id
+        self._active_run_id = session_id or "default-run"
+        self._active_turn_id = ""
         self.tool_calls.clear()
         self.tool_results.clear()
         self.sse_events.clear()
         self.mapspec_mutations.clear()
         self.ref_cursors.clear()
         self.exceptions.clear()
+        self._resolved_refs.clear()
+        self._validity_cache.clear()
         self.recovered_exceptions_count = 0
         self._in_error_state = False
+
+    # ── Raw event recording (sync, legacy-compatible) ────────────────────
 
     def record_tool_call(
         self, tool_call_id: str, name: str, arguments: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Intercept and record a tool call request payload."""
         call_entry = {
             "tool_call_id": tool_call_id,
             "name": name,
             "arguments": arguments or {},
+            "run_id": self._active_run_id,
+            "turn_id": self._active_turn_id,
+            "session_id": self.session_id,
         }
         self._append_capped(self.tool_calls, call_entry)
         self._scan_and_record_ref_cursors(tool_call_id, arguments)
@@ -85,8 +139,10 @@ class PiAgentHarness:
                 "tool_name": name,
                 "arguments": arguments,
                 "is_valid": False,
+                "run_id": self._active_run_id,
+                "turn_id": self._active_turn_id,
+                "session_id": self.session_id,
             })
-
         return call_entry
 
     def record_tool_result(
@@ -97,7 +153,6 @@ class PiAgentHarness:
         is_error: bool = False,
         error_msg: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Intercept and record a tool execution result."""
         result_entry = {
             "tool_call_id": tool_call_id,
             "name": name,
@@ -112,6 +167,7 @@ class PiAgentHarness:
                 "tool_call_id": tool_call_id,
                 "name": name,
                 "error_msg": error_msg or "",
+                "run_id": self._active_run_id,
             })
             self._in_error_state = True
         else:
@@ -120,20 +176,32 @@ class PiAgentHarness:
                 self._in_error_state = False
 
         if name in MAPSPEC_MUTATION_TOOLS:
+            # V2: MapSpec validity derives from REAL evidence — the tool result
+            # of a mutation carries ``is_compiled`` (pure-Python validate() outcome
+            # from MapSpecLifecycleEngine) and ``success``. "Didn't error" alone
+            # is mutation_accepted, NOT semantic validity.
             for mutation in reversed(self.mapspec_mutations):
                 if mutation["tool_call_id"] == tool_call_id:
-                    success = not is_error and result.get("success", True) is not False
-                    mutation["is_valid"] = success
+                    mutation_accepted = (
+                        not is_error and result.get("success", True) is not False
+                    )
+                    semantic_valid = (
+                        mutation_accepted
+                        and result.get("is_compiled") is True
+                    )
+                    mutation["is_valid"] = semantic_valid  # SEMANTIC_VALID tier
+                    mutation["mutation_accepted"] = mutation_accepted
+                    mutation["semantic_errors"] = result.get("warnings", [])
                     break
-
         return result_entry
 
     def record_sse_event(self, event: Dict[str, Any]) -> None:
-        """Intercept and record an SSE event dict."""
         self._append_capped(self.sse_events, event)
 
     def record_event(self, event: ToolCallEvent) -> None:
-        """Record a complete tool call event from the unified telemetry model."""
+        # Honour any session_id carried on the event for correlation.
+        if getattr(event, "session_id", None):
+            self.session_id = event.session_id  # type: ignore[assignment]
         self.record_tool_call(
             tool_call_id=event.tool_call_id,
             name=event.tool_name,
@@ -147,24 +215,172 @@ class PiAgentHarness:
             error_msg=event.error_msg,
         )
 
+    # ── Ref cursor scanning ──────────────────────────────────────────────
+
     def _scan_and_record_ref_cursors(self, tool_call_id: str, args: Dict[str, Any]) -> None:
-        """Scan tool arguments recursively for ref: cursor strings."""
         args_str = str(args)
-        found_refs = set(re.findall(r"ref:(?:geojson|raster|table):[a-zA-Z0-9_-]+", args_str))
+        found_refs = set(REF_CURSOR_PATTERN.findall(args_str))
         for ref in found_refs:
-            is_resolved = self._check_ref_cursor_resolved(ref)
             self._append_capped(self.ref_cursors, {
                 "tool_call_id": tool_call_id,
                 "ref_cursor": ref,
-                "is_resolved": is_resolved,
+                # Pre-resolution: syntactically valid ONLY. Real resolution happens
+                # in evaluate_with_evidence against the SessionStore. We never claim
+                # "resolved" from a string prefix check alone.
+                "is_resolved": False,
+                "status": RefResolutionStatus.SYNTACTICALLY_VALID.value,
+                "run_id": self._active_run_id,
+                "session_id": self.session_id,
             })
 
-    def _check_ref_cursor_resolved(self, ref_cursor: str) -> bool:
-        """Check if reference cursor is valid and resolved."""
-        return bool(ref_cursor and ref_cursor.startswith("ref:"))
+    # ── V2: real async evaluation against the SessionStore / validator ──
+
+    async def evaluate_with_evidence(
+        self,
+        expected_tools: Optional[List[str]] = None,
+        ideal_step_count: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Perform REAL ref resolution + structured evidence collection.
+
+        Returns a structured evaluation with the validity ladder + ref statuses.
+        Also caches resolutions so the legacy sync compute_* reflect real data.
+        """
+        expected_tools = expected_tools or []
+        ideal_step_count = 0 if ideal_step_count is None else ideal_step_count
+
+        run = EvaluationRun(
+            run_id=self._active_run_id,
+            session_id=self.session_id,
+            expected_tools=list(expected_tools),
+            ideal_step_count=ideal_step_count,
+        )
+
+        # 1. Resolve every recorded ref cursor against the real SessionStore.
+        if self.ref_resolver is not None:
+            for rc in self.ref_cursors:
+                ref = rc["ref_cursor"]
+                try:
+                    resolution = await self.ref_resolver(self.session_id, ref)
+                except Exception as e:
+                    resolution = RefResolution(
+                        ref=ref,
+                        session_id=self.session_id,
+                        status=RefResolutionStatus.NOT_FOUND,
+                        detail=f"resolver error: {e}",
+                    )
+                self._resolved_refs[ref] = resolution
+                rc["is_resolved"] = resolution.is_resolved
+                rc["status"] = resolution.status.value
+        # If no resolver wired: refs remain SYNTACTICALLY_VALID (not resolved) —
+        # the metrics below will honestly reflect "not verified".
+
+        # 2. Build per-tool-call evidence with correlation + validity ladder.
+        results_by_id = {r["tool_call_id"]: r for r in self.tool_results}
+        mutation_results = {
+            m["tool_call_id"]: m for m in self.mapspec_mutations
+        }
+
+        for tc in self.tool_calls:
+            tcid = tc["tool_call_id"]
+            res = results_by_id.get(tcid, {})
+            refs_for_call = [
+                self._resolved_refs.get(rc["ref_cursor"])
+                or RefResolution(
+                    ref=rc["ref_cursor"],
+                    session_id=self.session_id,
+                    status=RefResolutionStatus.SYNTACTICALLY_VALID,
+                )
+                for rc in self.ref_cursors
+                if rc["tool_call_id"] == tcid
+            ]
+
+            validity: Optional[MapSpecValidityEvidence] = None
+            if tc["name"] in MAPSPEC_MUTATION_TOOLS:
+                mut = mutation_results.get(tcid, {})
+                validity = self._validity_for_mutation(tcid, mut, res)
+                self._validity_cache[tcid] = validity
+
+            ev = ToolCallEvidence(
+                run_id=tc.get("run_id", self._active_run_id),
+                session_id=tc.get("session_id", self.session_id),
+                turn_id=tc.get("turn_id", ""),
+                tool_call_id=tcid,
+                tool_name=tc["name"],
+                duration_ms=int(res.get("duration_ms", 0)) if res else 0,
+                is_error=res.get("is_error", False) if res else False,
+                error_msg=res.get("error_msg", "") if res else "",
+                ref_resolutions=refs_for_call,
+                mapspec_validity=validity,
+            )
+            run.add(ev)
+
+        # 3. Structured + float metrics (both honest).
+        float_metrics = self.evaluate_all(expected_tools, ideal_step_count)
+        return {
+            "run_id": run.run_id,
+            "session_id": run.session_id,
+            "evidence": [self._evidence_to_dict(e) for e in run.evidence],
+            "metrics": float_metrics,
+            "ref_resolutions": {
+                ref: {"status": r.status.value, "resolved": r.is_resolved}
+                for ref, r in self._resolved_refs.items()
+            },
+        }
+
+    def _validity_for_mutation(
+        self, tcid: str, mut: Dict[str, Any], res: Dict[str, Any]
+    ) -> MapSpecValidityEvidence:
+        """Build the validity ladder from recorded mutation evidence."""
+        accepted = bool(mut.get("mutation_accepted", False))
+        semantic_valid_flag = bool(mut.get("is_valid", False))
+        if res.get("is_error"):
+            tier = MapSpecValidityTier.MUTATION_REJECTED
+        elif semantic_valid_flag:
+            tier = MapSpecValidityTier.SEMANTIC_VALID
+        elif accepted:
+            tier = MapSpecValidityTier.MUTATION_ACCEPTED
+        else:
+            tier = MapSpecValidityTier.NOT_EVALUATED
+        return MapSpecValidityEvidence(
+            tier=tier,
+            mutation_accepted=accepted if accepted else None,
+            semantic_errors=mut.get("semantic_errors", []),
+            mapspec_revision=res.get("mapspec_revision"),
+            checkpoint_id=res.get("checkpoint_id"),
+        )
+
+    @staticmethod
+    def _evidence_to_dict(ev: ToolCallEvidence) -> Dict[str, Any]:
+        v = ev.mapspec_validity
+        return {
+            "run_id": ev.run_id,
+            "session_id": ev.session_id,
+            "turn_id": ev.turn_id,
+            "tool_call_id": ev.tool_call_id,
+            "tool_name": ev.tool_name,
+            "duration_ms": ev.duration_ms,
+            "is_error": ev.is_error,
+            "error_msg": ev.error_msg,
+            "refs": [
+                {"ref": r.ref, "status": r.status.value, "resolved": r.is_resolved}
+                for r in ev.ref_resolutions
+            ],
+            "mapspec_validity": (
+                {
+                    "tier": v.tier.name,
+                    "is_valid": v.is_valid,
+                    "evaluated": v.evaluated,
+                    "semantic_errors": v.semantic_errors,
+                    "checkpoint_id": v.checkpoint_id,
+                }
+                if v else None
+            ),
+            "runtime_evidence_path": ev.runtime_evidence_path,
+        }
+
+    # ── Legacy float-metric surface (now evidence-honest) ────────────────
 
     def compute_tool_choice_accuracy(self, expected_tools: List[str]) -> float:
-        """ToolChoiceAccuracy = (correct_tool_invocations / total_expected_tools) * 100%"""
         if not expected_tools:
             return 100.0
         invoked_tools = [tc["name"] for tc in self.tool_calls]
@@ -178,23 +394,31 @@ class PiAgentHarness:
         return min(100.0, max(0.0, accuracy))
 
     def compute_mapspec_validity(self) -> float:
-        """MapSpecValidity = (valid_mapspec_mutations / total_mapspec_mutations) * 100%"""
+        """% of mutations with REAL semantic-validity evidence.
+
+        V2: a mutation that merely "didn't error" (MUTATION_ACCEPTED) does NOT
+        count as valid — only SEMANTIC_VALID+ counts. No mutations recorded →
+        0.0 (no evidence), not 100.0.
+        """
         if not self.mapspec_mutations:
-            return 100.0
+            return 0.0
         valid_count = sum(1 for m in self.mapspec_mutations if m.get("is_valid", False))
         validity = (valid_count / len(self.mapspec_mutations)) * 100.0
         return min(100.0, max(0.0, validity))
 
     def compute_cursor_resolution_rate(self) -> float:
-        """CursorResolutionRate = (resolved_ref_cursors / total_ref_cursors) * 100%"""
+        """% of refs that genuinely RESOLVED against the SessionStore.
+
+        V2: syntactic-only refs (no resolver run, or resolver returned not-found /
+        wrong-session) do NOT count. No refs recorded → 0.0 (no evidence), not 100.0.
+        """
         if not self.ref_cursors:
-            return 100.0
+            return 0.0
         resolved_count = sum(1 for c in self.ref_cursors if c.get("is_resolved", False))
         rate = (resolved_count / len(self.ref_cursors)) * 100.0
         return min(100.0, max(0.0, rate))
 
     def compute_step_efficiency(self, ideal_step_count: int) -> float:
-        """StepEfficiency = (ideal_step_count / actual_step_count) * 100%"""
         actual_step_count = len(self.tool_calls)
         if actual_step_count == 0:
             return 100.0 if ideal_step_count == 0 else 0.0
@@ -202,7 +426,6 @@ class PiAgentHarness:
         return min(100.0, max(0.0, efficiency))
 
     def compute_error_recovery_rate(self) -> float:
-        """ErrorRecoveryRate = (successful_recoveries / total_tool_exceptions) * 100%"""
         total_exceptions = len(self.exceptions)
         if total_exceptions == 0:
             return 100.0
@@ -210,12 +433,6 @@ class PiAgentHarness:
         return min(100.0, max(0.0, rate))
 
     def get_telemetry_summary(self) -> Dict[str, Dict[str, float]]:
-        """Return instant in-memory telemetry metrics summary.
-
-        Rates (0-100) and raw counts are separated so consumers can format
-        them correctly - previously both shared one flat Dict[str, float] and
-        the UI rendered counts (e.g. ToolCallsCount=42) with a ``%`` suffix.
-        """
         return {
             "rates": {
                 "MapSpecValidity": round(self.compute_mapspec_validity(), 2),
@@ -231,7 +448,6 @@ class PiAgentHarness:
     def evaluate_all(
         self, expected_tools: List[str], ideal_step_count: int
     ) -> Dict[str, float]:
-        """Compute all 5 evaluation metrics."""
         return {
             "ToolChoiceAccuracy": round(self.compute_tool_choice_accuracy(expected_tools), 2),
             "MapSpecValidity": round(self.compute_mapspec_validity(), 2),

--- a/app/lib/harness/ref_resolver.py
+++ b/app/lib/harness/ref_resolver.py
@@ -14,11 +14,13 @@ from app.lib.harness.evidence import RefResolution, RefResolutionStatus
 
 logger = logging.getLogger(__name__)
 
-_REF_RE = re.compile(r"^ref:(geojson|raster|table):([a-zA-Z0-9_-]+)$")
+_REF_RE = re.compile(r"^ref:([a-z][a-z0-9]*)-([a-zA-Z0-9_-]+)$")
 
 # Map ref type prefix to the expected top-level payload shape keyword. A resolved
 # payload whose shape contradicts the prefix is a TYPE_MISMATCH (not resolved).
-_TYPE_SHAPE_HINT = {
+# Only the typed prefixes are type-checked; "data" / "redis-unavailable" etc.
+# resolve on existence alone (no type contract).
+_TYPED_PREFIXES = {
     "geojson": ("type", "FeatureCollection"),
     "raster": ("raster", True),
     "table": ("columns", None),
@@ -66,7 +68,8 @@ def make_session_store_resolver(session_store: Any):
         # would have returned None above.
         actual_type = _infer_payload_type(payload)
         resolution.actual_type = actual_type
-        if actual_type is not None and actual_type != expected_type:
+        # Only typed prefixes (geojson/raster/table) carry a type contract.
+        if expected_type in _TYPED_PREFIXES and actual_type is not None and actual_type != expected_type:
             resolution.status = RefResolutionStatus.TYPE_MISMATCH
             resolution.detail = f"expected {expected_type}, got {actual_type}"
             return resolution

--- a/app/lib/harness/ref_resolver.py
+++ b/app/lib/harness/ref_resolver.py
@@ -1,0 +1,89 @@
+"""Real ref-cursor resolver backed by the SessionStore.
+
+V2 闭环（HARNESS-V2）：把 ref cursor 的"解析"从字符串前缀检查升级为真实
+SessionStore 验证：存在 + 归属正确 session + payload 类型匹配。跨 session /
+不存在的 ref 返回 NOT_FOUND / WRONG_SESSION，绝不计为 resolved。
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+
+from app.lib.harness.evidence import RefResolution, RefResolutionStatus
+
+logger = logging.getLogger(__name__)
+
+_REF_RE = re.compile(r"^ref:(geojson|raster|table):([a-zA-Z0-9_-]+)$")
+
+# Map ref type prefix to the expected top-level payload shape keyword. A resolved
+# payload whose shape contradicts the prefix is a TYPE_MISMATCH (not resolved).
+_TYPE_SHAPE_HINT = {
+    "geojson": ("type", "FeatureCollection"),
+    "raster": ("raster", True),
+    "table": ("columns", None),
+}
+
+
+def make_session_store_resolver(session_store: Any):
+    """Build an async ref resolver ``(session_id, ref) -> RefResolution``.
+
+    ``session_store`` is any object implementing the SessionStore protocol
+    (``async get(session_id, ref)``). Production wires ``session_data_manager``;
+    tests wire a fakeredis-backed manager or a fake.
+    """
+
+    async def resolve(session_id: str, ref: str) -> RefResolution:
+        m = _REF_RE.match(ref or "")
+        if not m:
+            return RefResolution(
+                ref=ref or "",
+                session_id=session_id,
+                status=RefResolutionStatus.MALFORMED,
+                detail="does not match ref:<type>:<id>",
+            )
+        expected_type, _seg = m.group(1), m.group(2)
+        resolution = RefResolution(
+            ref=ref,
+            session_id=session_id,
+            status=RefResolutionStatus.SYNTACTICALLY_VALID,
+            expected_type=expected_type,
+        )
+        try:
+            payload = await session_store.get(session_id, ref)
+        except Exception as e:  # store error → observable, not silent success
+            resolution.status = RefResolutionStatus.NOT_FOUND
+            resolution.detail = f"store error: {e}"
+            return resolution
+
+        if payload is None:
+            resolution.status = RefResolutionStatus.NOT_FOUND
+            resolution.detail = "ref not present in session store"
+            return resolution
+
+        # The store is session-scoped (get takes session_id), so a hit here
+        # already proves session ownership. A ref owned by another session
+        # would have returned None above.
+        actual_type = _infer_payload_type(payload)
+        resolution.actual_type = actual_type
+        if actual_type is not None and actual_type != expected_type:
+            resolution.status = RefResolutionStatus.TYPE_MISMATCH
+            resolution.detail = f"expected {expected_type}, got {actual_type}"
+            return resolution
+
+        resolution.status = RefResolutionStatus.RESOLVED
+        return resolution
+
+    return resolve
+
+
+def _infer_payload_type(payload: Any) -> Optional[str]:
+    """Best-effort payload type inference for type-match checking."""
+    if isinstance(payload, dict):
+        if payload.get("type") == "FeatureCollection":
+            return "geojson"
+        if "raster" in payload or payload.get("raster") is True or "band_data" in payload:
+            return "raster"
+        if "columns" in payload:
+            return "table"
+    return None

--- a/app/services/distributed_lock.py
+++ b/app/services/distributed_lock.py
@@ -6,13 +6,17 @@ two pods can process the same session concurrently unless routing is sticky.
 This module provides defense-in-depth: a Redis-backed per-session lock so a
 MapSpec mutation (or any critical per-session section) is mutually exclusive
 across pods when Redis is reachable, with a transparent fallback to an in-process
-asyncio.Lock when Redis is unavailable (single-worker / test).
+asyncio.Lock when Redis is unavailable (single-worker / test / outage).
 
 Contract:
 - ``async with session_lock(session_id): ...`` — mutually exclusive per session.
-- Auto-renews the TTL while held (best-effort) and releases with token check so a
-  slow holder never releases a different owner's lock.
-- Any Redis error degrades to an in-process lock (never blocks the request).
+- Resilient (review P2-1): a Redis error at acquire time (incl. post-startup
+  outages) degrades to an in-process lock for that acquisition — it NEVER raises
+  unhandled or blocks the request indefinitely.
+- TTL + token-checked Lua release so a slow holder never releases a different
+  owner's lock; best-effort renewal while held.
+- The in-process fallback registry is bounded with waiter-aware eviction (review
+  P2-5): only locks that are unlocked with zero waiters are evictable.
 """
 from __future__ import annotations
 
@@ -26,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TTL_MS = 30_000          # 30s base TTL
 _RENEW_INTERVAL_S = 8.0           # renew well before TTL expiry
+_FALLBACK_CAP = 4096              # bound the in-process fallback registry
 # Lua: release only if we still own the token (avoid releasing another's lock).
 _RELEASE_SCRIPT = (
     b"if redis.call('get', KEYS[1]) == ARGV[1] then "
@@ -39,6 +44,11 @@ class _InProcessLock:
     def __init__(self):
         self._lock = asyncio.Lock()
 
+    @property
+    def idle(self) -> bool:
+        """True iff unlocked AND no waiters — safe to evict (review P2-5)."""
+        return (not self._lock.locked()) and (not self._lock._waiters)
+
     async def __aenter__(self):
         await self._lock.acquire()
 
@@ -46,42 +56,74 @@ class _InProcessLock:
         self._lock.release()
 
 
-class _RedisSessionLock:
-    """A single Redis-backed lock acquisition (one-shot context manager)."""
+class _ResilientSessionLock:
+    """One-shot per-session lock: Redis when reachable, in-process on any error.
 
-    def __init__(self, client, key: str, ttl_ms: int = _DEFAULT_TTL_MS):
+    Acquisition never raises an unhandled Redis error: on connection failure /
+    timeout it logs once and falls back to the supplied in-process lock so the
+    caller's critical section is still serialized within the process.
+    """
+
+    def __init__(self, client, key: str, fallback: _InProcessLock,
+                 ttl_ms: int = _DEFAULT_TTL_MS):
         self._client = client
         self._key = key
+        self._fallback = fallback
         self._ttl_ms = ttl_ms
+        self._mode: str = "inprocess"   # "redis" once acquired via Redis
         self._token: Optional[str] = None
         self._renewer: Optional[asyncio.Task] = None
 
     async def __aenter__(self):
-        self._token = secrets.token_hex(16)
-        # Spin briefly to acquire — bounded so a contended lock fails fast rather
-        # than blocking indefinitely (the caller surfaces the failure).
-        deadline = asyncio.get_event_loop().time() + 10.0
-        while True:
-            ok = await self._client.set(self._key, self._token, nx=True, px=self._ttl_ms)
-            if ok:
-                self._renewer = asyncio.create_task(self._renew_loop())
-                return self
-            if asyncio.get_event_loop().time() > deadline:
-                raise TimeoutError(f"could not acquire session lock {self._key} after 10s")
-            await asyncio.sleep(0.05)
+        if self._client is not None:
+            try:
+                self._token = secrets.token_hex(16)
+                deadline = asyncio.get_event_loop().time() + 10.0
+                while True:
+                    ok = await self._client.set(
+                        self._key, self._token, nx=True, px=self._ttl_ms
+                    )
+                    if ok:
+                        self._mode = "redis"
+                        self._renewer = asyncio.create_task(self._renew_loop())
+                        return self
+                    if asyncio.get_event_loop().time() > deadline:
+                        raise TimeoutError(
+                            f"session lock contention: could not acquire {self._key} in 10s"
+                        )
+                    await asyncio.sleep(0.05)
+            except (TimeoutError, asyncio.TimeoutError):
+                # Genuine contention (another owner holds it): do NOT silently
+                # fall back — that would break cross-pod mutual exclusion. Re-raise
+                # so the caller surfaces a real "busy" rather than a lost update.
+                raise
+            except Exception as e:
+                # Redis unavailable / errored → degrade to in-process for this
+                # acquisition. Observable, non-fatal (review P2-1).
+                logger.warning(
+                    "session lock Redis acquire failed for %s, degrading to in-process: %s",
+                    self._key, e,
+                )
+                self._token = None
+        # In-process fallback (also the path when no client is configured).
+        await self._fallback.__aenter__()
+        return self
 
     async def __aexit__(self, exc_type, exc, tb):
-        if self._renewer:
-            self._renewer.cancel()
-            try:
-                await self._renewer
-            except (asyncio.CancelledError, Exception):
-                pass
-        if self._token:
-            try:
-                await self._client.eval(_RELEASE_SCRIPT, 1, self._key, self._token)
-            except Exception as e:  # release failure is observable but non-fatal
-                logger.warning("session lock release failed for %s: %s", self._key, e)
+        if self._mode == "redis":
+            if self._renewer:
+                self._renewer.cancel()
+                try:
+                    await self._renewer
+                except (asyncio.CancelledError, Exception):
+                    pass
+            if self._token:
+                try:
+                    await self._client.eval(_RELEASE_SCRIPT, 1, self._key, self._token)
+                except Exception as e:  # release failure is observable but non-fatal
+                    logger.warning("session lock release failed for %s: %s", self._key, e)
+        else:
+            await self._fallback.__aexit__(exc_type, exc, tb)
 
     async def _renew_loop(self):
         """Extend the TTL while held so a slow operation doesn't lose ownership."""
@@ -97,17 +139,25 @@ class _RedisSessionLock:
 
 
 class SessionLockRegistry:
-    """Per-session lock registry: Redis-backed when available, else in-process."""
+    """Per-session lock registry: Redis-backed when available, else in-process.
+
+    Re-verifies Redis reachability periodically (does not cache the "unavailable"
+    decision forever — review P2-1) and bounds the in-process fallback table with
+    waiter-aware eviction (review P2-5).
+    """
 
     def __init__(self):
         self._client = None
-        self._client_checked = False
+        self._last_check_s: float = 0.0
         self._fallback_locks: Dict[str, _InProcessLock] = {}
 
     def _get_client(self):
-        if self._client_checked:
+        import time as _time
+        now = _time.monotonic()
+        # Re-verify at most every 60s so a transient Redis outage is recovered.
+        if self._client is not None or (now - self._last_check_s) < 60.0:
             return self._client
-        self._client_checked = True
+        self._last_check_s = now
         redis_url = os.getenv("REDIS_URL")
         use_redis = os.getenv("USE_REDIS", "true").lower() in ("true", "1", "yes")
         if not redis_url or not use_redis:
@@ -121,13 +171,30 @@ class SessionLockRegistry:
             self._client = None
         return self._client
 
+    def _fallback_lock(self, session_id: str) -> _InProcessLock:
+        lock = self._fallback_locks.get(session_id)
+        if lock is None:
+            self._evict_idle_fallbacks()
+            lock = _InProcessLock()
+            self._fallback_locks[session_id] = lock
+        return lock
+
+    def _evict_idle_fallbacks(self) -> None:
+        """Bound the fallback table: drop only unlocked, zero-waiter locks."""
+        if len(self._fallback_locks) < _FALLBACK_CAP:
+            return
+        for sid in [s for s, lk in self._fallback_locks.items() if lk.idle]:
+            self._fallback_locks.pop(sid, None)
+            if len(self._fallback_locks) < _FALLBACK_CAP * 3 // 4:
+                break
+
     def lock(self, session_id: str, ttl_ms: int = _DEFAULT_TTL_MS):
         """Return an async context manager mutually exclusive for ``session_id``."""
         client = self._get_client()
-        if client is not None:
-            return _RedisSessionLock(client, f"webgis:sessionlock:{session_id}", ttl_ms)
-        # Fallback: in-process asyncio.Lock per session (single-worker / test).
-        return self._fallback_locks.setdefault(session_id, _InProcessLock())
+        fallback = self._fallback_lock(session_id)
+        return _ResilientSessionLock(
+            client, f"webgis:sessionlock:{session_id}", fallback, ttl_ms
+        )
 
 
 # Module-level singleton. Production uses Redis; tests (USE_REDIS=false) get

--- a/app/services/distributed_lock.py
+++ b/app/services/distributed_lock.py
@@ -1,0 +1,136 @@
+"""Distributed per-session lock for multi-worker safety (CONCURRENCY-V2).
+
+The architecture is single-process-per-pod by design (Pi subprocess ownership +
+localhost HTTP callback, ADR-0006). But production k8s runs replicas:2 + HPA, so
+two pods can process the same session concurrently unless routing is sticky.
+This module provides defense-in-depth: a Redis-backed per-session lock so a
+MapSpec mutation (or any critical per-session section) is mutually exclusive
+across pods when Redis is reachable, with a transparent fallback to an in-process
+asyncio.Lock when Redis is unavailable (single-worker / test).
+
+Contract:
+- ``async with session_lock(session_id): ...`` — mutually exclusive per session.
+- Auto-renews the TTL while held (best-effort) and releases with token check so a
+  slow holder never releases a different owner's lock.
+- Any Redis error degrades to an in-process lock (never blocks the request).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import secrets
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TTL_MS = 30_000          # 30s base TTL
+_RENEW_INTERVAL_S = 8.0           # renew well before TTL expiry
+# Lua: release only if we still own the token (avoid releasing another's lock).
+_RELEASE_SCRIPT = (
+    b"if redis.call('get', KEYS[1]) == ARGV[1] then "
+    b"return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+
+class _InProcessLock:
+    """Thin wrapper so the fallback path has the same context-manager API."""
+
+    def __init__(self):
+        self._lock = asyncio.Lock()
+
+    async def __aenter__(self):
+        await self._lock.acquire()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._lock.release()
+
+
+class _RedisSessionLock:
+    """A single Redis-backed lock acquisition (one-shot context manager)."""
+
+    def __init__(self, client, key: str, ttl_ms: int = _DEFAULT_TTL_MS):
+        self._client = client
+        self._key = key
+        self._ttl_ms = ttl_ms
+        self._token: Optional[str] = None
+        self._renewer: Optional[asyncio.Task] = None
+
+    async def __aenter__(self):
+        self._token = secrets.token_hex(16)
+        # Spin briefly to acquire — bounded so a contended lock fails fast rather
+        # than blocking indefinitely (the caller surfaces the failure).
+        deadline = asyncio.get_event_loop().time() + 10.0
+        while True:
+            ok = await self._client.set(self._key, self._token, nx=True, px=self._ttl_ms)
+            if ok:
+                self._renewer = asyncio.create_task(self._renew_loop())
+                return self
+            if asyncio.get_event_loop().time() > deadline:
+                raise TimeoutError(f"could not acquire session lock {self._key} after 10s")
+            await asyncio.sleep(0.05)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if self._renewer:
+            self._renewer.cancel()
+            try:
+                await self._renewer
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._token:
+            try:
+                await self._client.eval(_RELEASE_SCRIPT, 1, self._key, self._token)
+            except Exception as e:  # release failure is observable but non-fatal
+                logger.warning("session lock release failed for %s: %s", self._key, e)
+
+    async def _renew_loop(self):
+        """Extend the TTL while held so a slow operation doesn't lose ownership."""
+        try:
+            while True:
+                await asyncio.sleep(_RENEW_INTERVAL_S)
+                try:
+                    await self._client.pexpire(self._key, self._ttl_ms)
+                except Exception:
+                    pass  # best-effort; the initial TTL still bounds stale locks
+        except asyncio.CancelledError:
+            pass
+
+
+class SessionLockRegistry:
+    """Per-session lock registry: Redis-backed when available, else in-process."""
+
+    def __init__(self):
+        self._client = None
+        self._client_checked = False
+        self._fallback_locks: Dict[str, _InProcessLock] = {}
+
+    def _get_client(self):
+        if self._client_checked:
+            return self._client
+        self._client_checked = True
+        redis_url = os.getenv("REDIS_URL")
+        use_redis = os.getenv("USE_REDIS", "true").lower() in ("true", "1", "yes")
+        if not redis_url or not use_redis:
+            return None
+        try:
+            import redis.asyncio as aioredis  # local import: don't pay cost if unused
+            self._client = aioredis.from_url(redis_url, decode_responses=False)
+            logger.info("SessionLockRegistry: Redis-backed distributed locks enabled")
+        except Exception as e:  # noqa: BLE001
+            logger.warning("SessionLockRegistry: Redis unavailable, using in-process locks: %s", e)
+            self._client = None
+        return self._client
+
+    def lock(self, session_id: str, ttl_ms: int = _DEFAULT_TTL_MS):
+        """Return an async context manager mutually exclusive for ``session_id``."""
+        client = self._get_client()
+        if client is not None:
+            return _RedisSessionLock(client, f"webgis:sessionlock:{session_id}", ttl_ms)
+        # Fallback: in-process asyncio.Lock per session (single-worker / test).
+        return self._fallback_locks.setdefault(session_id, _InProcessLock())
+
+
+# Module-level singleton. Production uses Redis; tests (USE_REDIS=false) get
+# in-process locks. Either way the per-session mutual exclusion holds within a
+# process; Redis extends it across pods.
+session_lock_registry = SessionLockRegistry()

--- a/app/services/mapspec/checkpoint.py
+++ b/app/services/mapspec/checkpoint.py
@@ -130,6 +130,20 @@ def _write_ref_blobs_sync(
     return ref_blob_map
 
 
+def _write_blobs_and_hash_sync(
+    blob_dir: Path, materialized_refs: Dict[str, Any], mapspec: Dict[str, Any]
+) -> tuple:
+    """Offloaded: write ref blobs AND compute the whole-checkpoint content hash.
+
+    Both are O(payload size); running them on the event loop would block for a
+    large inline-GeoJSON mapspec. Combined into one thread call to avoid two
+    separate offloads over the same data.
+    """
+    ref_blob_map = _write_ref_blobs_sync(blob_dir, materialized_refs)
+    content_h = _content_hash(mapspec, ref_blob_map)
+    return ref_blob_map, content_h
+
+
 async def snapshot(
     mapspec: Dict[str, Any],
     session_dir: Path,
@@ -152,14 +166,13 @@ async def snapshot(
         mapspec, session_id_for_refs, session_data_manager
     )
 
-    # 2. ref blob 去重写入（卸载到线程）。返回 ref_id -> blob_hash 映射。
+    # 2. ref blob 去重写入 + 内容哈希（整体卸载到线程）。
     blob_dir = _blob_dir(session_dir)
-    ref_blob_map = await asyncio.to_thread(
-        _write_ref_blobs_sync, blob_dir, materialized_refs
+    ref_blob_map, content_h = await asyncio.to_thread(
+        _write_blobs_and_hash_sync, blob_dir, materialized_refs, mapspec
     )
 
     # 3. 整 checkpoint 内容哈希。
-    content_h = _content_hash(mapspec, ref_blob_map)
     manifest = await asyncio.to_thread(_load_manifest, session_dir)
 
     # 去重契约：

--- a/app/services/mapspec/checkpoint.py
+++ b/app/services/mapspec/checkpoint.py
@@ -1,9 +1,20 @@
 """CheckpointStore (app/services/mapspec/checkpoint.py).
 
 拥有 MapSpec 各种 Checkpoint Snapshot、Ref Materialization 与 Rollback 逻辑。
+
+可靠性 / 写放大契约（REL-05）：
+- Whole-checkpoint 内容寻址：相同 (mapspec + refs) 的重复 checkpoint 复用已有 id，
+  不重写完整 payload（满足"repeated unchanged checkpoint 不重复写大 payload"）。
+- Per-ref blob 去重：每个 ref 数据按内容哈希存为 ``blobs/<sha>.json``，相同 ref
+  不被每个 checkpoint 重复复制（满足"相同 ref 不被每个 checkpoint 重复复制"）。
+- 原子写（temp + os.replace）；manifest 损坏 / blob 缺失时回退可观察，不静默成功。
+- 向后兼容：旧 checkpoint（``mapspec.json`` + ``materialized_refs.json``，无
+  ``descriptor.json`` / manifest）仍可 rollback；新 checkpoint 额外写 descriptor。
 """
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
 import re
 import time
@@ -11,6 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from app.services.mapspec_source import ref as source_ref
+from app.services.mapspec.store import _atomic_write_json_sync, _read_json_sync
 
 # SEC-02: checkpoint_id is an LLM/user-supplied string that is joined directly
 # into a filesystem path. A value containing ``..`` or path separators could
@@ -18,6 +30,8 @@ from app.services.mapspec_source import ref as source_ref
 # traversal). Restrict to a safe charset; caller-controlled structure is never
 # permitted. See docs/research/deep-audit-performance-convergence.md SEC-02.
 _SAFE_CHECKPOINT_ID = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+_MANIFEST_VERSION = 1
 
 
 def _validate_checkpoint_id(ckpt_id: str) -> str:
@@ -34,47 +48,196 @@ def _validate_checkpoint_id(ckpt_id: str) -> str:
     return ckpt_id
 
 
+def _canonical_json(payload: Any) -> str:
+    """Deterministic JSON for stable hashing (sorted keys, no extra whitespace)."""
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _content_hash(mapspec: Dict[str, Any], ref_blob_map: Dict[str, str]) -> str:
+    """SHA256 over the canonical mapspec + the ref_id→blob_hash mapping.
+
+    The blob mapping (not the raw payload) is hashed so two checkpoints that
+    reference the same ref data hash identically — that is the dedup key.
+    """
+    h = hashlib.sha256()
+    h.update(_canonical_json(mapspec).encode("utf-8"))
+    h.update(b"\x1f")  # separator between the two segments
+    h.update(_canonical_json(ref_blob_map).encode("utf-8"))
+    return h.hexdigest()
+
+
+def _blob_filename(content_hash: str) -> str:
+    return f"{content_hash}.json"
+
+
+def _checkpoints_root(session_dir: Path) -> Path:
+    return session_dir / "checkpoints"
+
+
+def _blob_dir(session_dir: Path) -> Path:
+    return _checkpoints_root(session_dir) / "blobs"
+
+
+def _manifest_path(session_dir: Path) -> Path:
+    return _checkpoints_root(session_dir) / "manifest.json"
+
+
+def _load_manifest(session_dir: Path) -> Dict[str, Any]:
+    """Load the content-hash → checkpoint_id manifest. Missing/corrupt → empty."""
+    raw = _read_json_sync(_manifest_path(session_dir))
+    if isinstance(raw, dict) and isinstance(raw.get("entries"), dict):
+        return raw
+    return {"version": _MANIFEST_VERSION, "entries": {}}
+
+
+async def _materialize_refs(
+    mapspec: Dict[str, Any], session_id: str, session_data_manager
+) -> Dict[str, Any]:
+    """Fetch every ref: payload referenced by the mapspec's sources.
+
+    Returns {ref_id: payload}. Missing refs (get returned None) are omitted —
+    a checkpoint never persists a None payload as if it existed.
+    """
+    materialized: Dict[str, Any] = {}
+    for source in mapspec.get("sources", {}).values():
+        ref_candidate = source_ref(source) or ""
+        if isinstance(ref_candidate, str) and ref_candidate.startswith("ref:"):
+            ref_data = await session_data_manager.get(session_id, ref_candidate)
+            if ref_data is not None:
+                materialized[ref_candidate] = ref_data
+    return materialized
+
+
+def _write_ref_blobs_sync(
+    blob_dir: Path, materialized_refs: Dict[str, Any]
+) -> Dict[str, str]:
+    """Persist each ref payload as a content-addressed blob (dedup by hash).
+
+    Returns {ref_id: blob_hash}. Existing blobs are not rewritten. Each blob is
+    written atomically so a crash cannot leave a partial blob that later
+    rollback would trust.
+    """
+    blob_dir.mkdir(parents=True, exist_ok=True)
+    ref_blob_map: Dict[str, str] = {}
+    for ref_id, payload in materialized_refs.items():
+        blob_hash = hashlib.sha256(
+            _canonical_json(payload).encode("utf-8")
+        ).hexdigest()
+        blob_path = blob_dir / _blob_filename(blob_hash)
+        if not blob_path.exists():
+            _atomic_write_json_sync(blob_path, payload)
+        ref_blob_map[ref_id] = blob_hash
+    return ref_blob_map
+
+
 async def snapshot(
     mapspec: Dict[str, Any],
     session_dir: Path,
     session_data_manager,
     checkpoint_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """生成 MapSpec Checkpoint Snapshot 及其引用的 ref 数据物理副本"""
+    """生成 MapSpec Checkpoint Snapshot 及其引用的 ref 数据物理副本。
+
+    写放大控制：
+    1. ref 数据按内容哈希存为 blobs/<sha>.json，相同 ref 复用 blob；
+    2. 整个 checkpoint 的内容哈希命中 manifest 时，复用已有 checkpoint_id，
+       不重写 mapspec/descriptor。
+    """
     ckpt_id = checkpoint_id or f"ckpt_{int(time.time() * 1000)}"
     _validate_checkpoint_id(ckpt_id)
-    ckpt_dir = session_dir / "checkpoints" / ckpt_id
-    ckpt_dir.mkdir(parents=True, exist_ok=True)
-
-    with open(ckpt_dir / "mapspec.json", "w", encoding="utf-8") as f:
-        json.dump(mapspec, f, ensure_ascii=False, indent=2)
 
     session_id_for_refs = session_dir.name
-    materialized_refs: Dict[str, Any] = {}
-    for source in mapspec.get("sources", {}).values():
-        ref_candidate = source_ref(source) or ""
-        if isinstance(ref_candidate, str) and ref_candidate.startswith("ref:"):
-            ref_data = await session_data_manager.get(session_id_for_refs, ref_candidate)
-            if ref_data is not None:
-                materialized_refs[ref_candidate] = ref_data
+    # 1. 物化所有 ref（async）。这是数据读取，去重省的是写入，不是读取。
+    materialized_refs = await _materialize_refs(
+        mapspec, session_id_for_refs, session_data_manager
+    )
 
-    with open(ckpt_dir / "materialized_refs.json", "w", encoding="utf-8") as f:
-        json.dump(materialized_refs, f, ensure_ascii=False, indent=2)
+    # 2. ref blob 去重写入（卸载到线程）。返回 ref_id -> blob_hash 映射。
+    blob_dir = _blob_dir(session_dir)
+    ref_blob_map = await asyncio.to_thread(
+        _write_ref_blobs_sync, blob_dir, materialized_refs
+    )
 
-    meta = {
+    # 3. 整 checkpoint 内容哈希。
+    content_h = _content_hash(mapspec, ref_blob_map)
+    manifest = await asyncio.to_thread(_load_manifest, session_dir)
+
+    # 去重契约：
+    # - ref blob 去重永远生效（第 2 步，不影响 checkpoint 身份）。
+    # - whole-checkpoint 内容去重（复用已有 id、跳过写入）**仅对自动 checkpoint**
+    #   （checkpoint_id is None）生效。显式 id 由调用方指定（供按名 rollback），
+    #   必须落地该 id 对应目录；否则 rollback(checkpoint_id) 会找不到目录。
+    if checkpoint_id is None:
+        existing = manifest["entries"].get(content_h)
+        if existing and isinstance(existing, str):
+            existing_dir = _checkpoints_root(session_dir) / existing
+            if existing_dir.exists():
+                return {
+                    "success": True,
+                    "checkpoint_id": existing,
+                    "checkpoint_dir": str(existing_dir),
+                    "ref_count": len(ref_blob_map),
+                    "deduplicated": True,
+                    "summary": (
+                        f"Checkpoint reused as '{existing}' "
+                        f"(content-identical; {len(ref_blob_map)} refs deduplicated)"
+                    ),
+                }
+            # manifest 指向已删除目录：清理并继续写一个新 checkpoint。
+
+    # 4. 写 checkpoint 目录。显式 id 若已存在且内容相同则跳过（幂等），否则写入。
+    ckpt_dir = _checkpoints_root(session_dir) / ckpt_id
+    if ckpt_dir.exists():
+        prior_descriptor = await asyncio.to_thread(
+            _read_json_sync, ckpt_dir / "descriptor.json"
+        )
+        if (
+            isinstance(prior_descriptor, dict)
+            and prior_descriptor.get("content_hash") == content_h
+        ):
+            # 同 id 同内容：已落地，跳过重写（仍记录 manifest 命中）。
+            manifest["entries"][content_h] = ckpt_id
+            await asyncio.to_thread(
+                _atomic_write_json_sync, _manifest_path(session_dir), manifest
+            )
+            return {
+                "success": True,
+                "checkpoint_id": ckpt_id,
+                "checkpoint_dir": str(ckpt_dir),
+                "ref_count": len(ref_blob_map),
+                "deduplicated": True,
+                "summary": (
+                    f"Checkpoint '{ckpt_id}' unchanged; skipped rewrite "
+                    f"({len(ref_blob_map)} refs deduplicated)"
+                ),
+            }
+
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    descriptor = {
         "checkpoint_id": ckpt_id,
+        "content_hash": content_h,
         "timestamp": time.time(),
-        "ref_count": len(materialized_refs),
+        "ref_count": len(ref_blob_map),
+        "refs": ref_blob_map,  # ref_id -> blob_hash
     }
-    with open(ckpt_dir / "checkpoint_meta.json", "w", encoding="utf-8") as f:
-        json.dump(meta, f, ensure_ascii=False, indent=2)
+
+    def _write_checkpoint_sync() -> None:
+        _atomic_write_json_sync(ckpt_dir / "mapspec.json", mapspec)
+        _atomic_write_json_sync(ckpt_dir / "descriptor.json", descriptor)
+
+    await asyncio.to_thread(_write_checkpoint_sync)
+
+    # 5. 更新 manifest（content_hash -> checkpoint_id），原子写。
+    manifest["entries"][content_h] = ckpt_id
+    await asyncio.to_thread(_atomic_write_json_sync, _manifest_path(session_dir), manifest)
 
     return {
         "success": True,
         "checkpoint_id": ckpt_id,
         "checkpoint_dir": str(ckpt_dir),
-        "ref_count": len(materialized_refs),
-        "summary": f"Checkpoint '{ckpt_id}' created with {len(materialized_refs)} materialized refs",
+        "ref_count": len(ref_blob_map),
+        "deduplicated": False,
+        "summary": f"Checkpoint '{ckpt_id}' created with {len(ref_blob_map)} materialized refs",
     }
 
 
@@ -83,27 +246,66 @@ async def rollback(
     checkpoint_id: str,
     session_data_manager,
 ) -> Dict[str, Any]:
-    """回滚恢复 Checkpoint Snapshot"""
+    """回滚恢复 Checkpoint Snapshot。
+
+    支持两种磁盘布局：
+    - 新格式：``descriptor.json``（ref_id -> blob_hash）+ ``blobs/<sha>.json``；
+    - 旧格式（向后兼容）：``materialized_refs.json``（ref_id -> 内联 payload）。
+    """
     _validate_checkpoint_id(checkpoint_id)
-    ckpt_dir = session_dir / "checkpoints" / checkpoint_id
+    ckpt_dir = _checkpoints_root(session_dir) / checkpoint_id
     if not ckpt_dir.exists():
         return {"success": False, "message": f"Checkpoint '{checkpoint_id}' not found"}
 
     mapspec_file = ckpt_dir / "mapspec.json"
-    with open(mapspec_file, "r", encoding="utf-8") as f:
-        mapspec = json.load(f)
+    mapspec = await asyncio.to_thread(_read_json_sync, mapspec_file)
+    if mapspec is None:
+        return {
+            "success": False,
+            "message": f"Checkpoint '{checkpoint_id}' mapspec.json missing or corrupt",
+        }
 
     session_id_for_refs = session_dir.name
-    refs_file = ckpt_dir / "materialized_refs.json"
-    if refs_file.exists():
-        with open(refs_file, "r", encoding="utf-8") as f:
-            refs_data = json.load(f)
-            for ref_id, payload in refs_data.items():
-                await session_data_manager.overwrite(session_id_for_refs, ref_id, payload)
+
+    # 优先新格式 descriptor（ref -> blob），回退旧格式 materialized_refs（内联）。
+    descriptor = await asyncio.to_thread(_read_json_sync, ckpt_dir / "descriptor.json")
+    if isinstance(descriptor, dict) and isinstance(descriptor.get("refs"), dict):
+        blob_dir = _blob_dir(session_dir)
+        restored = 0
+        missing_blobs = []
+        for ref_id, blob_hash in descriptor["refs"].items():
+            if not isinstance(blob_hash, str):
+                continue
+            blob_path = blob_dir / _blob_filename(blob_hash)
+            payload = await asyncio.to_thread(_read_json_sync, blob_path)
+            if payload is None:
+                missing_blobs.append(ref_id)
+                continue
+            await session_data_manager.overwrite(session_id_for_refs, ref_id, payload)
+            restored += 1
+        if missing_blobs:
+            return {
+                "success": False,
+                "message": (
+                    f"Checkpoint '{checkpoint_id}' references missing blobs: "
+                    f"{missing_blobs}"
+                ),
+            }
+        ref_count = restored
+    else:
+        # 旧格式：materialized_refs.json 内联 payload。
+        refs_file = ckpt_dir / "materialized_refs.json"
+        refs_data = await asyncio.to_thread(_read_json_sync, refs_file)
+        refs_data = refs_data if isinstance(refs_data, dict) else {}
+        ref_count = 0
+        for ref_id, payload in refs_data.items():
+            await session_data_manager.overwrite(session_id_for_refs, ref_id, payload)
+            ref_count += 1
 
     return {
         "success": True,
         "checkpoint_id": checkpoint_id,
         "mapspec": mapspec,
+        "ref_count": ref_count,
         "summary": f"Recovered checkpoint '{checkpoint_id}'",
     }

--- a/app/services/mapspec/coordinator.py
+++ b/app/services/mapspec/coordinator.py
@@ -123,8 +123,13 @@ def validate(mapspec: Dict[str, Any]) -> Dict[str, Any]:
                 m_type = method.get("method")
                 if m_type in ("interpolate", "step"):
                     stops = method.get("stops", [])
-                    if len(stops) < 2:
-                        errors.append({"code": "INVALID_STOPS_COUNT", "message": f"Property '{prop}' in layer '{layer.get('id')}' requires at least 2 stops"})
+                    # Method-aware minimum: interpolate needs a range (>=2 stops);
+                    # a MapLibre `step` with a single threshold + default is valid,
+                    # so step needs >=1. Requiring >=2 for step was a false positive
+                    # that rejected legitimate graduated classifications.
+                    min_stops = 2 if m_type == "interpolate" else 1
+                    if len(stops) < min_stops:
+                        errors.append({"code": "INVALID_STOPS_COUNT", "message": f"Property '{prop}' in layer '{layer.get('id')}' requires at least {min_stops} stops for {m_type}"})
                     else:
                         for i in range(len(stops) - 1):
                             if stops[i][0] >= stops[i + 1][0]:

--- a/app/services/mapspec/lifecycle_engine.py
+++ b/app/services/mapspec/lifecycle_engine.py
@@ -22,6 +22,7 @@ from app.services.mapspec.store import mapspec_store_instance, _should_remove_la
 from app.services.mapspec.pipeline import process_layer_ingestion
 from app.services.mapspec.coordinator import validate as validate_mapspec
 from app.services.mapspec.checkpoint import snapshot as create_checkpoint, rollback as rollback_checkpoint
+from app.services.distributed_lock import session_lock_registry
 
 logger = logging.getLogger(__name__)
 
@@ -162,9 +163,17 @@ class MapSpecLifecycleEngine:
         session_id: str,
         intent: MutationIntent,
     ) -> MapSpecResult:
-        """原子执行 MapSpec 意图变迁，带 per-session 互斥锁 + 事务 rollback。"""
+        """原子执行 MapSpec 意图变迁，带 per-session 互斥锁 + 事务 rollback。
+
+        双层锁：外层 distributed lock（Redis，跨 pod 互斥；单 worker/测试降级为
+        in-process），内层 asyncio.Lock（同进程内协程序列化）。两层都持有才能
+        避免跨 pod 的同 session 并发 mutation 产生 lost update。
+        """
         lock = self._get_lock(session_id)
-        async with lock:
+        # Two independent locks acquired in one async-with (no extra indent):
+        # outer = distributed (Redis, cross-pod; falls back to in-process),
+        # inner = asyncio (in-process coroutine serialization).
+        async with session_lock_registry.lock(session_id), lock:
             # 事务快照：失败时回滚 mapspec + redis layers 到此刻状态。
             old_map_state = await session_data_manager.get_map_state(session_id)
             old_layers = list(old_map_state.get("layers", []) or [])

--- a/app/services/mapspec/lifecycle_engine.py
+++ b/app/services/mapspec/lifecycle_engine.py
@@ -176,8 +176,13 @@ class MapSpecLifecycleEngine:
                 # snapshot (aliasing) and mask newly-introduced blocking errors.
                 # The Redis backend already returns fresh copies; deepcopy is a
                 # no-op-equivalent safety there. prior_mapspec stays un-mutated.
+                # Offload the deepcopy: for a large inline-GeoJSON mapspec this is
+                # O(features) and must not block the event loop (REL-07).
                 prior_mapspec = loaded
-                mapspec = copy.deepcopy(loaded) if loaded is not None else None
+                mapspec = (
+                    await asyncio.to_thread(copy.deepcopy, loaded)
+                    if loaded is not None else None
+                )
 
                 # 1. 针对未初始化会话自动构建根框架
                 if not mapspec and not isinstance(intent, (InitProjectIntent, RollbackIntent)):

--- a/app/services/mapspec/lifecycle_engine.py
+++ b/app/services/mapspec/lifecycle_engine.py
@@ -2,11 +2,19 @@
 
 深入封装 MapSpec 意图变迁 (InitProject, SetView, UpsertLayer, RemoveLayer, SetLayout)、
 自动 Spatial Profiling、Pre-compile Structure Validation、Redis map_state 双写与 Checkpoint 物理快照。
+
+可靠性契约（REL-06 / REL-07）：
+- 事务语义：先在内存构建 candidate，校验通过后才落盘。引入新的 blocking 校验
+  错误的 mutation 被拒绝，last-known-good 不被污染。
+- 落盘顺序：checkpoint → save_mapspec(disk+redis mapspec) → 同步 redis layers。
+  任一步失败 → rollback 恢复旧 mapspec + layers，返回 is_error。杜绝半提交。
+- process_layer_ingestion（GeoJSON profiling / raster PNG）经 asyncio.to_thread
+  卸载，不阻塞 event loop（大 inline GeoJSON 不再冻结所有 session 的 I/O）。
 """
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from app.services.session_data import session_data_manager
 from app.services.mapspec.store import mapspec_store_instance, _should_remove_layer
@@ -15,6 +23,16 @@ from app.services.mapspec.coordinator import validate as validate_mapspec
 from app.services.mapspec.checkpoint import snapshot as create_checkpoint, rollback as rollback_checkpoint
 
 logger = logging.getLogger(__name__)
+
+# Blocking 校验错误码：这些代表 mutation 引入的真实语义缺陷（引用不存在的
+# source、stops 不足/非单调）。引入此类错误的 mutation 必须被拒绝。
+# MISSING_SOURCES 不在其中：空 source 集合是"项目尚未成熟"的基线状态（如
+# InitProject / 仅有 view 的会话），不是某次 mutation 的缺陷，保留为 warning。
+BLOCKING_VALIDATION_CODES = {
+    "INVALID_SOURCE_REF",
+    "INVALID_STOPS_COUNT",
+    "NON_INCREASING_STOPS",
+}
 
 
 @dataclass
@@ -125,21 +143,31 @@ class MapSpecLifecycleEngine:
     def _get_lock(self, session_id: str) -> asyncio.Lock:
         if len(self._session_locks) > self._MAX_LOCKS:
             evict_count = self._MAX_LOCKS // 4
-            for sid in list(self._session_locks.keys())[:
-                evict_count]:
+            for sid in list(self._session_locks.keys())[:evict_count]:
                 lock_to_evict = self._session_locks[sid]
                 if not lock_to_evict.locked():
                     self._session_locks.pop(sid, None)
         return self._session_locks.setdefault(session_id, asyncio.Lock())
+
+    @staticmethod
+    def _blocking_error_codes(validation: Dict[str, Any]) -> set:
+        return {
+            e.get("code") for e in validation.get("errors", [])
+            if e.get("code") in BLOCKING_VALIDATION_CODES
+        }
 
     async def apply_mutation(
         self,
         session_id: str,
         intent: MutationIntent,
     ) -> MapSpecResult:
-        """原子执行 MapSpec 意图变迁，带 per-session 互斥锁 protection"""
+        """原子执行 MapSpec 意图变迁，带 per-session 互斥锁 + 事务 rollback。"""
         lock = self._get_lock(session_id)
         async with lock:
+            # 事务快照：失败时回滚 mapspec + redis layers 到此刻状态。
+            old_map_state = await session_data_manager.get_map_state(session_id)
+            old_layers = list(old_map_state.get("layers", []) or [])
+
             try:
                 mapspec = await self.store.get_mapspec(session_id)
 
@@ -158,11 +186,16 @@ class MapSpecLifecycleEngine:
                     })
                     mapspec = init_res["mapspec"]
 
+                # 2. 在内存构建 candidate；记录 deferred redis layer 操作。
+                #    重 IO/CPU 的 process_layer_ingestion 卸载到线程，不阻塞 event loop。
                 auto_checkpoint = False
-                checkpoint_id_created = None
+                checkpoint_id_created: Optional[str] = None
                 ckpt_ref_count = 0
+                # pending_layer_op: (op, layer_id, layer?) — 提交时才写 redis layers
+                pending_layer_op: Optional[Tuple[str, str, Optional[Dict[str, Any]]]] = None
+                # rollback 意图需要恢复 refs，单独走快路径（不经 candidate 校验拒绝）
+                is_rollback = False
 
-                # 2. 分发具体意图
                 if isinstance(intent, InitProjectIntent):
                     mapspec = {
                         "version": "1.0",
@@ -189,8 +222,11 @@ class MapSpecLifecycleEngine:
 
                 elif isinstance(intent, UpsertLayerIntent):
                     session_dir = self.store.get_session_dir(session_id)
-                    processed_layer, source_entry, suggested_view = process_layer_ingestion(
-                        mapspec, intent.layer, intent.source_data, session_dir
+                    # 卸载重计算（GeoJSON profiling / raster PNG 渲染）到线程，
+                    # 释放 event loop 给其它 session 的 I/O（REL-07）。
+                    processed_layer, source_entry, suggested_view = await asyncio.to_thread(
+                        process_layer_ingestion,
+                        mapspec, intent.layer, intent.source_data, session_dir,
                     )
                     source_id = processed_layer.get("source", "default_source")
                     mapspec.setdefault("sources", {})[source_id] = source_entry
@@ -210,9 +246,8 @@ class MapSpecLifecycleEngine:
                     if not updated:
                         layers.append(processed_layer)
 
-                    # Keep Redis map_state dual-write in sync for runtime state
-                    await session_data_manager.update_layer_in_state(
-                        session_id,
+                    pending_layer_op = (
+                        "upsert",
                         processed_layer.get("id", "layer"),
                         processed_layer,
                     )
@@ -222,7 +257,7 @@ class MapSpecLifecycleEngine:
                     layers = mapspec.get("layers", [])
                     filtered_layers = [layer for layer in layers if not _should_remove_layer(layer, intent.layer_id)]
                     mapspec["layers"] = filtered_layers
-                    await session_data_manager.remove_layer_from_state(session_id, intent.layer_id)
+                    pending_layer_op = ("remove", intent.layer_id, None)
                     auto_checkpoint = True
 
                 elif isinstance(intent, SetLayoutIntent):
@@ -253,6 +288,10 @@ class MapSpecLifecycleEngine:
                             error_msg=rb_res.get("message", "Rollback failed"),
                         )
                     mapspec = rb_res["mapspec"]
+                    ckpt_ref_count = rb_res.get("ref_count", 0)
+                    # rollback 恢复了 refs + mapspec；运行时 layers 需整体对齐到
+                    # 恢复后的 mapspec.layers（用特殊 op 标记）。
+                    is_rollback = True
 
                 elif isinstance(intent, SetTimeIntent):
                     time_cfg = mapspec.setdefault("time", {
@@ -283,19 +322,54 @@ class MapSpecLifecycleEngine:
                     if intent.speed is not None:
                         time_cfg["speed"] = intent.speed
 
-                # 3. Pre-compile 校验
+                # 3. Pre-compile 校验。Rollback 不走拒绝逻辑（恢复的是历史合法 spec）。
                 validation = validate_mapspec(mapspec)
                 warnings = [e["message"] for e in validation.get("errors", [])] + validation.get("warnings", [])
 
-                # 4. 结构改变时先生成物理 Checkpoint（确保 checkpoint 成功后再持久化）
+                if not is_rollback:
+                    prior = await self.store.get_mapspec(session_id)
+                    prior_blocking = (
+                        self._blocking_error_codes(validate_mapspec(prior))
+                        if prior else set()
+                    )
+                    new_blocking = self._blocking_error_codes(validation) - prior_blocking
+                    if new_blocking:
+                        # 引入新的 blocking 错误：拒绝，不落盘，last-known-good 不变。
+                        msg = "; ".join(
+                            e["message"] for e in validation.get("errors", [])
+                            if e.get("code") in new_blocking
+                        )
+                        return MapSpecResult(
+                            is_error=True,
+                            error_msg=f"MapSpec 校验失败: {msg}",
+                            correction_hint=(
+                                "该意图会引入无效的 source 引用或非法 stops，已拒绝；"
+                                "last-known-good MapSpec 保持不变。"
+                            ),
+                        )
+
+                # 4. 提交（checkpoint → save_mapspec → redis layers），任一失败回滚。
                 if auto_checkpoint and not checkpoint_id_created:
                     session_dir = self.store.get_session_dir(session_id)
                     ckpt_res = await create_checkpoint(mapspec, session_dir, session_data_manager)
                     checkpoint_id_created = ckpt_res.get("checkpoint_id")
                     ckpt_ref_count = ckpt_res.get("ref_count", 0)
 
-                # 5. 双写持久化 (Disk + Redis) — checkpoint 成功后再写入
                 await self.store.save_mapspec(session_id, mapspec)
+
+                if pending_layer_op is not None:
+                    op, layer_id, layer = pending_layer_op
+                    if op == "upsert":
+                        await session_data_manager.update_layer_in_state(
+                            session_id, layer_id, layer
+                        )
+                    elif op == "remove":
+                        await session_data_manager.remove_layer_from_state(session_id, layer_id)
+                elif is_rollback:
+                    # 把运行时 layers 对齐到恢复后的 mapspec.layers。
+                    await session_data_manager.set_map_state(
+                        session_id, "layers", list(mapspec.get("layers", []))
+                    )
 
                 return MapSpecResult(
                     mapspec=mapspec,
@@ -308,11 +382,32 @@ class MapSpecLifecycleEngine:
 
             except Exception as e:
                 logger.error(f"MapSpec mutation failed for session {session_id}: {e}", exc_info=True)
+                # 事务 rollback：恢复 mapspec + redis layers 到 mutation 前。
+                await self._rollback_to_snapshot(session_id, old_map_state, old_layers)
                 return MapSpecResult(
                     is_error=True,
                     error_msg=f"MapSpec 意图更新失败: {e}",
-                    correction_hint="请检查传入的图层配置或图层数据格式。",
+                    correction_hint="事务已回滚，last-known-good MapSpec 与运行时状态保持一致。",
                 )
+
+    async def _rollback_to_snapshot(
+        self,
+        session_id: str,
+        old_map_state: Dict[str, Any],
+        old_layers: List[Any],
+    ) -> None:
+        """恢复 mutation 前的 mapspec + redis layers，避免半提交。"""
+        try:
+            old_mapspec = old_map_state.get("mapspec")
+            if old_mapspec is not None:
+                await self.store.save_mapspec(session_id, old_mapspec)
+            await session_data_manager.set_map_state(session_id, "layers", old_layers)
+        except Exception as rb_err:
+            # rollback 自身失败必须大声报错——绝不静默。
+            logger.error(
+                f"MapSpec transaction rollback FAILED for session {session_id}: {rb_err}",
+                exc_info=True,
+            )
 
 
 mapspec_lifecycle_engine = MapSpecLifecycleEngine()

--- a/app/services/mapspec/lifecycle_engine.py
+++ b/app/services/mapspec/lifecycle_engine.py
@@ -12,6 +12,7 @@
   卸载，不阻塞 event loop（大 inline GeoJSON 不再冻结所有 session 的 I/O）。
 """
 import asyncio
+import copy
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -169,7 +170,14 @@ class MapSpecLifecycleEngine:
             old_layers = list(old_map_state.get("layers", []) or [])
 
             try:
-                mapspec = await self.store.get_mapspec(session_id)
+                loaded = await self.store.get_mapspec(session_id)
+                # Deep-copy before mutating: the in-memory session store returns
+                # REFERENCES, so in-place mutation would also mutate the "prior"
+                # snapshot (aliasing) and mask newly-introduced blocking errors.
+                # The Redis backend already returns fresh copies; deepcopy is a
+                # no-op-equivalent safety there. prior_mapspec stays un-mutated.
+                prior_mapspec = loaded
+                mapspec = copy.deepcopy(loaded) if loaded is not None else None
 
                 # 1. 针对未初始化会话自动构建根框架
                 if not mapspec and not isinstance(intent, (InitProjectIntent, RollbackIntent)):
@@ -184,7 +192,8 @@ class MapSpecLifecycleEngine:
                         },
                         "thresholds": {"maxFeatures": 50000, "timeoutMs": 30000},
                     })
-                    mapspec = init_res["mapspec"]
+                    mapspec = copy.deepcopy(init_res["mapspec"])
+                    prior_mapspec = None
 
                 # 2. 在内存构建 candidate；记录 deferred redis layer 操作。
                 #    重 IO/CPU 的 process_layer_ingestion 卸载到线程，不阻塞 event loop。
@@ -327,10 +336,9 @@ class MapSpecLifecycleEngine:
                 warnings = [e["message"] for e in validation.get("errors", [])] + validation.get("warnings", [])
 
                 if not is_rollback:
-                    prior = await self.store.get_mapspec(session_id)
                     prior_blocking = (
-                        self._blocking_error_codes(validate_mapspec(prior))
-                        if prior else set()
+                        self._blocking_error_codes(validate_mapspec(prior_mapspec))
+                        if prior_mapspec else set()
                     )
                     new_blocking = self._blocking_error_codes(validation) - prior_blocking
                     if new_blocking:

--- a/app/services/mapspec/lifecycle_engine.py
+++ b/app/services/mapspec/lifecycle_engine.py
@@ -139,17 +139,12 @@ class MapSpecLifecycleEngine:
 
     def __init__(self):
         self.store = mapspec_store_instance
-        self._session_locks: Dict[str, asyncio.Lock] = {}
-        self._MAX_LOCKS = 200
-
-    def _get_lock(self, session_id: str) -> asyncio.Lock:
-        if len(self._session_locks) > self._MAX_LOCKS:
-            evict_count = self._MAX_LOCKS // 4
-            for sid in list(self._session_locks.keys())[:evict_count]:
-                lock_to_evict = self._session_locks[sid]
-                if not lock_to_evict.locked():
-                    self._session_locks.pop(sid, None)
-        return self._session_locks.setdefault(session_id, asyncio.Lock())
+        # Per-session serialization is provided by session_lock_registry
+        # (Redis-backed in prod → cross-pod; in-process fallback in tests).
+        # The previous in-engine asyncio.Lock table evicted "unlocked" locks,
+        # which could hand two concurrent same-session coroutines different lock
+        # objects (lost update) — review P1-2. The registry lock is the sole
+        # serializer; no in-engine lock table.
 
     @staticmethod
     def _blocking_error_codes(validation: Dict[str, Any]) -> set:
@@ -163,25 +158,23 @@ class MapSpecLifecycleEngine:
         session_id: str,
         intent: MutationIntent,
     ) -> MapSpecResult:
-        """原子执行 MapSpec 意图变迁，带 per-session 互斥锁 + 事务 rollback。
+        """原子执行 MapSpec 意图变迁，带 per-session 分布式锁 + 事务 rollback。
 
-        双层锁：外层 distributed lock（Redis，跨 pod 互斥；单 worker/测试降级为
-        in-process），内层 asyncio.Lock（同进程内协程序列化）。两层都持有才能
-        避免跨 pod 的同 session 并发 mutation 产生 lost update。
+        锁：session_lock_registry.lock(session_id) — Redis 跨 pod 互斥（生产），
+        in-process asyncio.Lock（单 worker / 测试）。该锁序列化同 session 的并发
+        mutation，避免 lost update。
         """
-        lock = self._get_lock(session_id)
-        # Two independent locks acquired in one async-with (no extra indent):
-        # outer = distributed (Redis, cross-pod; falls back to in-process),
-        # inner = asyncio (in-process coroutine serialization).
-        async with session_lock_registry.lock(session_id), lock:
-            # 事务快照：失败时回滚 mapspec + redis layers 到此刻状态。
-            old_map_state = await session_data_manager.get_map_state(session_id)
-            old_layers = list(old_map_state.get("layers", []) or [])
-
+        async with session_lock_registry.lock(session_id):
+            # 事务快照（deepcopy，避免 in-memory store 的引用别名）：失败时回滚
+            # mapspec + redis layers 到此刻状态。Review P1-1: 此前快照捕获的是
+            # live 引用 + 在 load 之前，导致 rollback 静默 no-op / 半提交残留。
+            pre_state = await session_data_manager.get_map_state(session_id)
+            old_layers_snapshot = copy.deepcopy(pre_state.get("layers", []) or [])
             try:
                 loaded = await self.store.get_mapspec(session_id)
+                old_mapspec_snapshot = copy.deepcopy(loaded) if loaded is not None else None
                 # Deep-copy before mutating: the in-memory session store returns
-                # REFERENCES, so in-place mutation would also mutate the "prior"
+                # REFERENCES, so in-place mutation would also mutate the prior
                 # snapshot (aliasing) and mask newly-introduced blocking errors.
                 # The Redis backend already returns fresh copies; deepcopy is a
                 # no-op-equivalent safety there. prior_mapspec stays un-mutated.
@@ -193,9 +186,10 @@ class MapSpecLifecycleEngine:
                     if loaded is not None else None
                 )
 
-                # 1. 针对未初始化会话自动构建根框架
+                # 1. 针对未初始化会话自动构建根框架（仅内存；commit 阶段才落盘 —
+                #    Review P2-3: 此前在 reject 前就 save_mapspec，reject 会残留骨架）
                 if not mapspec and not isinstance(intent, (InitProjectIntent, RollbackIntent)):
-                    init_res = await self.store.save_mapspec(session_id, {
+                    mapspec = {
                         "version": "1.0",
                         "view": {},
                         "sources": {},
@@ -205,8 +199,8 @@ class MapSpecLifecycleEngine:
                             "controls": [{"type": "navigation", "position": "top-right"}],
                         },
                         "thresholds": {"maxFeatures": 50000, "timeoutMs": 30000},
-                    })
-                    mapspec = copy.deepcopy(init_res["mapspec"])
+                    }
+                    prior_mapspec = None
                     prior_mapspec = None
 
                 # 2. 在内存构建 candidate；记录 deferred redis layer 操作。
@@ -405,7 +399,9 @@ class MapSpecLifecycleEngine:
             except Exception as e:
                 logger.error(f"MapSpec mutation failed for session {session_id}: {e}", exc_info=True)
                 # 事务 rollback：恢复 mapspec + redis layers 到 mutation 前。
-                await self._rollback_to_snapshot(session_id, old_map_state, old_layers)
+                await self._rollback_to_snapshot(
+                    session_id, old_mapspec_snapshot, old_layers_snapshot
+                )
                 return MapSpecResult(
                     is_error=True,
                     error_msg=f"MapSpec 意图更新失败: {e}",
@@ -415,12 +411,17 @@ class MapSpecLifecycleEngine:
     async def _rollback_to_snapshot(
         self,
         session_id: str,
-        old_map_state: Dict[str, Any],
+        old_mapspec: Optional[Dict[str, Any]],
         old_layers: List[Any],
     ) -> None:
-        """恢复 mutation 前的 mapspec + redis layers，避免半提交。"""
+        """恢复 mutation 前的 mapspec + redis layers，避免半提交。
+
+        ``old_mapspec`` / ``old_layers`` are deep-copied snapshots captured at
+        load time (review P1-1): they are independent of the live store state, so
+        restoring them is not a silent no-op even under the in-memory backend's
+        reference aliasing.
+        """
         try:
-            old_mapspec = old_map_state.get("mapspec")
             if old_mapspec is not None:
                 await self.store.save_mapspec(session_id, old_mapspec)
             await session_data_manager.set_map_state(session_id, "layers", old_layers)

--- a/app/services/mapspec/store.py
+++ b/app/services/mapspec/store.py
@@ -2,9 +2,19 @@
 
 负责 MapSpec JSON 文件的持久化、版本 Revision 生成，
 以及 Redis map_state 的底层缓存同步。
+
+可靠性契约（REL-03 / REL-04）：
+- 磁盘写入原子（temp + os.replace），崩溃不会留下半截 mapspec.json。
+- 文件 IO 经 asyncio.to_thread 卸载，不阻塞 event loop（大 inline GeoJSON
+  不再冻结所有 session 的 I/O）。
+- 磁盘与 Redis 双写的顺序：先落盘（durability），再写 Redis（cache）。落盘
+  失败绝不写 Redis，避免 cache 持有磁盘没有的 state。
 """
+import asyncio
 import json
 import logging
+import os
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -38,6 +48,42 @@ def view_has_center(mapspec: Dict[str, Any]) -> bool:
     return "center" in view and center is not None
 
 
+def _atomic_write_json_sync(path: Path, payload: Any) -> None:
+    """同步原子写 JSON：写到同目录临时文件再 os.replace。
+
+    POSIX 下 os.replace 是原子的；崩溃要么看到旧文件、要么看到新文件，
+    不会出现半截写入。临时文件与目标同目录保证 replace 不跨文件系统。
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(payload, ensure_ascii=False, indent=2)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
+        os.replace(tmp_name, str(path))
+    except BaseException:
+        # 清理未替换的临时文件，避免遗留垃圾
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _read_json_sync(path: Path) -> Optional[Any]:
+    """同步读 JSON；文件不存在或损坏返回 None（不抛）。"""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        logger.warning(f"[mapspec] read failed for {path}: {e}")
+        return None
+
+
 class MapSpecStore:
     """MapSpec JSON 文件持久化与 Revision 管理服务"""
 
@@ -52,42 +98,48 @@ class MapSpecStore:
             return map_state["mapspec"]
 
         mapspec_file = self.get_session_dir(session_id) / "mapspec.json"
-        if mapspec_file.exists():
-            try:
-                with open(mapspec_file, "r", encoding="utf-8") as f:
-                    mapspec = json.load(f)
-                    await session_data_manager.set_map_state(session_id, "mapspec", mapspec)
-                    return mapspec
-            except Exception as e:
-                logger.error(f"Error reading mapspec file for session {session_id}: {e}")
+        # 文件读卸载到线程，避免大文件阻塞 event loop。
+        mapspec = await asyncio.to_thread(_read_json_sync, mapspec_file)
+        if mapspec is not None:
+            await session_data_manager.set_map_state(session_id, "mapspec", mapspec)
+            return mapspec
 
         return None
 
     async def save_mapspec(self, session_id: str, mapspec: Dict[str, Any]) -> Dict[str, Any]:
         session_dir = self.get_session_dir(session_id)
         rev_dir = session_dir / "revisions"
-        rev_dir.mkdir(parents=True, exist_ok=True)
-
         mapspec_path = session_dir / "mapspec.json"
 
         # No-op 保护（Phase 8）：若磁盘与 Redis 均已持有相同 spec，跳过全部
         # 三重写入。重复/幂等保存（如快速连续相同意图）因此不产生 IO。
-        if mapspec_path.exists():
-            try:
-                with open(mapspec_path, "r", encoding="utf-8") as f:
-                    if json.load(f) == mapspec:
-                        state = await session_data_manager.get_map_state(session_id)
-                        if state.get("mapspec") == mapspec:
-                            return {"mapspec": mapspec}
-            except Exception as e:
-                logger.warning(f"[mapspec] no-op check failed for {session_id}: {e}")
+        # 磁盘读卸载到线程。
+        disk_current = await asyncio.to_thread(_read_json_sync, mapspec_path)
+        if disk_current == mapspec:
+            state = await session_data_manager.get_map_state(session_id)
+            if state.get("mapspec") == mapspec:
+                return {"mapspec": mapspec}
 
-        with open(mapspec_path, "w", encoding="utf-8") as f:
-            json.dump(mapspec, f, ensure_ascii=False, indent=2)
+        # 原子落盘（mapspec.json + revision 快照 + 裁剪）整体卸载到线程，
+        # 避免大 GeoJSON 的 json.dump 阻塞 event loop。
+        await asyncio.to_thread(
+            self._persist_disk_sync, mapspec_path, rev_dir, mapspec
+        )
 
+        # 落盘成功后再写 Redis cache（顺序契约：cache 不持有磁盘没有的 state）。
+        await session_data_manager.set_map_state(session_id, "mapspec", mapspec)
+        return {"mapspec": mapspec}
+
+    @staticmethod
+    def _persist_disk_sync(
+        mapspec_path: Path, rev_dir: Path, mapspec: Dict[str, Any]
+    ) -> None:
+        """同步：原子写 mapspec.json + 写 revision + 裁剪旧 revision。"""
+        _atomic_write_json_sync(mapspec_path, mapspec)
+
+        rev_dir.mkdir(parents=True, exist_ok=True)
         rev_filename = f"mapspec_rev_{int(time.time() * 1000)}.json"
-        with open(rev_dir / rev_filename, "w", encoding="utf-8") as f:
-            json.dump(mapspec, f, ensure_ascii=False, indent=2)
+        _atomic_write_json_sync(rev_dir / rev_filename, mapspec)
 
         # Revision 保留上限：裁剪到最近 MAPSPEC_REV_RETENTION 份
         # （按文件名时间戳排序，删除最旧）。
@@ -97,10 +149,7 @@ class MapSpecStore:
                 for stale in rev_files[:-MAPSPEC_REV_RETENTION]:
                     stale.unlink(missing_ok=True)
         except OSError as e:
-            logger.warning(f"[mapspec] revision pruning failed for {session_id}: {e}")
-
-        await session_data_manager.set_map_state(session_id, "mapspec", mapspec)
-        return {"mapspec": mapspec}
+            logger.warning(f"[mapspec] revision pruning failed: {e}")
 
 
 mapspec_store_instance = MapSpecStore()

--- a/app/services/mapspec_store.py
+++ b/app/services/mapspec_store.py
@@ -29,6 +29,28 @@ from app.services.mapspec.store import (
 logger = logging.getLogger(__name__)
 
 
+def _with_evidence(res, base: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge real MapSpec-result evidence into an adapter return dict.
+
+    HARNESS-V2 / CARTO-LOOP: the harness MapSpecValidity ladder reads
+    ``is_compiled`` (real validate() outcome) and ``success`` from the recorded
+    tool result. Without this forwarding the harness is starved of evidence and
+    every production run scores 0% validity. Also surfaces ``correction_hint`` /
+    ``message`` on rejection so the agent gets actionable guidance (not a bare
+    failure). Review P1-3 / P2-2.
+    """
+    base["is_compiled"] = res.is_compiled
+    if res.warnings:
+        base["warnings"] = res.warnings
+    if res.checkpoint_id:
+        base["checkpoint_id"] = res.checkpoint_id
+    if res.is_error:
+        base["message"] = res.error_msg
+        if res.correction_hint:
+            base["correction_hint"] = res.correction_hint
+    return base
+
+
 class MapSpecStore:
     """MapSpecStore 兼容 Adapter 代理"""
 
@@ -116,19 +138,19 @@ class MapSpecStore:
                     processed_layer = existing_layer
                     break
 
-        return {
+        return _with_evidence(res, {
             "success": not res.is_error,
             "mapspec": res.mapspec,
             "layer": processed_layer,
-        }
+        })
 
     async def layer_remove(self, session_id: str, layer_id: str) -> Dict[str, Any]:
         res = await self.engine.apply_mutation(session_id, RemoveLayerIntent(layer_id=layer_id))
-        return {
+        return _with_evidence(res, {
             "success": not res.is_error,
             "mapspec": res.mapspec,
             "removed_id": layer_id,
-        }
+        })
 
     async def compile_mapspec_cli(self, session_id: str, out_dir: Optional[Path] = None) -> Dict[str, Any]:
         mapspec = await self.get_mapspec(session_id)
@@ -157,29 +179,29 @@ class MapSpecStore:
         res = await self.engine.apply_mutation(
             session_id, SetLayoutIntent(legend=legend, controls=controls, margins=margins)
         )
-        return {
+        return _with_evidence(res, {
             "success": not res.is_error,
             "layout": res.mapspec.get("layout", {}) if res.mapspec else {},
             "mapspec": res.mapspec,
-        }
+        })
 
     async def checkpoint(self, session_id: str, checkpoint_id: Optional[str] = None) -> Dict[str, Any]:
         res = await self.engine.apply_mutation(session_id, CheckpointIntent(checkpoint_id=checkpoint_id))
-        return {
+        return _with_evidence(res, {
             "success": not res.is_error,
             "checkpoint_id": res.checkpoint_id,
             "ref_count": res.ref_count,
             "summary": f"Checkpoint '{res.checkpoint_id}' created",
-        }
+        })
 
     async def rollback(self, session_id: str, checkpoint_id: str) -> Dict[str, Any]:
         res = await self.engine.apply_mutation(session_id, RollbackIntent(checkpoint_id=checkpoint_id))
-        return {
+        return _with_evidence(res, {
             "success": not res.is_error,
             "checkpoint_id": checkpoint_id,
             "mapspec": res.mapspec,
             "summary": f"Rolled back to checkpoint '{checkpoint_id}'",
-        }
+        })
 
 
 mapspec_store = MapSpecStore()

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -373,11 +373,22 @@ async def execute_plan_async(
             if failure is not None:
                 break
 
-        # 失败 → 取消同波次尚未完成的任务（已完成的兄弟步骤保留结果）
-        for t in pending:
-            t.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        # 失败处理：按本函数契约（见 docstring / line 252），同波次已 dispatch 的
+        # 兄弟步骤应跑到完成、其成功结果计入 executed；"立即中止"指不再启动 *新波次*。
+        # 此前这里 cancel 了 pending 兄弟，在较慢的 runner 上 s2 快速失败会 race 掉
+        # 即将完成的 s1，导致 flaky executed=[]（master CI 间歇性失败）。
+        if failure is not None and pending:
+            done_siblings, _ = await asyncio.wait(pending)  # 不 cancel，让兄弟完成
+            for t in done_siblings:
+                sid_sib = task_to_sid.get(t)
+                if sid_sib is None:
+                    continue
+                try:
+                    r_sib = t.result()
+                except Exception:
+                    continue  # 兄弟也失败；已记录首个 failure，忽略
+                if isinstance(r_sib, dict) and r_sib.get("success") is not False:
+                    wave_successes[sid_sib] = r_sib
 
         # 按拓扑序提交成功结果（确定性）
         for sid in wave:

--- a/app/services/spatial_decision/mapspec_integration.py
+++ b/app/services/spatial_decision/mapspec_integration.py
@@ -45,7 +45,7 @@ async def apply_decision_to_mapspec(
     # 2. Ingest Simulation GeoJSON Layer
     layer_id = f"sim_layer_{result.decision_id}"
     layer_title = f"{result.scenario.name} - 空间影响图层"
-    
+
     # Thematic style method: color by zone (direct vs indirect)
     style_spec = {
         "color": {
@@ -66,6 +66,11 @@ async def apply_decision_to_mapspec(
         "id": layer_id,
         "name": layer_title,
         "type": "polygon",
+        # The layer must reference its source explicitly. process_layer_ingestion
+        # creates sources[layer.source] from source_data; without a source ref the
+        # structural validator flags INVALID_SOURCE_REF and the transaction rejects
+        # the mutation (previously warn-and-saved an invalid spec).
+        "source": layer_id,
         "style": style_spec,
     }
 
@@ -116,6 +121,8 @@ async def apply_comparison_to_mapspec(
         "id": layer_id,
         "name": layer_title,
         "type": "polygon",
+        # See apply_decision_to_mapspec: source must reference the ingested source.
+        "source": layer_id,
         "style": style_spec,
     }
 

--- a/app/services/tool_metrics.py
+++ b/app/services/tool_metrics.py
@@ -198,15 +198,27 @@ def record_tool_call(
     cache_hit: bool,
     error: Optional[str],
     session_id: Optional[str],
+    tool_call_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    turn_id: Optional[str] = None,
     requested_execution_policy: Optional[str] = None,
     actual_execution_mode: Optional[str] = None,
     compute_ms: Optional[int] = None,
     queue_wait_ms: Optional[int] = None,
 ) -> None:
-    """落一行 JSONL（入队，异步落盘）+ 更新聚合器。失败不抛。"""
+    """落一行 JSONL（入队，异步落盘）+ 更新聚合器。失败不抛。
+
+    Correlation fields (tool_call_id / run_id / turn_id) tie a tool call across
+    the harness evidence trail, this metrics log, and MapSpec/runtime evidence,
+    so a single map's full chain (tool → ref → mapspec revision → checkpoint →
+    compile → runtime) is reconstructable from logs (OBSERVABILITY-V2).
+    """
     row = {
         "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
         "tool": tool,
+        "tool_call_id": tool_call_id,
+        "run_id": run_id,
+        "turn_id": turn_id,
         "session_id": session_id,
         "arg_bytes": arg_bytes,
         "result_bytes": result_bytes,
@@ -237,6 +249,7 @@ def record_event(event: ToolCallEvent) -> None:
         cache_hit=event.cache_hit,
         error=event.error_msg if event.is_error else None,
         session_id=event.session_id,
+        tool_call_id=event.tool_call_id,
     )
 
 

--- a/docs/adr/0051-harness-evaluation-v2-and-multi-worker.md
+++ b/docs/adr/0051-harness-evaluation-v2-and-multi-worker.md
@@ -1,0 +1,113 @@
+# 0051. Harness Evaluation V2 + MapSpec Reliability + Multi-Worker Decision
+
+**Date:** 2026-08-11
+**Status:** Accepted
+
+## Context
+
+The Performance & Reliability Convergence V2 + Harness–Cartography Closed Loop
+audit found four classes of false-success / reliability defects:
+
+1. **Harness "didn't-error = success".** `MapSpecValidity` equated a mutation
+   that returned without error with a valid MapSpec; `CursorResolutionRate` was
+   a tautological ref-prefix check (the real ref format `ref:<type>-<id>` never
+   matched the legacy colon pattern, so the rate was *structurally always 100*).
+   The harness was a long-lived global accumulator with no run/session/turn
+   correlation.
+2. **MapSpec validation was non-gating.** `apply_mutation` warn-and-save-always:
+   invalid MapSpecs persisted to disk + Redis; no transaction / rollback; eager
+   Redis layer write could half-commit; file IO was non-atomic; checkpoints
+   re-copied every ref on every snapshot (write amplification).
+3. **`process_layer_ingestion` blocked the event loop** (the sibling
+   `source_profile` path was offloaded; the hot upsert path was not).
+4. **Multi-worker assumption violated.** ADR-0006 assumes single-uvicorn-per-pod,
+   but `deploy/k8s` runs `replicas: 2` + HPA `minReplicas: 2, maxReplicas: 10`.
+   Per-process state (`_session_executed_sets`, `_dispatch_result_cache`,
+   `_harness`, per-session `asyncio.Lock` tables, disk MapSpec writes) is not
+   cross-pod safe.
+
+## Decisions
+
+### 1. Harness Evaluation V2 (evidence-driven, no false success)
+
+- `MapSpecValidity` is a **tiered ladder** from real evidence:
+  `NOT_EVALUATED → MUTATION_REJECTED → MUTATION_ACCEPTED → SEMANTIC_VALID →
+  COMPILE_VALID → RUNTIME_VALID`. "Didn't error" is only `MUTATION_ACCEPTED`,
+  not valid. `is_compiled` (the real `validate()` outcome from the lifecycle
+  engine) lifts a mutation to `SEMANTIC_VALID`. Missing evidence = 0.0, never
+  100.0.
+- `CursorResolutionRate` resolves refs against the real `SessionStore`
+  (`ref_resolver.make_session_store_resolver`): exists + session-scoped +
+  typed-prefix match. Cross-session / nonexistent refs do not count. Fixed the
+  ref-pattern to the real `ref:<type>-<id>` dash format.
+- Every evidence record carries `run_id / session_id / turn_id / tool_call_id /
+  mapspec_revision / checkpoint_id / compile / runtime` correlation — no
+  cross-session pool.
+- `evaluate_evidence()` gate policy: a dimension with no evidence **fails**
+  (`require_evaluated=True`), or is exempted when legitimately N/A.
+- Legacy float surface (`compute_*`, `evaluate_all`, `get_telemetry_summary`)
+  preserved for existing consumers, now computed from real evidence.
+
+### 2. MapSpec transaction semantics + atomic IO + dedup
+
+- `apply_mutation`: build candidate → semantic-validate → **reject mutations
+  that introduce NEW blocking errors** (`INVALID_SOURCE_REF`, `INVALID_STOPS_COUNT`,
+  `NON_INCREASING_STOPS`) → checkpoint → `save_mapspec` → sync Redis layers, with
+  rollback-to-snapshot on any failure. No half-commit.
+- `process_layer_ingestion`, `deepcopy`, content-hash, and disk IO all run via
+  `asyncio.to_thread` — no event-loop blocking (measured 50k-feature upsert lag
+  ≈ 59 ms vs ≈ 300 ms if on-loop).
+- Atomic writes (`tempfile` + `os.replace`); disk-before-Redis order.
+- Checkpoint **content-addressed ref blobs** + **whole-checkpoint hash dedup**
+  for auto checkpoints. A second identical checkpoint writes 0 new bytes.
+  Explicit checkpoint ids always materialize (rollback-by-name contract).
+- Validator fix: `INVALID_STOPS_COUNT` is method-aware (`interpolate` ≥2,
+  `step` ≥1) — a single-threshold step + default is valid MapLibre (the analysis
+  converter emits exactly this).
+
+### 3. Cartography closed loop (deterministic semantic checks)
+
+- `app/lib/cartography/semantic_checks.py` connects GIS profile ↔ MapSpec:
+  `SOURCE_LAYER_REF` / `EMPTY_DATA` (errors), `GEOMETRY_LAYER_TYPE` /
+  `STOPS_DATA_RANGE` / `INTERPOLATE_NUMERIC_FIELD` / `LEGEND_FIELD_CONSISTENCY`
+  (warnings). Missing profile → `not_evaluated`, never a fake pass.
+- Empty-data (zero features) is an error, not a silent map success.
+
+### 4. Multi-worker decision
+
+The architecture is **single-process-per-pod by design** (Pi subprocess
+ownership + localhost HTTP callback — ADR-0006). Multi-pod HA therefore
+requires **session affinity (sticky routing)** so a session's requests reach one
+pod. This ADR does **not** change that invariant; instead it adds defense-in-depth:
+
+- **MapSpec mutations** take a Redis-backed distributed per-session lock
+  (`app/services/distributed_lock.py`), so even without sticky routing two pods
+  cannot concurrently mutate the same session's MapSpec (no lost update). Falls
+  back to an in-process `asyncio.Lock` when Redis is unavailable (single-worker /
+  tests). TTL + token-checked release + best-effort renewal.
+- **Pi path** remains per-pod-safe (localhost callback) — no change.
+- **Deployment guidance**: for HA without sticky routing, keep `replicas` low and
+  rely on the Redis lock; the Pi subprocess per pod caps horizontal scale anyway.
+
+## Consequences
+
+- Positive: invalid MapSpecs can no longer reach "valid" status; refs must really
+  resolve; concurrent same-session mutations serialize; checkpoints no longer
+  amplify writes; event loop stays responsive during large upserts.
+- Negative: a mutation that previously warn-and-saved an invalid MapSpec now
+  **fails fast** (the intended behavior). Callers that relied on invalid specs
+  being silently persisted must handle the `is_error` result.
+- The Redis lock adds one network round-trip per mutation when Redis is reachable.
+- Cross-pod correctness for the (non-Pi) legacy ChatEngine per-process state is
+  still bounded by the single-process-per-pod + sticky-routing invariant; a full
+  Redis move of `_session_executed_sets` / `_dispatch_result_cache` is deferred.
+
+## Evidence
+
+- `tests/cartography/` (@cartography, 19 tests): transaction rejection, real ref
+  resolution (resolved / not-found / wrong-session / type-mismatch), validity
+  ladder via the real engine, semantic checks, fault injection (save failure →
+  rollback), checkpoint dedup, gate policy, concurrency.
+- `tests/benchmarks/test_perf_mapspec_e2e.py` (@perf): 50k-feature upsert
+  event-loop lag 58.93 ms; checkpoint dedup 2nd-write 0 B; scaling 1k/10k/50k.
+- Full unit + cartography suite: 1100+ pass, no regression vs the 1076 baseline.

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,3 +21,4 @@ filterwarnings =
 markers =
     heavy: tests that need heavy deps (geopandas/numpy/rasterio). CI runs them; tests needing Node/Playwright self-skip.
     perf: deterministic performance regression harness (tests/benchmarks/test_perf_harness.py). Run with -m perf; refresh baselines with PERF_UPDATE_BASELINES=1.
+    cartography: deterministic release-blocking cartography & harness closed-loop gate (MapSpec transactions, ref resolution, validity evidence ladder, cartographic semantic checks, fault-injection subset). No Node/Chromium/LLM/network. Run with -m cartography.

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,11 @@ redis>=5.0.0,<6.0.0
 # 之前漏列导致 CI 装 sqlalchemy 但没有 driver -> ModuleNotFoundError。
 aiosqlite>=0.19.0
 asyncpg>=0.29.0
+# 同步 Postgres 驱动：app/core/database.py:11 get_engine() 用同步 create_engine
+# 连 postgresql:// URL，SQLAlchemy 默认选 psycopg2 驱动；生产镜像此前漏装导致
+# API 容器启动 ModuleNotFoundError: No module named 'psycopg2'（preview 栈 502）。
+# psycopg2-binary 是生产/CI 的二进制 wheel（无需 pg_config 编译）。
+psycopg2-binary>=2.9.9
 matplotlib>=3.8.0
 
 # RAG & Vector Search

--- a/tests/benchmarks/test_perf_mapspec_e2e.py
+++ b/tests/benchmarks/test_perf_mapspec_e2e.py
@@ -1,0 +1,189 @@
+"""End-to-end MapSpec performance benchmarks (@pytest.mark.perf).
+
+Deterministic, no network/LLM. Provides measured evidence for the acceptance
+criteria:
+- process_layer_ingestion offload: a large inline-GeoJSON upsert must NOT block
+  the event loop (max lag bounded). Proves the asyncio.to_thread offload.
+- MapSpec upsert scaling at 1k / 10k / 50k features (median latency recorded).
+- Checkpoint content-addressed dedup: a repeated unchanged checkpoint writes
+  ~zero new bytes (no write amplification for identical refs).
+"""
+import asyncio
+import shutil
+import statistics
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from app.services.mapspec.checkpoint import snapshot
+from app.services.mapspec.lifecycle_engine import (
+    InitProjectIntent,
+    MapSpecLifecycleEngine,
+    UpsertLayerIntent,
+)
+from app.services.mapspec.store import BASE_STORAGE_DIR, MapSpecStore
+from app.services.session_data import session_data_manager
+
+
+def _features(n: int):
+    return [
+        {"type": "Feature",
+         "geometry": {"type": "Point", "coordinates": [i % 180, i % 90]},
+         "properties": {"v": i, "cat": str(i % 5)}}
+        for i in range(n)
+    ]
+
+
+class _LagMonitor:
+    """Minimal event-loop lag monitor (10ms tick)."""
+
+    def __init__(self, interval=0.01):
+        self.interval = interval
+        self.lags = []
+        self._running = False
+        self._task = None
+
+    async def _ticker(self):
+        while self._running:
+            t0 = time.perf_counter()
+            await asyncio.sleep(self.interval)
+            self.lags.append(max(0.0, (time.perf_counter() - t0 - self.interval) * 1000.0))
+
+    def start(self):
+        self.lags.clear()
+        self._running = True
+        self._task = asyncio.create_task(self._ticker())
+
+    async def stop(self):
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        if not self.lags:
+            return 0.0
+        return round(max(self.lags), 2)
+
+
+def _dir_bytes(p: Path) -> int:
+    if not p.exists():
+        return 0
+    return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+
+
+@pytest.fixture
+async def bench_session():
+    sid = f"perf-mapspec-{uuid.uuid4().hex[:8]}"
+    await session_data_manager.clear_session(sid)
+    yield sid
+    await session_data_manager.clear_session(sid)
+    d = BASE_STORAGE_DIR / sid
+    if d.exists():
+        shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+async def test_layer_upsert_does_not_block_event_loop(bench_session):
+    """REL-07 regression guard: a 50k-feature inline GeoJSON upsert must run with
+    bounded event-loop lag (process_layer_ingestion offloaded to a thread)."""
+    engine = MapSpecLifecycleEngine()
+    await engine.apply_mutation(bench_session, InitProjectIntent())
+
+    geojson = {"type": "FeatureCollection", "features": _features(50_000)}
+    layer = {"id": "big", "source": "s", "type": "circle", "paint": {"circle-color": "#f00"}}
+
+    monitor = _LagMonitor()
+    monitor.start()
+    res = await engine.apply_mutation(
+        bench_session, UpsertLayerIntent(layer=layer, source_data=geojson)
+    )
+    max_lag = await monitor.stop()
+
+    assert not res.is_error, f"upsert failed: {res.error_msg}"
+    # The per-feature profiling (the dominant O(n) cost) runs off-loop via
+    # asyncio.to_thread — that is the REL-07 fix this gate guards. Measured
+    # residual lag at 50k features: ~56-69ms (serialization + asyncio scheduling
+    # that remains on-loop). If the offload were removed, the 50k-feature
+    # profiling would run on-loop and lag would spike to ~300ms (≈ the full
+    # upsert latency). The 100ms threshold catches that regression with margin
+    # over the measured residual, without masking a race/deadlock.
+    assert max_lag < 100.0, (
+        f"event loop blocked during upsert: max_lag={max_lag}ms "
+        f"(offload likely regressed; expected <100ms at 50k features)"
+    )
+    print(f"\n[layer-upsert-eventloop-lag-ms] 50k_features={max_lag}")
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+async def test_mapspec_upsert_scaling_recorded(bench_session):
+    """Record median upsert latency at 1k / 10k / 50k features (informational +
+    regression floor). Not a hard threshold; values are printed for the report."""
+    engine = MapSpecLifecycleEngine()
+    await engine.apply_mutation(bench_session, InitProjectIntent())
+    results = {}
+    for n in (1_000, 10_000, 50_000):
+        geojson = {"type": "FeatureCollection", "features": _features(n)}
+        layer = {"id": f"L{n}", "source": f"s{n}", "type": "circle", "paint": {"circle-color": "#00f"}}
+        samples = []
+        for _ in range(3):
+            sid = f"{bench_session}-scale-{n}-{uuid.uuid4().hex[:4]}"
+            await session_data_manager.clear_session(sid)
+            eng = MapSpecLifecycleEngine()
+            await eng.apply_mutation(sid, InitProjectIntent())
+            t0 = time.perf_counter()
+            r = await eng.apply_mutation(sid, UpsertLayerIntent(layer={**layer, "id": f"L{n}"}, source_data=geojson))
+            samples.append((time.perf_counter() - t0) * 1000.0)
+            assert not r.is_error
+            await session_data_manager.clear_session(sid)
+            sd = BASE_STORAGE_DIR / sid
+            if sd.exists():
+                shutil.rmtree(sd, ignore_errors=True)
+        results[n] = round(statistics.median(samples), 2)
+    # Print for the benchmark report (captured by pytest -s in the gate).
+    print(f"\n[mapspec-upsert-median-ms] {results}")
+    # Sanity floor: 50k must complete in a reasonable window (not a hard regression
+    # gate, just guards against catastrophic O(n^2) regressions).
+    assert results[50_000] < 60_000.0
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+async def test_checkpoint_dedup_no_write_amplification(bench_session):
+    """A repeated identical auto-checkpoint must write ~zero new bytes (content-
+    addressed ref blobs + whole-checkpoint dedup). Proves the REL-05 fix."""
+    # Store a sizable ref, build a mapspec referencing it, checkpoint twice.
+    big_payload = {"type": "FeatureCollection", "features": _features(5_000)}
+    ref_id = await session_data_manager.store(bench_session, big_payload, prefix="geojson")
+    mapspec = {
+        "version": "1.0", "view": {},
+        "sources": {"s1": {"type": "geojson", "url": ref_id}},
+        "layers": [{"id": "L", "source": "s1", "type": "circle"}],
+        "layout": {},
+    }
+    store = MapSpecStore()
+    sd = store.get_session_dir(bench_session)
+    ckpt_root = sd / "checkpoints"
+
+    r1 = await snapshot(mapspec, sd, session_data_manager, None)  # auto id
+    assert r1.get("success") is True
+    bytes_after_first = _dir_bytes(ckpt_root)
+    assert bytes_after_first > 0, "first checkpoint must write payload"
+
+    r2 = await snapshot(mapspec, sd, session_data_manager, None)  # identical
+    bytes_after_second = _dir_bytes(ckpt_root)
+    delta = bytes_after_second - bytes_after_first
+
+    assert r2.get("deduplicated") is True
+    # Second identical checkpoint must add only a tiny manifest entry, NOT a full
+    # payload copy. Allow a small budget for the manifest map entry.
+    assert delta < 4096, (
+        f"write amplification: second identical checkpoint added {delta} bytes "
+        f"(first={bytes_after_first}, second={bytes_after_second})"
+    )
+    print(f"\n[checkpoint-dedup] first={bytes_after_first}B second_delta={delta}B")

--- a/tests/cartography/test_cartography_closed_loop.py
+++ b/tests/cartography/test_cartography_closed_loop.py
@@ -313,6 +313,73 @@ async def test_save_failure_triggers_rollback(clean_session):
 
 @pytest.mark.cartography
 @pytest.mark.asyncio
+async def test_post_save_failure_rolls_back_mutation(clean_session):
+    """Regression for review P1-1: a failure AFTER save_mapspec succeeds (e.g.
+    update_layer_in_state raises) must roll the mapspec back to pre-mutation
+    state. Previously the rollback snapshot aliased the live store, so restoring
+    was a silent no-op and the half-commit survived."""
+    engine = MapSpecLifecycleEngine()
+    await engine.apply_mutation(clean_session, InitProjectIntent())
+    # Establish a known-good baseline with one valid layer.
+    await engine.apply_mutation(
+        clean_session,
+        UpsertLayerIntent(layer={"id": "base", "source": "sb", "type": "circle",
+                                 "paint": {"circle-color": "#000"}},
+                          source_data=_geojson([
+                              {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]},
+                               "properties": {}}]))
+    )
+    baseline = await mapspec_store_instance.get_mapspec(clean_session)
+    assert any(lyr["id"] == "base" for lyr in baseline["layers"])
+
+    # Now mutate again; save succeeds, but the post-save redis-layers sync fails.
+    with patch.object(
+        session_data_manager, "update_layer_in_state",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        res = await engine.apply_mutation(
+            clean_session,
+            UpsertLayerIntent(layer={"id": "extra", "source": "se", "type": "circle",
+                                     "paint": {"circle-color": "#fff"}},
+                              source_data=_geojson())
+        )
+    assert res.is_error is True
+    # The "extra" layer must NOT have survived (rollback restored the baseline).
+    after = await mapspec_store_instance.get_mapspec(clean_session)
+    ids = {lyr["id"] for lyr in after["layers"]}
+    assert "base" in ids
+    assert "extra" not in ids, "post-save failure must roll back, not half-commit"
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_validity_evidence_flows_through_adapter(clean_session):
+    """Regression for review P1-3: the MapSpecStore adapter (and thus the
+    production dispatch path) must carry real is_compiled evidence so the harness
+    MapSpecValidity ladder isn't starved (every run scoring 0%)."""
+    from app.services.mapspec_store import mapspec_store
+
+    res = await mapspec_store.layer_upsert(
+        clean_session,
+        layer={"id": "L", "source": "s", "type": "circle", "paint": {"circle-color": "#0f0"}},
+        source_data=_geojson([
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]},
+             "properties": {}}
+        ]),
+    )
+    # The adapter must forward real evidence, not just success/mapspec/layer.
+    assert res["success"] is True
+    assert res["is_compiled"] is True, "adapter must forward is_compiled evidence"
+
+    # And the harness, fed the adapter shape (not res.to_dict()), scores validity.
+    harness = PiAgentHarness(session_id=clean_session)
+    harness.record_tool_call("c1", "webgis_layer_upsert", {"layer": {"id": "L"}})
+    harness.record_tool_result("c1", "webgis_layer_upsert", res)
+    assert harness.compute_mapspec_validity() == 100.0
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
 async def test_checkpoint_dedup_no_write_amplification(clean_session):
     """Repeated unchanged auto-checkpoints must not rewrite identical payloads.
     Two identical upserts → the second checkpoint dedups."""

--- a/tests/cartography/test_cartography_closed_loop.py
+++ b/tests/cartography/test_cartography_closed_loop.py
@@ -1,0 +1,354 @@
+"""Cartography & Harness closed-loop gate tests (@pytest.mark.cartography).
+
+Deterministic, release-blocking, no Node/Chromium/LLM/network. Exercises the
+REAL closed loop: GIS ref → MapSpec mutation → semantic validation → transaction
+semantics → ref resolution → cartographic semantic checks → fault injection.
+
+These are the tests the ``cartography-smoke`` CI gate runs (``pytest -m cartography``).
+"""
+import shutil
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.lib.cartography.semantic_checks import evaluate_cartography_semantics
+from app.lib.harness.evaluator import HarnessEvaluator
+from app.lib.harness.pi_agent_harness import PiAgentHarness
+from app.lib.harness.ref_resolver import make_session_store_resolver
+from app.services.mapspec.lifecycle_engine import (
+    InitProjectIntent,
+    MapSpecLifecycleEngine,
+    UpsertLayerIntent,
+)
+from app.services.mapspec.store import BASE_STORAGE_DIR, mapspec_store_instance
+from app.services.session_data import session_data_manager
+
+
+@pytest.fixture
+async def clean_session():
+    sid = f"cart-session-{uuid.uuid4().hex[:8]}"
+    await session_data_manager.clear_session(sid)
+    yield sid
+    await session_data_manager.clear_session(sid)
+    session_dir = BASE_STORAGE_DIR / sid
+    if session_dir.exists():
+        shutil.rmtree(session_dir, ignore_errors=True)
+
+
+def _geojson(features=None):
+    return {"type": "FeatureCollection", "features": features or []}
+
+
+# ── 1. MapSpec transaction: invalid mutation rejected, last-known-good kept ─
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_invalid_stops_mutation_rejected_last_known_good_preserved(clean_session):
+    """A mutation introducing NON_INCREASING_STOPS must be rejected; the
+    previously-saved valid MapSpec must remain intact on disk + Redis."""
+    engine = MapSpecLifecycleEngine()
+    # Establish a valid baseline: a project + a valid layer.
+    await engine.apply_mutation(clean_session, InitProjectIntent(view={"center": [0, 0], "zoom": 2}))
+    good_layer = {
+        "id": "good", "source": "src-good", "type": "circle",
+        "paint": {"circle-color": "#ff0000"},
+    }
+    ok = await engine.apply_mutation(
+        clean_session, UpsertLayerIntent(layer=good_layer, source_data=_geojson([
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]},
+             "properties": {"v": 1}},
+        ]))
+    )
+    assert ok.is_error is False
+    baseline = await mapspec_store_instance.get_mapspec(clean_session)
+    assert any(lyr["id"] == "good" for lyr in baseline["layers"])
+
+    # Now attempt a mutation that INTRODUCES a blocking error: non-increasing stops.
+    bad_layer = {
+        "id": "bad", "source": "src-bad", "type": "circle",
+        "paint": {"circle-color": {"method": "interpolate", "field": "v", "stops": [
+            [10, "#fff"], [5, "#000"]  # non-increasing
+        ]}},
+    }
+    bad = await engine.apply_mutation(
+        clean_session, UpsertLayerIntent(layer=bad_layer, source_data=_geojson())
+    )
+    assert bad.is_error is True, "non-increasing-stops mutation must be rejected"
+
+    # last-known-good preserved: bad layer never landed.
+    after = await mapspec_store_instance.get_mapspec(clean_session)
+    layer_ids = [lyr["id"] for lyr in after["layers"]]
+    assert "good" in layer_ids
+    assert "bad" not in layer_ids
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_invalid_source_ref_mutation_rejected(clean_session):
+    """Direct structural defect: a layer referencing a source that doesn't exist.
+    We bypass upsert's auto-source-creation by writing the mapspec directly then
+    validating that a subsequent bad mutation is rejected."""
+    engine = MapSpecLifecycleEngine()
+    await engine.apply_mutation(clean_session, InitProjectIntent(view={"center": [0, 0], "zoom": 2}))
+    # Manually persist a mapspec with a layer pointing at a missing source, via the
+    # engine's store, then prove the engine's own guard treats it as blocking on
+    # the next structural mutation that would preserve it.
+    store = mapspec_store_instance
+    bad_spec = {
+        "version": "1.0", "view": {"center": [0, 0], "zoom": 2},
+        "sources": {"src-a": {"type": "geojson"}},
+        "layers": [{"id": "L", "source": "src-MISSING", "type": "circle"}],
+        "layout": {},
+    }
+    await store.save_mapspec(clean_session, bad_spec)
+    # A SetView mutation should be REJECTED because the pre-existing mapspec already
+    # has the blocking INVALID_SOURCE_REF error — but per policy we reject only NEW
+    # errors. SetView introduces no new blocking error, so it is allowed (it doesn't
+    # make things worse). Instead, test the rejection path by introducing a NEW bad
+    # layer via a raw candidate check.
+    from app.services.mapspec.coordinator import validate
+    res = validate(bad_spec)
+    codes = {e["code"] for e in res["errors"]}
+    assert "INVALID_SOURCE_REF" in codes
+
+
+# ── 2. ref resolution V2: real SessionStore, session-scoped ──────────────
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_ref_resolution_resolved_notfound_session_scoped(clean_session):
+    """Real SessionStore resolution: existing ref resolves; missing ref does not;
+    a ref stored in session A does not resolve from session B."""
+    other = f"cart-other-{uuid.uuid4().hex[:8]}"
+    await session_data_manager.clear_session(other)
+    try:
+        ref_id = await session_data_manager.store(
+            clean_session, _geojson([
+                {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]},
+                 "properties": {}}
+            ]),
+            prefix="geojson",
+        )
+        resolver = make_session_store_resolver(session_data_manager)
+
+        r_ok = await resolver(clean_session, ref_id)
+        assert r_ok.is_resolved, f"existing ref must resolve, got {r_ok.status}"
+
+        r_missing = await resolver(clean_session, "ref:geojson:does-not-exist")
+        assert not r_missing.is_resolved
+
+        # Cross-session: ref owned by clean_session must NOT resolve from `other`.
+        r_cross = await resolver(other, ref_id)
+        assert not r_cross.is_resolved, "ref must not leak across sessions"
+    finally:
+        await session_data_manager.clear_session(other)
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_ref_resolution_type_mismatch(clean_session):
+    """A ref whose payload type contradicts its typed prefix is TYPE_MISMATCH.
+    Store a FeatureCollection under the 'raster' prefix → ref:raster-<id> with a
+    geojson payload → resolver flags the contradiction."""
+    ref_id = await session_data_manager.store(
+        clean_session, _geojson(), prefix="raster",
+    )
+    assert ref_id.startswith("ref:raster-"), ref_id
+    resolver = make_session_store_resolver(session_data_manager)
+    r = await resolver(clean_session, ref_id)
+    assert not r.is_resolved
+    assert r.status.value == "type_mismatch", r.status
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_harness_cursor_rate_reflects_real_resolution(clean_session):
+    """End-to-end: harness CursorResolutionRate reflects real SessionStore state,
+    not ref-string prefixes. A nonexistent ref must NOT score as resolved."""
+    harness = PiAgentHarness(
+        session_id=clean_session,
+        ref_resolver=make_session_store_resolver(session_data_manager),
+    )
+    harness.record_tool_call("c1", "st_dbscan", {"data": "ref:geojson:ghost"})
+    harness.record_tool_result("c1", "st_dbscan", {"success": True})
+    await harness.evaluate_with_evidence(expected_tools=["st_dbscan"], ideal_step_count=1)
+    assert harness.compute_cursor_resolution_rate() == 0.0
+
+
+# ── 3. MapSpecValidity ladder via the real engine ────────────────────────
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_validity_ladder_semantic_valid_via_real_engine(clean_session):
+    """A successful real UpsertLayer yields is_compiled=True → harness records the
+    mutation as SEMANTIC_VALID (not merely mutation_accepted)."""
+    engine = MapSpecLifecycleEngine()
+    await engine.apply_mutation(clean_session, InitProjectIntent())
+    layer = {"id": "L1", "source": "s1", "type": "circle", "paint": {"circle-color": "#00f"}}
+    res = await engine.apply_mutation(
+        clean_session, UpsertLayerIntent(layer=layer, source_data=_geojson([
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]},
+             "properties": {}}
+        ]))
+    )
+    result_dict = res.to_dict()
+    assert result_dict["is_compiled"] is True, "a valid upsert must compile-validate"
+
+    harness = PiAgentHarness(session_id=clean_session)
+    harness.record_tool_call("c1", "webgis_layer_upsert", {"layer": layer})
+    harness.record_tool_result("c1", "webgis_layer_upsert", result_dict)
+    assert harness.compute_mapspec_validity() == 100.0
+
+
+# ── 4. Deterministic cartographic semantic checks ────────────────────────
+
+
+@pytest.mark.cartography
+def test_semantic_check_missing_paint_field():
+    mapspec = {
+        "sources": {"s1": {}},
+        "layers": [{
+            "id": "L", "source": "s1", "type": "circle",
+            "paint": {"circle-color": {"method": "interpolate", "field": "nofield", "stops": [
+                [0, "#fff"], [10, "#000"]]}},
+        }],
+    }
+    profiles = {"s1": {"featureCount": 5, "geometryTypes": ["Point"],
+                       "fields": {"v": {"type": "number", "min": 0, "max": 10}}}}
+    report = evaluate_cartography_semantics(mapspec, profiles)
+    codes = {f.check for f in report.findings if f.evaluated}
+    assert "PAINT_FIELD_EXISTS" in codes
+    assert not report.ok  # error-severity finding
+
+
+@pytest.mark.cartography
+def test_semantic_check_empty_data_is_error_not_success():
+    mapspec = {"sources": {"s1": {}}, "layers": [{"id": "L", "source": "s1", "type": "circle"}]}
+    profiles = {"s1": {"featureCount": 0, "geometryTypes": [], "fields": {}}}
+    report = evaluate_cartography_semantics(mapspec, profiles)
+    codes = {f.check for f in report.findings if f.evaluated}
+    assert "EMPTY_DATA" in codes
+    assert not report.ok
+
+
+@pytest.mark.cartography
+def test_semantic_check_stops_data_range_and_geom_mismatch():
+    mapspec = {
+        "sources": {"s1": {}},
+        "layers": [{
+            "id": "L", "source": "s1", "type": "fill",  # fill but data is Point
+            "paint": {"fill-color": {"method": "step", "field": "v", "stops": [
+                [100, "#fff"], [200, "#000"]]}},  # stops far outside data [0,10]
+        }],
+    }
+    profiles = {"s1": {"featureCount": 3, "geometryTypes": ["Point"],
+                       "fields": {"v": {"type": "number", "min": 0, "max": 10}}}}
+    report = evaluate_cartography_semantics(mapspec, profiles)
+    codes = {f.check for f in report.findings if f.evaluated}
+    assert "GEOMETRY_LAYER_TYPE" in codes
+    assert "STOPS_DATA_RANGE" in codes
+
+
+@pytest.mark.cartography
+def test_semantic_check_clean_mapspec_passes():
+    mapspec = {
+        "sources": {"s1": {}},
+        "layers": [{
+            "id": "L", "source": "s1", "type": "circle",
+            "paint": {"circle-color": {"method": "interpolate", "field": "v", "stops": [
+                [0, "#fff"], [10, "#000"]]}},
+        }],
+        "layout": {"legend": {"field": "v"}},
+    }
+    profiles = {"s1": {"featureCount": 5, "geometryTypes": ["Point"],
+                       "fields": {"v": {"type": "number", "min": 0, "max": 10}}}}
+    report = evaluate_cartography_semantics(mapspec, profiles)
+    assert report.ok, f"expected clean mapspec, got: {[f.to_dict() if hasattr(f,'to_dict') else f for f in report.findings]}"
+
+
+@pytest.mark.cartography
+def test_semantic_check_missing_profile_is_not_evaluated_not_fake_pass():
+    """When no profile is available, field checks are 'not_evaluated' (info),
+    never a fake pass. But structural SOURCE_LAYER_REF still errors."""
+    mapspec = {"sources": {"s1": {}},
+               "layers": [{"id": "L", "source": "s1", "type": "circle",
+                           "paint": {"circle-color": {"method": "interpolate", "field": "v", "stops": [[0, "#fff"], [1, "#000"]]}}}]}
+    report = evaluate_cartography_semantics(mapspec, source_profiles={})  # no profile
+    not_eval = [f for f in report.findings if not f.evaluated]
+    assert any(f.check == "PAINT_FIELD_EXISTS" for f in not_eval)
+    # No fake PAINT_FIELD_EXISTS error without a profile.
+    assert not any(f.check == "PAINT_FIELD_EXISTS" and f.severity == "error" for f in report.findings)
+
+
+# ── 5. Fault injection: failure must not produce false success ───────────
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_save_failure_triggers_rollback(clean_session):
+    """If save_mapspec raises after the engine has built a candidate, the
+    transaction must roll back and report is_error — never a silent success."""
+    engine = MapSpecLifecycleEngine()
+    await engine.apply_mutation(clean_session, InitProjectIntent())
+    original = await mapspec_store_instance.get_mapspec(clean_session)
+
+    with patch.object(
+        mapspec_store_instance, "save_mapspec", new=AsyncMock(side_effect=RuntimeError("disk full"))
+    ):
+        res = await engine.apply_mutation(
+            clean_session, UpsertLayerIntent(
+                layer={"id": "Lx", "source": "sx", "type": "circle"},
+                source_data=_geojson(),
+            )
+        )
+    assert res.is_error is True
+    # last-known-good intact
+    after = await mapspec_store_instance.get_mapspec(clean_session)
+    assert after == original
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_checkpoint_dedup_no_write_amplification(clean_session):
+    """Repeated unchanged auto-checkpoints must not rewrite identical payloads.
+    Two identical upserts → the second checkpoint dedups."""
+    engine = MapSpecLifecycleEngine()
+    await engine.apply_mutation(clean_session, InitProjectIntent())
+    layer = {"id": "L", "source": "s", "type": "circle", "paint": {"circle-color": "#f00"}}
+    await engine.apply_mutation(
+        clean_session, UpsertLayerIntent(layer=layer, source_data=_geojson())
+    )
+    # Force an identical explicit checkpoint twice → second is deduped.
+    from app.services.mapspec.checkpoint import snapshot
+    from app.services.mapspec.store import MapSpecStore
+    store = MapSpecStore()
+    sd = store.get_session_dir(clean_session)
+    mapspec = await store.get_mapspec(clean_session)
+    r1 = await snapshot(mapspec, sd, session_data_manager, None)  # auto id
+    r2 = await snapshot(mapspec, sd, session_data_manager, None)  # auto id, identical
+    assert r1.get("success") is True
+    assert r2.get("deduplicated") is True, "identical auto checkpoint must dedup"
+
+
+# ── 6. Closed-loop gate policy: missing evidence fails ──────────────────
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_closed_loop_gate_fails_on_no_cartography_evidence(clean_session):
+    """A run that performed no MapSpec mutation and used no refs must FAIL the
+    closed-loop gate (require_evaluated), not pass via fake 100s."""
+    harness = PiAgentHarness(
+        session_id=clean_session,
+        ref_resolver=make_session_store_resolver(session_data_manager),
+    )
+    harness.record_tool_call("c1", "st_dbscan", {})  # analysis tool, no mapspec, no ref
+    harness.record_tool_result("c1", "st_dbscan", {"success": True})
+    ev = await harness.evaluate_with_evidence(expected_tools=["st_dbscan"], ideal_step_count=1)
+    gated = HarnessEvaluator().evaluate_evidence(ev)
+    assert gated["overall_passed"] is False
+    assert gated["checks"]["MapSpecValidity"]["reason"] == "not_evaluated_policy_fail"

--- a/tests/cartography/test_concurrency_closed_loop.py
+++ b/tests/cartography/test_concurrency_closed_loop.py
@@ -1,0 +1,140 @@
+"""Concurrency & multi-worker safety tests (@pytest.mark.cartography).
+
+Validates the stability acceptance criteria:
+- Same-session MapSpec mutations serialize (no lost update under concurrency).
+- Concurrent different-session mutations do not contaminate each other.
+- The per-session distributed lock (Redis in prod, in-process fallback in tests)
+  provides mutual exclusion; the in-process asyncio.Lock serializes coroutines.
+
+Cross-pod (two-process) mutual exclusion is provided by the Redis lock and is
+documented in the multi-worker ADR; these tests cover the in-process semantics
+that the lock preserves under concurrent coroutines.
+"""
+import asyncio
+import shutil
+import uuid
+
+import pytest
+
+from app.services.mapspec.lifecycle_engine import (
+    InitProjectIntent,
+    MapSpecLifecycleEngine,
+    UpsertLayerIntent,
+)
+from app.services.mapspec.store import BASE_STORAGE_DIR
+from app.services.session_data import session_data_manager
+
+
+@pytest.fixture
+async def clean_session():
+    sid = f"conc-session-{uuid.uuid4().hex[:8]}"
+    await session_data_manager.clear_session(sid)
+    yield sid
+    await session_data_manager.clear_session(sid)
+    d = BASE_STORAGE_DIR / sid
+    if d.exists():
+        shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_concurrent_same_session_mutations_serialize_no_lost_update(clean_session):
+    """N concurrent layer upserts on the SAME session must all land — no lost
+    update. Without per-session serialization the read-modify-write would lose
+    layers (last-writer-wins on a stale read)."""
+    engine = MapSpecLifecycleEngine()
+    await engine.apply_mutation(clean_session, InitProjectIntent())
+
+    n = 12
+
+    async def upsert(i):
+        layer = {
+            "id": f"L{i}", "source": f"s{i}", "type": "circle",
+            "paint": {"circle-color": "#ff0000"},
+        }
+        res = await engine.apply_mutation(
+            clean_session,
+            UpsertLayerIntent(layer=layer, source_data={"type": "FeatureCollection", "features": [
+                {"type": "Feature", "geometry": {"type": "Point", "coordinates": [i, i]},
+                 "properties": {"v": i}}
+            ]}),
+        )
+        assert not res.is_error, f"upsert {i} failed: {res.error_msg}"
+
+    await asyncio.gather(*(upsert(i) for i in range(n)))
+
+    # All n layers must be present — serialization prevented lost updates.
+    from app.services.mapspec.store import mapspec_store_instance
+    final = await mapspec_store_instance.get_mapspec(clean_session)
+    ids = {layer["id"] for layer in final["layers"]}
+    missing = {f"L{i}" for i in range(n)} - ids
+    assert not missing, f"lost updates — missing layers: {sorted(missing)}"
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_concurrent_different_sessions_no_contamination():
+    """Two sessions mutated concurrently must not pollute each other's MapSpec."""
+    sessions = [f"conc-iso-{uuid.uuid4().hex[:8]}" for _ in range(2)]
+    for s in sessions:
+        await session_data_manager.clear_session(s)
+    try:
+        engine = MapSpecLifecycleEngine()
+
+        async def seed(sid, layer_id):
+            await engine.apply_mutation(sid, InitProjectIntent())
+            res = await engine.apply_mutation(
+                sid,
+                UpsertLayerIntent(
+                    layer={"id": layer_id, "source": "s", "type": "circle",
+                           "paint": {"circle-color": "#00f"}},
+                    source_data={"type": "FeatureCollection", "features": [
+                        {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]},
+                         "properties": {}}
+                    ]},
+                ),
+            )
+            assert not res.is_error
+
+        await asyncio.gather(
+            seed(sessions[0], "only-in-A"),
+            seed(sessions[1], "only-in-B"),
+        )
+
+        from app.services.mapspec.store import mapspec_store_instance
+        a = await mapspec_store_instance.get_mapspec(sessions[0])
+        b = await mapspec_store_instance.get_mapspec(sessions[1])
+        a_ids = {lyr["id"] for lyr in a["layers"]}
+        b_ids = {lyr["id"] for lyr in b["layers"]}
+        assert a_ids == {"only-in-A"}, f"session A contaminated: {a_ids}"
+        assert b_ids == {"only-in-B"}, f"session B contaminated: {b_ids}"
+    finally:
+        for s in sessions:
+            await session_data_manager.clear_session(s)
+            d = BASE_STORAGE_DIR / s
+            if d.exists():
+                shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.mark.cartography
+@pytest.mark.asyncio
+async def test_distributed_lock_falls_back_in_process_when_no_redis():
+    """With USE_REDIS=false (tests), the lock registry uses in-process locks.
+    Verify the registry still grants a working async context manager that
+    serializes — i.e. the fallback path is functional, not a no-op."""
+    from app.services.distributed_lock import SessionLockRegistry
+
+    reg = SessionLockRegistry()  # fresh; USE_REDIS=false → in-process fallback
+    order = []
+
+    async def hold(name, delay):
+        async with reg.lock("sess-x"):
+            order.append(f"{name}-enter")
+            await asyncio.sleep(delay)
+            order.append(f"{name}-exit")
+
+    await asyncio.gather(hold("a", 0.02), hold("b", 0.01))
+    # Serialized: each enter is followed by its own exit before the other enters.
+    a_idx = order.index("a-enter")
+    assert order[a_idx + 1] == "a-exit"
+    assert "b-enter" in order[order.index("a-exit") + 1:]

--- a/tests/unit/test_harness_dispatch_hook.py
+++ b/tests/unit/test_harness_dispatch_hook.py
@@ -17,14 +17,16 @@ def test_harness_records_tool_call_via_record_event():
         tool_call_id="tc_1",
         tool_name="webgis_layer_upsert",
         arguments={"layer": {"id": "test"}},
-        result={"success": True},
+        result={"success": True, "is_compiled": True},
         is_error=False,
     )
     harness.record_event(event)
-    
+
     assert len(harness.tool_calls) == 1
     assert len(harness.tool_results) == 1
     assert harness.tool_calls[0]["name"] == "webgis_layer_upsert"
+    # V2: is_valid requires real semantic-validity evidence (is_compiled), not
+    # merely "didn't error".
     assert harness.mapspec_mutations[0]["is_valid"] is True
 
 

--- a/tests/unit/test_mapspec_compile_coordinator.py
+++ b/tests/unit/test_mapspec_compile_coordinator.py
@@ -49,13 +49,26 @@ def test_validate_flags_non_increasing_stops():
 
 
 def test_validate_flags_too_few_stops():
+  # Method-aware minimum: a `step` with ZERO stops is degenerate (flagged);
+  # a `step` with ONE threshold + default is a valid MapLibre step (NOT flagged).
   mapspec = {
       "sources": {"s1": {"type": "geojson"}},
       "layers": [{
           "id": "l1", "source": "s1", "type": "circle",
-          "paint": {"color": {"method": "step", "field": "mag", "stops": [[5, "#f00"]]}},
+          "paint": {"color": {"method": "step", "field": "mag", "default": "#000", "stops": []}},
       }],
   }
   result = validate(mapspec)
   assert result["success"] is False
   assert any(e["code"] == "INVALID_STOPS_COUNT" for e in result["errors"])
+
+  # A single-threshold step is a valid graduated classification — must NOT be flagged.
+  valid = {
+      "sources": {"s1": {"type": "geojson"}},
+      "layers": [{
+          "id": "l1", "source": "s1", "type": "circle",
+          "paint": {"color": {"method": "step", "field": "mag", "default": "#000", "stops": [[5, "#f00"]]}},
+      }],
+  }
+  ok = validate(valid)
+  assert ok["success"] is True, ok["errors"]

--- a/tests/unit/test_pi_harness.py
+++ b/tests/unit/test_pi_harness.py
@@ -1,56 +1,30 @@
 """
-Unit tests for PiAgentHarness, HarnessEvaluator, and harness_runner
+Unit tests for PiAgentHarness V2, HarnessEvaluator, and harness_runner.
+
+V2 contract under test:
+- MapSpecValidity is derived from REAL evidence (is_compiled), not "didn't error".
+- CursorResolutionRate is derived from REAL SessionStore resolution, not ref prefix.
+- Missing evidence → 0.0 (honest), never 100.0 (fake success).
+- Each evidence record carries run/session/turn correlation (no cross-session pollution).
 """
+import pytest
+
 from app.lib.harness.evaluator import HarnessEvaluator
 from app.lib.harness.pi_agent_harness import PiAgentHarness
 from app.tools.harness_runner import run_benchmark_scenario
 
 
-def test_pi_harness_metric_computation():
-    harness = PiAgentHarness(session_id="test_session_1")
+class _FakeStore:
+    """Minimal async session store for ref-resolution tests."""
 
-    # Record tool call & result
-    harness.record_tool_call(
-        tool_call_id="call_1",
-        name="st_dbscan",
-        arguments={"geojson": "ref:geojson:12345", "eps1": 500}
-    )
-    harness.record_tool_result(
-        tool_call_id="call_1",
-        name="st_dbscan",
-        result={"success": True},
-        is_error=False
-    )
+    def __init__(self, data: dict | None = None):
+        self._data = data or {}
 
-    metrics = harness.evaluate_all(
-        expected_tools=["st_dbscan"],
-        ideal_step_count=1
-    )
-
-    assert metrics["ToolChoiceAccuracy"] == 100.0
-    assert metrics["CursorResolutionRate"] == 100.0
-    assert metrics["StepEfficiency"] == 100.0
-    assert metrics["ErrorRecoveryRate"] == 100.0
+    async def get(self, session_id, ref):
+        return self._data.get(ref)
 
 
-def test_pi_harness_error_recovery_tracking():
-    harness = PiAgentHarness(session_id="test_session_2")
-
-    # Step 1: Exception
-    harness.record_tool_call("c1", "st_dbscan", {})
-    harness.record_tool_result("c1", "st_dbscan", {}, is_error=True, error_msg="Invalid CRS")
-
-    # Step 2: Recovery
-    harness.record_tool_call("c2", "st_dbscan", {"crs": "EPSG:4326"})
-    harness.record_tool_result("c2", "st_dbscan", {"success": True}, is_error=False)
-
-    metrics = harness.evaluate_all(
-        expected_tools=["st_dbscan"],
-        ideal_step_count=1
-    )
-
-    assert metrics["ErrorRecoveryRate"] == 100.0
-    assert metrics["StepEfficiency"] == 50.0  # 1 ideal / 2 actual = 50%
+# ── Legacy compatibility: evaluator gate on an explicit metric dict ──────
 
 
 def test_evaluator_quality_gate_checks():
@@ -62,7 +36,6 @@ def test_evaluator_quality_gate_checks():
         "StepEfficiency": 85.0,
         "ErrorRecoveryRate": 90.0,
     }
-
     result = evaluator.evaluate_session(metrics)
     assert result["overall_passed"] is True
 
@@ -71,15 +44,210 @@ def test_evaluator_quality_gate_checks():
     assert "✅ PASSED" in report
 
 
-def test_run_benchmark_scenario_runner():
-    res = run_benchmark_scenario(
-        scenario_id="scenario_cartography",
-        expected_tools=["combine_map_theme"],
-        ideal_step_count=1,
-        simulated_tool_calls=[{"id": "c1", "name": "combine_map_theme", "arguments": {"preset": "cyber_dark"}}],
-        simulated_tool_results=[{"id": "c1", "name": "combine_map_theme", "result": {"success": True}}]
-    )
+# ── V2: MapSpecValidity is evidence-driven, not "didn't error" ───────────
 
-    assert res["scenario_id"] == "scenario_cartography"
-    assert res["evaluation"]["overall_passed"] is True
+
+def test_mapspec_validity_requires_real_evidence():
+    """V2 core fix: a mutation that 'didn't error' but lacks is_compiled
+    evidence is NOT counted as valid. MapSpecValidity must be 0, not 100."""
+    harness = PiAgentHarness(session_id="s1")
+
+    # mutation tool that returned success but NO semantic validation evidence
+    harness.record_tool_call("c1", "webgis_layer_upsert", {"layer": {"id": "L"}})
+    harness.record_tool_result("c1", "webgis_layer_upsert", {"success": True})
+
+    assert harness.compute_mapspec_validity() == 0.0
+
+
+def test_mapspec_validity_semantic_valid_when_is_compiled():
+    """A mutation with is_compiled=True carries real semantic-validity evidence."""
+    harness = PiAgentHarness(session_id="s2")
+    harness.record_tool_call("c1", "webgis_layer_upsert", {"layer": {"id": "L"}})
+    harness.record_tool_result(
+        "c1", "webgis_layer_upsert", {"success": True, "is_compiled": True}
+    )
+    assert harness.compute_mapspec_validity() == 100.0
+
+
+def test_mapspec_validity_no_mutations_is_zero_not_hundred():
+    """No mutations recorded → 0.0 (no evidence), NOT 100.0 (fake success)."""
+    harness = PiAgentHarness(session_id="s3")
+    assert harness.compute_mapspec_validity() == 0.0
+
+
+def test_mapspec_validity_mixed_mutations():
+    """1 semantic-valid + 1 evidence-less mutation → 50%, reflecting honest split."""
+    harness = PiAgentHarness(session_id="s4")
+    harness.record_tool_call("c1", "webgis_layer_upsert", {})
+    harness.record_tool_result("c1", "webgis_layer_upsert", {"success": True, "is_compiled": True})
+    harness.record_tool_call("c2", "webgis_view_set", {})
+    harness.record_tool_result("c2", "webgis_view_set", {"success": True})  # no is_compiled
+    assert harness.compute_mapspec_validity() == 50.0
+
+
+# ── V2: CursorResolutionRate from REAL SessionStore resolution ───────────
+
+
+def test_cursor_resolution_no_resolver_is_zero_not_hundred():
+    """Without a real resolver, refs are syntactically-valid only → NOT resolved.
+    No resolver + a ref present → 0.0, not 100.0."""
+    harness = PiAgentHarness(session_id="s5")  # no ref_resolver wired
+    harness.record_tool_call("c1", "st_dbscan", {"geojson": "ref:geojson:12345"})
+    harness.record_tool_result("c1", "st_dbscan", {"success": True})
+    assert harness.compute_cursor_resolution_rate() == 0.0
+
+
+def test_cursor_resolution_no_refs_is_zero_not_hundred():
+    harness = PiAgentHarness(session_id="s6")
+    assert harness.compute_cursor_resolution_rate() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_cursor_resolution_real_resolver_resolved_and_missing():
+    """A real resolver resolves an existing ref but NOT a missing one."""
+    store = _FakeStore({"ref:geojson:exists": {"type": "FeatureCollection", "features": []}})
+    harness = PiAgentHarness(
+        session_id="s7",
+        ref_resolver=_build_resolver(store),
+    )
+    harness.record_tool_call("c1", "st_dbscan", {
+        "a": "ref:geojson:exists",      # present
+        "b": "ref:geojson:missing",     # absent
+    })
+    harness.record_tool_result("c1", "st_dbscan", {"success": True})
+
+    await harness.evaluate_with_evidence(expected_tools=["st_dbscan"], ideal_step_count=1)
+    # 1 of 2 resolved → 50%
+    assert harness.compute_cursor_resolution_rate() == 50.0
+
+
+@pytest.mark.asyncio
+async def test_cursor_resolution_type_mismatch_not_resolved():
+    """A ref whose payload type contradicts its prefix is TYPE_MISMATCH, not resolved."""
+    store = _FakeStore({"ref:raster:x": {"type": "FeatureCollection", "features": []}})
+    harness = PiAgentHarness(
+        session_id="s8", ref_resolver=_build_resolver(store),
+    )
+    harness.record_tool_call("c1", "render", {"data": "ref:raster:x"})
+    harness.record_tool_result("c1", "render", {"success": True})
+    await harness.evaluate_with_evidence(expected_tools=["render"], ideal_step_count=1)
+    assert harness.compute_cursor_resolution_rate() == 0.0
+
+
+# ── V2: session/run/turn correlation scoping ────────────────────────────
+
+
+def test_evidence_carries_correlation_fields():
+    harness = PiAgentHarness(session_id="scope_session")
+    harness.set_correlation(run_id="run_42", turn_id="turn_7")
+    harness.record_tool_call("c1", "webgis_layer_upsert", {})
+    harness.record_tool_result("c1", "webgis_layer_upsert", {"success": True, "is_compiled": True})
+
+    ev = harness.tool_calls[0]
+    assert ev["run_id"] == "run_42"
+    assert ev["turn_id"] == "turn_7"
+    assert ev["session_id"] == "scope_session"
+
+
+@pytest.mark.asyncio
+async def test_two_runs_do_not_cross_contaminate():
+    """Concurrent sessions pool into separate correlation scopes; evidence is
+    not shared across runs (no pollution)."""
+    store = _FakeStore({"ref:geojson:own": {"type": "FeatureCollection", "features": []}})
+    h1 = PiAgentHarness(session_id="sess_A", ref_resolver=_build_resolver(store))
+    h2 = PiAgentHarness(session_id="sess_B", ref_resolver=_build_resolver(store))
+
+    h1.set_correlation(run_id="run_A")
+    h2.set_correlation(run_id="run_B")
+
+    h1.record_tool_call("a1", "st_dbscan", {"data": "ref:geojson:own"})
+    h2.record_tool_call("b1", "st_dbscan", {"data": "ref:geojson:missing"})
+
+    assert h1.tool_calls[0]["run_id"] == "run_A"
+    assert h2.tool_calls[0]["run_id"] == "run_B"
+    assert len(h1.ref_cursors) == 1
+    assert len(h2.ref_cursors) == 1
+
+
+@pytest.mark.asyncio
+async def test_evaluate_with_evidence_builds_structured_trail():
+    store = _FakeStore({"ref:geojson:ok": {"type": "FeatureCollection", "features": []}})
+    harness = PiAgentHarness(session_id="s9", ref_resolver=_build_resolver(store))
+    harness.record_tool_call("c1", "webgis_layer_upsert", {"src": "ref:geojson:ok"})
+    harness.record_tool_result("c1", "webgis_layer_upsert", {"success": True, "is_compiled": True})
+
+    result = await harness.evaluate_with_evidence(
+        expected_tools=["webgis_layer_upsert"], ideal_step_count=1
+    )
+    assert result["run_id"]
+    ev = result["evidence"][0]
+    assert ev["tool_name"] == "webgis_layer_upsert"
+    assert ev["mapspec_validity"]["tier"] == "SEMANTIC_VALID"
+    assert ev["mapspec_validity"]["is_valid"] is True
+    assert result["ref_resolutions"]["ref:geojson:ok"]["status"] == "resolved"
+
+
+# ── V2: evaluate_evidence gate policy — missing evidence is NOT success ──
+
+
+@pytest.mark.asyncio
+async def test_evaluate_evidence_fails_when_cartography_not_evaluated():
+    """A run with no mutations/refs must FAIL the gate under default policy
+    (require_evaluated=True), not pass via fake 100s."""
+    harness = PiAgentHarness(session_id="s10")
+    harness.record_tool_call("c1", "st_dbscan", {})
+    harness.record_tool_result("c1", "st_dbscan", {"success": True})
+    ev_result = await harness.evaluate_with_evidence(expected_tools=["st_dbscan"], ideal_step_count=1)
+
+    evaluator = HarnessEvaluator()
+    gated = evaluator.evaluate_evidence(ev_result)
+    assert gated["overall_passed"] is False
+    assert gated["checks"]["MapSpecValidity"]["reason"] == "not_evaluated_policy_fail"
+
+
+# ── Error recovery + step efficiency (unchanged mechanics, re-asserted) ──
+
+
+def test_error_recovery_tracking():
+    harness = PiAgentHarness(session_id="s11")
+    harness.record_tool_call("c1", "st_dbscan", {})
+    harness.record_tool_result("c1", "st_dbscan", {}, is_error=True, error_msg="Invalid CRS")
+    harness.record_tool_call("c2", "st_dbscan", {"crs": "EPSG:4326"})
+    harness.record_tool_result("c2", "st_dbscan", {"success": True}, is_error=False)
+
+    metrics = harness.evaluate_all(expected_tools=["st_dbscan"], ideal_step_count=1)
+    assert metrics["ErrorRecoveryRate"] == 100.0
+    assert metrics["StepEfficiency"] == 50.0  # 1 ideal / 2 actual
+
+
+# ── harness_runner: honest metric reporting ──────────────────────────────
+
+
+def test_run_benchmark_scenario_reports_honest_metrics():
+    """The runner must report honest V2 metrics. A mutation scenario with real
+    is_compiled evidence yields MapSpecValidity=100; a non-cartography scenario
+    honestly yields 0 where there is no evidence."""
+    res = run_benchmark_scenario(
+        scenario_id="scenario_cartography_v2",
+        expected_tools=["webgis_layer_upsert"],
+        ideal_step_count=1,
+        simulated_tool_calls=[{
+            "id": "c1", "name": "webgis_layer_upsert",
+            "arguments": {"layer": {"id": "L"}},
+        }],
+        simulated_tool_results=[{
+            "id": "c1", "name": "webgis_layer_upsert",
+            "result": {"success": True, "is_compiled": True},
+        }],
+    )
+    assert res["scenario_id"] == "scenario_cartography_v2"
+    assert res["metrics"]["MapSpecValidity"] == 100.0
+    # No refs in this scenario → CursorResolutionRate is honestly 0 (no evidence).
+    assert res["metrics"]["CursorResolutionRate"] == 0.0
     assert "ToolChoiceAccuracy" in res["metrics"]
+
+
+def _build_resolver(store: _FakeStore):
+    """Build a resolver using the real make_session_store_resolver against a fake store."""
+    from app.lib.harness.ref_resolver import make_session_store_resolver
+    return make_session_store_resolver(store)

--- a/tests/unit/test_pi_harness.py
+++ b/tests/unit/test_pi_harness.py
@@ -92,7 +92,7 @@ def test_cursor_resolution_no_resolver_is_zero_not_hundred():
     """Without a real resolver, refs are syntactically-valid only → NOT resolved.
     No resolver + a ref present → 0.0, not 100.0."""
     harness = PiAgentHarness(session_id="s5")  # no ref_resolver wired
-    harness.record_tool_call("c1", "st_dbscan", {"geojson": "ref:geojson:12345"})
+    harness.record_tool_call("c1", "st_dbscan", {"geojson": "ref:geojson-12345"})
     harness.record_tool_result("c1", "st_dbscan", {"success": True})
     assert harness.compute_cursor_resolution_rate() == 0.0
 
@@ -105,14 +105,14 @@ def test_cursor_resolution_no_refs_is_zero_not_hundred():
 @pytest.mark.asyncio
 async def test_cursor_resolution_real_resolver_resolved_and_missing():
     """A real resolver resolves an existing ref but NOT a missing one."""
-    store = _FakeStore({"ref:geojson:exists": {"type": "FeatureCollection", "features": []}})
+    store = _FakeStore({"ref:geojson-exists": {"type": "FeatureCollection", "features": []}})
     harness = PiAgentHarness(
         session_id="s7",
         ref_resolver=_build_resolver(store),
     )
     harness.record_tool_call("c1", "st_dbscan", {
-        "a": "ref:geojson:exists",      # present
-        "b": "ref:geojson:missing",     # absent
+        "a": "ref:geojson-exists",      # present
+        "b": "ref:geojson-missing",     # absent
     })
     harness.record_tool_result("c1", "st_dbscan", {"success": True})
 
@@ -124,11 +124,11 @@ async def test_cursor_resolution_real_resolver_resolved_and_missing():
 @pytest.mark.asyncio
 async def test_cursor_resolution_type_mismatch_not_resolved():
     """A ref whose payload type contradicts its prefix is TYPE_MISMATCH, not resolved."""
-    store = _FakeStore({"ref:raster:x": {"type": "FeatureCollection", "features": []}})
+    store = _FakeStore({"ref:raster-x": {"type": "FeatureCollection", "features": []}})
     harness = PiAgentHarness(
         session_id="s8", ref_resolver=_build_resolver(store),
     )
-    harness.record_tool_call("c1", "render", {"data": "ref:raster:x"})
+    harness.record_tool_call("c1", "render", {"data": "ref:raster-x"})
     harness.record_tool_result("c1", "render", {"success": True})
     await harness.evaluate_with_evidence(expected_tools=["render"], ideal_step_count=1)
     assert harness.compute_cursor_resolution_rate() == 0.0
@@ -153,15 +153,15 @@ def test_evidence_carries_correlation_fields():
 async def test_two_runs_do_not_cross_contaminate():
     """Concurrent sessions pool into separate correlation scopes; evidence is
     not shared across runs (no pollution)."""
-    store = _FakeStore({"ref:geojson:own": {"type": "FeatureCollection", "features": []}})
+    store = _FakeStore({"ref:geojson-own": {"type": "FeatureCollection", "features": []}})
     h1 = PiAgentHarness(session_id="sess_A", ref_resolver=_build_resolver(store))
     h2 = PiAgentHarness(session_id="sess_B", ref_resolver=_build_resolver(store))
 
     h1.set_correlation(run_id="run_A")
     h2.set_correlation(run_id="run_B")
 
-    h1.record_tool_call("a1", "st_dbscan", {"data": "ref:geojson:own"})
-    h2.record_tool_call("b1", "st_dbscan", {"data": "ref:geojson:missing"})
+    h1.record_tool_call("a1", "st_dbscan", {"data": "ref:geojson-own"})
+    h2.record_tool_call("b1", "st_dbscan", {"data": "ref:geojson-missing"})
 
     assert h1.tool_calls[0]["run_id"] == "run_A"
     assert h2.tool_calls[0]["run_id"] == "run_B"
@@ -171,9 +171,9 @@ async def test_two_runs_do_not_cross_contaminate():
 
 @pytest.mark.asyncio
 async def test_evaluate_with_evidence_builds_structured_trail():
-    store = _FakeStore({"ref:geojson:ok": {"type": "FeatureCollection", "features": []}})
+    store = _FakeStore({"ref:geojson-ok": {"type": "FeatureCollection", "features": []}})
     harness = PiAgentHarness(session_id="s9", ref_resolver=_build_resolver(store))
-    harness.record_tool_call("c1", "webgis_layer_upsert", {"src": "ref:geojson:ok"})
+    harness.record_tool_call("c1", "webgis_layer_upsert", {"src": "ref:geojson-ok"})
     harness.record_tool_result("c1", "webgis_layer_upsert", {"success": True, "is_compiled": True})
 
     result = await harness.evaluate_with_evidence(
@@ -184,7 +184,7 @@ async def test_evaluate_with_evidence_builds_structured_trail():
     assert ev["tool_name"] == "webgis_layer_upsert"
     assert ev["mapspec_validity"]["tier"] == "SEMANTIC_VALID"
     assert ev["mapspec_validity"]["is_valid"] is True
-    assert result["ref_resolutions"]["ref:geojson:ok"]["status"] == "resolved"
+    assert result["ref_resolutions"]["ref:geojson-ok"]["status"] == "resolved"
 
 
 # ── V2: evaluate_evidence gate policy — missing evidence is NOT success ──


### PR DESCRIPTION
## Summary

End-to-end convergence of three lines to production-grade: (1) release-gate reality, (2) Harness ↔ GIS ↔ MapSpec ↔ Cartography closed loop with **no false success**, (3) MapSpec reliability + measured performance. Driven by a five-area deep audit, implemented in 6 commits, passed an independent review (3 P1 + 5 P2 findings, all P1 + high-value P2 fixed with regression tests).

- **Baseline:** master `5cbf51a` → **1076 pass / 1 skip**
- **Final:** `97004ae` → **1105 pass / 1 skip / 1 deselect (env-only)**, **0 regressions**

## Confirmed findings (P0/P1)

- **F1** Performance Regression Gate was structurally **non-blocking** (`test-perf` not in `build` needs).
- **F2** No cartography/runtime smoke gate on the master→deploy path.
- **F3** Security dependency audits masked with `|| true` inside the blocking `security` job.
- **F4** Harness `MapSpecValidity` = "didn't error" fake boolean; default 100% when no mutations.
- **F5** `CursorResolutionRate` was a tautological ref-prefix check; the real ref format (`ref:<type>-<id>`) never matched the legacy colon pattern → rate **structurally always 100**.
- **F6** Harness was a global accumulator; no run/session/turn correlation.
- **F7** `apply_mutation` warn-and-save-always: invalid MapSpecs persisted; validation non-gating.
- **F8** No transaction/rollback; eager Redis layer write could half-commit.
- **F9** `process_layer_ingestion` blocked the event loop (sibling `source_profile` was offloaded; hot path was not).
- **F10** Non-atomic file IO; crash → corrupt `mapspec.json`.
- **F11** Checkpoint write amplification (full copy every ref every snapshot).
- **F12/F13** k8s `replicas:2` + HPA violates ADR-0006 single-worker assumption; no distributed session lock.

## What changed

### CI / Release DAG (REL-01/02)
- New **`release-gate`** aggregator job: `needs: [lint, test-backend, test-frontend, security, test-perf, cartography-smoke]`; `build needs: [release-gate]`; `deploy-prod needs: [build]`. Perf + cartography now **truly block** release.
- New **`cartography-smoke`** job (deterministic, no Node/Chromium/LLM/network) + `@cartography` marker.
- Removed `|| true` from the blocking `security` job; `pip-audit`/`npm-audit` moved to an honestly non-blocking **`dependency-audit`** job.
- New **`nightly-matrix`** job (schedule/dispatch only) for the heavier matrix.

### Harness Evaluation V2 (HARNESS-V2) — no false success
- `MapSpecValidity` is a **tiered ladder** from real evidence: `NOT_EVALUATED → MUTATION_REJECTED → MUTATION_ACCEPTED → SEMANTIC_VALID → COMPILE_VALID → RUNTIME_VALID`. "Didn't error" ≠ valid. Missing evidence → 0.0, never 100.0.
- `CursorResolutionRate` resolves refs against the real **SessionStore** (exists + session-scoped + typed-prefix match). Fixed the ref-pattern to the real `ref:<type>-<id>` dash format.
- Every evidence record carries `run_id/session_id/turn_id/tool_call_id/mapspec_revision/checkpoint_id`.
- `evaluate_with_evidence()` (async, real resolution) + `evaluate_evidence()` gate policy (unevaluated dimensions **fail** under `require_evaluated=True`).
- Production bridge + adapter forward real `is_compiled`/`warnings`/`correction_hint` evidence (review P1-3).

### MapSpec reliability (REL-03..07)
- Transaction: build candidate → reject NEW blocking errors → checkpoint → atomic save → sync Redis layers, **rollback-to-snapshot** on any failure (deep-copied snapshots — review P1-1).
- Atomic writes (`tempfile` + `os.replace`); disk-before-Redis.
- `process_layer_ingestion` / deepcopy / content-hash / file IO offloaded via `asyncio.to_thread`.
- Checkpoint **content-addressed ref blobs** + whole-checkpoint hash dedup (2nd identical checkpoint writes **0 bytes**).
- Validator fix: `INVALID_STOPS_COUNT` method-aware (`interpolate` ≥2, `step` ≥1) — a single-threshold step is valid MapLibre.

### Cartography closed loop (CARTO-LOOP)
- `app/lib/cartography/semantic_checks.py`: deterministic GIS-profile ↔ MapSpec checks (`SOURCE_LAYER_REF`/`EMPTY_DATA` errors; geometry/stops/field/legend warnings). Missing profile → `not_evaluated`, never fake pass.

### Concurrency / multi-worker (CONCURRENCY-V2)
- `app/services/distributed_lock.py`: Redis-backed per-session lock (SET NX + TTL + token-checked Lua release + renewal); **resilient fallback** to in-process on Redis error (review P2-1). Wired into MapSpec mutations.
- ADR-0051 documents the single-process-per-pod invariant + sticky-routing requirement.

### Observability (OBSERVABILITY-V2)
- `tool_metrics` now logs `tool_call_id`/`run_id`/`turn_id` so a map's full chain is reconstructable from logs.

## Closed-loop data flow

```
NL goal → agent picks GIS tool → GIS result → ref_id (SessionStore)
  → MapSpec mutation (transactional) → semantic validate → checkpoint
  → atomic save (disk+Redis) → redis layers sync
  → [opt] compile (TS) → [opt] runtime (Playwright)
  → HarnessEvaluationV2 (evidence ladder + real ref resolution + semantic checks)
  → quality gate (missing evidence FAILS, not fakes success)
```

## Performance (measured, local py3.14 + fakeredis)

| benchmark | before-mental-model | measured |
|---|---|---|
| existing 11 perf workloads | — | **11/11 pass** (no regression) |
| 50k-feature upsert event-loop lag | would be ~300ms on-loop | **58.93 ms** (offloaded) |
| upsert median 1k / 10k / 50k | — | 8.9 / 68.7 / 338.1 ms |
| checkpoint 2nd identical write | full copy | **0 bytes** (dedup) |

## Tests

- Backend: **1105 pass / 1 skip / 1 deselect** (the deselect is `test_harness_disabled_by_default`, which spawns a `python -c` subprocess that the local ZCode host harness intercepts; passes on CI clean runners).
- New: `tests/cartography/` (19 @cartography: transactions, real ref resolution, validity ladder, semantic checks, fault injection, concurrency), `tests/benchmarks/test_perf_mapspec_e2e.py` (3 @perf).
- Coverage **66.37%** (floor 10%). ruff / bandit / eslint / typecheck / next build / alembic smoke all green.

## Review findings & fixes (Phase 13)

Independent review found 3 P1 + 5 P2. Fixed all P1 + high-value P2:
- **P1-1** rollback silent no-op (snapshot aliasing) → deep-copied snapshots + regression test.
- **P1-2** in-engine lock eviction broke mutual exclusion → removed; registry lock is sole serializer.
- **P1-3** validity starved in production (adapter/bridge stripped `is_compiled`) → forwarded + regression test.
- **P2-1** Redis post-startup outage raised unhandled → resilient fallback. **P2-2** correction_hint forwarded. **P2-3** auto-init no longer persists before validation. **P2-5** fallback registry bounded.

## Deferred (non-blocking)
- Compile/runtime evidence tiers (COMPILE_VALID/RUNTIME_VALID) need Node/Chromium → wired as opt-in seams; full Playwright E2E scenarios are nightly-matrix territory (the blocking gate is deterministic pure-Python).
- `_session_executed_sets` / `_dispatch_result_cache` cross-pod move — bounded by the single-process-per-pod + sticky-routing invariant (ADR-0006/0051).
- `test_decision_engine.py` live-network geocoding (pre-existing, environment-gated).

## Acceptance check
- [x] production Docker build required; perf gate + cartography gate block release; failed checks can't reach production
- [x] invalid MapSpec no longer "100% valid"; nonexistent ref not resolved; session/run scoped; no fake success
- [x] MapSpec: invalid mutation no pollution, no half-commit, rollback works, old checkpoints compatible
- [x] perf: existing workloads green, new e2e baseline, measured hotspot evidence, no event-loop block, dedup works
- [x] stability: concurrent-session + same-session serialization green; multi-worker semantics explicit (ADR-0051); fault-injection no false-success
- [x] quality: backend / frontend / typecheck / build / ruff / eslint / bandit / alembic / perf / cartography green

> Note: required-check name `release-gate` is new — please add it to branch protection required checks (the existing per-job checks remain valid too).