### PR TITLE
feat(geo): follow-up hardening — isochrone frontier clip, band_math nodata, KNN vectorize

### DIFF
--- a/app/lib/geo_analysis/network.py
+++ b/app/lib/geo_analysis/network.py
@@ -100,14 +100,45 @@ def calculate_isochrones(network_geojson: dict | str, facility_points: dict | st
             )
 
             # Collect reachable EDGE geometry (network-constrained), not the
-            # convex hull of reachable point samples. An edge qualifies if
-            # either endpoint is within the travel budget.
+            # convex hull of reachable point samples. Partially-reachable
+            # edges (one endpoint beyond the cutoff) are clipped at the
+            # travel-budget fraction so the polygon does not over-extend past
+            # the last reachable point (review C).
+            from shapely.ops import substring
             reachable_edges = []
             for u, v, edata in G.edges(data=True):
                 eg = edata.get("geometry")
                 if eg is None:
                     continue
-                if (u in lengths) or (v in lengths):
+                du = lengths.get(u)
+                dv = lengths.get(v)
+                if du is None and dv is None:
+                    continue
+                du_ok = du is not None and du <= max_dist
+                dv_ok = dv is not None and dv <= max_dist
+                if du_ok and dv_ok:
+                    reachable_edges.append(eg)  # fully within budget
+                    continue
+                # Partially reachable: clip at the budget fraction(s).
+                try:
+                    w = edata.get("weight") or eg.length
+                    if w <= 0:
+                        w = eg.length or 1.0
+                    if du_ok:
+                        frac = min(1.0, max(0.0, (max_dist - du) / w))
+                        if frac > 0:
+                            seg = substring(eg, 0.0, frac, normalized=True)
+                            if not seg.is_empty:
+                                reachable_edges.append(seg)
+                    if dv_ok:
+                        frac = min(1.0, max(0.0, (max_dist - dv) / w))
+                        if frac > 0:
+                            seg = substring(eg, 1.0 - frac, 1.0, normalized=True)
+                            if not seg.is_empty:
+                                reachable_edges.append(seg)
+                except Exception:
+                    # Clipping failed (degenerate geometry / topology): fall
+                    # back to the full edge rather than drop it.
                     reachable_edges.append(eg)
 
             reachable = True

--- a/app/lib/geo_analysis/raster_math.py
+++ b/app/lib/geo_analysis/raster_math.py
@@ -130,12 +130,21 @@ def _nodata_valid_mask(arr: np.ndarray, nodata) -> np.ndarray:
     Handles the NaN-nodata case correctly: ``arr != NaN`` is all-True
     (``NaN != NaN``), so a naive value comparison would treat every pixel as
     valid. Mirrors reclassify's ``_valid_mask``. (R-F03)
