### PR TITLE
feat(cartography): unify MapSpec thematic style and legend pipeline

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -193,11 +193,17 @@ Multi-tenant root entity. All users, layers, and documents belong to an organiza
 ### HistoryStore & HistoryContext
 Deepened conversation persistence seam. `HistoryContext` consolidates Conversation ORM metadata, owner token validation (SEC-08), and role-converted LLM messages (`llm_messages`). `HistoryStoreProtocol` defines 4 intent operations: `load_context`, `commit_interaction`, `delete_history`, and `summarize_session_title`.
 
-### CartographicStyle (Thematic Style Module)
-The canonical deep module (`app/services/cartographic_style.py`) for thematic cartographic classification
-(Fisher-Jenks, quantiles, equal interval, LISA) and palette color generation. Solves the dual-pipeline
-friction between live map overlay state (`legend_spec`) and MapSpec compiler paint specifications
-(`StyleMethod`) by offering a unified model with twin adapters (`.to_legend_spec()` and `.to_style_method()`).
+### Thematic Style Contract (`legend_spec`)
+`legend_spec` is the canonical thematic style — the single source of truth for thematic
+classification + visual encoding. Both MapSpec `paint` (a `StyleMethod`, backend) and the live
+map's MapLibre color expression (frontend) are deterministic **projections** of the same
+`legend_spec`, as is the `<ThematicLegend>` overlay. The contract lives in
+`app/lib/cartography/thematic_spec.py` (single classification via `CartographyService.classify`,
+one palette-resolution path, finite/NaN filtering, `spec_to_paint` projection, `normalize_legend_spec`
+for legacy payloads); its frontend mirror is `frontend/lib/mapspec-runtime/thematic-paint.ts`
+(`legendSpecToColorExpression`, incl. a no-data guard). This replaces the aspirational
+`CartographicStyle` service ADR-0007 deferred — see ADR-0052. `CartographyService` remains the
+classification engine (ADR-0012) and the two converters stay separate renderers (ADR-0017).
 
 ### MapSpec (Cartographic Intent)
 The declarative, high-level cartographic specification: view, layers with high-level style
@@ -228,17 +234,20 @@ two-`type` collision. The TS compiler (`frontend/lib/mapspec-compiler/`) is the 
 for compiling MapSpec → MapLibre style.
 
 ### Cartographic Intent vs. Runtime State
-Two sources with distinct responsibilities — **currently connected headless-only, not live**:
+Two sources with distinct responsibilities — **now connected live via MapSpecRuntime (ADR-0036)**:
 - **Runtime State** = `map_state` in `SessionStore` (Redis). What the running map *actually
   renders*: live layer refs, viewport, and inline `layer.style` + `layer.legend_spec` (the
-  live-map overlay path). The frontend `map-kit` renders from this.
+  live-map overlay path).
 - **Cartographic Intent** = `MapSpec`. What the map *should be*: high-level style/layout/legend.