+
+    Float arrays also exclude *undeclared* NaN pixels — where the declared
+    nodata is a scalar (or None) but the data still contains NaN — so a
+    ``where(A > 0, A, 0)``-style expression cannot turn an undeclared NaN into
+    a valid-looking 0 (review B). Integer arrays cannot hold NaN.
     """
     if nodata is None:
-        return np.ones(arr.shape, dtype=bool)
-    if isinstance(nodata, float) and np.isnan(nodata):
-        return ~np.isnan(arr)
-    return arr != nodata
+        base = np.ones(arr.shape, dtype=bool)
+    elif isinstance(nodata, float) and np.isnan(nodata):
+        base = ~np.isnan(arr)
+    else:
+        base = arr != nodata
+    if np.issubdtype(arr.dtype, np.floating):
+        base = base & ~np.isnan(arr)
+    return base
 
 
 def _compute_dtype(arr: np.ndarray) -> np.ndarray:

--- a/app/lib/geo_analysis/statistics.py
+++ b/app/lib/geo_analysis/statistics.py
@@ -37,12 +37,14 @@ def _build_weights(gdf: gpd.GeoDataFrame, k: int = 8) -> sparse.coo_matrix:
     tree = cKDTree(coords)
     # Query one extra neighbour so dropping self always leaves k_actual.
     _, idx = tree.query(coords, k=k_actual + 1)
+    # Vectorized self-exclusion (E-4): each row's k_actual+1 nearest contains
+    # self exactly once (self is distance 0), so masking self out leaves
+    # exactly k_actual neighbours per row, in distance order. Boolean-index
+    # flattens row-major with column order preserved — O(n·k), no Python loop
+    # (review G: the per-row loop was a 46x stage regression at n=10k).
+    mask = idx != np.arange(n)[:, None]
+    cols = idx[mask]  # (n·k_actual,) row-major, each row's k_actual non-self
     rows = np.repeat(np.arange(n), k_actual)
-    cols = np.empty(n * k_actual, dtype=np.int64)
-    for i in range(n):
-        # first k_actual neighbours that are NOT this row (distance-sorted)
-        nb = idx[i][idx[i] != i][:k_actual]
-        cols[i * k_actual:(i + 1) * k_actual] = nb
     data = np.ones(len(rows), dtype=float)
     return sparse.coo_matrix((data, (rows, cols)), shape=(n, n))
 

--- a/app/services/rs/band_math.py
+++ b/app/services/rs/band_math.py
@@ -41,26 +41,30 @@ class RasterAnalysisResult:
         }
 
 
-# Pure index formulas for Sentinel-2 bands
+# Pure index formulas for Sentinel-2 bands.
+# Where-guarded divide: pixels where the denominator is <= 0 (notably
+# Sentinel-2 L2A nodata, where bands are 0) are left at NaN, not 0, so they
+# are excluded by compute_raster_stats instead of diluting vegetation/water
+# coverage as plausible-looking 0.0 indices (audit B-F09).
 INDEX_FORMULAS: Dict[str, Tuple[List[str], Callable[..., np.ndarray]]] = {
     "ndvi": (["red", "nir"], lambda r, nir: np.divide(
         nir - r, nir + r,
-        out=np.zeros_like(nir - r, dtype=float),
+        out=np.full_like(nir - r, np.nan, dtype=float),
         where=(nir + r) > 0,
     )),
     "ndwi": (["green", "nir"], lambda g, nir: np.divide(
         g - nir, g + nir,
-        out=np.zeros_like(g - nir, dtype=float),
+        out=np.full_like(g - nir, np.nan, dtype=float),
         where=(g + nir) > 0,
     )),
     "nbr": (["nir", "swir12"], lambda nir, swir: np.divide(
         nir - swir, nir + swir,
-        out=np.zeros_like(nir - swir, dtype=float),
+        out=np.full_like(nir - swir, np.nan, dtype=float),
         where=(nir + swir) > 0,
     )),
     "evi": (["blue", "red", "nir"], lambda b, r, nir: 2.5 * np.divide(
         nir - r, nir + 6 * r - 7.5 * b + 1,
-        out=np.zeros_like(nir - r, dtype=float),
+        out=np.full_like(nir - r, np.nan, dtype=float),
         where=(nir + 6 * r - 7.5 * b + 1) > 0,
     )),
 }

--- a/tests/test_critical_backend_correctness.py
+++ b/tests/test_critical_backend_correctness.py
@@ -57,10 +57,12 @@ def test_c1_ndvi_formula_masks_zero_denominator():
 
 
 def test_c1_rs_service_formula_masks_negative_reflectance():
-    """C1：植被指数公式对负反射率像元（nir+red<=0）必须返回 0，而非伪值。
+    """C1：植被指数公式对负反射率像元（nir+red<=0）必须返回 NaN，而非伪值或 0。
 
     直接测试 app.services.rs_service 中导出的 INDEX_FORMULAS 契约，
-    验证生产公式的 mask 语义：分母 <=0 的像元取 out 数组的 0。
+    验证生产公式的 mask 语义：分母 <=0 的像元取 NaN（审计 B-F09）——
+    0 是一个看似合法的指数值（如裸土 NDVI≈0），会稀释植被/水体覆盖度并被
+    compute_raster_stats 计为有效；NaN 才能被正确排除。
     """
     import numpy as np
     from app.services.rs.band_math import INDEX_FORMULAS
@@ -72,14 +74,16 @@ def test_c1_rs_service_formula_masks_negative_reflectance():
     nir = np.array([3000.0, -800.0, -100.0, -200.0])
 
     result = ndvi_formula(red, nir)
-    # nir+red <= 0 的位置（下标 1/2/3）必须 mask 为 0
-    assert result[1] == 0.0, f"负分母像元应被 mask 为 0，实际 {result[1]}"
-    assert result[2] == 0.0
-    assert result[3] == 0.0
     # 正常像元（nir+red>0，下标 0）应是真实 NDVI 值
     np.testing.assert_allclose(result[0], (3000 - 1000) / (3000 + 1000), rtol=1e-6)
-    # 关键回归断言：mask 像元不能是旧 bug 的几千伪值（(nir-r)/1）
-    assert abs(result[1]) < 1.0, "负分母像元返回了伪值（旧 np.where(...,1) bug 回归）"
+    # nir+red <= 0 的位置（下标 1/2/3）必须 mask 为 NaN（B-F09）。
+    # 关键回归断言：既不能是旧 bug 的几千伪值（(nir-r)/1），
+    # 也不能是会污染统计的合法值 0.0 —— 必须是 NaN 才会被 compute_raster_stats 排除。
+    for i in (1, 2, 3):
+        assert np.isnan(result[i]), (
+            f"下标 {i} 负分母像元应为 NaN，实际 {result[i]} "
+            "（旧 np.where(...,1) 伪值回归或被错误 mask 为 0）"
+        )
 
 
 

--- a/tests/unit/test_raster_math_hardening.py
+++ b/tests/unit/test_raster_math_hardening.py
@@ -120,3 +120,27 @@ def test_compute_dtype_promotes_integers_to_float64():
 def test_compute_dtype_preserves_float():
     arr = np.array([1.0, 2.0], dtype=np.float32)
     assert _compute_dtype(arr).dtype == np.float32
+
+
+def test_nodata_valid_mask_excludes_undeclared_nan():
+    """A float raster whose declared nodata is None / a scalar but which still
+    contains NaN must exclude those NaN pixels (review B silent-correctness)."""
+    arr = np.array([1.0, float("nan"), 3.0])
+    # nodata=None: NaN must still be masked out
+    assert _nodata_valid_mask(arr, None).tolist() == [True, False, True]
+    # nodata=-9999 scalar: NaN is not the declared nodata but still invalid
+    assert _nodata_valid_mask(arr, -9999.0).tolist() == [True, False, True]
+
+
+def test_calculator_undeclared_nan_becomes_nodata(_data_dir):
+    """An undeclared NaN pixel (nodata=None) must not pass through a where()
+    expression as a valid 0; it must become output nodata (review B)."""
+    a = np.array([[10.0, float("nan")], [3.0, 4.0]], dtype=np.float32)
+    pa = _write_raster(os.path.join(_data_dir, "undeclared.tif"), a)  # nodata=None
+    stats = raster_calculator(pa, raster_b=None, expression="A * B", constant=1.0)
+    # Only the 3 finite pixels count; the NaN pixel is excluded.
+    assert stats["pixel_count"] == 3
+    with rasterio.open(stats["output_path"]) as out:
+        arr = out.read(1)
+    # The NaN position is the output nodata (0 by default), not a computed value.
+    assert arr[0, 1] == 0

--- a/tests/unit/test_rs_service_module.py
+++ b/tests/unit/test_rs_service_module.py
@@ -33,6 +33,34 @@ def test_compute_index_array_unsupported():
         compute_index_array("unknown", red=np.array([1.0]))
 
 
+def test_compute_index_array_nodata_is_nan_not_zero():
+    """Sentinel-2 L2A nodata is 0; nir+red==0 must yield NaN, not a
+    plausible-looking NDVI 0 (bare soil), so it is excluded from stats
+    (audit B-F09)."""
+    red = np.array([100.0, 0.0])
+    nir = np.array([500.0, 0.0])
+    result = compute_index_array("ndvi", red=red, nir=nir)
+    assert abs(result[0] - (400.0 / 600.0)) < 1e-5
+    assert np.isnan(result[1])  # nodata pixel, not 0.0
+
+
+def test_compute_slope_horn_matches_known_plane():
+    """Reference: a plane tilted only in x at a known angle must recover that
+    angle exactly (guards the Horn weights against inversion — audit B-F10
+    was verified as a false positive)."""
+    import math
+    cell = 30.0
+    n = 12
+    for true_deg in (15.0, 30.0, 45.0):
+        ang = math.radians(true_deg)
+        z = np.tan(ang) * (np.arange(n) * cell)
+        dem = np.tile(z, (n, 1)).astype(float)
+        slope = compute_slope(dem, cell)
+        interior = slope[1:-1, 1:-1]
+        assert abs(interior.mean() - true_deg) < 1e-3
+        assert np.abs(interior - true_deg).max() < 1e-3
+
+
 def test_terrain_kernel_functions():
     dem = np.array([
         [10.0, 15.0, 20.0],


### PR DESCRIPTION
## Context

Follow-up to #335 (core GIS algorithm foundation, merged). Two review-driven
geo/raster hardening commits were present on the local working branch but had
not been pushed/merged into #335 before it landed. They are surfaced and
landed here so no valid work is stranded and master stays the authoritative
integration point.

Rebased onto current master (post #334); clean apply — orthogonal to the
transport changes.

## Changes

**fix(rs): band_math nodata→NaN; refine isochrone frontier edges**
- B-F09 (P2): NDVI/NDWI/NBR/EVI index formulas left denominator≤0 pixels
  (e.g. Sentinel-2 L2A nodata where bands are 0) at `out=0`, a
  plausible-looking index that diluted vegetation/water coverage and was
  counted as valid in stats. `out` is now NaN so nodata pixels are excluded
  by `compute_raster_stats`. (+ test)
- B-F10 (audit, FALSE POSITIVE): Horn slope weights were reported inverted,
  but a 30° tilted plane recovers exactly 30° (verified). Added a
  known-plane reference test to guard the correct weights.
- review C (P2): isochrone partially-reachable edges are now clipped at the
  travel-budget fraction (shapely `substring`) instead of buffered in full,
  so the polygon no longer over-extends past the last reachable point along
  long edges. Falls back to the full edge if clipping fails.

**perf+fix(geo): vectorize KNN weights; mask undeclared NaN in calculator**
- _build_weights (review G perf): replace the per-row Python loop introduced
  by the self-exclusion fix with a vectorized boolean-index selection
  (`idx[mask]`, O(n·k)). Correctness preserved; scales better at large n.
- raster_calculator (review B silent-correctness): `_nodata_valid_mask` now
  also excludes *undeclared* NaN in float arrays (declared nodata scalar/None
  but data still contains NaN). Previously a `where()`-style expression turned
  an undeclared NaN into a valid-looking 0; it now becomes output nodata.
  (+ undeclared-NaN mask & calculator tests)

## Validation
- ruff: clean
- 163 geo/raster/rs/network unit tests pass on the new base