-- The **MapSpec Compiler** turns Intent → MapLibre Style (`style.json`/`index.html`). **This
-  output does NOT feed the live map today** — it drives only headless consumers: the Playwright
-  runtime validator, eval-evidence scoring, and the static exporter. The function that would
-  apply compiled MapSpec to the live map (`applyMapSpecToMap`) has no live callers. Making the
-  live map render from compiled MapSpec is an unrealized spec aspiration (the "dual-write
-  tension"), not the current architecture.
+- The live map **renders from a derived MapSpec**: `map-panel.tsx` calls `hudStateToMapSpec(...)`
+  → `MapSpecRuntime.reconcileAsync(spec)`, which diffs against the applied spec and patches the
+  MapLibre map. The orphaned `applyMapSpecToMap` was deleted (ADR-0036); `hudStateToMapSpec` is
+  the pure adapter that fans HUD `Layer[]` into a flat MapSpec, and since ADR-0052 it derives
+  thematic paint from each layer's `legend_spec` (the same source `<ThematicLegend>` reads).
+- The **MapSpec Compiler** still turns Intent → MapLibre Style (`style.json`/`index.html`) for
+  headless consumers: the Playwright runtime validator, eval-evidence scoring, and the static
+  exporter. The runtime applies a layer's `paint` dict straight to MapLibre; both paths produce
+  byte-identical thematic expressions.
 - **MapSpec is authoritative for intent and headless acceptance.** Frontend live-UI edits
   (drag, opacity slider, paint tweaks) write `map_state` directly and are **transient** — they
   are *not* back-synced to MapSpec. To persist a manual edit, the user invokes

--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -256,7 +256,9 @@ async def dispatch_tool(request: PiToolRequest) -> PiToolResponse:
         # full mapspec is fetched via fetch-on-demand, never logged wholesale.
         ev = {"status": result.status, "llm_payload_len": len(result.llm_payload)}
         raw = result.raw_result if isinstance(result.raw_result, dict) else {}
-        for k in ("success", "is_compiled", "warnings", "checkpoint_id", "message", "correction_hint"):
+        # ADR-0052: also forward cartography_findings so the Harness surfaces
+        # thematic drift (paint↔legend equivalence) in semantic_errors.
+        for k in ("success", "is_compiled", "warnings", "checkpoint_id", "message", "correction_hint", "cartography_findings"):
             if k in raw:
                 ev[k] = raw[k]
         event = ToolCallEvent(

--- a/app/lib/cartography/semantic_checks.py
+++ b/app/lib/cartography/semantic_checks.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from app.lib.cartography.thematic_spec import palette_size, thematic_field
+
 # Layer "type" expected for a given geometry type. A Point layer painted as
 # "fill" is almost certainly a configuration defect.
 _GEOM_LAYER_TYPE = {
@@ -73,13 +75,349 @@ class CartographyReport:
         }
 
 
+def _normalize_paint_spec(prop: str, spec: Any) -> Optional[Dict[str, Any]]:
+    """Normalize a paint property value into a method-discriminated spec.
+
+    Recognizes two forms:
+      1. The canonical StyleMethod dict (``{method: step|interpolate|match, ...}``).
+      2. MapLibre-native categorical ``{property, type: "categorical", stops}``
+         emitted by ``CompositeMapSpecBuilder`` — normalized to a ``match`` so
+         the semantic checks no longer have a categorical blind spot.
+    """
+    if not isinstance(spec, dict):
+        return None
+    method = spec.get("method")
+    if method in ("interpolate", "step", "match"):
+        return spec
+    # MapLibre-native categorical: {"property": field, "type": "categorical", "stops": [[val,color],...]}
+    if spec.get("type") == "categorical" and spec.get("property"):
+        stops = spec.get("stops") or []
+        cases = [[s[0], s[1]] for s in stops if isinstance(s, (list, tuple)) and len(s) >= 2]
+        default = cases[-1][1] if cases else "#999999"
+        return {"method": "match", "field": spec.get("property"), "cases": cases, "default": default}
+    # MapLibre-native interval stops: {"property", "type":"interval"|"exponential", "stops"}
+    if spec.get("property") and spec.get("type") in ("interval", "exponential"):
+        stops = spec.get("stops") or []
+        norm_stops = [[s[0], s[1]] for s in stops if isinstance(s, (list, tuple)) and len(s) >= 2]
+        if spec.get("type") == "interval":
+            default = norm_stops[0][1] if norm_stops else "#999999"
+            return {"method": "step", "field": spec.get("property"), "default": default,
+                    "stops": norm_stops[1:] if norm_stops else []}
+        return {"method": "interpolate", "field": spec.get("property"), "stops": norm_stops}
+    return None
+
+
 def _paint_methods(paint: Dict[str, Any]):
     """Yield (prop_name, method_dict) for every data-driven paint property."""
     if not isinstance(paint, dict):
         return
     for prop, spec in paint.items():
-        if isinstance(spec, dict) and spec.get("method") in ("interpolate", "step", "match"):
-            yield prop, spec
+        normalized = _normalize_paint_spec(prop, spec)
+        if normalized is not None:
+            yield prop, normalized
+
+
+def _paint_output_colors(spec: Dict[str, Any]) -> List[str]:
+    """Ordered output colors a StyleMethod produces (for legend equivalence)."""
+    method = spec.get("method")
+    if method == "step":
+        colors = [spec.get("default")] if spec.get("default") is not None else []
+        colors.extend(s[1] for s in (spec.get("stops") or []) if isinstance(s, (list, tuple)) and len(s) >= 2)
+        return [c for c in colors if c is not None]
+    if method == "interpolate":
+        return [s[1] for s in (spec.get("stops") or []) if isinstance(s, (list, tuple)) and len(s) >= 2]
+    if method == "match":
+        return [c[1] for c in (spec.get("cases") or []) if isinstance(c, (list, tuple)) and len(c) >= 2]
+    return []
+
+
+def _paint_input_stops(spec: Dict[str, Any]) -> List[float]:
+    """Ordered numeric inputs of a step/interpolate spec (for domain checks)."""
+    method = spec.get("method")
+    if method in ("step", "interpolate"):
+        return [float(s[0]) for s in (spec.get("stops") or []) if isinstance(s, (list, tuple)) and len(s) >= 2 and _is_num(s[0])]
+    return []
+
+
+def _legend_colors(legend_spec: Dict[str, Any]) -> List[str]:
+    """Ordered thematic colors declared by a legend_spec.
+
+    For graduated/continuous/divergent the ramp is ``palette_colors`` (alias
+    ``colors``). For categorical there is no ramp — colors live on each
+    ``categories[{key,color,label}]`` entry, so they are extracted per-category.
+    The previous ``or []`` made the categorical branch dead (a categorical spec
+    has no ramp → ``[]`` → returned immediately), so categorical color drift was
+    never detected. Fixed.
+    """
+    if not isinstance(legend_spec, dict):
+        return []
+    ramp = legend_spec.get("palette_colors") or legend_spec.get("colors")
+    if isinstance(ramp, list) and ramp:
+        return [c for c in ramp if isinstance(c, str)]
+    # categorical: extract per-category colors in declared order.
+    cats = legend_spec.get("categories") or []
+    return [c.get("color") for c in cats if isinstance(c, dict) and c.get("color")]
+
+
+def _categorical_color_map(legend_spec: Dict[str, Any]) -> Dict[Any, str]:
+    """{key: color} for a categorical legend_spec (order-independent)."""
+    out: Dict[Any, str] = {}
+    for c in (legend_spec.get("categories") or []) if isinstance(legend_spec, dict) else []:
+        if isinstance(c, dict) and c.get("key") is not None and c.get("color"):
+            out[c.get("key")] = c.get("color")
+    return out
+
+
+def _approx_eq_list(a: List[float], b: List[float], tol: float = 1e-6) -> bool:
+    """Order-sensitive float list equality within tolerance."""
+    if len(a) != len(b):
+        return False
+    return all(abs(x - y) <= tol for x, y in zip(a, b))
+
+
+def _is_num(v: Any) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+def _thematic_color_spec(paint: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Pick the load-bearing thematic color spec from a layer's paint.
+
+    Prefers the semantic ``color`` property; falls back to the first
+    method-discriminated paint property (so composite categorical is seen too).
+    """
+    for prop, spec in _paint_methods(paint):
+        if prop == "color":
+            return spec
+    for _prop, spec in _paint_methods(paint):
+        return spec
+    return None
+
+
+def _check_thematic_consistency(
+    report: "CartographyReport",
+    lid: Optional[str],
+    sid: Optional[str],
+    layer: Dict[str, Any],
+    profile: Optional[Dict[str, Any]],
+) -> None:
+    """ADR-0052 cartographic-semantic checks pairing a layer's legend_spec with
+    its paint + source profile. Each check is NOT_EVALUATED when the evidence it
+    needs (legend_spec, paint, or profile fields) is absent — never a fake pass.
+    """
+    legend_spec = layer.get("legend_spec")
+    color_spec = _thematic_color_spec(layer.get("paint") or {})
+    fields_profile = (profile or {}).get("fields") or {}
+
+    has_legend = isinstance(legend_spec, dict)
+    if not has_legend and color_spec is None:
+        return  # nothing thematic to check on this layer
+
+    # ── LEGEND_STYLE_EQUIVALENCE ────────────────────────────────────────────
+    # The live paint and the legend must derive from the same classification:
+    # same field, same colors, same numeric thresholds. This is THE drift
+    # detector. Categorical comparison is order-independent (match case order is
+    # semantically irrelevant in MapLibre); graduated also compares break values.
+    if has_legend and color_spec is not None:
+        lfield = thematic_field(legend_spec)
+        pfield = color_spec.get("field")
+        if lfield and pfield and lfield != pfield:
+            report.findings.append(CartographyFinding(
+                check="LEGEND_STYLE_EQUIVALENCE", severity="error",
+                message=(f"Layer '{lid}' legend field '{lfield}' differs from "
+                         f"paint field '{pfield}'"),
+                layer_id=lid, source_id=sid,
+            ))
+        ltype = legend_spec.get("type")
+        if ltype == "categorical":
+            # Compare as {key: color} maps — order-independent.
+            legend_map = _categorical_color_map(legend_spec)
+            paint_map: Dict[Any, str] = {}
+            for case in (color_spec.get("cases") or []):
+                if isinstance(case, (list, tuple)) and len(case) >= 2:
+                    paint_map[case[0]] = case[1]
+            if legend_map and paint_map:
+                drifted = [k for k in legend_map if k in paint_map and paint_map[k] != legend_map[k]]
+                if drifted:
+                    report.findings.append(CartographyFinding(
+                        check="LEGEND_STYLE_EQUIVALENCE", severity="error",
+                        message=(f"Layer '{lid}' categorical color drift for keys "
+                                 f"{drifted}: legend {legend_map} vs paint {paint_map}"),
+                        layer_id=lid, source_id=sid,
+                    ))
+        else:
+            # graduated / continuous / divergent: ordered color ramp comparison.
+            legend_colors = _legend_colors(legend_spec)
+            paint_colors = _paint_output_colors(color_spec)
+            if legend_colors and paint_colors and legend_colors != paint_colors:
+                report.findings.append(CartographyFinding(
+                    check="LEGEND_STYLE_EQUIVALENCE", severity="error",
+                    message=(f"Layer '{lid}' legend colors {legend_colors} differ "
+                             f"from paint output colors {paint_colors}"),
+                    layer_id=lid, source_id=sid,
+                ))
+            # graduated: also compare interior break thresholds (value drift).
+            if ltype == "graduated" and color_spec.get("method") == "step":
+                legend_interior = [float(b) for b in (legend_spec.get("breaks") or [])[1:-1] if _is_num(b)]
+                paint_stops = _paint_input_stops(color_spec)
+                if (legend_interior and paint_stops
+                        and not _approx_eq_list(legend_interior, paint_stops)):
+                    report.findings.append(CartographyFinding(
+                        check="LEGEND_STYLE_EQUIVALENCE", severity="error",
+                        message=(f"Layer '{lid}' graduated break values {legend_interior} "
+                                 f"differ from paint step stops {paint_stops}"),
+                        layer_id=lid, source_id=sid,
+                    ))
+
+    # ── CLASSIFICATION_CARDINALITY ──────────────────────────────────────────
+    # breaks / categories / colors / labels / paint stops must all agree on the
+    # class count.
+    if has_legend:
+        ltype = legend_spec.get("type")
+        colors = _legend_colors(legend_spec)
+        if ltype == "graduated":
+            breaks = [b for b in (legend_spec.get("breaks") or []) if _is_num(b)]
+            labels = legend_spec.get("labels") or []
+            expected = max(1, len(breaks) - 1) if len(breaks) >= 2 else len(colors)
+            if len(breaks) >= 2 and len(colors) != expected:
+                report.findings.append(CartographyFinding(
+                    check="CLASSIFICATION_CARDINALITY", severity="error",
+                    message=(f"Layer '{lid}' graduated: {len(colors)} colors vs "
+                             f"{expected} classes (breaks={len(breaks)})"),
+                    layer_id=lid, source_id=sid,
+                ))
+            if isinstance(labels, list) and labels and len(labels) != expected:
+                report.findings.append(CartographyFinding(
+                    check="CLASSIFICATION_CARDINALITY", severity="warning",
+                    message=(f"Layer '{lid}' graduated: {len(labels)} labels vs "
+                             f"{expected} classes"),
+                    layer_id=lid, source_id=sid,
+                ))
+            if color_spec is not None and color_spec.get("method") == "step":
+                paint_color_count = len(_paint_output_colors(color_spec))
+                if paint_color_count and paint_color_count != expected:
+                    report.findings.append(CartographyFinding(
+                        check="CLASSIFICATION_CARDINALITY", severity="error",
+                        message=(f"Layer '{lid}' graduated: paint has {paint_color_count} "
+                                 f"colors vs {expected} legend classes"),
+                        layer_id=lid, source_id=sid,
+                    ))
+        elif ltype == "categorical":
+            cats = legend_spec.get("categories") or []
+            if color_spec is not None and color_spec.get("method") == "match":
+                paint_keys = {c[0] for c in (color_spec.get("cases") or []) if isinstance(c, (list, tuple)) and c}
+                legend_keys = {c.get("key") for c in cats if isinstance(c, dict) and c.get("key") is not None}
+                if paint_keys != legend_keys and (paint_keys or legend_keys):
+                    report.findings.append(CartographyFinding(
+                        check="CLASSIFICATION_CARDINALITY", severity="error",
+                        message=(f"Layer '{lid}' categorical: legend keys {sorted(legend_keys, key=str)} "
+                                 f"!= paint keys {sorted(paint_keys, key=str)}"),
+                        layer_id=lid, source_id=sid,
+                    ))
+
+    # ── DIVERGENT_DOMAIN ────────────────────────────────────────────────────
+    if has_legend and legend_spec.get("type") == "divergent":
+        center, mn, mx = legend_spec.get("center"), legend_spec.get("min"), legend_spec.get("max")
+        if _is_num(center) and _is_num(mn) and _is_num(mx):
+            if not (mn <= center <= mx):
+                report.findings.append(CartographyFinding(
+                    check="DIVERGENT_DOMAIN", severity="error",
+                    message=(f"Layer '{lid}' divergent center {center} outside "
+                             f"domain [{mn}, {mx}]"),
+                    layer_id=lid, source_id=sid,
+                ))
+            elif center == mn or center == mx:
+                report.findings.append(CartographyFinding(
+                    check="DIVERGENT_DOMAIN", severity="warning",
+                    message=(f"Layer '{lid}' divergent center {center} at a domain "
+                             f"edge — one arm of the ramp is empty"),
+                    layer_id=lid, source_id=sid,
+                ))
+
+    # ── PALETTE_CARDINALITY ─────────────────────────────────────────────────
+    # More classes than palette swatches → silent color cycling.
+    if has_legend and legend_spec.get("type") == "graduated":
+        pal = legend_spec.get("palette")
+        psize = palette_size(pal) if isinstance(pal, str) else 0
+        n_colors = len(_legend_colors(legend_spec))
+        if psize and n_colors > psize:
+            report.findings.append(CartographyFinding(
+                check="PALETTE_CARDINALITY", severity="warning",
+                message=(f"Layer '{lid}' graduated: {n_colors} classes but palette "
+                         f"'{pal}' has {psize} colors (silent cycling)"),
+                layer_id=lid, source_id=sid,
+            ))
+
+    # ── NO_DATA_SEMANTICS ───────────────────────────────────────────────────
+    # A numeric classification without a no-data rule sends null/missing values
+    # to the lowest class via to-number coercion. Only fires when the profile
+    # actually reports nulls (null_count); otherwise NOT_EVALUATED.
+    if has_legend and legend_spec.get("type") in ("graduated", "continuous", "divergent"):
+        lfield = thematic_field(legend_spec)
+        finfo = fields_profile.get(lfield) if lfield else None
+        if isinstance(finfo, dict):
+            null_count = finfo.get("null_count")
+            if _is_num(null_count) and null_count > 0 and not legend_spec.get("nodata"):
+                report.findings.append(CartographyFinding(
+                    check="NO_DATA_SEMANTICS", severity="warning",
+                    message=(f"Layer '{lid}' numeric field '{lfield}' has {int(null_count)} "
+                             f"null/missing values but legend_spec declares no no-data rule"),
+                    layer_id=lid, source_id=sid,
+                ))
+            elif null_count is None:
+                report.findings.append(CartographyFinding(
+                    check="NO_DATA_SEMANTICS", severity="info",
+                    message=(f"Layer '{lid}' no-data handling not evaluable "
+                             f"(profile lacks null_count for '{lfield}')"),
+                    layer_id=lid, source_id=sid, evaluated=False,
+                ))
+
+    # ── CLASSIFICATION_DOMAIN_COVERAGE ──────────────────────────────────────
+    # Graduated breaks must span the data; otherwise features fall through to
+    # the default color or get clamped.
+    if has_legend and legend_spec.get("type") == "graduated":
+        breaks = [b for b in (legend_spec.get("breaks") or []) if _is_num(b)]
+        lfield = thematic_field(legend_spec)
+        finfo = fields_profile.get(lfield) if lfield else None
+        if (len(breaks) >= 2 and isinstance(finfo, dict)
+                and _is_num(finfo.get("min")) and _is_num(finfo.get("max"))):
+            fmin, fmax = float(finfo["min"]), float(finfo["max"])
+            b_lo, b_hi = float(breaks[0]), float(breaks[-1])
+            if b_hi < fmin or b_lo > fmax:
+                report.findings.append(CartographyFinding(
+                    check="CLASSIFICATION_DOMAIN_COVERAGE", severity="error",
+                    message=(f"Layer '{lid}' breaks [{b_lo}, {b_hi}] do not overlap "
+                             f"data range [{fmin}, {fmax}]"),
+                    layer_id=lid, source_id=sid,
+                ))
+            else:
+                rng = (fmax - fmin) or 1.0
+                if b_lo > fmin + 0.25 * rng or b_hi < fmax - 0.25 * rng:
+                    report.findings.append(CartographyFinding(
+                        check="CLASSIFICATION_DOMAIN_COVERAGE", severity="warning",
+                        message=(f"Layer '{lid}' breaks [{b_lo}, {b_hi}] do not fully "
+                                 f"cover data range [{fmin}, {fmax}]"),
+                        layer_id=lid, source_id=sid,
+                    ))
+
+    # ── CATEGORICAL_DOMAIN_CONSISTENCY ──────────────────────────────────────
+    # Data values present in the source should appear as legend categories.
+    if has_legend and legend_spec.get("type") == "categorical" and isinstance(profile, dict):
+        lfield = thematic_field(legend_spec)
+        finfo = fields_profile.get(lfield) if lfield else None
+        if isinstance(finfo, dict):
+            sample = finfo.get("sampleValues") or finfo.get("values") or []
+            # Normalize both sides to str: builders coerce category keys with
+            # str(), but profile sampleValues may be ints (numeric-coded cats).
+            legend_keys = {str(c.get("key")) for c in (legend_spec.get("categories") or [])
+                           if isinstance(c, dict) and c.get("key") is not None}
+            missing = [v for v in sample if str(v) not in legend_keys]
+            if missing:
+                report.findings.append(CartographyFinding(
+                    check="CATEGORICAL_DOMAIN_CONSISTENCY", severity="warning",
+                    message=(f"Layer '{lid}' data values {missing} for field '{lfield}' "
+                             f"have no legend category"),
+                    layer_id=lid, source_id=sid,
+                ))
 
 
 def evaluate_cartography_semantics(
@@ -198,6 +536,11 @@ def evaluate_cartography_semantics(
                                 ),
                                 layer_id=lid, source_id=sid,
                             ))
+
+        # 4b-10. ADR-0052 thematic consistency: paint ↔ legend equivalence,
+        # cardinality, domain coverage, no-data, divergent, palette, categorical
+        # domain. Each NOT_EVALUATED when its evidence is absent.
+        _check_thematic_consistency(report, lid, sid, layer, profile)
 
     # 7. Legend / style field consistency (warning).
     legend = (mapspec.get("layout") or {}).get("legend") or {}

--- a/app/lib/cartography/thematic_spec.py
+++ b/app/lib/cartography/thematic_spec.py
@@ -1,0 +1,533 @@
+"""Canonical thematic-style contract — the single source of truth for thematic
+cartography on both the MapSpec paint path and the legend path.
+
+ADR-0052 supersedes ADR-0007. ADR-0007 deferred a unified cartographic-style
+module because MapSpec ``paint`` was headless-only (``applyMapSpecToMap`` had
+zero live callers). ADR-0036 replaced that orphan with ``MapSpecRuntime``,
+which IS the live map path (``map-panel.tsx`` → ``hudStateToMapSpec`` →
+``runtime.reconcile``). The revisit trigger is now satisfied, so the
+``legend_spec`` payload — already the cross-boundary wire format and already a
+discriminated union on both sides — is promoted from "legend-only" to the
+canonical thematic style. Both MapSpec ``paint`` (StyleMethod) and the legend
+UI derive from the SAME ``legend_spec``.
+
+This module is a CONTRACT + pure helpers, not a service. It does not merge the
+converters (ADR-0017 keeps ``analysis_cartography_converter`` and
+``raster_cartography_converter`` as separate renderers) and it does not replace
+``CartographyService`` (ADR-0012 keeps it as the classification engine).
+Instead it:
+
+  * owns the single classification-result path (delegates the algorithm to
+    ``CartographyService.classify`` — never reimplements Jenks/quantile);
+  * resolves palette colors through ONE function (fixing the historical
+    three-way divergence: midpoint sampling vs verbatim truncation vs raw
+    slice);
+  * filters NaN/Inf/null ONCE so nulls cannot poison classification;
+  * projects ``legend_spec`` → MapSpec ``paint.color`` StyleMethod through ONE
+    pure function (``spec_to_paint``), consumed by both the vector converter
+    and the semantic checks;
+  * normalizes legacy ``legend_spec`` shapes so old payloads keep working.
+
+Contract: ``legend_spec`` is a JSON-serializable discriminated union::
+
+    {
+      "type": "graduated" | "continuous" | "categorical" | "divergent",
+      "field": str,                       # the data field (always present)
+      # graduated:
+      "breaks": [number],                 # class boundaries (len >= 2)
+      # continuous / divergent:
+      "min": number, "max": number,       # value domain
+      "center": number,                   # divergent only
+      # categorical:
+      "categories": [{"key","color","label"}],
+      # shared visual encoding:
+      "palette": str,                     # palette identity (for traceability)
+      "palette_colors": [str],            # resolved hex colors
+      "labels": [str],                    # optional per-class labels
+      "method": str,                      # optional classification method
+      "nodata": {"color": str, "label": str} | null,  # optional no-data rule
+      "unit": str | null, "title": str | null,        # optional
+    }
+
+Deterministic, framework-agnostic (no React/MapLibre instances, no numpy
+beyond what ``CartographyService.classify`` already uses).
+"""
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from app.lib.cartography.palettes import (
+    COLOR_PALETTES,
+    get_color_from_palette,
+    resolve_palette_colors,
+)
+
+logger = logging.getLogger(__name__)
+
+# Discriminant values for the canonical thematic-style union.
+GRADUATED = "graduated"
+CONTINUOUS = "continuous"
+CATEGORICAL = "categorical"
+DIVERGENT = "divergent"
+_THEMATIC_MODES = (GRADUATED, CONTINUOUS, CATEGORICAL, DIVERGENT)
+
+#: Default no-data swatch when a thematic style declares no-data handling.
+NODATA_DEFAULT: Dict[str, str] = {"color": "#cccccc", "label": "No data"}
+
+
+# ─── value hygiene ──────────────────────────────────────────────────────────
+
+
+def is_finite_number(val: Any) -> bool:
+    """True for a real numeric value (int/float), excluding bool/NaN/Inf."""
+    return isinstance(val, (int, float)) and not isinstance(val, bool) and math.isfinite(val)
+
+
+def finite_numbers(values: Sequence[Any]) -> List[float]:
+    """Project a raw property stream to finite floats (NaN/Inf/None/bool/str dropped).
+
+    This is the SINGLE place thematic classification filters bad values, so a
+    stray NaN in one column can no longer poison ``np.quantile``/Jenks breaks.
+    """
+    out: List[float] = []
+    for v in values:
+        if is_finite_number(v):
+            out.append(float(v))
+    return out
+
+
+# ─── palette resolution (single path) ───────────────────────────────────────
+
+
+def resolve_thematic_colors(
+    palette: str,
+    k: int,
+    breaks: Optional[Sequence[float]] = None,
+    min_val: Optional[float] = None,
+    max_val: Optional[float] = None,
+) -> List[str]:
+    """Resolve exactly ``k`` thematic colors for a palette, ONE consistent way.
+
+    For graduated classification the colors are sampled at each class midpoint
+    (normalized over ``[min_val, max_val]``) — the same scheme
+    ``CartographyService.build_thematic_style`` already used. For non-graduated
+    use (continuous/divergent ramps) the full resolved palette is returned.
+
+    This collapses the historical divergence where ``build_thematic_style``
+    sampled by midpoint, ``h3_binning`` took ``resolve_palette_colors(palette)[:5]``
+    verbatim, and ``kde_contours`` sliced ``COLOR_PALETTES['Viridis'][:5]`` —
+    three different color sets for the same palette name.
+    """
+    if k <= 0:
+        return []
+    if breaks is not None and len(breaks) >= 2 and is_finite_number(min_val) and is_finite_number(max_val):
+        val_range = (float(max_val) - float(min_val)) or 1.0  # guard flat domain
+        colors: List[str] = []
+        for i in range(len(breaks) - 1):
+            mid = (float(breaks[i]) + float(breaks[i + 1])) / 2.0
+            normalized = (mid - float(min_val)) / val_range
+            colors.append(get_color_from_palette(palette, normalized))
+        return colors
+    # Continuous/divergent ramp: the full resolved palette is the ramp itself.
+    return resolve_palette_colors(palette)
+
+
+# ─── canonical builders ─────────────────────────────────────────────────────
+
+
+def build_graduated_spec(
+    geojson: Dict[str, Any],
+    field: str,
+    method: str = "quantiles",
+    k: int = 5,
+    palette: str = "YlOrRd",
+    *,
+    nodata: Optional[Dict[str, str]] = None,
+    unit: Optional[str] = None,
+    title: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Build a graduated ``legend_spec`` from a GeoJSON feature collection.
+
+    Runs the SINGLE classification (``CartographyService.classify``) over the
+    finite values of ``field`` and resolves colors through
+    ``resolve_thematic_colors``. Returns ``None`` when there is too little
+    numeric data to classify (matches the legacy ``build_thematic_style``
+    contract so existing callers/tests are unaffected).
+    """
+    # Local import to respect ADR-0012 (CartographyService is the engine; this
+    # module delegates the algorithm rather than reimplementing it).
+    from app.services.cartography_service import CartographyService
+
+    features = (geojson or {}).get("features", []) or []
+    raw = (f.get("properties", {}).get(field) for f in features if isinstance(f, dict))
+    values = finite_numbers(raw)
+    if len(values) < 2:
+        return None
+
+    breaks = CartographyService.classify(values, method, k)
+    if not breaks or len(breaks) < 2:
+        return None
+
+    min_val, max_val = min(values), max(values)
+    palette_colors = resolve_thematic_colors(palette, len(breaks) - 1, breaks, min_val, max_val)
+    labels = [_graduated_label(breaks[i], breaks[i + 1]) for i in range(len(breaks) - 1)]
+
+    spec: Dict[str, Any] = {
+        "type": GRADUATED,
+        "field": field,
+        "breaks": [float(b) for b in breaks],
+        "palette": palette,
+        "palette_colors": palette_colors,
+        "method": method,
+        "labels": labels,
+    }
+    # Default a no-data rule so null/missing field values are diverted to the
+    # no-data color on the live map instead of being coerced by `to-number`
+    # into the lowest class (ADR-0052 no-data semantics).
+    spec["nodata"] = nodata if nodata is not None else dict(NODATA_DEFAULT)
+    if unit is not None:
+        spec["unit"] = unit
+    if title is not None:
+        spec["title"] = title
+    return spec
+
+
+def build_categorical_spec(
+    field: str,
+    categories: Sequence[Dict[str, str]],
+    *,
+    palette: Optional[str] = None,
+    nodata: Optional[Dict[str, str]] = None,
+    title: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Build a categorical ``legend_spec`` from explicit ``{key,color,label}`` entries.
+
+    LISA and other categorical emitters already know their category set; this
+    normalizes them into the canonical shape with a stable field identity and
+    per-category labels. Returns ``None`` when no valid categories are given.
+    """
+    cats: List[Dict[str, str]] = []
+    for c in categories or []:
+        if isinstance(c, dict) and c.get("key") is not None and c.get("color"):
+            cats.append({
+                "key": str(c["key"]),
+                "color": str(c["color"]),
+                "label": str(c.get("label") or c["key"]),
+            })
+        elif isinstance(c, (list, tuple)) and len(c) >= 2:
+            cats.append({"key": str(c[0]), "color": str(c[1]), "label": str(c[2] if len(c) > 2 else c[0])})
+    if not cats:
+        return None
+
+    spec: Dict[str, Any] = {
+        "type": CATEGORICAL,
+        "field": field,
+        "categories": cats,
+    }
+    if palette:
+        spec["palette"] = palette
+    if nodata is not None:
+        spec["nodata"] = nodata
+    if title is not None:
+        spec["title"] = title
+    return spec
+
+
+def build_continuous_spec(
+    min_val: float,
+    max_val: float,
+    palette: str,
+    *,
+    field: str = "",
+    palette_colors: Optional[Sequence[str]] = None,
+    nodata: Optional[Dict[str, str]] = None,
+    unit: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Build a continuous ``legend_spec`` over ``[min_val, max_val]``.
+
+    ``field`` is REQUIRED for the paint derivation to produce a data-driven
+    interpolate expression (the legacy continuous shape omitted it, which
+    silently fell back to constant paint). Emitters that know the field should
+    pass it; when absent the legacy shape is preserved for backward compat but
+    ``spec_to_paint`` will fall back to constant.
+    """
+    # Accept a flat domain (min == max, e.g. a degenerate KDE with one contour
+    # band): emit a constant-domain legend rather than dropping it — the legend
+    # overlay still appears, and spec_to_paint falls back to a constant color
+    # (correct: a constant field has one class). Preserves the pre-ADR-0052
+    # behavior where kde_contours emitted a legend whenever features existed.
+    if not (is_finite_number(min_val) and is_finite_number(max_val) and float(min_val) <= float(max_val)):
+        return None
+    colors = list(palette_colors) if palette_colors else resolve_palette_colors(palette)
+    if len(colors) < 2:
+        return None
+
+    spec: Dict[str, Any] = {
+        "type": CONTINUOUS,
+        "min": float(min_val),
+        "max": float(max_val),
+        "palette": palette,
+        "palette_colors": colors,
+    }
+    if field:
+        spec["field"] = field
+    # Default no-data rule (see build_graduated_spec).
+    spec["nodata"] = nodata if nodata is not None else dict(NODATA_DEFAULT)
+    if unit is not None:
+        spec["unit"] = unit
+    return spec
+
+
+def build_divergent_spec(
+    values: Sequence[Any],
+    field: str,
+    center: float,
+    palette: str,
+    *,
+    k: int = 5,
+    nodata: Optional[Dict[str, str]] = None,
+    unit: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Build a divergent ``legend_spec`` centered at ``center``.
+
+    The domain is derived from the finite ``values`` (clamped to be symmetric
+    around ``center`` so both arms of the diverging ramp are represented), and
+    the breaks are symmetric quantile steps from ``center``. No producer emits
+    divergent today; this builder + its projections + the DIVERGENT_DOMAIN
+    check make the mode first-class so a future emitter cannot silently drift.
+    """
+    nums = finite_numbers(values)
+    if len(nums) < 2 or not is_finite_number(center):
+        return None
+    lo, hi = min(nums), max(nums)
+    # Symmetric half-range around center so the diverging ramp covers both arms.
+    half = max(abs(lo - center), abs(hi - center)) or 1.0
+    min_val = center - half
+    max_val = center + half
+    colors = resolve_palette_colors(palette)
+    if len(colors) < 2:
+        return None
+    spec: Dict[str, Any] = {
+        "type": DIVERGENT,
+        "field": field,
+        "center": float(center),
+        "min": float(min_val),
+        "max": float(max_val),
+        "palette": palette,
+        "palette_colors": colors,
+    }
+    # Default no-data rule (see build_graduated_spec).
+    spec["nodata"] = nodata if nodata is not None else dict(NODATA_DEFAULT)
+    if unit is not None:
+        spec["unit"] = unit
+    return spec
+
+
+# ─── legend_spec → MapSpec paint.color StyleMethod (single projection) ───────
+
+
+def spec_to_paint(
+    legend_spec: Any,
+    fallback_color: str = "#999999",
+) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    """Project a canonical ``legend_spec`` to a MapSpec ``paint.color`` StyleMethod.
+
+    Returns ``(style_method_or_None, warnings)``. ``None`` signals "fall back to
+    a constant color" — the caller decides the constant. This is the SINGLE
+    construction site for the paint projection: the vector converter and the
+    semantic checks both consume it, so paint and legend cannot diverge.
+
+    Output is byte-identical to the converter's historical ``_convert_*_legend``
+    functions (pinned by ``tests/unit/test_analysis_cartography_converter.py``).
+    """
+    warnings: List[str] = []
+    if legend_spec is None:
+        return None, warnings
+    if not isinstance(legend_spec, dict):
+        warnings.append("invalid_legend_spec: legend_spec must be a dictionary")
+        return None, warnings
+
+    ltype = legend_spec.get("type")
+
+    if ltype == GRADUATED:
+        return _graduated_to_step(legend_spec, warnings)
+
+    if ltype in (CONTINUOUS, DIVERGENT):
+        return _domain_to_interpolate(legend_spec, warnings)
+
+    if ltype == CATEGORICAL:
+        return _categorical_to_match(legend_spec, fallback_color, warnings)
+
+    warnings.append(f"unrecognized_legend_type: {ltype}")
+    return None, warnings
+
+
+def _graduated_to_step(legend_spec: Dict[str, Any], warnings: List[str]) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    field = legend_spec.get("field", "")
+    breaks = legend_spec.get("breaks", [])
+    palette_colors = legend_spec.get("palette_colors") or legend_spec.get("colors") or []
+
+    valid_breaks = isinstance(breaks, list) and len(breaks) >= 2 and all(is_finite_number(b) for b in breaks)
+    valid_colors = isinstance(palette_colors, list) and len(palette_colors) >= 1
+
+    if field and valid_breaks and valid_colors:
+        default_color = palette_colors[0]
+        stops: List[List[Any]] = []
+        for i in range(1, len(breaks) - 1):
+            color_i = palette_colors[i] if i < len(palette_colors) else palette_colors[-1]
+            stops.append([float(breaks[i]), color_i])
+        return {"method": "step", "field": field, "default": default_color, "stops": stops}, warnings
+
+    warnings.append("graduated_legend_invalid: insufficient breaks or palette_colors")
+    return None, warnings
+
+
+def _domain_to_interpolate(legend_spec: Dict[str, Any], warnings: List[str]) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    field = legend_spec.get("field", "")
+    min_val = legend_spec.get("min")
+    max_val = legend_spec.get("max")
+    palette_colors = legend_spec.get("palette_colors") or legend_spec.get("colors") or []
+
+    if (
+        field
+        and is_finite_number(min_val)
+        and is_finite_number(max_val)
+        and float(min_val) < float(max_val)
+        and isinstance(palette_colors, list)
+        and len(palette_colors) >= 2
+    ):
+        n = len(palette_colors)
+        step = (float(max_val) - float(min_val)) / (n - 1)
+        stops = [[round(float(min_val) + i * step, 6), palette_colors[i]] for i in range(n)]
+        return {"method": "interpolate", "field": field, "stops": stops}, warnings
+
+    warnings.append("continuous_legend_invalid: missing field, palette_colors (min 2), or min must be strictly less than max")
+    return None, warnings
+
+
+def _categorical_to_match(
+    legend_spec: Dict[str, Any], fallback_color: str, warnings: List[str]
+) -> Tuple[Optional[Dict[str, Any]], List[str]]:
+    field = legend_spec.get("field", "")
+    categories = legend_spec.get("categories", [])
+
+    if field and isinstance(categories, list) and len(categories) >= 1:
+        cases: List[List[Any]] = []
+        for cat in categories:
+            if isinstance(cat, dict):
+                key = cat.get("key")
+                color = cat.get("color")
+                if key is not None and color:
+                    cases.append([key, color])
+            elif isinstance(cat, (list, tuple)) and len(cat) >= 2:
+                cases.append([cat[0], cat[1]])
+        if cases:
+            # Spec contract: default = last category color (legend_spec.default ignored).
+            default_color = cases[-1][1] or fallback_color
+            return {"method": "match", "field": field, "cases": cases, "default": default_color}, warnings
+        warnings.append("categorical_legend_invalid: no valid category entries")
+        return None, warnings
+
+    warnings.append("categorical_legend_invalid: missing field or categories")
+    return None, warnings
+
+
+# ─── normalization & identity (backward compat) ─────────────────────────────
+
+
+def normalize_legend_spec(legend_spec: Any) -> Optional[Dict[str, Any]]:
+    """Normalize a legacy / inbound ``legend_spec`` into the canonical shape.
+
+    Semantics-preserving: sorts graduated breaks deterministically, drops
+    non-finite breaks, back-fills a missing ``field`` where another field on
+    the spec implies it, and coerces legacy ``colors`` → ``palette_colors``.
+    Returns ``None`` for non-dict input. Never raises.
+    """
+    if not isinstance(legend_spec, dict):
+        return None
+    spec = dict(legend_spec)
+    ltype = spec.get("type")
+
+    # Legacy `colors` alias → canonical `palette_colors`.
+    if "palette_colors" not in spec and spec.get("colors"):
+        spec["palette_colors"] = spec["colors"]
+
+    if ltype == GRADUATED:
+        breaks = [b for b in (spec.get("breaks") or []) if is_finite_number(b)]
+        if len(breaks) >= 2:
+            breaks = sorted(set(breaks))
+        spec["breaks"] = breaks
+        if not spec.get("field"):
+            spec["field"] = ""
+    elif ltype in (CONTINUOUS, DIVERGENT):
+        # Continuous/Divergent may carry an explicit field; leave it as-is.
+        pass
+    elif ltype == CATEGORICAL:
+        cats = []
+        for c in (spec.get("categories") or []):
+            if isinstance(c, dict) and c.get("key") is not None and c.get("color"):
+                cats.append({
+                    "key": str(c["key"]),
+                    "color": str(c["color"]),
+                    "label": str(c.get("label") or c["key"]),
+                })
+        spec["categories"] = cats
+        if not spec.get("field"):
+            spec["field"] = ""
+    return spec
+
+
+def thematic_field(legend_spec: Any) -> Optional[str]:
+    """The single thematic field identity for a ``legend_spec`` (or None).
+
+    Consumers that need "the field this thematic map encodes" (legend filter,
+    MapSpec paint, semantic checks) all read this, so the legend filter, the
+    paint expression and the consistency check can never reference three
+    different fields.
+    """
+    if not isinstance(legend_spec, dict):
+        return None
+    field = legend_spec.get("field")
+    if isinstance(field, str) and field:
+        return field
+    return None
+
+
+def is_thematic(legend_spec: Any) -> bool:
+    """True when a ``legend_spec`` carries a usable thematic encoding."""
+    if not isinstance(legend_spec, dict):
+        return False
+    return legend_spec.get("type") in _THEMATIC_MODES and thematic_field(legend_spec) is not None
+
+
+def palette_size(palette: str) -> int:
+    """The declared number of swatches for a palette name (0 if unknown)."""
+    colors = COLOR_PALETTES.get(palette)
+    return len(colors) if colors else 0
+
+
+def _graduated_label(lo: float, hi: float) -> str:
+    return f"{lo:.2f} - {hi:.2f}"
+
+
+__all__ = [
+    "GRADUATED",
+    "CONTINUOUS",
+    "CATEGORICAL",
+    "DIVERGENT",
+    "NODATA_DEFAULT",
+    "is_finite_number",
+    "finite_numbers",
+    "resolve_thematic_colors",
+    "build_graduated_spec",
+    "build_categorical_spec",
+    "build_continuous_spec",
+    "build_divergent_spec",
+    "spec_to_paint",
+    "normalize_legend_spec",
+    "thematic_field",
+    "is_thematic",
+    "palette_size",
+]

--- a/app/lib/geo_analysis/density.py
+++ b/app/lib/geo_analysis/density.py
@@ -330,20 +330,20 @@ def kde_contours(
         level_vals = [
             float(f.get("properties", {}).get("density_value", 0.0))
             for f in out_features
+            if isinstance(f.get("properties", {}).get("density_value"), (int, float))
         ]
-        level_vals = [v for v in level_vals if v is not None]
         if level_vals:
             try:
-                from app.services.cartography_service import COLOR_PALETTES
-                palette = "Viridis"
-                palette_colors = list(COLOR_PALETTES.get(palette, []))
-                legend_spec = {
-                    "type": "continuous",
-                    "min": min(level_vals),
-                    "max": max(level_vals),
-                    "palette": palette,
-                    "palette_colors": palette_colors[:5] if palette_colors else ["#440154", "#21908c", "#fde725"],
-                }
+                # ADR-0052: route through the canonical continuous builder so the
+                # legend carries `field` (the live map's interpolate needs it) and
+                # the ramp resolves through one path — replacing the hand-built
+                # palette_colors[:5] truncation + missing-field drift. The builder
+                # accepts a flat domain (min==max) so a degenerate KDE still gets
+                # a legend overlay (paint falls back to constant).
+                from app.lib.cartography.thematic_spec import build_continuous_spec
+                legend_spec = build_continuous_spec(
+                    min(level_vals), max(level_vals), "Viridis", field="density_value",
+                )
             except Exception:  # noqa: BLE001
                 legend_spec = None
 

--- a/app/lib/harness/pi_agent_harness.py
+++ b/app/lib/harness/pi_agent_harness.py
@@ -194,7 +194,21 @@ class PiAgentHarness:
                     )
                     mutation["is_valid"] = semantic_valid  # SEMANTIC_VALID tier
                     mutation["mutation_accepted"] = mutation_accepted
-                    mutation["semantic_errors"] = result.get("warnings", [])
+                    # ADR-0052: semantic_errors carries BOTH the structural
+                    # validate() warnings AND the deterministic cartography
+                    # findings (paint↔legend drift, cardinality, domain, …) so
+                    # "structurally valid but thematically inconsistent" is
+                    # surfaced as evidence. Tier logic is unchanged — structural
+                    # validity (is_compiled) ≠ thematic correctness; the findings
+                    # are the evidence channel. Profile-dependent cartography
+                    # checks report NOT_EVALUATED (never a fake pass).
+                    cartography_errors = [
+                        f"{f.get('check')}: {f.get('message')}"
+                        for f in (result.get("cartography_findings") or [])
+                        if isinstance(f, dict) and f.get("severity") == "error"
+                        and f.get("evaluated", True)
+                    ]
+                    mutation["semantic_errors"] = result.get("warnings", []) + cartography_errors
                     break
         return result_entry
 

--- a/app/services/analysis_cartography_converter.py
+++ b/app/services/analysis_cartography_converter.py
@@ -5,9 +5,10 @@ Converts spatial analysis results (GeoAnalysisResult output) into MapSpec layer 
 from collections import Counter
 from datetime import datetime, timezone
 import logging
-import math
 import re
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.lib.cartography.thematic_spec import spec_to_paint
 
 logger = logging.getLogger(__name__)
 
@@ -34,11 +35,6 @@ DEFAULT_CONSTANT_PAINTS = {
 
 
 # ─── small shared helpers (extracted to kill duplicated logic shape) ────────
-
-
-def _is_number(val: Any) -> bool:
-    """Check if val is a valid finite number (int/float, excluding bool and NaN/Inf)."""
-    return isinstance(val, (int, float)) and not isinstance(val, bool) and math.isfinite(val)
 
 
 def _slugify(name: str) -> str:
@@ -185,119 +181,12 @@ def _infer_geometry_category(geojson: Optional[Dict[str, Any]]) -> Tuple[str, Li
     return majority_cat, warnings
 
 
-# ─── legend_spec -> StyleMethod converters ─────────────────────────────────
-# Each returns (style_method_or_None, warnings). None signals "fall back to constant".
-
-
-def _convert_graduated_legend(legend_spec: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], List[str]]:
-    """Converts a graduated legend_spec into a step StyleMethod."""
-    warnings: List[str] = []
-    field = legend_spec.get("field", "")
-    breaks = legend_spec.get("breaks", [])
-    palette_colors = legend_spec.get("palette_colors") or legend_spec.get("colors") or []
-
-    valid_breaks = isinstance(breaks, list) and len(breaks) >= 2 and all(_is_number(b) for b in breaks)
-    valid_colors = isinstance(palette_colors, list) and len(palette_colors) >= 1
-
-    if field and valid_breaks and valid_colors:
-        default_color = palette_colors[0]
-        stops = []
-        for i in range(1, len(breaks) - 1):
-            color_i = palette_colors[i] if i < len(palette_colors) else palette_colors[-1]
-            stops.append([float(breaks[i]), color_i])
-
-        return {
-            "method": "step",
-            "field": field,
-            "default": default_color,
-            "stops": stops,
-        }, warnings
-
-    warnings.append("graduated_legend_invalid: insufficient breaks or palette_colors")
-    return None, warnings
-
-
-def _convert_continuous_legend(legend_spec: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], List[str]]:
-    """Converts a continuous legend_spec into an interpolate StyleMethod."""
-    warnings: List[str] = []
-    field = legend_spec.get("field", "")
-    min_val = legend_spec.get("min")
-    max_val = legend_spec.get("max")
-    palette_colors = legend_spec.get("palette_colors") or legend_spec.get("colors") or []
-
-    if (
-        field
-        and _is_number(min_val)
-        and _is_number(max_val)
-        and float(min_val) < float(max_val)
-        and isinstance(palette_colors, list)
-        and len(palette_colors) >= 2
-    ):
-        n = len(palette_colors)
-        step = (float(max_val) - float(min_val)) / (n - 1)
-        stops = [
-            [round(float(min_val) + i * step, 6), palette_colors[i]]
-            for i in range(n)
-        ]
-
-        return {
-            "method": "interpolate",
-            "field": field,
-            "stops": stops,
-        }, warnings
-
-    warnings.append("continuous_legend_invalid: missing field, palette_colors (min 2), or min must be strictly less than max")
-    return None, warnings
-
-
-def _convert_categorical_legend(
-    legend_spec: Dict[str, Any], default_fallback: str = "#999999"
-) -> Tuple[Optional[Dict[str, Any]], List[str]]:
-    """Converts a categorical legend_spec into a match StyleMethod.
-
-    Per the legend_spec contract the categorical variant carries only
-    `categories: [{key, color, label}]`; the match default is the last
-    category color (falling back to `default_fallback` if a category lacks one).
-    """
-    warnings: List[str] = []
-    field = legend_spec.get("field", "")
-    categories = legend_spec.get("categories", [])
-
-    if field and isinstance(categories, list) and len(categories) >= 1:
-        cases = []
-        for cat in categories:
-            if isinstance(cat, dict):
-                key = cat.get("key")
-                color = cat.get("color")
-                if key is not None and color:
-                    cases.append([key, color])
-            elif isinstance(cat, (list, tuple)) and len(cat) >= 2:
-                cases.append([cat[0], cat[1]])
-
-        if cases:
-            # Spec contract: default = last category color.
-            default_color = cases[-1][1] or default_fallback
-            return {
-                "method": "match",
-                "field": field,
-                "cases": cases,
-                "default": default_color,
-            }, warnings
-
-        warnings.append("categorical_legend_invalid: no valid category entries")
-        return None, warnings
-
-    warnings.append("categorical_legend_invalid: missing field or categories")
-    return None, warnings
-
-
-# Dispatch table: drives the legend arms from one map so the converter body
-# doesn't repeat the same convert→extend→flag shape per type.
-_LEGEND_CONVERTERS: Dict[str, Callable[[Dict[str, Any], str], Tuple[Optional[Dict[str, Any]], List[str]]]] = {
-    "graduated": lambda spec, fallback: _convert_graduated_legend(spec),
-    "continuous": lambda spec, fallback: _convert_continuous_legend(spec),
-    "categorical": _convert_categorical_legend,
-}
+# ─── legend_spec -> StyleMethod paint.color (single projection) ─────────────
+# Paint derivation delegates to ``thematic_spec.spec_to_paint`` — the ONE
+# construction site shared with the frontend adapter and the semantic checks
+# (ADR-0052). Keeping a single projection is what guarantees the live map's
+# paint and the legend can never diverge: both are deterministic functions of
+# the same canonical ``legend_spec``.
 
 
 def _resolve_paint_color(
@@ -309,21 +198,7 @@ def _resolve_paint_color(
     is absent/malformed, paint_color stays None and the caller applies the
     constant default.
     """
-    warnings: List[str] = []
-    if legend_spec is None:
-        return None, False, warnings
-    if not isinstance(legend_spec, dict):
-        warnings.append("invalid_legend_spec: legend_spec must be a dictionary")
-        return None, False, warnings
-
-    legend_type = legend_spec.get("type")
-    converter = _LEGEND_CONVERTERS.get(legend_type)
-    if converter is None:
-        warnings.append(f"unrecognized_legend_type: {legend_type}")
-        return None, False, warnings
-
-    paint_color, legend_warns = converter(legend_spec, _default_color(layer_type))
-    warnings.extend(legend_warns)
+    paint_color, warnings = spec_to_paint(legend_spec, _default_color(layer_type))
     return paint_color, paint_color is not None, warnings
 
 
@@ -421,6 +296,14 @@ def convert_analysis_to_mapspec_layer(
         source_id = base_layer.get("source") or f"{layer_id}_source"
 
         res_layer = _build_layer(base_layer, layer_id, source_id, layer_type, paint, provenance)
+        # ADR-0052: attach the canonical legend_spec onto the output layer so the
+        # cartography semantic checks can verify paint ↔ legend equivalence on
+        # the SAME MapSpec (previously the vector path dropped legend_spec while
+        # the raster path kept it — an asymmetry that made drift undetectable).
+        # Extra keys are ignored by the compiler/runtime (they forward only
+        # id/type/source/paint/layout/filter to MapLibre).
+        if isinstance(legend_spec, dict):
+            res_layer["legend_spec"] = legend_spec
         return res_layer, inline_geojson, unique_warnings
 
     except Exception as e:

--- a/app/services/cartography_service.py
+++ b/app/services/cartography_service.py
@@ -6,9 +6,6 @@ from typing import List, Dict, Any, Optional
 import numpy as np
 
 from app.lib.cartography.palettes import get_color_from_palette
-# COLOR_PALETTES re-exported for app.lib.geo_analysis.density (KDE legend_spec).
-# noqa: F401 — deliberate cross-module re-export.
-from app.lib.cartography.palettes import COLOR_PALETTES  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +101,10 @@ class CartographyService:
                 if val in ["HH", "LL", "HL", "LH", "NS"]:
                     lisa_values.append(val)
             else:
-                if isinstance(val, (int, float)):
+                # Filter NaN/Inf/bool once at the value-collection seam so a
+                # stray null in the column can no longer poison the quantile/
+                # Jenks breaks (ADR-0052 no-data semantics).
+                if isinstance(val, (int, float)) and not isinstance(val, bool) and np.isfinite(val):
                     values.append(float(val))
 
         if method == "lisa":
@@ -136,20 +136,13 @@ class CartographyService:
         # 计算间断点
         breaks = cls.classify(values, method, k)
         min_val, max_val = min(values), max(values)
-        val_range = max_val - min_val if max_val > min_val else 1.0
 
-        colors = []
-        legend_labels = []
-        for i in range(len(breaks) - 1):
-            # 获取颜色
-            b_min = breaks[i]
-            b_max = breaks[i+1]
-            # 用区间的中间值来取颜色
-            mid_val = (b_min + b_max) / 2.0
-            normalized = (mid_val - min_val) / val_range
-            color = cls.get_color_from_palette(palette, normalized)
-            colors.append(color)
-            legend_labels.append(f"{b_min:.2f} - {b_max:.2f}")
+        # ADR-0052: resolve palette colors through the single midpoint-sampling
+        # path (resolve_thematic_colors) so build_thematic_style, build_graduated_spec
+        # and h3_binning all share one palette-resolution implementation.
+        from app.lib.cartography.thematic_spec import resolve_thematic_colors
+        colors = resolve_thematic_colors(palette, len(breaks) - 1, breaks, min_val, max_val)
+        legend_labels = [f"{breaks[i]:.2f} - {breaks[i + 1]:.2f}" for i in range(len(breaks) - 1)]
 
         return {
             "type": "choropleth",

--- a/app/services/mapspec/lifecycle_engine.py
+++ b/app/services/mapspec/lifecycle_engine.py
@@ -21,6 +21,7 @@ from app.services.session_data import session_data_manager
 from app.services.mapspec.store import mapspec_store_instance, _should_remove_layer
 from app.services.mapspec.pipeline import process_layer_ingestion
 from app.services.mapspec.coordinator import validate as validate_mapspec
+from app.lib.cartography.semantic_checks import evaluate_cartography_semantics
 from app.services.mapspec.checkpoint import snapshot as create_checkpoint, rollback as rollback_checkpoint
 from app.services.distributed_lock import session_lock_registry
 
@@ -48,6 +49,12 @@ class MapSpecResult:
     is_error: bool = False
     error_msg: str = ""
     correction_hint: str = ""
+    # ADR-0052: deterministic cartography-semantic findings (paint ↔ legend
+    # equivalence, cardinality, domain coverage, no-data, …). Structural
+    # validity (is_compiled) ≠ thematic correctness — these findings are the
+    # evidence the Harness surfaces so "structurally valid but legend/paint
+    # drift" is detectable. Checks needing a source profile are NOT_EVALUATED.
+    cartography_findings: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         if self.is_error:
@@ -61,6 +68,7 @@ class MapSpecResult:
             "warnings": self.warnings,
             "is_compiled": self.is_compiled,
             "checkpoint_id": self.checkpoint_id,
+            "cartography_findings": self.cartography_findings,
         }
 
 
@@ -394,6 +402,13 @@ class MapSpecLifecycleEngine:
                     checkpoint_id=checkpoint_id_created,
                     ref_count=ckpt_ref_count,
                     is_error=False,
+                    # ADR-0052: attach thematic-consistency evidence (no source
+                    # profile available here → profile-dependent checks report
+                    # NOT_EVALUATED; profile-free checks like
+                    # LEGEND_STYLE_EQUIVALENCE still fire on layers carrying a
+                    # legend_spec). Never blocks commit — structural validate()
+                    # remains the gate; these are evidence for the Harness.
+                    cartography_findings=evaluate_cartography_semantics(mapspec).to_dict().get("findings", []),
                 )
 
             except Exception as e:

--- a/app/services/mapspec/lifecycle_engine.py
+++ b/app/services/mapspec/lifecycle_engine.py
@@ -395,6 +395,17 @@ class MapSpecLifecycleEngine:
                         session_id, "layers", list(mapspec.get("layers", []))
                     )
 
+                # ADR-0052: attach thematic-consistency evidence (no source
+                # profile available here → profile-dependent checks report
+                # NOT_EVALUATED; profile-free checks like LEGEND_STYLE_EQUIVALENCE
+                # still fire on layers carrying a legend_spec). Wrapped in its own
+                # try/except so a cartography-check failure on an edge-case spec
+                # can NEVER roll back an already-committed valid mutation — these
+                # are evidence for the Harness, not a commit gate.
+                try:
+                    cartography_findings = evaluate_cartography_semantics(mapspec).to_dict().get("findings", [])
+                except Exception:  # noqa: BLE001 — evidence must never block commit
+                    cartography_findings = []
                 return MapSpecResult(
                     mapspec=mapspec,
                     warnings=warnings,
@@ -402,13 +413,7 @@ class MapSpecLifecycleEngine:
                     checkpoint_id=checkpoint_id_created,
                     ref_count=ckpt_ref_count,
                     is_error=False,
-                    # ADR-0052: attach thematic-consistency evidence (no source
-                    # profile available here → profile-dependent checks report
-                    # NOT_EVALUATED; profile-free checks like
-                    # LEGEND_STYLE_EQUIVALENCE still fire on layers carrying a
-                    # legend_spec). Never blocks commit — structural validate()
-                    # remains the gate; these are evidence for the Harness.
-                    cartography_findings=evaluate_cartography_semantics(mapspec).to_dict().get("findings", []),
+                    cartography_findings=cartography_findings,
                 )
 
             except Exception as e:

--- a/app/services/mapspec_store.py
+++ b/app/services/mapspec_store.py
@@ -44,6 +44,12 @@ def _with_evidence(res, base: Dict[str, Any]) -> Dict[str, Any]:
         base["warnings"] = res.warnings
     if res.checkpoint_id:
         base["checkpoint_id"] = res.checkpoint_id
+    # ADR-0052: forward deterministic cartography-semantic findings (paint↔legend
+    # drift, cardinality, domain, …) so the Harness semantic_errors evidence
+    # channel is not starved in production. Structural validity (is_compiled) ≠
+    # thematic correctness; these findings are what make drift detectable.
+    if getattr(res, "cartography_findings", None):
+        base["cartography_findings"] = res.cartography_findings
     if res.is_error:
         base["message"] = res.error_msg
         if res.correction_hint:

--- a/app/services/raster_cartography_converter.py
+++ b/app/services/raster_cartography_converter.py
@@ -21,6 +21,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
+from app.lib.cartography.palettes import resolve_palette_colors
+
 logger = logging.getLogger(__name__)
 
 # Default colormap for raster overlays (NDVI/DEM). Viridis is perceptually
@@ -179,12 +181,23 @@ def build_raster_layer(
 
     png = render_array_to_png(array, palette=palette)
 
-    a_min, a_max = float(np.min(array)), float(np.max(array))
+    # Legend min/max must use the SAME finite mask as render_array_to_png
+    # (GIS-05): raw np.min/np.max return NaN when any nodata is present, which
+    # would make legend_spec.min/max disagree with the correctly-masked PNG.
+    resolved_palette = palette if palette in _known_palettes() else DEFAULT_RASTER_PALETTE
+    finite = array[np.isfinite(array)]
+    if finite.size == 0:
+      a_min, a_max = 0.0, 0.0
+    else:
+      a_min, a_max = float(finite.min()), float(finite.max())
     legend = {
         "type": "continuous",
         "min": round(a_min, 6),
         "max": round(a_max, 6),
-        "palette": palette if palette in _known_palettes() else DEFAULT_RASTER_PALETTE,
+        "palette": resolved_palette,
+        # Carry the resolved ramp so the legend swatches match the baked PNG
+        # pixels exactly (both derive from COLOR_PALETTES via one path).
+        "palette_colors": resolve_palette_colors(resolved_palette, fallback=DEFAULT_RASTER_PALETTE),
     }
 
     layer = {

--- a/app/tools/advanced_spatial.py
+++ b/app/tools/advanced_spatial.py
@@ -267,25 +267,17 @@ def register_advanced_spatial_tools(registry: ToolRegistry):
             else:
                 stat_field_name = "count"
             if isinstance(out_geojson, dict):
-                values = [
-                    float(f.get("properties", {}).get(stat_field_name))
-                    for f in out_geojson.get("features", [])
-                    if isinstance(f.get("properties", {}).get(stat_field_name), (int, float))
-                ]
-                if len(values) >= 2:
-                    from app.services.cartography_service import CartographyService
-                    from app.lib.cartography.palettes import resolve_palette_colors
-                    breaks = CartographyService.classify(values, "quantiles", 5)
-                    palette = "YlOrRd"
-                    palette_colors = resolve_palette_colors(palette)[:5]
-                    if isinstance(payload, dict):
-                        payload["legend_spec"] = {
-                            "type": "graduated",
-                            "field": stat_field_name,
-                            "breaks": breaks,
-                            "palette": palette,
-                            "palette_colors": palette_colors,
-                        }
+                # Single canonical graduated-spec builder (ADR-0052): runs the
+                # one classification algorithm, resolves palette colors through
+                # one path (midpoint sampling, matching create_thematic_map), and
+                # filters NaN/Inf once. Replaces the verbatim palette truncation
+                # that diverged from every other graduated emitter.
+                from app.lib.cartography.thematic_spec import build_graduated_spec
+                spec = build_graduated_spec(
+                    out_geojson, stat_field_name, method="quantiles", k=5, palette="YlOrRd"
+                )
+                if spec is not None and isinstance(payload, dict):
+                    payload["legend_spec"] = spec
         except Exception as e:  # noqa: BLE001 — legend failure never blocks tool result
             import logging
             logging.getLogger(__name__).warning(f"[h3_binning] legend_spec construction failed: {e}")

--- a/app/tools/cartography.py
+++ b/app/tools/cartography.py
@@ -109,22 +109,42 @@ def register_cartography_tools(registry: ToolRegistry):
             data = _safe_parse_geojson(geojson)
             if not data:
                 return {"error": "Invalid GeoJSON input"}
-            
+
             from app.services.cartography_service import CartographyService
-            style_def = CartographyService.build_thematic_style(
-                geojson=data,
-                field=field,
-                method=method,
-                k=k,
-                palette=palette
-            )
-            
+            from app.lib.cartography.thematic_spec import build_graduated_spec
+
+            # ADR-0052: legend_spec is the canonical thematic style — the single
+            # source both the live MapSpec paint and the <ThematicLegend> overlay
+            # derive from. Built through ONE classification (CartographyService
+            # stays the engine; the canonical builder delegates to classify, then
+            # resolves palette + filters finite values once). For non-lisa we
+            # classify exactly once via build_graduated_spec and synthesize the
+            # legacy `style_def` view from it (no double Jenks pass).
+            legend_spec = None
+            style_def = None
+            if method == "lisa":
+                style_def = CartographyService.build_thematic_style(
+                    geojson=data, field=field, method="lisa", k=k, palette=palette
+                )
+                legend_spec = CartographyService.build_legend_spec(style_def, palette=palette)
+            else:
+                legend_spec = build_graduated_spec(
+                    data, field=field, method=method, k=k, palette=palette,
+                )
+                if legend_spec is not None:
+                    style_def = {
+                        "type": "choropleth",
+                        "field": field,
+                        "breaks": legend_spec.get("breaks", []),
+                        "colors": legend_spec.get("palette_colors", []),
+                        "legend_labels": legend_spec.get("labels", []),
+                    }
+
             return_dict = {
                 "geojson": data,  # return unmodified geojson
                 "group": group,
                 "style": style_def,
             }
-            legend_spec = CartographyService.build_legend_spec(style_def, palette=palette)
             if legend_spec is not None:
                 return_dict["legend_spec"] = legend_spec
                 return_dict["layer_meta"] = {

--- a/docs/adr/0007-no-unified-cartographic-style-module.md
+++ b/docs/adr/0007-no-unified-cartographic-style-module.md
@@ -1,6 +1,12 @@
 # No unified cartographic-style module until MapSpec feeds the live map
 
-**Status:** accepted
+**Status:** superseded by [ADR-0052](0052-unified-thematic-style-contract.md) (2026-08-12)
+
+> **Superseded.** The revisit trigger below was satisfied by [ADR-0036](0036-mapspec-runtime.md):
+> `applyMapSpecToMap` was deleted and replaced with `MapSpecRuntime.reconcile`, which IS the
+> live map path (`map-panel.tsx` → `hudStateToMapSpec` → `runtime.reconcileAsync`). ADR-0052
+> introduces the canonical thematic-style contract this ADR deferred. The text below is
+> preserved as the historical rationale.
 
 We will **not** introduce a unified `CartographicStyle` module (one canonical shape with adapters
 emitting both `legend_spec` and MapSpec `paint.color: StyleMethod`) at this time. The two

--- a/docs/adr/0052-unified-thematic-style-contract.md
+++ b/docs/adr/0052-unified-thematic-style-contract.md
@@ -1,0 +1,176 @@
+# 52. Unified thematic-style contract — `legend_spec` as the single source of truth
+
+Date: 2026-08-12
+
+## Status
+
+Accepted — supersedes [ADR-0007](0007-no-unified-cartographic-style-module.md).
+
+## Context
+
+ADR-0007 deferred a unified cartographic-style module on a single, explicit condition: it
+would earn its keep only when `applyMapSpecToMap` gained a **live** caller — i.e. when "the
+live map renders from compiled MapSpec." Until then the MapSpec `paint.color` path was
+headless-only (Playwright validator, eval scoring, static exporter), so a shared internal
+representation would satisfy a *hypothetical* seam, not a real one. That reasoning was
+**correct at the time**: with only one live consumer (`legend_spec` → `<ThematicLegend>`),
+unifying was speculative.
+
+### What changed — the revisit trigger is now satisfied
+
+[ADR-0036](0036-mapspec-runtime.md) deleted the orphaned `applyMapSpecToMap` (zero callers)
+and replaced it with `MapSpecRuntime`, a reconciliation engine that IS the live map path.
+`map-panel.tsx` no longer hand-builds MapLibre paint inline; it calls
+`hudStateToMapSpec(...)` → `runtime.reconcileAsync(spec)`, and the runtime applies the spec's
+`paint` dict straight to MapLibre. The live map now renders from a derived MapSpec — exactly
+the condition ADR-0007 named. MapSpec `paint` and the legend are now **two parallel live
+consumers** of the same thematic intent.
+
+### Why unification now has real value — the drift is concrete
+
+With two live consumers, the absence of a shared representation stopped being hypothetical
+and became a live, **undetectable** bug. Code evidence:
+
+1. `CartographyService.build_thematic_style` (`app/services/cartography_service.py`) computes
+   `breaks`/`colors` but **does not modify the GeoJSON** — no `fill_color` is baked into
+   features.
+2. `create_thematic_map` (`app/tools/cartography.py`) returns the unmodified GeoJSON plus a
+   separate `legend_spec`.
+3. The frontend SSE handler (`use-sse-stream.ts`) keeps `legend_spec`, sets
+   `style: { color: accentColor }`, and **drops** the `style_def` carrying the breaks/colors.
+4. The `hudStateToMapSpec` adapter (`frontend/lib/mapspec-runtime/adapter.ts`) painted every
+   feature as `["coalesce", ["get", "fill_color"], color||"#16a34a"]`. Features had no
+   `fill_color`, so the whole layer rendered as a flat single color.
+5. `<ThematicLegend>` (`frontend/components/map/thematic-legend.tsx`) read `legend_spec` and
+   rendered a full 5-class graduated palette.
+
+**Net result: a `create_thematic_map` result rendered as a flat green/orange map while the
+legend showed a classified palette — maximal drift, and no check could catch it** because
+paint and legend were two independent data paths with no common source and no consistency
+assertion. This is precisely the "thematic correctness is never asserted" gap ADR-0007
+called a *deferred feature*; with MapSpecRuntime live, it became an *architecture flaw*.
+
+Secondary drift sites the same investigation surfaced:
+- `palette_colors` computed three different ways for the same palette name (midpoint sampling
+  in `build_thematic_style`, verbatim `[:5]` truncation in `h3_binning`, raw slice in
+  `kde_contours`).
+- `continuous` `legend_spec` omitted `field`, so the vector converter's continuous arm
+  silently fell back to constant paint.
+- the raster legend `min`/`max` used raw `np.min/np.max` (NaN when nodata present) while the
+  PNG render correctly used a finite mask — legend and baked raster disagreed.
+- `CartographyService.build_thematic_style` accepted NaN/Inf into classification, poisoning
+  quantile/Jenks breaks.
+- three independent "field identities": `source.metadata.field` (filter), `legend_spec.field`
+  (legend UI), and the hardcoded `fill_color`/`stroke_color` property keys (paint).
+- `evaluate_cartography_semantics` (deterministic cartography checks) had **zero production
+  callers**; the Harness's `SEMANTIC_VALID` tier was actually structural validity
+  (`coordinator.validate`), so a structurally-valid-but-thematically-wrong MapSpec passed.
+
+## Decision
+
+Promote **`legend_spec`** — already the cross-boundary wire format and already a
+discriminated union (`graduated | continuous | categorical | divergent`) on both sides — from
+"legend-only" to the **canonical thematic style**: the single source of truth for thematic
+classification + visual encoding. Both MapSpec `paint` and the legend UI become deterministic
+**projections** of the same `legend_spec`.
+
+This is delivered as a **contract + pure helpers**, not a service:
+
+- `app/lib/cartography/thematic_spec.py` — the canonical contract module. It owns:
+  - the single classification-result path (delegates the algorithm to
+    `CartographyService.classify` — it never reimplements Jenks/quantile);
+  - one palette-resolution function (`resolve_thematic_colors`), collapsing the three-way
+    divergence;
+  - finite/NaN/null filtering at one seam (`finite_numbers`) so nulls cannot poison breaks;
+  - the single paint projection (`spec_to_paint`), consumed by BOTH the vector converter and
+    the semantic checks;
+  - canonical builders (`build_graduated_spec`, `build_continuous_spec`,
+    `build_categorical_spec`, `build_divergent_spec`), `normalize_legend_spec` for legacy
+    payloads, and `thematic_field` (the single field identity).
+- `frontend/lib/mapspec-runtime/thematic-paint.ts` — the frontend mirror
+  (`legendSpecToColorExpression`) producing MapLibre-native expressions (the runtime applies
+  paint directly, unlike the headless compiler which lowers `StyleMethod` via
+  `compileStyleMethod`; both produce byte-identical expressions). Includes a no-data guard so
+  null/missing values are diverted to a no-data color instead of being coerced by `to-number`
+  into the lowest class.
+- The `hudStateToMapSpec` adapter derives `fill-color`/`line-color`/`circle-color` from
+  `legendSpecToColorExpression(layer.legend_spec)`; when no thematic spec is present it keeps
+  the legacy `fill_color` coalesce + flat fallback byte-for-byte (non-thematic layers
+  unchanged). The legend filter range uses `thematicField(legend_spec)` so paint, filter and
+  legend share one field identity.
+- The vector converter (`analysis_cartography_converter`) delegates paint derivation to
+  `spec_to_paint` (single construction site) and now **attaches** `legend_spec` to its output
+  layer (previously dropped on the vector path — an asymmetry that made drift undetectable).
+
+### New deterministic semantic checks (`app/lib/cartography/semantic_checks.py`)
+
+`evaluate_cartography_semantics` gains profile-/legend-driven checks, each NOT_EVALUATED when
+its evidence is absent (never a fake pass): `LEGEND_STYLE_EQUIVALENCE` (paint field/colors == legend),
+`CLASSIFICATION_CARDINALITY` (breaks/categories/labels/colors/paint-stops agree),
+`CLASSIFICATION_DOMAIN_COVERAGE`, `CATEGORICAL_DOMAIN_CONSISTENCY`, `NO_DATA_SEMANTICS`,
+`DIVERGENT_DOMAIN`, `PALETTE_CARDINALITY`. The `_paint_methods` helper now also recognizes
+MapLibre-native `{property,type:"categorical",stops}` paint (the composite-builder form),
+closing a categorical blind spot.
+
+### Harness closure
+
+`MapSpecLifecycleEngine` runs `evaluate_cartography_semantics` at commit and attaches the
+findings to `MapSpecResult.cartography_findings`; the Pi agent harness surfaces error-severity
+findings in `MapSpecValidityEvidence.semantic_errors`. **Tier logic is unchanged**: structural
+validity (`is_compiled`) ≠ thematic correctness; the findings are the evidence channel.
+Profile-dependent checks report NOT_EVALUATED, so a missing source profile is never recorded
+as a thematic pass.
+
+## What stays separate (respecting ADR-0012 / ADR-0017)
+
+This is **not** a God `CartographyService`:
+
+- `CartographyService` remains the canonical classification engine (Fisher-Jenks, quantiles,
+  equal-interval, LISA) — ADR-0012. `thematic_spec` *delegates* to `classify`; it does not
+  reimplement classification.
+- `analysis_cartography_converter` and `raster_cartography_converter` remain separate
+  renderers — ADR-0017. They *consume* the contract; they are not merged.
+- `COLOR_PALETTES` stays single-sourced in `app/lib/cartography/palettes.py`.
+
+The seam is a **data contract + pure projections**, not a service that owns conversion. The
+two converters keep their distinct best-effort/geometry-inference/PNG-rendering
+responsibilities; they just read/write the same canonical shape.
+
+## Backward compatibility
+
+- The `legend_spec` wire shape is preserved exactly; new fields (`method`, `labels`,
+  `nodata`, `unit`, `title`) are **optional and additive**. `normalize_legend_spec` accepts
+  legacy shapes (e.g. `colors` alias, unsorted breaks, `continuous` without `field`).
+- Existing producers (`create_thematic_map`, `h3_binning`) are routed through the canonical
+  builder; their output `legend_spec` shape is unchanged (tests pin it), only the
+  *construction* converges (consistent palette, finite-filtered, no-data aware).
+- Non-thematic layers (`apply_layer_style` single-color, plain results) keep the
+  `fill_color`/`#16a34a` flat path byte-for-byte; the adapter only overrides color when a
+  valid `legend_spec` is present.
+
+## Consequences
+
+- The live map's paint and the legend overlay are now both projections of one
+  `legend_spec`, so legend/map color and field drift is **impossible by construction** and
+  **detectable by check** (`LEGEND_STYLE_EQUIVALENCE`).
+- Thematic paint derivation is O(classes) per layer — it reads `legend_spec`, never scans
+  features. (The adapter's pre-existing O(features) geometry introspection is unchanged and
+  is not classification.)
+- `divergent` is now a first-class mode (contract + builder + projection + `DIVERGENT_DOMAIN`
+  check) even though no producer emits it yet, so a future emitter cannot silently drift.
+- The contract is polyglot (Python producer, TS consumer). The two projections are kept
+  consistent by cross-check tests (`tests/cartography/test_thematic_convergence.py`,
+  `frontend/lib/mapspec-runtime/thematic-paint.test.ts`) that assert byte-identical output
+  mode-for-mode — the anti-pattern guarded against is two handwritten types that
+  *semantically* diverge, not the unavoidable polyglot mirror.
+
+## Relationship to prior ADRs
+
+- **Supersedes ADR-0007** (its revisit trigger is satisfied by ADR-0036).
+- **Honors ADR-0012** (`CartographyService` stays the engine; no `CartographicStyle` service
+  replaces it — the contract is a data shape + helpers, not a facade).
+- **Honors ADR-0017** (the two converters stay separate renderers; not merged into a
+  `CartographyEngine`).
+- **Honors ADR-0015** (legend emitters still attach `legend_spec` at top level; the contract
+  formalizes what that payload means).
+- **Builds on ADR-0036** (the live MapSpec path whose existence justifies the contract).

--- a/frontend/lib/map-kit/types.ts
+++ b/frontend/lib/map-kit/types.ts
@@ -28,8 +28,13 @@ export interface GeoAnalysisResult {
 }
 
 // ─── Legend Spec contract (backend → frontend) ───────────────────────────────
+// ADR-0052: legend_spec is the canonical thematic style — the single source
+// both the live MapSpec paint (thematic-paint.ts) and <ThematicLegend> derive
+// from. The optional fields below (method/labels/nodata/title) are additive and
+// produced by the canonical builders; legacy payloads omit them cleanly.
 
 export type LegendCategoryEntry = { key: string; color: string; label: string };
+export type NoDataRule = { color: string; label: string };
 
 export type GraduatedLegendSpec = {
   type: 'graduated';
@@ -37,7 +42,11 @@ export type GraduatedLegendSpec = {
   breaks: number[];
   palette: string;
   palette_colors: string[];
+  method?: string;        // classification method (quantiles/equal_interval/natural_breaks)
+  labels?: string[];      // per-class labels (count == breaks.length - 1)
+  nodata?: NoDataRule;    // no-data rule (null/missing → nodata color on the live map)
   unit?: string;
+  title?: string;
   format?: 'number' | 'percent' | 'currency';
 };
 
@@ -48,12 +57,17 @@ export type ContinuousLegendSpec = {
   max: number;
   palette: string;
   palette_colors: string[];
+  nodata?: NoDataRule;
+  unit?: string;
 };
 
 export type CategoricalLegendSpec = {
   type: 'categorical';
   field: string;
   categories: LegendCategoryEntry[];
+  palette?: string;
+  nodata?: NoDataRule;
+  title?: string;
 };
 
 export type DivergentLegendSpec = {
@@ -64,6 +78,8 @@ export type DivergentLegendSpec = {
   max: number;
   palette: string;
   palette_colors: string[];
+  nodata?: NoDataRule;
+  unit?: string;
 };
 
 export type LegendSpec =

--- a/frontend/lib/mapspec-runtime/adapter.thematic.test.ts
+++ b/frontend/lib/mapspec-runtime/adapter.thematic.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { hudStateToMapSpec } from "@/lib/mapspec-runtime/adapter";
+import type { Layer } from "@/lib/types/layer";
+import type { GeoJSONFeatureCollection } from "@/lib/types";
+
+/**
+ * ADR-0052 adapter drift-fix regression. Before the fix, a thematic layer
+ * (create_thematic_map result) rendered every feature as a flat `style.color`
+ * / `#16a34a` while <ThematicLegend> showed a full graduated palette — because
+ * the adapter painted from a pre-baked `fill_color` property that the backend
+ * never set. Now the adapter derives the MapLibre color expression from the
+ * SAME legend_spec the legend reads, so map and legend agree.
+ */
+
+function polyFeatures(n = 3): GeoJSONFeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: Array.from({ length: n }, (_, i) => ({
+      type: "Feature" as const,
+      geometry: { type: "Polygon" as const, coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      properties: { pop: i * 10 },
+    })),
+  };
+}
+
+function layer(overrides: Partial<Layer> = {}): Layer {
+  return {
+    id: "thematic-1", name: "t", type: "vector", visible: true, opacity: 1,
+    source: polyFeatures(), ...overrides,
+  } as Layer;
+}
+
+describe("adapter derives thematic paint from legend_spec (drift fix)", () => {
+  it("emits a step fill-color from a graduated legend_spec, NOT flat #16a34a", () => {
+    const l = layer({
+      legend_spec: {
+        type: "graduated", field: "pop", breaks: [0, 10, 20, 30], palette: "YlOrRd",
+        palette_colors: ["#ffffb2", "#fd8d3c", "#bd0026"],
+      } as any,
+      style: { color: "#16a34a" },
+    });
+    const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
+    const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
+    expect(fill.paint["fill-color"]).toEqual([
+      "step", ["to-number", ["get", "pop"]], "#ffffb2",
+      10, "#fd8d3c", 20, "#bd0026",
+    ]);
+  });
+
+  it("the legend field is the SAME field the paint reads (no field drift)", () => {
+    const l = layer({
+      legend_spec: {
+        type: "graduated", field: "income", breaks: [0, 10, 20], palette: "YlOrRd",
+        palette_colors: ["#a", "#b"],
+      } as any,
+    });
+    const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
+    const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
+    // paint references the legend's field, not a hardcoded metadata field.
+    expect(JSON.stringify(fill.paint["fill-color"])).toContain('"get","income"');
+  });
+
+  it("applies the no-data guard when legend_spec declares nodata", () => {
+    const l = layer({
+      legend_spec: {
+        type: "graduated", field: "pop", breaks: [0, 10, 20], palette: "YlOrRd",
+        palette_colors: ["#a", "#b"], nodata: { color: "#ccc", label: "No data" },
+      } as any,
+    });
+    const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
+    const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
+    const expr = fill.paint["fill-color"] as unknown[];
+    expect(expr[0]).toBe("case");
+    expect(JSON.stringify(expr)).toContain('"#ccc"');
+  });
+
+  it("non-thematic layer keeps the legacy fill_color coalesce + flat fallback", () => {
+    const l = layer({ style: { color: "#ff0000" } }); // no legend_spec
+    const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
+    const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
+    // byte-identical to the pre-refactor behavior.
+    expect(fill.paint["fill-color"]).toEqual(["coalesce", ["get", "fill_color"], "#ff0000"]);
+  });
+
+  it("categorical legend_spec emits a match expression on the live map", () => {
+    const l = layer({
+      legend_spec: {
+        type: "categorical", field: "landuse", categories: [
+          { key: "residential", color: "#0", label: "Res" },
+          { key: "commercial", color: "#1", label: "Com" },
+        ],
+      } as any,
+    });
+    const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
+    const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
+    expect(fill.paint["fill-color"]).toEqual([
+      "match", ["get", "landuse"], "residential", "#0", "commercial", "#1", "#1",
+    ]);
+  });
+
+  it("legend filter range uses the legend field (single identity)", () => {
+    const l = layer({
+      legend_spec: {
+        type: "graduated", field: "score", breaks: [0, 50, 100], palette: "YlOrRd",
+        palette_colors: ["#a", "#b"],
+      } as any,
+    });
+    const spec = hudStateToMapSpec({
+      layers: [l], processLayers: {},
+      activeFilters: { "thematic-1": [[0, 50]] }, is3D: false,
+    });
+    const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
+    const filter = JSON.stringify(fill.filter);
+    // The range filter references the legend field 'score', proving paint and
+    // filter share one field identity.
+    expect(filter).toContain('"get","score"');
+    expect(filter).toContain('"score"');
+  });
+
+  it("thematic derivation is O(classes): a 50k-feature layer produces ONE step expression", () => {
+    // Build a large feature collection; the adapter must NOT scan per-feature
+    // to derive the thematic color (it reads legend_spec, O(1) per layer).
+    const big = polyFeatures(1);
+    big.features = Array.from({ length: 50000 }, (_, i) => ({
+      type: "Feature" as const,
+      geometry: { type: "Polygon" as const, coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      properties: { pop: i },
+    }));
+    const l = layer({
+      id: "big", source: big,
+      legend_spec: {
+        type: "graduated", field: "pop", breaks: [0, 10000, 20000, 40000], palette: "YlOrRd",
+        palette_colors: ["#a", "#b", "#c"],
+      } as any,
+    });
+    const t0 = Date.now();
+    const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
+    const dt = Date.now() - t0;
+    const fill = spec.layers.find((x) => x.id === "big__fill")!;
+    // The color expression is a single step (3 classes), independent of 50k features.
+    expect((fill.paint["fill-color"] as unknown[])[0]).toBe("step");
+    // Guard: must complete quickly — thematic derivation must not be O(features).
+    // (Geometry introspection is pre-existing O(features) and allowed; this
+    // bounds total wall-clock as a coarse sanity check.)
+    expect(dt).toBeLessThan(4000);
+  });
+});

--- a/frontend/lib/mapspec-runtime/adapter.ts
+++ b/frontend/lib/mapspec-runtime/adapter.ts
@@ -1,6 +1,7 @@
 import type { Layer } from "@/lib/types/layer";
 import type { GeoJSONFeatureCollection, HeatmapRasterSource } from "@/lib/types";
 import type { MapSpec, MapSpecSource, MapSpecLayer, MapSpecLayerPaint } from "@/lib/mapspec-compiler/types";
+import { legendSpecToColorExpression, thematicField } from "@/lib/mapspec-runtime/thematic-paint";
 
 /**
  * hudStateToMapSpec — pure adapter (ADR-0036, Q2 = "derived MapSpec").
@@ -130,13 +131,18 @@ export function hudStateToMapSpec(input: HudToSpecInput): MapSpec {
     const isNativeHeatmap = layer.type === "heatmap" && src && !isHeatmapRasterSource(layer.source);
     const isHeatmapMode = layer.type === "heatmap" || layer.style?.renderType === "heatmap" || layer.style?.renderType === "grid";
 
-    // Filter expression builder (map-panel.tsx:207-214)
-    const thematicField = src && typeof src === "object" ? (src as any).metadata?.field : null;
+    // Filter expression builder (map-panel.tsx:207-214).
+    // ADR-0052: when a layer carries a thematic legend_spec, its field is the
+    // SINGLE identity shared by paint, legend filter and the legend UI — so the
+    // range filter can never reference a different field than the painted one.
+    // Falls back to source metadata.field for non-thematic layers (back compat).
+    const srcMetaField = src && typeof src === "object" ? (src as any).metadata?.field : null;
+    const filterField = thematicField(layer.legend_spec) ?? srcMetaField;
     const filterRanges = activeFilters[layer.id];
     const buildLayerFilter = (baseType: string): unknown[] => {
       const base: unknown[] = ["==", "$type", baseType];
-      if (thematicField && filterRanges) {
-        const rangeFilters = filterRanges.map((range: number[]) => ["all", [">=", ["get", thematicField], range[0]], ["<", ["get", thematicField], range[1]]]);
+      if (filterField && filterRanges) {
+        const rangeFilters = filterRanges.map((range: number[]) => ["all", [">=", ["get", filterField], range[0]], ["<", ["get", filterField], range[1]]]);
         return ["all", base, ["any", ...rangeFilters]];
       }
       return base;
@@ -144,6 +150,16 @@ export function hudStateToMapSpec(input: HudToSpecInput): MapSpec {
 
     const color = layer.style?.color || "#16a34a";
     const strokeColor = layer.style?.strokeColor || layer.style?.color || "#16a34a";
+
+    // ADR-0052: derive the live map's thematic color expression from the SAME
+    // legend_spec the <ThematicLegend> overlay reads. Before this, the adapter
+    // painted every feature as a flat `style.color`/`#16a34a` while the legend
+    // showed a full classified palette — a maximal, undetectable drift. When no
+    // thematic spec is present (plain single-color / apply_layer_style layers)
+    // thematicColor is null and each color site keeps its legacy fill_color
+    // coalesce + flat fallback, byte-identical to the pre-refactor behavior
+    // (pinned by adapter.test.ts).
+    const thematicColor = legendSpecToColorExpression(layer.legend_spec);
 
     const pushLayer = (sub: string, type: MapSpecLayer["type"], paint: MapSpecLayerPaint, filter?: unknown[]) => {
       outLayers.push({
@@ -192,17 +208,18 @@ export function hudStateToMapSpec(input: HudToSpecInput): MapSpec {
         }, buildLayerFilter("Polygon"));
       } else {
         // Normal polygon: fill (map-panel.tsx:295-304)
+        const fillEnabled = layer.style?.fill !== false;
         pushLayer("fill", "fill", {
-          "fill-color": layer.style?.fill !== false
-            ? ["coalesce", ["get", "fill_color"], color] as any
-            : "rgba(0,0,0,0)" as any,
-          "fill-opacity": layer.style?.fill !== false ? (layer.opacity || 1) * 0.3 : (0 as any),
+          "fill-color": (fillEnabled
+            ? (thematicColor ?? ["coalesce", ["get", "fill_color"], color])
+            : "rgba(0,0,0,0)") as any,
+          "fill-opacity": fillEnabled ? (layer.opacity || 1) * 0.3 : (0 as any),
         }, buildLayerFilter("Polygon"));
 
         // Conditional fill-extrusion when 3D (map-panel.tsx:306-317)
         if (is3D) {
           pushLayer("extrusion", "fill-extrusion", {
-            "fill-extrusion-color": color as any,
+            "fill-extrusion-color": (thematicColor ?? color) as any,
             "fill-extrusion-height": ["coalesce", ["get", "height"], 20] as any,
             "fill-extrusion-base": (0 as any),
             "fill-extrusion-opacity": (layer.opacity || 0.8) as any,
@@ -211,7 +228,7 @@ export function hudStateToMapSpec(input: HudToSpecInput): MapSpec {
 
         // Outline line (map-panel.tsx:318-328)
         const outlinePaint: Record<string, unknown> = {
-          "line-color": ["coalesce", ["get", "stroke_color"], ["get", "fill_color"], strokeColor],
+          "line-color": (thematicColor ?? ["coalesce", ["get", "stroke_color"], ["get", "fill_color"], strokeColor]) as any,
           "line-width": layer.style?.strokeWidth ?? 2,
           "line-opacity": layer.opacity || 1,
         };
@@ -225,7 +242,7 @@ export function hudStateToMapSpec(input: HudToSpecInput): MapSpec {
     // Lines (map-panel.tsx:330-341)
     if (hasLines && !isNativeHeatmap) {
       const linePaint: Record<string, unknown> = {
-        "line-color": ["coalesce", ["get", "fill_color"], strokeColor],
+        "line-color": (thematicColor ?? ["coalesce", ["get", "fill_color"], strokeColor]) as any,
         "line-width": layer.style?.strokeWidth ?? 2,
         "line-opacity": layer.opacity || 1,
       };
@@ -244,7 +261,7 @@ export function hudStateToMapSpec(input: HudToSpecInput): MapSpec {
           : 6;
       pushLayer("point", "circle", {
         "circle-radius": radius as any,
-        "circle-color": ["coalesce", ["get", "fill_color"], color] as any,
+        "circle-color": (thematicColor ?? ["coalesce", ["get", "fill_color"], color]) as any,
         "circle-stroke-width": (1.5 as any),
         "circle-stroke-color": "rgba(22, 163, 74, 0.3)" as any,
         "circle-opacity": (layer.opacity || 1) as any,

--- a/frontend/lib/mapspec-runtime/thematic-paint.test.ts
+++ b/frontend/lib/mapspec-runtime/thematic-paint.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { legendSpecToColorExpression, thematicField, isThematic } from "@/lib/mapspec-runtime/thematic-paint";
+import { compileStyleMethod } from "@/lib/mapspec-compiler/compiler";
+import type { LegendSpec } from "@/lib/map-kit/types";
+
+/**
+ * ADR-0052 frontend thematic-paint contract. These pin the live-path
+ * projection of legend_spec → MapLibre color expression, and assert it mirrors
+ * the backend `spec_to_paint` + the compiler's `compileStyleMethod` so the live
+ * map and the legend cannot diverge.
+ */
+describe("legendSpecToColorExpression — graduated → step", () => {
+  it("builds a step over the field with default = palette_colors[0]", () => {
+    const spec = {
+      type: "graduated", field: "population",
+      breaks: [0, 10, 20, 30], palette: "YlOrRd",
+      palette_colors: ["#ffffb2", "#fd8d3c", "#bd0026"],
+    } as LegendSpec;
+    expect(legendSpecToColorExpression(spec)).toEqual([
+      "step", ["to-number", ["get", "population"]], "#ffffb2",
+      10, "#fd8d3c", 20, "#bd0026",
+    ]);
+  });
+
+  it("returns null when breaks/colors are insufficient", () => {
+    expect(legendSpecToColorExpression({ type: "graduated", field: "x", breaks: [1], palette_colors: [] } as any)).toBeNull();
+  });
+});
+
+describe("legendSpecToColorExpression — continuous/divergent → interpolate", () => {
+  it("builds an interpolate with evenly-spaced stops min→max", () => {
+    const spec = {
+      type: "continuous", field: "density", min: 0, max: 100, palette: "Blues",
+      palette_colors: ["#eff3ff", "#6baed6", "#08519c"],
+    } as LegendSpec;
+    expect(legendSpecToColorExpression(spec)).toEqual([
+      "interpolate", ["linear"], ["to-number", ["get", "density"]],
+      0, "#eff3ff", 50, "#6baed6", 100, "#08519c",
+    ]);
+  });
+
+  it("divergent interpolates the symmetric domain", () => {
+    const spec = {
+      type: "divergent", field: "dev", center: 0, min: -100, max: 100,
+      palette: "Viridis", palette_colors: ["#1", "#2", "#3"],
+    } as LegendSpec;
+    expect(legendSpecToColorExpression(spec)).toEqual([
+      "interpolate", ["linear"], ["to-number", ["get", "dev"]],
+      -100, "#1", 0, "#2", 100, "#3",
+    ]);
+  });
+});
+
+describe("legendSpecToColorExpression — categorical → match", () => {
+  it("builds a match with default = last category color", () => {
+    const spec = {
+      type: "categorical", field: "landuse", categories: [
+        { key: "residential", color: "#0", label: "Res" },
+        { key: "commercial", color: "#1", label: "Com" },
+      ],
+    } as LegendSpec;
+    expect(legendSpecToColorExpression(spec)).toEqual([
+      "match", ["get", "landuse"], "residential", "#0", "commercial", "#1", "#1",
+    ]);
+  });
+});
+
+describe("no-data guard", () => {
+  it("wraps numeric expressions so null/missing → nodata color", () => {
+    const spec = {
+      type: "graduated", field: "pop", breaks: [0, 10, 20], palette: "YlOrRd",
+      palette_colors: ["#a", "#b"], nodata: { color: "#cccccc", label: "No data" },
+    } as any;
+    expect(legendSpecToColorExpression(spec)).toEqual([
+      "case", ["==", ["get", "pop"], null], "#cccccc",
+      ["step", ["to-number", ["get", "pop"]], "#a", 10, "#b"],
+    ]);
+  });
+
+  it("does not guard categorical (match default absorbs unmatched/null)", () => {
+    const spec = {
+      type: "categorical", field: "u", categories: [{ key: "a", color: "#0", label: "a" }],
+      nodata: { color: "#ccc", label: "nd" },
+    } as any;
+    expect(legendSpecToColorExpression(spec)).toEqual([
+      "match", ["get", "u"], "a", "#0", "#0",
+    ]);
+  });
+});
+
+describe("field identity + validity", () => {
+  it("thematicField reads the canonical field", () => {
+    expect(thematicField({ type: "graduated", field: "pop", breaks: [], palette_colors: [] } as any)).toBe("pop");
+    expect(thematicField({ type: "continuous", min: 0, max: 1, palette: "Blues", palette_colors: [] } as any)).toBeNull();
+  });
+  it("isThematic is true for known modes with a field, false otherwise", () => {
+    expect(isThematic({ type: "graduated", field: "x", breaks: [0, 1], palette_colors: ["#a"] } as any)).toBe(true);
+    expect(isThematic({ type: "continuous", min: 0, max: 1, palette: "Blues", palette_colors: ["#a"] } as any)).toBe(false); // no field
+    expect(isThematic({ type: "unknown", field: "x" } as any)).toBe(false); // unknown mode
+    expect(isThematic(null)).toBe(false);
+  });
+  it("returns null for absent/invalid spec", () => {
+    expect(legendSpecToColorExpression(null)).toBeNull();
+    expect(legendSpecToColorExpression({ type: "unknown" } as any)).toBeNull();
+  });
+});
+
+describe("ADR-0052 cross-check: legend_spec→expression matches compileStyleMethod", () => {
+  // Pins that the live direct projection (legendSpecToColorExpression) and the
+  // headless compiler lowering (compileStyleMethod of the StyleMethod that
+  // spec_to_paint would emit) agree mode-for-mode. A future change to either
+  // path that reintroduces live-vs-export drift fails here.
+  it("graduated: direct step == compileStyleMethod(step)", () => {
+    
+    const spec = { type: "graduated", field: "pop", breaks: [0, 10, 20, 30], palette_colors: ["#a", "#b", "#c"] } as any;
+    const styleMethod = { method: "step", field: "pop", default: "#a", stops: [[10, "#b"], [20, "#c"]] };
+    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod));
+  });
+  it("continuous: direct interpolate == compileStyleMethod(interpolate)", () => {
+    
+    const spec = { type: "continuous", field: "d", min: 0, max: 100, palette_colors: ["#1", "#2", "#3"] } as any;
+    const styleMethod = { method: "interpolate", field: "d", stops: [[0, "#1"], [50, "#2"], [100, "#3"]] };
+    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod));
+  });
+  it("categorical: direct match == compileStyleMethod(match)", () => {
+    
+    const spec = { type: "categorical", field: "u", categories: [{ key: "a", color: "#0", label: "a" }, { key: "b", color: "#1", label: "b" }] } as any;
+    const styleMethod = { method: "match", field: "u", cases: [["a", "#0"], ["b", "#1"]], default: "#1" };
+    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod));
+  });
+});

--- a/frontend/lib/mapspec-runtime/thematic-paint.ts
+++ b/frontend/lib/mapspec-runtime/thematic-paint.ts
@@ -1,0 +1,171 @@
+import type { LegendSpec } from "@/lib/map-kit/types";
+
+/**
+ * Derive a MapLibre data-driven color expression from a canonical
+ * {@link LegendSpec} (ADR-0052).
+ *
+ * This is the frontend mirror of the backend
+ * `app/lib/cartography/thematic_spec.py::spec_to_paint`. Both are deterministic
+ * projections of the SAME `legend_spec`, so the live map's paint and the legend
+ * overlay cannot diverge — they read one source.
+ *
+ * The MapSpecRuntime applies a layer's `paint` dict straight to MapLibre
+ * (`runtime.ts::addLayerSafe` → `map.addLayer({paint})`), so unlike the headless
+ * compiler path (which lowers a `StyleMethod` via `compileStyleMethod`) the live
+ * adapter must emit **MapLibre-native** expressions directly. For step /
+ * interpolate / match the expression shapes match `compileStyleMethod`'s output,
+ * so live and headless agree — EXCEPT the optional no-data guard
+ * (`withNoDataGuard`, below) is applied only on the live path when
+ * `legend_spec.nodata` is set; the headless `spec_to_paint` does not encode it,
+ * so a thematic spec with a `nodata` rule renders slightly differently live vs
+ * export (live diverts nulls to the no-data color; export coerces them into the
+ * lowest class).
+ *
+ * Returns `null` when `legend_spec` is absent/invalid → the caller keeps the
+ * legacy flat-color path (`fill_color` property coalesce + `style.color`
+ * fallback), preserving backward compatibility for non-thematic layers
+ * (`apply_layer_style`, plain single-color results).
+ *
+ * No-data semantics: for numeric encodings (step/interpolate) a null/missing
+ * field value would otherwise be coerced by `to-number` to `0` and silently
+ * land in the LOWEST class. When `legend_spec.nodata` is present the expression
+ * is wrapped so null/missing values take the no-data color instead. Categorical
+ * (`match`) needs no guard — its `default` arm already absorbs unmatched/null
+ * values.
+ */
+
+/** True when a legend_spec carries a usable thematic encoding.
+ * Aligned with the backend `is_thematic` contract: a known mode AND a non-empty
+ * field. (A data-driven live-map expression requires a field; a spec without one
+ * yields a null expression and the flat-color fallback.) */
+const THEMATIC_MODES = new Set(["graduated", "continuous", "categorical", "divergent"]);
+export function isThematic(spec: LegendSpec | null | undefined): spec is LegendSpec {
+  return (
+    !!spec &&
+    typeof spec === "object" &&
+    THEMATIC_MODES.has((spec as any).type) &&
+    typeof (spec as any).field === "string" &&
+    (spec as any).field.length > 0
+  );
+}
+
+/** The single thematic field identity for filter/paint/legend consistency. */
+export function thematicField(spec: LegendSpec | null | undefined): string | null {
+  if (!spec) return null;
+  const f = (spec as any).field;
+  return typeof f === "string" && f.length > 0 ? f : null;
+}
+
+/**
+ * Build a MapLibre color expression from a legend_spec, or `null` if the spec
+ * does not yield a data-driven thematic expression (caller falls back to flat
+ * color). Pure: no React/MapLibre instances, O(classes) work only.
+ */
+export function legendSpecToColorExpression(
+  spec: LegendSpec | null | undefined,
+): unknown | null {
+  if (!spec || typeof spec !== "object") return null;
+  const type = (spec as any).type as string;
+
+  if (type === "graduated") return graduatedToStep(spec as any);
+  if (type === "continuous" || type === "divergent") return domainToInterpolate(spec as any);
+  if (type === "categorical") return categoricalToMatch(spec as any);
+
+  return null;
+}
+
+// ─── projections (mirror backend thematic_spec._*_to_*) ─────────────────────
+
+function graduatedToStep(spec: any): unknown | null {
+  const field: string | undefined = spec.field;
+  const breaks: unknown[] = Array.isArray(spec.breaks) ? spec.breaks : [];
+  const colors: unknown[] = Array.isArray(spec.palette_colors)
+    ? spec.palette_colors
+    : Array.isArray(spec.colors)
+      ? spec.colors
+      : [];
+
+  const numericBreaks = breaks.filter(isFiniteNumber);
+  if (!field || numericBreaks.length < 2 || colors.length < 1) return null;
+
+  // Backend contract: default = palette_colors[0]; stops start at breaks[1].
+  const defaultValue = colors[0];
+  const stops: unknown[] = [];
+  for (let i = 1; i < numericBreaks.length - 1; i++) {
+    const color = i < colors.length ? colors[i] : colors[colors.length - 1];
+    stops.push(Number(numericBreaks[i]), color);
+  }
+  const thematic = ["step", ["to-number", ["get", field]], defaultValue, ...stops];
+  return withNoDataGuard(field, thematic, spec.nodata);
+}
+
+function domainToInterpolate(spec: any): unknown | null {
+  const field: string | undefined = spec.field;
+  const min = spec.min;
+  const max = spec.max;
+  const colors: unknown[] = Array.isArray(spec.palette_colors)
+    ? spec.palette_colors
+    : Array.isArray(spec.colors)
+      ? spec.colors
+      : [];
+
+  if (
+    !field ||
+    !isFiniteNumber(min) ||
+    !isFiniteNumber(max) ||
+    !(Number(min) < Number(max)) ||
+    colors.length < 2
+  ) {
+    return null;
+  }
+
+  const n = colors.length;
+  const step = (Number(max) - Number(min)) / (n - 1);
+  const stops: unknown[] = [];
+  for (let i = 0; i < n; i++) {
+    const stopVal = round6(Number(min) + i * step);
+    stops.push(stopVal, colors[i]);
+  }
+  const thematic = ["interpolate", ["linear"], ["to-number", ["get", field]], ...stops];
+  return withNoDataGuard(field, thematic, spec.nodata);
+}
+
+function categoricalToMatch(spec: any): unknown | null {
+  const field: string | undefined = spec.field;
+  const categories: any[] = Array.isArray(spec.categories) ? spec.categories : [];
+  if (!field || categories.length < 1) return null;
+
+  const cases: unknown[] = [];
+  for (const cat of categories) {
+    if (cat && typeof cat === "object" && cat.key != null && cat.color) {
+      cases.push(cat.key, cat.color);
+    } else if (Array.isArray(cat) && cat.length >= 2) {
+      cases.push(cat[0], cat[1]);
+    }
+  }
+  if (cases.length === 0) return null;
+
+  // Backend contract: default = last category color (legend_spec.default ignored).
+  const lastColor = cases[cases.length - 1];
+  return ["match", ["get", field], ...cases, lastColor];
+}
+
+/**
+ * Wrap a numeric thematic expression so a null/missing field value is diverted
+ * to the no-data color instead of being coerced by `to-number` into the lowest
+ * class. `["get", field]` returns null for both null-valued and absent
+ * properties in MapLibre, so a single `== null` test covers both. No-op when
+ * no `nodata` rule is declared (backward compat for legacy legend_specs).
+ */
+function withNoDataGuard(field: string, thematic: unknown[], nodata: any): unknown {
+  if (!nodata || typeof nodata !== "object" || !nodata.color) return thematic;
+  return ["case", ["==", ["get", field], null], nodata.color, thematic];
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+function round6(v: number): number {
+  return Math.round(v * 1e6) / 1e6;
+}

--- a/tests/cartography/test_thematic_convergence.py
+++ b/tests/cartography/test_thematic_convergence.py
@@ -1,0 +1,482 @@
+"""ADR-0052 thematic-style convergence regression suite.
+
+Pins the single-source-of-truth contract: ``legend_spec`` is the canonical
+thematic style; MapSpec ``paint`` and the legend UI are deterministic
+projections of it. These tests are the GREEN target for the drift regressions
+(field drift, color drift, no-data, divergent, cardinality, domain coverage)
+and the compatibility guarantees (legacy legend_spec, NOT_EVALUATED policy).
+"""
+from app.lib.cartography import thematic_spec as ts
+from app.lib.cartography.semantic_checks import evaluate_cartography_semantics
+from app.services.analysis_cartography_converter import convert_analysis_to_mapspec_layer
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+def _mapspec(layers, sources=None, layout=None):
+    return {
+        "version": "1.0",
+        "sources": sources or {"src1": {"type": "geojson"}},
+        "layers": layers,
+        **({"layout": layout} if layout else {}),
+    }
+
+
+def _graduated_layer(breaks, colors, field="population", legend_field=None, paint_field=None,
+                     layer_id="L1", source="src1", palette="YlOrRd", labels=None, nodata=None):
+    """Build a layer with a step paint AND a matching legend_spec (drift-free by default)."""
+    legend_field = legend_field if legend_field is not None else field
+    paint_field = paint_field if paint_field is not None else field
+    stops = [[float(breaks[i]), colors[i]] for i in range(1, len(breaks) - 1)]
+    paint = {"color": {"method": "step", "field": paint_field,
+                       "default": colors[0], "stops": stops}}
+    legend = {"type": "graduated", "field": legend_field, "breaks": list(breaks),
+              "palette": palette, "palette_colors": list(colors)}
+    if labels is not None:
+        legend["labels"] = labels
+    if nodata is not None:
+        legend["nodata"] = nodata
+    return {"id": layer_id, "source": source, "type": "fill", "paint": paint, "legend_spec": legend}
+
+
+def _profile(field="population", ftype="number", fmin=0.0, fmax=100.0,
+             sample_values=None, null_count=None):
+    info = {"type": ftype}
+    if ftype == "number":
+        info["min"], info["max"] = fmin, fmax
+    if sample_values is not None:
+        info["sampleValues"] = sample_values
+    if null_count is not None:
+        info["null_count"] = null_count
+    return {"src1": {"featureCount": 50, "geometryTypes": ["Polygon"], "fields": {field: info}}}
+
+
+def _check_names(report, evaluated_only=True):
+    return {f.check for f in report.findings if (f.evaluated or not evaluated_only)}
+
+
+# ─── spec_to_paint projections (parity with converter) ──────────────────────
+
+
+def test_spec_to_paint_graduated_matches_converter_contract():
+    spec = {"type": "graduated", "field": "pop", "breaks": [0.0, 10.0, 20.0, 30.0],
+            "palette_colors": ["#a", "#b", "#c"]}
+    paint, warns = ts.spec_to_paint(spec)
+    assert paint == {"method": "step", "field": "pop", "default": "#a",
+                     "stops": [[10.0, "#b"], [20.0, "#c"]]}
+    assert warns == []
+
+
+def test_spec_to_paint_continuous_even_stops():
+    spec = {"type": "continuous", "field": "d", "min": 0.0, "max": 100.0,
+            "palette_colors": ["#1", "#2", "#3"]}
+    paint, _ = ts.spec_to_paint(spec)
+    assert paint["method"] == "interpolate"
+    assert paint["stops"] == [[0.0, "#1"], [50.0, "#2"], [100.0, "#3"]]
+
+
+def test_spec_to_paint_categorical_default_is_last_color():
+    spec = {"type": "categorical", "field": "use",
+            "categories": [{"key": "r", "color": "#0", "label": "Res"},
+                           {"key": "c", "color": "#1", "label": "Com"}]}
+    paint, _ = ts.spec_to_paint(spec)
+    assert paint["default"] == "#1"  # last category, NOT legend_spec.default
+    assert paint["cases"] == [["r", "#0"], ["c", "#1"]]
+
+
+def test_spec_to_paint_divergent_interpolates_domain():
+    spec = ts.build_divergent_spec([-100, -5, 0, 7, 100], "dev", center=0, palette="Viridis")
+    assert spec is not None
+    paint, _ = ts.spec_to_paint(spec)
+    assert paint["method"] == "interpolate"
+    assert paint["stops"][0][0] == spec["min"]
+    assert paint["stops"][-1][0] == spec["max"]
+
+
+# ─── single classification + finite filtering ───────────────────────────────
+
+
+def test_build_graduated_spec_filters_nan_inf_null():
+    geojson = {"type": "FeatureCollection", "features": [
+        {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+         "properties": {"v": v}} for v in [1, 2, 3, 4, 5, float("nan"), float("inf"), None, "x"]
+    ]}
+    spec = ts.build_graduated_spec(geojson, "v", method="quantiles", k=4, palette="YlOrRd")
+    assert spec is not None
+    # NaN/Inf/None/str filtered: breaks computed over [1..5] only — no NaN leaks.
+    import math
+    assert all(math.isfinite(b) for b in spec["breaks"])
+    assert spec["field"] == "v"
+    assert len(spec["palette_colors"]) == max(1, len(spec["breaks"]) - 1)
+
+
+def test_build_graduated_spec_colors_match_breaks_cardinality():
+    geojson = {"type": "FeatureCollection", "features": [
+        {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+         "properties": {"v": float(i)}} for i in range(1, 21)
+    ]}
+    spec = ts.build_graduated_spec(geojson, "v", method="equal_interval", k=5, palette="YlOrRd")
+    assert spec is not None
+    assert len(spec["palette_colors"]) == len(spec["breaks"]) - 1
+
+
+def test_build_graduated_spec_defaults_nodata_rule():
+    """ADR-0052 no-data semantics: graduated/continuous/divergent specs default to
+    a no-data rule so null/missing values are diverted on the live map rather
+    than coerced by to-number into the lowest class."""
+    geojson = {"type": "FeatureCollection", "features": [
+        {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+         "properties": {"v": float(i)}} for i in range(1, 11)
+    ]}
+    spec = ts.build_graduated_spec(geojson, "v", method="quantiles", k=4, palette="YlOrRd")
+    assert spec is not None and spec.get("nodata") is not None
+    assert "color" in spec["nodata"] and "label" in spec["nodata"]
+    # continuous + divergent also default nodata
+    cont = ts.build_continuous_spec(0.0, 10.0, "Blues", field="d")
+    assert cont is not None and cont.get("nodata") is not None
+    div = ts.build_divergent_spec([-5, 0, 5], "d", center=0, palette="Viridis")
+    assert div is not None and div.get("nodata") is not None
+    # a caller can still override nodata
+    custom = ts.build_graduated_spec(geojson, "v", k=4, palette="YlOrRd",
+                                     nodata={"color": "#000", "label": "missing"})
+    assert custom["nodata"] == {"color": "#000", "label": "missing"}
+
+
+# ─── semantic checks: drift regressions ─────────────────────────────────────
+
+
+def test_legend_field_drift_is_detected():
+    # Map paints field=population, legend declares field=income → drift.
+    layer = _graduated_layer([0, 10, 20, 30], ["#a", "#b", "#c"],
+                             paint_field="population", legend_field="income")
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    assert "LEGEND_STYLE_EQUIVALENCE" in _check_names(report)
+    assert any("income" in f.message and "population" in f.message for f in report.findings)
+
+
+def test_legend_color_drift_is_detected():
+    # Map paints A/B/C, legend shows A/X/C.
+    layer = _graduated_layer([0, 10, 20, 30], ["#a", "#b", "#c"])
+    # Tamper: legend palette_colors diverge from paint output colors.
+    layer["legend_spec"]["palette_colors"] = ["#a", "#X", "#c"]
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    assert "LEGEND_STYLE_EQUIVALENCE" in _check_names(report)
+
+
+def test_drift_free_graduated_passes_clean():
+    layer = _graduated_layer([0, 10, 20, 30], ["#a", "#b", "#c"])
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(fmin=0, fmax=30))
+    names = _check_names(report)
+    assert "LEGEND_STYLE_EQUIVALENCE" not in names
+    assert "CLASSIFICATION_CARDINALITY" not in names
+    assert report.ok  # no errors
+
+
+# ─── semantic checks: numeric bad field ─────────────────────────────────────
+
+
+def test_interpolate_on_string_field_flagged():
+    paint = {"color": {"method": "interpolate", "field": "name",
+                       "stops": [[0, "#a"], [10, "#b"]]}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint}
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(field="name", ftype="string"))
+    assert "INTERPOLATE_NUMERIC_FIELD" in _check_names(report)
+
+
+# ─── semantic checks: domain mismatch ───────────────────────────────────────
+
+
+def test_breaks_outside_data_range_is_error():
+    # data range 0..100, breaks 1000..2000 → no overlap.
+    layer = _graduated_layer([1000, 1500, 2000], ["#a", "#b"])
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(fmin=0, fmax=100))
+    names = _check_names(report)
+    assert "CLASSIFICATION_DOMAIN_COVERAGE" in names
+    assert any(f.severity == "error" for f in report.findings if f.check == "CLASSIFICATION_DOMAIN_COVERAGE")
+
+
+def test_breaks_partial_coverage_is_warning():
+    # data 0..100, breaks 30..60 → covers < 75% → warning (not error).
+    layer = _graduated_layer([30, 45, 60], ["#a", "#b"])
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(fmin=0, fmax=100))
+    cov = [f for f in report.findings if f.check == "CLASSIFICATION_DOMAIN_COVERAGE"]
+    assert cov and all(f.severity == "warning" for f in cov)
+
+
+# ─── semantic checks: categorical ───────────────────────────────────────────
+
+
+def test_categorical_drift_free():
+    legend = {"type": "categorical", "field": "use", "categories": [
+        {"key": "residential", "color": "#0", "label": "Res"},
+        {"key": "commercial", "color": "#1", "label": "Com"},
+        {"key": "industrial", "color": "#2", "label": "Ind"}]}
+    paint = {"color": {"method": "match", "field": "use",
+                       "cases": [["residential", "#0"], ["commercial", "#1"], ["industrial", "#2"]],
+                       "default": "#2"}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint, "legend_spec": legend}
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(field="use", ftype="string",
+                                                                       sample_values=["residential", "commercial"]))
+    names = _check_names(report)
+    assert "CLASSIFICATION_CARDINALITY" not in names
+    assert "CATEGORICAL_DOMAIN_CONSISTENCY" not in names
+
+
+def test_categorical_missing_category_in_legend():
+    # Data has 'foo' but legend has no 'foo' category.
+    legend = {"type": "categorical", "field": "use", "categories": [
+        {"key": "residential", "color": "#0", "label": "Res"}]}
+    paint = {"color": {"method": "match", "field": "use", "cases": [["residential", "#0"]], "default": "#0"}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint, "legend_spec": legend}
+    report = evaluate_cartography_semantics(
+        _mapspec([layer]),
+        _profile(field="use", ftype="string", sample_values=["residential", "foo"]),
+    )
+    assert "CATEGORICAL_DOMAIN_CONSISTENCY" in _check_names(report)
+
+
+# ─── semantic checks: no-data ───────────────────────────────────────────────
+
+
+def test_no_data_nulls_without_rule_flagged():
+    layer = _graduated_layer([0, 10, 20], ["#a", "#b"], nodata=None)
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(fmin=0, fmax=20, null_count=7))
+    assert "NO_DATA_SEMANTICS" in _check_names(report)
+
+
+def test_no_data_rule_present_not_flagged():
+    layer = _graduated_layer([0, 10, 20], ["#a", "#b"], nodata={"color": "#ccc", "label": "No data"})
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(fmin=0, fmax=20, null_count=7))
+    assert "NO_DATA_SEMANTICS" not in _check_names(report)
+
+
+def test_no_data_not_evaluated_without_null_count():
+    layer = _graduated_layer([0, 10, 20], ["#a", "#b"])
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(field="population", fmin=0, fmax=20))
+    nodata_findings = [f for f in report.findings if f.check == "NO_DATA_SEMANTICS"]
+    # A profile EXISTS but lacks null_count → an explicit NOT_EVALUATED info
+    # finding must be present (never a fake pass, never silent). Asserting
+    # presence guards against the check being silently dropped.
+    assert any(not f.evaluated for f in nodata_findings), \
+        "NO_DATA_SEMANTICS must emit a NOT_EVALUATED info finding when null_count is absent"
+    assert all((not f.evaluated) or f.severity != "error" for f in nodata_findings)
+
+
+# ─── semantic checks: divergent ─────────────────────────────────────────────
+
+
+def test_divergent_center_outside_domain_is_error():
+    legend = {"type": "divergent", "field": "dev", "center": 500, "min": -100, "max": 100,
+              "palette": "Viridis", "palette_colors": ["#1", "#2", "#3"]}
+    paint = {"color": {"method": "interpolate", "field": "dev",
+                       "stops": [[-100, "#1"], [0, "#2"], [100, "#3"]]}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint, "legend_spec": legend}
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    div = [f for f in report.findings if f.check == "DIVERGENT_DOMAIN"]
+    assert div and any(f.severity == "error" for f in div)
+
+
+def test_divergent_center_at_edge_is_warning():
+    legend = {"type": "divergent", "field": "dev", "center": -100, "min": -100, "max": 100,
+              "palette": "Viridis", "palette_colors": ["#1", "#2"]}
+    paint = {"color": {"method": "interpolate", "field": "dev", "stops": [[-100, "#1"], [100, "#2"]]}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint, "legend_spec": legend}
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    div = [f for f in report.findings if f.check == "DIVERGENT_DOMAIN"]
+    assert div and all(f.severity == "warning" for f in div)
+
+
+def test_divergent_center_in_domain_is_clean():
+    spec = ts.build_divergent_spec([-100, -5, 0, 7, 100], "dev", center=0, palette="Viridis")
+    paint, _ = ts.spec_to_paint(spec)
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": {"color": paint}, "legend_spec": spec}
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    assert "DIVERGENT_DOMAIN" not in _check_names(report)
+
+
+# ─── semantic checks: cardinality + palette ─────────────────────────────────
+
+
+def test_palette_cardinality_too_many_classes():
+    # 8 classes declared but palette 'Reds' has 5 colors.
+    layer = _graduated_layer(list(range(9)), ["#%d" % i for i in range(8)], palette="Reds")
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    assert "PALETTE_CARDINALITY" in _check_names(report)
+
+
+def test_cardinality_colors_breaks_mismatch():
+    legend = {"type": "graduated", "field": "v", "breaks": [0, 10, 20, 30, 40],
+              "palette": "YlOrRd", "palette_colors": ["#a", "#b"]}  # 4 classes, 2 colors
+    paint = {"color": {"method": "step", "field": "v", "default": "#a",
+                       "stops": [[10, "#b"], [20, "#b"], [30, "#b"]]}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint, "legend_spec": legend}
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    names = _check_names(report)
+    assert "CLASSIFICATION_CARDINALITY" in names
+
+
+# ─── semantic checks: NOT_EVALUATED policy ──────────────────────────────────
+
+
+def test_missing_evidence_is_not_evaluated_not_success():
+    # No profile → checks must be NOT_EVALUATED, never a fake pass.
+    layer = _graduated_layer([0, 10, 20], ["#a", "#b"])
+    report = evaluate_cartography_semantics(_mapspec([layer]))  # no source_profiles
+    # No-data / domain checks that need a profile are NOT_EVALUATED (info).
+    evaluated = [f for f in report.findings if f.check in ("NO_DATA_SEMANTICS", "CLASSIFICATION_DOMAIN_COVERAGE") and f.evaluated]
+    assert evaluated == []
+    # And the report is still .ok (no error-severity fakes).
+    assert report.ok
+
+
+# ─── legacy compatibility ───────────────────────────────────────────────────
+
+
+def test_legacy_legend_spec_through_converter_normalizes():
+    # A legacy legend_spec with `colors` alias + unsorted breaks still converts.
+    geojson = {"type": "FeatureCollection", "features": [
+        {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]}, "properties": {"v": 1}}]}
+    analysis = {"algorithm": "legacy", "data": geojson, "legend_spec": {
+        "type": "graduated", "field": "v", "breaks": [0.0, 10.0, 20.0], "colors": ["#a", "#b"]}}
+    layer, _geojson, warnings = convert_analysis_to_mapspec_layer(analysis)
+    # converter attaches legend_spec + derives step paint from it.
+    assert layer.get("legend_spec") is not None
+    assert layer["paint"]["color"]["method"] == "step"
+    # normalization: colors alias → palette_colors, breaks sorted.
+    norm = ts.normalize_legend_spec(layer["legend_spec"])
+    assert norm["palette_colors"] == ["#a", "#b"]
+
+
+def test_composite_categorical_paint_is_seen_by_checks():
+    # MapLibre-native categorical {property,type,stops} (no `method`) must now be
+    # visible to semantic checks (previously a blind spot). POSITIVE assertion:
+    # a composite-categorical paint referencing an ABSENT field fires
+    # PAINT_FIELD_EXISTS — only possible if the normalizer saw it. (Under the
+    # old blind spot the paint was invisible, so the check never ran.)
+    paint = {"color": {"property": "missing_field", "type": "categorical",
+                       "stops": [["residential", "#0"], ["commercial", "#1"]]}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint}
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(field="use", ftype="string"))
+    assert "PAINT_FIELD_EXISTS" in _check_names(report)
+
+
+def test_categorical_color_drift_is_detected():
+    # Categorical color drift: same keys, different color for 'residential'.
+    legend = {"type": "categorical", "field": "use", "categories": [
+        {"key": "residential", "color": "#0", "label": "Res"},
+        {"key": "commercial", "color": "#1", "label": "Com"}]}
+    paint = {"color": {"method": "match", "field": "use",
+                       "cases": [["residential", "#WRONG"], ["commercial", "#1"]],
+                       "default": "#1"}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint, "legend_spec": legend}
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    assert "LEGEND_STYLE_EQUIVALENCE" in _check_names(report)
+    assert any("residential" in f.message for f in report.findings if f.check == "LEGEND_STYLE_EQUIVALENCE")
+
+
+def test_graduated_break_value_drift_is_detected():
+    # Same field/colors/class-count, but the paint step uses DIFFERENT break
+    # thresholds (5,15 vs 10,20). Color/count checks pass; only the break-value
+    # comparison catches it.
+    legend = {"type": "graduated", "field": "v", "breaks": [0, 10, 20, 30],
+              "palette": "YlOrRd", "palette_colors": ["#a", "#b", "#c"]}
+    paint = {"color": {"method": "step", "field": "v", "default": "#a",
+                       "stops": [[5, "#b"], [15, "#c"]]}}
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": paint, "legend_spec": legend}
+    report = evaluate_cartography_semantics(_mapspec([layer]))
+    drift = [f for f in report.findings if f.check == "LEGEND_STYLE_EQUIVALENCE" and "break" in f.message.lower()]
+    assert drift, "graduated break-value drift must be detected"
+
+
+# ─── closed loop: valid mapspec + thematic consistency ──────────────────────
+
+
+def test_closed_loop_graduated_paint_equals_legend():
+    """The canonical invariant: paint output colors == legend palette_colors."""
+    geojson = {"type": "FeatureCollection", "features": [
+        {"type": "Feature", "geometry": {"type": "Polygon",
+                                          "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+         "properties": {"pop": float(v)}} for v in [5, 15, 25, 35, 45, 55, 65, 75, 85, 95]]}
+    spec = ts.build_graduated_spec(geojson, "pop", method="equal_interval", k=4, palette="YlOrRd")
+    assert spec is not None
+    paint, _ = ts.spec_to_paint(spec)
+    # Paint output colors must equal the legend palette_colors exactly.
+    paint_colors = [paint["default"]] + [s[1] for s in paint["stops"]]
+    assert paint_colors == spec["palette_colors"]
+    # And the semantic check confirms no drift.
+    layer = {"id": "L1", "source": "src1", "type": "fill", "paint": {"color": paint}, "legend_spec": spec}
+    report = evaluate_cartography_semantics(_mapspec([layer]), _profile(field="pop", fmin=5, fmax=95))
+    assert "LEGEND_STYLE_EQUIVALENCE" not in _check_names(report)
+    assert report.ok
+
+
+def test_cartography_findings_flow_to_mapspec_result_and_harness_evidence():
+    """ADR-0052 Phase 7: a drift mapspec's cartography errors must surface in
+    MapSpecResult.cartography_findings and thence in the harness semantic_errors
+    evidence channel (structural validity ≠ thematic correctness)."""
+    from app.services.mapspec.lifecycle_engine import MapSpecResult
+
+    # Drift: paint field=population, legend field=income.
+    layer = _graduated_layer([0, 10, 20, 30], ["#a", "#b", "#c"],
+                             paint_field="population", legend_field="income")
+    findings = evaluate_cartography_semantics(_mapspec([layer])).to_dict()["findings"]
+    res = MapSpecResult(
+        mapspec=_mapspec([layer]), warnings=[], is_compiled=True,
+        cartography_findings=findings,
+    )
+    d = res.to_dict()
+    # cartography_findings carried on the result…
+    assert any(f["check"] == "LEGEND_STYLE_EQUIVALENCE" and f["severity"] == "error"
+               for f in d["cartography_findings"])
+
+    # Drive the REAL harness with this result and confirm the merge surfaces the
+    # cartography error into semantic_errors (the evidence channel).
+    from app.lib.harness.pi_agent_harness import PiAgentHarness
+    from app.lib.harness.tool_call_event import ToolCallEvent
+    harness = PiAgentHarness(session_id="drift_test")
+    harness.record_event(ToolCallEvent(
+        tool_call_id="tc_drift", tool_name="webgis_layer_upsert",
+        arguments={"layer": {"id": "L1"}},
+        result={"success": True, "is_compiled": True, "cartography_findings": findings},
+        is_error=False,
+    ))
+    mut = harness.mapspec_mutations[0]
+    # Structural tier is SEMANTIC_VALID (is_compiled True), but the thematic
+    # drift is surfaced as a semantic_errors entry.
+    assert mut["is_valid"] is True
+    assert any("LEGEND_STYLE_EQUIVALENCE" in e for e in mut["semantic_errors"])
+
+
+def test_cartography_findings_forwarded_through_production_evidence_channel():
+    """ADR-0052 Phase 7 (Round-2 fix): cartography_findings must survive the
+    production tool/adapter/bridge forwarding layers (mapspec_store._with_evidence
+    + agent_pi_bridge whitelist) — not just exist on MapSpecResult. Without this,
+    the harness semantic_errors channel is starved in production while tests that
+    hand-feed MapSpecResult pass."""
+    from app.services.mapspec.lifecycle_engine import MapSpecResult
+    from app.services.mapspec_store import _with_evidence
+
+    findings = [{"check": "LEGEND_STYLE_EQUIVALENCE", "severity": "error",
+                 "message": "drift", "evaluated": True}]
+    res = MapSpecResult(is_compiled=True, cartography_findings=findings)
+    forwarded = _with_evidence(res, {"success": True})
+    # _with_evidence must carry cartography_findings onto the adapter dict.
+    assert forwarded.get("cartography_findings") == findings
+
+    # And the bridge whitelist includes it (the field is named in the forward list).
+    import re
+    bridge_src = open("app/agent_pi_bridge.py").read()
+    assert "cartography_findings" in bridge_src
+
+
+def test_cartography_not_evaluated_when_no_profile_no_legend():
+    """A structurally-valid mapspec with no thematic encoding produces an empty
+    (or NOT_EVALUATED-only) cartography report — never a fake thematic pass."""
+    layer = {"id": "L1", "source": "src1", "type": "fill",
+             "paint": {"color": "#3b82f6"}}  # plain constant, no legend_spec
+    findings = evaluate_cartography_semantics(_mapspec([layer])).to_dict()["findings"]
+    # No thematic checks fire (no legend_spec, no method-paint); any findings are
+    # info/NOT_EVALUATED, never an error faking thematic correctness.
+    assert not any(f.get("severity") == "error" and f.get("evaluated") for f in findings)
+

--- a/tests/test_cartography_tools.py
+++ b/tests/test_cartography_tools.py
@@ -118,7 +118,14 @@ async def test_h3_binning_emits_graduated_legend_spec(advanced_registry):
     assert spec is not None
     assert spec["type"] == "graduated"
     assert len(spec["breaks"]) >= 2
-    assert len(spec["palette_colors"]) >= 2
+    # ADR-0052 canonical contract: palette_colors count MUST track the class
+    # count (len(breaks) - 1), not be padded independently. The old h3_binning
+    # path took resolve_palette_colors(palette)[:5] verbatim — always 5 colors
+    # regardless of how many classes the data actually produced, so breaks and
+    # colors silently disagreed. This degenerate cluster legitimately yields
+    # few classes; what matters is that colors and breaks now agree by
+    # construction.
+    assert len(spec["palette_colors"]) == max(1, len(spec["breaks"]) - 1)
 
 
 from app.tools.spatial_stats import register_spatial_stats_tools


### PR DESCRIPTION
## Problem

ADR-0007 deferred a unified cartographic-style module until MapSpec fed the live map. ADR-0036 made `MapSpecRuntime` the live map path (`hudStateToMapSpec` → `runtime.reconcileAsync`), so that revisit trigger is **now satisfied**. With two live consumers of the same thematic intent (paint + legend), the missing shared source became a concrete, **undetectable** drift bug:

- `create_thematic_map` returned unmodified GeoJSON (no baked `fill_color`) + a separate `legend_spec`.
- The SSE handler kept `legend_spec`, set `style: {color: accent}`, and **dropped** the `style_def` carrying breaks/colors.
- The adapter painted `["coalesce", ["get","fill_color"], "#16a34a"]` → every feature rendered flat green while `<ThematicLegend>` showed a full 5-class palette.

Secondary drift: three different `palette_colors` computations for one palette name; `continuous` legend omitted `field`; raster legend `min/max` diverged from the masked PNG; NaN/Inf poisoned classification; three independent field identities; and `evaluate_cartography_semantics` had **zero production callers** (the harness `SEMANTIC_VALID` tier was actually structural validity).

## Architecture

`legend_spec` is promoted to the **canonical thematic style** (single source). Classification + visual encoding flow one direction:

```
GIS result → CartographyService.classify (single algorithm, ADR-0012)
          → legend_spec (canonical) ──┬─→ MapSpec paint (spec_to_paint)
                                      ├─→ live MapLibre expression (legendSpecToColorExpression)
                                      └─→ <ThematicLegend> overlay
          → cartography semantic checks → Harness semantic_errors
```

New contract module `app/lib/cartography/thematic_spec.py` (pure helpers, **not** a God service — ADR-0012/0017 honored: `CartographyService` stays the engine, converters stay separate) + frontend mirror `thematic-paint.ts`. No-data rule defaults on numeric specs so null/missing is diverted (not coerced into the lowest class).

## Compatibility

- `legend_spec` wire shape unchanged; new fields (`method`/`labels`/`nodata`/`unit`/`title`) are optional/additive. `normalize_legend_spec` accepts legacy shapes (`colors` alias, unsorted breaks).
- Existing producers (`create_thematic_map`, `h3_binning`, `kde_contours`) routed through canonical builders; output shapes preserved (only construction converges).
- **Non-thematic layers unchanged byte-for-byte** — `apply_layer_style`/flat-color paths keep `fill_color`/`#16a34a` (pinned by `adapter.test.ts`). Adapter only overrides color when a valid `legend_spec` is present.

## Semantic correctness (new deterministic checks)

`LEGEND_STYLE_EQUIVALENCE` (paint field + ordered colors for graduated/continuous/divergent; `{key:color}` map for categorical; **break-value** comparison for graduated), `CLASSIFICATION_CARDINALITY`, `CLASSIFICATION_DOMAIN_COVERAGE`, `CATEGORICAL_DOMAIN_CONSISTENCY`, `NO_DATA_SEMANTICS`, `DIVERGENT_DOMAIN`, `PALETTE_CARDINALITY`. Composite-builder `{property,type:"categorical"}` paint is now visible (was a blind spot). Missing evidence → `NOT_EVALUATED` (info), never a fake pass. Findings flow through `_with_evidence` + the bridge whitelist into Harness `semantic_errors`.

## Performance

Thematic paint derivation is **O(classes) per layer** — it reads `legend_spec`, never scans features. `evaluate_cartography_semantics` at commit is O(layers × paint-props × classes), no feature scaling. Pinned by a 50k-feature adapter test asserting a single step expression + bounded wall-clock.

## Local verification

> **LOCAL TESTS ONLY — CI/CD was not used as validation evidence.**

- Backend: **121 passed** (cartography/mapspec/harness/converter/kde/heatmap/layer-style suites). (`tests/unit/test_harness_dispatch_hook::test_harness_disabled_by_default` is a pre-existing environmental failure: `sys.executable` is the ZCode AppImage here, not Python, so the test's `subprocess.run([sys.executable,…])` spawns the Electron app — unrelated to this diff, reproduces at the base SHA.)
- Frontend: **599 passed, 3 skipped** (77 vitest files).
- `ruff check app/` — clean. `tsc --noEmit` — clean. `eslint` (modified frontend) — clean. `next build` — exit 0.

## Review

Two independent adversarial review rounds (7 reviewers round 1; 2 focused reviewers round 2). Round 1 found a P0 (categorical color-drift undetected via a dead `_legend_colors` branch) + P1s (graduated break-value drift, ADR number collision → renumbered to **0052**, `kde_contours` missing field, harness test not driving the real harness). Round 2 found a P0 (cartography findings stripped by `_with_evidence`/bridge whitelist — production evidence channel dead) + P1 (no-data rule not defaulted → nulls in lowest class). **All P0/P1 and high-value P2s fixed**; both rounds re-verified clean (P0=0, P1=0 after fixes).

BASE_SHA: `59b661a` · Supersedes ADR-0007 · Honors ADR-0012/0015/0017 · Builds on ADR-0036.