### PR TITLE
feat(tasks): unify durable job runtime and cancellation lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,92 @@
 # Changelog
 
+## [Unreleased] - 2026-08-12
+
+### Unified durable job runtime & cancellation lifecycle (ADR-0052)
+
+Replaces three disconnected task-state stores (in-memory `TaskTracker`, the
+zero-caller `analysis_tasks` table, and the process-local
+`TaskQueueService._task_owners` dict) with one durable job lifecycle spanning
+Agent task → tool step → heavy GIS job → Celery worker → artifact.
+
+- **Cancellation now actually stops compute.** `TaskTracker.cancel()` used to flip
+  a bool that was polled only *between* tool calls, so an in-flight NDVI or buffer
+  analysis ran to completion (30–60s) before stopping — CPU was never released.
+  A `CancellationToken` is now lit on cancel and propagates three ways: the stream
+  engine `await`s it inside the parallel tool wave and **preemptively** cancels
+  in-flight asyncio tasks; a ContextVar carries it into synchronous GIS code
+  (`asyncio.to_thread` copies context, so ~40 tool signatures stay unchanged) where
+  hot loops exit at `jobs.checkpoint()`; and a per-job watchdog thread pushes the
+  durable cancel fact to cross-process workers. Benchmark: cancelling after 50 of
+  10 000 chunks now executes 51 chunks (99.49% of the work skipped).
+- **Task ownership survives API restart.** `_task_owners` is demoted to a fast-path
+  cache; the durable row is the source of truth. After a restart a legitimate owner
+  can still query *and* cancel their Celery job, while other users still get 404.
+  Ownership accepts three proofs (authenticated `creator_id`, anonymous
+  `owner_token` mirroring SEC-08, or a verified `session_id`); with none of them the
+  predicate is constant-false rather than an unfiltered scan.
+- **Explicit state machine with atomic transitions.** Every status write is a
+  conditional `UPDATE ... WHERE status IN (<legal predecessors>)`, so `cancelled`
+  and `completed` can never be overwritten — a worker's late success after a cancel
+  converges to `cancelled` and its result is discarded. Double cancel is idempotent;
+  cancelled jobs are never retried.
+- **Worker-crash recovery.** Workers heartbeat independently of progress reporting;
+  a 60s sweeper converges heartbeat-timed-out jobs to `stale` (retryable) — or to
+  `cancelled` when the worker died mid-cancellation — so a job can no longer stay
+  `running` forever.
+- **Bounded progress writes.** Unified `{phase, progress, message, current_step,
+  total_steps}` contract that explicitly allows `progress = null` for indeterminate
+  work (no fake 99% that then hangs). Throttling at ≥1% / ≥500ms turns 100 000
+  progress reports into ~100 DB writes.
+- **Atomic artifact commit.** NDVI output and the `raster_math` windowed writers now
+  write a temp file and `os.replace` on success; cancel/failure discards the partial
+  file, so a cancelled task can no longer leave half a GeoTIFF that looks valid.
+  Already-finalized artifacts are never deleted by later cleanup.
+- **Agent ↔ job linkage.** Durable jobs created inside a tool inherit
+  session/owner/run/turn/tool_call/step from a ContextVar and are reported back on
+  `step_result` as `background_job_ids`, so a background GIS job is shown under the
+  step that started it instead of as an unrelated entry.
+- **Unified task API (expand-contract).** New owner-scoped `GET /tasks/jobs`,
+  `GET|DELETE /tasks/jobs/{job_id}`, `POST /tasks/jobs/{job_id}/retry` returning a
+  single `JobView` shape for both agent tasks and durable jobs. All five pre-existing
+  `/tasks/*` endpoints keep their contract; `/tasks/status/{celery_task_id}` gains
+  durable `job_id`/`durable_status`/`progress` and now degrades gracefully when the
+  Celery result backend is unavailable instead of returning 500.
+- **Retry is real or refused.** Retry re-enqueues the task using a persisted
+  `dispatch_spec`; when no faithful spec exists (missing, oversized, or carrying a
+  sensitive argument) it is refused with a reason rather than flipping the row to
+  `queued` with nothing to run it.
+- **Frontend Task Center.** New sidebar tab showing name/type/status/progress/message/
+  elapsed with cancel and retry. Cancel shows "取消中…" until the backend confirms a
+  terminal state. Polling is strictly bounded: none without active jobs, paused when
+  the tab is hidden, aborted on unmount/session switch, capped after consecutive
+  errors, with generation+session guards so a stale response can never write into a
+  new session's UI. No new websocket transport.
+- **Payload safety.** Task rows and API responses carry redacted, size-capped
+  summaries — credentials are replaced, large GeoJSON/raster payloads become
+  `{__omitted__, count}`, and errors are single-line (never a traceback). Task-center
+  responses measure ~478 B/job.
+
+### Fixed (pre-existing bugs surfaced by this work)
+
+- NDVI analysis assets were never registered: the insert used `format="tif"`, which
+  `ck_upload_format` rejects (`geotiff` is the allowed value), and the resulting
+  `IntegrityError` was swallowed as a warning — so the tool's "结果已入库" claim was
+  never true on a constraint-enforcing database.
+- Migration `e46935cd5dd1` only dropped `analysis_tasks.creator_id NOT NULL` on the
+  PostgreSQL branch, leaving SQLite dev databases diverged from the model.
+- `analysis_tasks.status` carried both `index=True` and an explicit `idx_task_status`,
+  producing two identical indexes under `create_all`.
+
+### Migration
+
+`0013_unified_durable_job_runtime` — additive: 17 nullable columns, 5 indexes,
+widened `ck_task_status` (adds `cancelling`, `stale`), and relaxed
+`org_id`/`creator_id` nullability. Upgrade and downgrade are both implemented and
+existing rows survive the round trip (`cancelling`/`stale` normalize to `failed` on
+downgrade rather than being deleted). Dialect-split: SQLite rebuilds the table via
+`batch_alter_table`, PostgreSQL uses idempotent `IF NOT EXISTS` DDL.
+
 ## [Unreleased] - 2026-08-07
 
 ### Performance — Full-stack optimization (spatial compute / agent dispatch / rendering / storage)

--- a/app/api/routes/jobs.py
+++ b/app/api/routes/jobs.py
@@ -1,0 +1,315 @@
+"""统一任务中心 API（ADR-0052，规范 §9 / §10 / §34）。
+
+与既有 `/api/v1/tasks/*` 的关系（expand-contract）：
+
+  * 旧端点全部保留、语义不变 —— `GET /tasks/{task_id}`、`GET /tasks`、
+    `DELETE /tasks/{task_id}`、`GET|DELETE /tasks/status/{celery_task_id}`。
+    它们是公开 API，本次不删不改。
+  * 新增本模块的 `/tasks/jobs*`，提供统一视图：内存 agent task 与 durable GIS job
+    在同一个列表里，形状一致（JobView），前端只需处理一种形状。
+
+为什么是独立 router 而不是往 task.py 里塞：`GET /tasks/{task_id}` 会把字面量
+`jobs` 当成 task_id 吃掉，所以 `/tasks/jobs` 必须**先**注册。独立模块 + 在
+main.py 中先 include，比依赖同文件内的定义顺序更难写错。
+
+安全：所有端点 owner scoped。归属证明有三条链（已认证 user_id / 匿名 owner_token /
+已验证归属的 session_id），任一命中即可；三者皆无 → 看不到任何 job。不存在与无权
+一律 404，不泄露存在性。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.routes.chat import get_engine
+from app.core.auth import get_current_user_optional, get_owner_token, verify_session_owner
+from app.core.database import get_async_db
+from app.services.task_queue import celery_app
+from app.services.jobs import (
+    ACTIVE_POLL_INTERVAL_MS,
+    DEFAULT_LIST_LIMIT,
+    DurableJobStore,
+    JobCancelResponse,
+    JobListResponse,
+    JobNotFound,
+    JobRetryResponse,
+    JobStatus,
+    JobView,
+    build_list_response,
+    classify_job_id,
+    coerce_status,
+    job_from_agent_task,
+    job_from_record,
+    registry as cancellation_registry,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/tasks/jobs", tags=["任务管理"])
+
+
+def _resolved_owner(user: dict | None) -> Optional[str]:
+    """把 auth 依赖的返回收敛成 owner_id。匿名用户没有 owner_id。"""
+    if not user:
+        return None
+    user_id = user.get("user_id")
+    if not user_id or user_id == "anonymous":
+        return None
+    return str(user_id)
+
+
+async def _proven_session_ids(
+    db: AsyncSession,
+    session_id: Optional[str],
+    *,
+    owner_id: Optional[str],
+    owner_token: Optional[str],
+) -> list[str]:
+    """校验调用方确实拥有 session_id，通过则返回 [session_id]。
+
+    这一步不能省：session_id 是查询参数，若不验证就直接用作归属谓词，任何人都能
+    用别人的 session_id 拉到别人的 job（这正是审计 S33 修过的那类漏洞）。
+    """
+    if not session_id:
+        return []
+    # 不属于调用方时 verify_session_owner 抛 404（不泄露存在性）
+    await verify_session_owner(db, session_id, user_id=owner_id, owner_token=owner_token)
+    return [session_id]
+
+
+@router.get("", response_model=JobListResponse)
+async def list_jobs(
+    session_id: Optional[str] = Query(
+        default=None,
+        description="按会话过滤。匿名调用方必须提供（否则无归属证明，返回空列表）",
+    ),
+    active_only: bool = Query(default=False, description="只返回未终结的 job"),
+    limit: int = Query(default=DEFAULT_LIST_LIMIT, ge=1, le=200),
+    db: AsyncSession = Depends(get_async_db),
+    user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
+) -> JobListResponse:
+    """统一任务列表：durable GIS job + 本进程内存中的 agent task。
+
+    浏览器刷新后前端调这个接口恢复任务中心 —— durable job 来自数据库，所以
+    API 重启/前端重连都不影响可见性。
+    """
+    owner_id = _resolved_owner(user)
+    session_ids = await _proven_session_ids(
+        db, session_id, owner_id=owner_id, owner_token=owner_token
+    )
+
+    records = await DurableJobStore.list_for_owner(
+        db,
+        owner_id=owner_id,
+        owner_token=owner_token,
+        session_ids=session_ids,
+        active_only=active_only,
+        limit=limit,
+    )
+    jobs: list[JobView] = [job_from_record(r) for r in records]
+
+    # agent task 只在证明了 session 归属时才纳入 —— 它们只存在于内存，没有
+    # creator_id 可比对，session 归属是唯一可验证的证明链。
+    if session_ids:
+        try:
+            tracker = get_engine().tracker
+        except Exception:  # pragma: no cover - 引擎未初始化（单测/降级）
+            tracker = None
+        if tracker is not None:
+            for task_info in tracker.list_by_session(session_ids[0]):
+                view = job_from_agent_task(
+                    task_info, background_job_ids=task_info.background_job_ids
+                )
+                if active_only and not view.active:
+                    continue
+                jobs.append(view)
+
+    jobs.sort(key=lambda j: (j.created_at or ""), reverse=True)
+    # has_active 必须基于**全量**归属范围判断：若只看被 limit 截断的这一页，当活跃
+    # job 比这一页更旧时会误判「无活跃任务」→ 前端停止轮询 → 运行中的任务卡住。
+    has_active_durable = await DurableJobStore.has_active_for_owner(
+        db, owner_id=owner_id, owner_token=owner_token, session_ids=session_ids
+    )
+    page = jobs[:limit]
+    response = build_list_response(page)
+    if has_active_durable and not response.has_active:
+        response.has_active = True
+        response.poll_after_ms = ACTIVE_POLL_INTERVAL_MS
+    return response
+
+
+@router.get("/{job_id}", response_model=JobView)
+async def get_job(
+    job_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
+) -> JobView:
+    """查询单个 job。durable job id（数字）与 agent task id（task-xxxx）都接受。"""
+    owner_id = _resolved_owner(user)
+
+    if classify_job_id(job_id) == "agent":
+        task_info = _agent_task_or_404(job_id)
+        await verify_session_owner(
+            db, task_info.session_id, user_id=owner_id, owner_token=owner_token
+        )
+        return job_from_agent_task(task_info, background_job_ids=task_info.background_job_ids)
+
+    record = await _durable_or_404(db, job_id, owner_id=owner_id, owner_token=owner_token)
+    return job_from_record(record)
+
+
+@router.delete("/{job_id}", response_model=JobCancelResponse)
+async def cancel_job(
+    job_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
+) -> JobCancelResponse:
+    """请求取消 job。
+
+    幂等（规范 §5）：重复取消返回 200 且 ``cancel_requested=false``，不报错。
+    终态 job 取消是 no-op —— 绝不把 completed 改回 cancelling。
+
+    取消是两段式：先把 ``cancel_requested_at`` 落库（持久事实，API 重启不丢），再
+    点燃本进程的 token 让在飞执行体立即感知。worker 在另一个进程时，靠它自己的
+    探针从 DB 读到取消 —— 所以取消不依赖「取消请求恰好落在执行它的那个进程」。
+    """
+    owner_id = _resolved_owner(user)
+
+    if classify_job_id(job_id) == "agent":
+        task_info = _agent_task_or_404(job_id)
+        await verify_session_owner(
+            db, task_info.session_id, user_id=owner_id, owner_token=owner_token
+        )
+        already = bool(getattr(task_info, "_cancelled", False))
+        get_engine().tracker.cancel(job_id)
+        # 级联：本 turn 派生的 durable job 一起请求取消
+        for durable_id in task_info.background_job_ids:
+            await DurableJobStore.request_cancel(db, durable_id)
+            cancellation_registry.cancel(durable_id, "parent agent task cancelled")
+        await db.commit()
+        return JobCancelResponse(
+            id=job_id,
+            status=JobStatus.cancelling.value if not already else JobStatus.cancelled.value,
+            cancel_requested=not already,
+            cancelling=not already,
+        )
+
+    record = await _durable_or_404(db, job_id, owner_id=owner_id, owner_token=owner_token)
+    changed, current = await DurableJobStore.request_cancel(db, record.id)
+    await db.commit()
+    # 同进程的执行体（eager Celery / 线程池工具）立即感知；跨进程 worker 走 DB 探针
+    cancellation_registry.cancel(str(record.id), "cancelled by user")
+    return JobCancelResponse(
+        id=str(record.id),
+        status=current.value,
+        cancel_requested=changed,
+        cancelling=(current == JobStatus.cancelling),
+    )
+
+
+@router.post("/{job_id}/retry", response_model=JobRetryResponse)
+async def retry_job(
+    job_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    user: dict = Depends(get_current_user_optional),
+    owner_token: Optional[str] = Depends(get_owner_token),
+) -> JobRetryResponse:
+    """重试 failed/stale job，作为**新 attempt**。
+
+    只有 durable job 可重试（agent turn 的重试语义是「用户重发消息」，不在这里）。
+    被取消的 job 永不重试（规范 §17）；attempt 递增且保留首次失败的 error_trace
+    作为证据（规范 §18）。
+    """
+    if classify_job_id(job_id) == "agent":
+        raise HTTPException(status_code=400, detail="Agent tasks are not retryable; resend the message")
+
+    owner_id = _resolved_owner(user)
+    record = await _durable_or_404(db, job_id, owner_id=owner_id, owner_token=owner_token)
+
+    spec = record.dispatch_spec if isinstance(record.dispatch_spec, dict) else None
+    ok, reason = await DurableJobStore.start_retry(db, record.id)
+    await db.commit()
+
+    if ok:
+        # 状态已是 queued —— 现在必须真的把任务重新交给 worker。
+        # 只改状态而不入队会留下一个永远不推进的 job（比不提供 retry 更糟）。
+        try:
+            async_result = celery_app.send_task(
+                spec["task"],
+                args=list(spec.get("args") or []),
+                kwargs={**(spec.get("kwargs") or {}), "job_id": int(record.id)},
+            )
+        except Exception as exc:  # noqa: BLE001 —— broker 不可用不应让端点 500
+            # 入队本身失败 → 消息不存在，把 job 收敛为 failed 才是真话
+            logger.error("[jobs] retry enqueue failed job_id=%s: %s", record.id, exc)
+            await DurableJobStore.mark_failed(
+                db, record.id, error=exc, message="retry enqueue failed"
+            )
+            await db.commit()
+            ok, reason = False, "enqueue_failed"
+        else:
+            # 消息已经进 broker：从这里开始**绝不**把 job 标成 failed —— 那会让
+            # worker 拿到消息时看到终态而直接跳过，一次已投递的重试被静默丢弃。
+            # 回填 celery id 失败只是旧 /tasks/status 端点查不到，不影响执行。
+            try:
+                await DurableJobStore.attach_celery_task(db, record.id, async_result.id)
+                await db.commit()
+            except Exception as exc:  # noqa: BLE001
+                await db.rollback()
+                logger.warning(
+                    "[jobs] retry enqueued but celery id backfill failed job_id=%s: %s",
+                    record.id, exc,
+                )
+
+    refreshed = await DurableJobStore.get(db, record.id)
+    if refreshed is not None:
+        await db.refresh(refreshed)
+    status = coerce_status(refreshed.status if refreshed else None)
+    return JobRetryResponse(
+        id=str(record.id),
+        status=status.value,
+        retried=ok,
+        reason=reason,
+        attempt=int((refreshed.attempt if refreshed else 1) or 1),
+    )
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _agent_task_or_404(task_id: str):
+    """取内存 agent task；不存在或无法证明归属一律 404。"""
+    try:
+        tracker = get_engine().tracker
+    except Exception:  # pragma: no cover
+        tracker = None
+    task_info = tracker.get(task_id) if tracker is not None else None
+    if task_info is None:
+        raise HTTPException(status_code=404, detail=f"Job {task_id} not found")
+    if not task_info.session_id:
+        # 无 session 的老任务无法证明归属 —— 统一拒绝（沿用审计 S34 的判断）
+        raise HTTPException(status_code=404, detail=f"Job {task_id} not found")
+    return task_info
+
+
+async def _durable_or_404(
+    db: AsyncSession, job_id: str, *, owner_id: Optional[str], owner_token: Optional[str]
+):
+    """按归属取 durable job。
+
+    注意这里**不**接受 session_ids 作为归属证明 —— 单条读取时调用方没有提供
+    session_id 参数，只能凭 user_id 或 owner_token。这样匿名用户换个 session
+    也拿不到别人的 job。
+    """
+    try:
+        return await DurableJobStore.get_for_owner(
+            db, job_id, owner_id=owner_id, owner_token=owner_token
+        )
+    except JobNotFound:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")

--- a/app/api/routes/task.py
+++ b/app/api/routes/task.py
@@ -138,9 +138,21 @@ async def cancel_task(
     db: AsyncSession = Depends(get_async_db),
     _user: dict = Depends(get_current_user),
 ) -> TaskCancelResponse:
-    """取消正在执行的任务"""
+    """取消正在执行的任务。
+
+    ADR-0052：除了点燃 agent task 的 token，这里也把该 turn 派生的 durable job 的
+    取消请求**落库** —— 否则跨进程 worker 观察不到取消，后台 GIS 计算会一路跑完。
+    行为与新的 ``DELETE /tasks/jobs/{job_id}`` 端点一致。
+    """
     await _verify_task_owner(db, task_id, _user.get("user_id"))
-    cancelled = get_engine().tracker.cancel(task_id)
+    tracker = get_engine().tracker
+    task_info = tracker.get(task_id)
+    background_job_ids = list(task_info.background_job_ids) if task_info else []
+    cancelled = tracker.cancel(task_id)
+    for job_id in background_job_ids:
+        await DurableJobStore.request_cancel(db, job_id)
+    if background_job_ids:
+        await db.commit()
     return TaskCancelResponse(cancelled=cancelled)
 
 

--- a/app/api/routes/task.py
+++ b/app/api/routes/task.py
@@ -4,9 +4,16 @@ from pydantic import BaseModel
 from typing import Optional
 
 from app.api.routes.chat import get_engine
-from app.core.auth import get_current_user, require_owned_session, verify_session_owner
+from app.core.auth import (
+    get_current_user,
+    get_owner_token,
+    require_owned_session,
+    verify_session_owner,
+)
 from app.core.database import get_async_db
 from app.models.db_model import Conversation
+from app.services.jobs import DurableJobStore
+from app.services.jobs import registry as cancellation_registry
 from app.services.task_queue import TaskQueueService
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -139,18 +146,76 @@ async def cancel_task(
 
 # ── Celery Task Status API ──────────────────────────────────────────
 
+
+async def _verify_celery_owner(
+    db: AsyncSession, celery_task_id: str, user_id: str, owner_token: Optional[str]
+) -> None:
+    """校验 celery task 归属。
+
+    ADR-0052：以前唯一事实源是 ``TaskQueueService._task_owners`` —— 一个进程内
+    class dict。后果是 API 重启后所有 Celery 任务突然 404（合法用户也查不到、
+    取消不了），多副本部署下更是「注册在哪个 pod 就只有那个 pod 认」。
+
+    现在内存 map 降级为快路径缓存，durable 行（analysis_tasks.celery_task_id +
+    归属列）才是事实源。任一命中即通过；两者都不认才 404。
+    """
+    if TaskQueueService.verify_owner(celery_task_id, user_id):
+        return
+    if await DurableJobStore.verify_celery_owner(
+        db, celery_task_id, owner_id=(user_id or None), owner_token=owner_token
+    ):
+        return
+    raise HTTPException(status_code=404, detail="Task not found")
+
+
 @router.get("/status/{task_id}")
-async def get_celery_task_status(task_id: str, _user: dict = Depends(get_current_user)):
-    """查询 Celery 异步任务状态（审计 S34：校验任务所有权）"""
-    if not TaskQueueService.verify_owner(task_id, _user.get("user_id", "")):
-        raise HTTPException(status_code=404, detail="Task not found")
-    return TaskQueueService.get_task_status(task_id)
+async def get_celery_task_status(
+    task_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    _user: dict = Depends(get_current_user),
+    owner_token: Optional[str] = Depends(get_owner_token),
+):
+    """查询 Celery 异步任务状态（审计 S34：校验任务所有权）
+
+    ADR-0052：保持原响应键不变（Celery 语义的 status/result/progress），但在存在
+    durable job 行时用它补充 job_id / durable_status / progress —— Celery result
+    backend 不可用（无 Redis）时进度仍然可读，因为事实源已经在数据库里。
+    """
+    await _verify_celery_owner(db, task_id, _user.get("user_id", ""), owner_token)
+    payload = TaskQueueService.get_task_status(task_id)
+
+    job = await DurableJobStore.get_by_celery_id(db, task_id)
+    if job is not None:
+        payload["job_id"] = str(job.id)
+        payload["durable_status"] = str(job.status or "")
+        if job.progress is not None:
+            payload["progress"] = int(job.progress)
+        if job.progress_message:
+            payload["message"] = job.progress_message
+    return payload
 
 
 @router.delete("/status/{task_id}")
-async def revoke_celery_task(task_id: str, _user: dict = Depends(get_current_user)):
-    """撤销 Celery 异步任务（审计 S34：校验任务所有权）"""
-    if not TaskQueueService.verify_owner(task_id, _user.get("user_id", "")):
-        raise HTTPException(status_code=404, detail="Task not found")
+async def revoke_celery_task(
+    task_id: str,
+    db: AsyncSession = Depends(get_async_db),
+    _user: dict = Depends(get_current_user),
+    owner_token: Optional[str] = Depends(get_owner_token),
+):
+    """撤销 Celery 异步任务（审计 S34：校验任务所有权）
+
+    ADR-0052：撤销改为「先协作、后 revoke」—— 先把 durable job 的
+    ``cancel_requested_at`` 落库并点燃本进程 token（worker 在 checkpoint 处优雅
+    退出，顺带清理临时产物），再调 Celery revoke 兜底。terminate 不再是所有任务
+    的第一取消手段（规范 §12）。
+    """
+    await _verify_celery_owner(db, task_id, _user.get("user_id", ""), owner_token)
+
+    job = await DurableJobStore.get_by_celery_id(db, task_id)
+    if job is not None:
+        await DurableJobStore.request_cancel(db, job.id)
+        await db.commit()
+        cancellation_registry.cancel(str(job.id), "cancelled by user")
+
     revoked = TaskQueueService.revoke_task(task_id)
     return {"revoked": revoked, "task_id": task_id}

--- a/app/lib/geo_analysis/aggregation.py
+++ b/app/lib/geo_analysis/aggregation.py
@@ -5,6 +5,10 @@ import geopandas as gpd
 from shapely.geometry import box, Polygon
 from app.lib.geo_processor.core import GeoAnalysisResult
 from app.lib.geo_processor.core import to_utm_gdf
+# ADR-0052: 协作式取消检查点。cancellable() 在 chunk 边界读一次 contextvar，
+# 未绑定 token 时开销为零；用户取消后长循环立即抛 OperationCancelled 退出，
+# 真正释放 CPU 而不是只改 UI 状态。
+from app.services.jobs.cancellation import cancellable
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +264,7 @@ def h3_binning(geojson: dict | str, resolution: int | None = None, stat_field: s
             
         # Create Polygons from H3 indices
         polygons = []
-        for h3_id in grouped['h3_index']:
+        for h3_id in cancellable(grouped['h3_index'], every=512):
             # cell_to_boundary returns ((lat, lng), ...)
             boundary = h3.cell_to_boundary(h3_id)
             # shapely expects (lng, lat)

--- a/app/lib/geo_analysis/geometry_ops.py
+++ b/app/lib/geo_analysis/geometry_ops.py
@@ -20,6 +20,10 @@ from shapely.geometry import box, mapping, Polygon
 
 from app.lib.geo_processor.core import GeoAnalysisResult, to_utm_gdf
 from app.lib.geo_analysis._vector import extract_centroids
+# ADR-0052: 协作式取消检查点。cancellable() 在 chunk 边界读一次 contextvar，
+# 未绑定 token 时开销为零；用户取消后长循环立即抛 OperationCancelled 退出，
+# 真正释放 CPU 而不是只改 UI 状态。
+from app.services.jobs.cancellation import cancellable
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +105,7 @@ def voronoi_polygons(
             logger.warning("voronoi: invalid clip_bounds %s ignored: %s", clip_bounds, e)
     raw_polys = []  # (poly, props) - batch CRS after loop
 
-    for i in range(len(coords)):
+    for i in cancellable(range(len(coords)), every=256):
         region_idx = vor.point_region[i]
         region = vor.regions[region_idx]
         if -1 in region or len(region) == 0:

--- a/app/lib/geo_analysis/interpolation.py
+++ b/app/lib/geo_analysis/interpolation.py
@@ -31,6 +31,10 @@ import numpy as np
 import pandas as pd
 from scipy.spatial import cKDTree
 from shapely.geometry import Polygon, mapping
+# ADR-0052: 协作式取消检查点。cancellable() 在 chunk 边界读一次 contextvar，
+# 未绑定 token 时开销为零；用户取消后长循环立即抛 OperationCancelled 退出，
+# 真正释放 CPU 而不是只改 UI 状态。
+from app.services.jobs.cancellation import cancellable
 
 logger = logging.getLogger(__name__)
 
@@ -334,7 +338,7 @@ def h3_to_geojson(results: list[dict], value_field: str = "value") -> dict:
     than re-implementing cell-to-polygon conversion.
     """
     features = []
-    for res in results:
+    for res in cancellable(results, every=512):
         cell = res["h3_index"]
         val = res["value"]
         boundary = h3.cell_to_boundary(cell)  # [(lat, lng), ...]

--- a/app/lib/geo_analysis/network.py
+++ b/app/lib/geo_analysis/network.py
@@ -6,6 +6,10 @@ from shapely.geometry import Point, LineString, mapping
 from shapely.ops import unary_union
 from app.lib.geo_processor.core import GeoAnalysisResult
 from app.lib.geo_processor.core import to_utm_gdf
+# ADR-0052: 协作式取消检查点。cancellable() 在 chunk 边界读一次 contextvar，
+# 未绑定 token 时开销为零；用户取消后长循环立即抛 OperationCancelled 退出，
+# 真正释放 CPU 而不是只改 UI 状态。
+from app.services.jobs.cancellation import cancellable
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +92,7 @@ def calculate_isochrones(network_geojson: dict | str, facility_points: dict | st
         # follows the actual road network.
         _buffer_m = 30.0 if mode == "walking" else 20.0
 
-        for idx, facility in gdf_facilities.iterrows():
+        for idx, facility in cancellable(gdf_facilities.iterrows()):
             start_point = np.array([facility.geometry.x, facility.geometry.y])
 
             # Find nearest node via cKDTree
@@ -106,7 +110,7 @@ def calculate_isochrones(network_geojson: dict | str, facility_points: dict | st
             # the last reachable point (review C).
             from shapely.ops import substring
             reachable_edges = []
-            for u, v, edata in G.edges(data=True):
+            for u, v, edata in cancellable(G.edges(data=True), every=1024):
                 eg = edata.get("geometry")
                 if eg is None:
                     continue

--- a/app/lib/geo_analysis/raster_math.py
+++ b/app/lib/geo_analysis/raster_math.py
@@ -9,6 +9,11 @@ from rasterio.enums import Resampling
 from rasterio.windows import Window
 from rasterio.warp import reproject, calculate_default_transform
 
+# ADR-0052: 窗口写入循环现在（a）在窗口边界检查取消，（b）写临时文件再原子
+# os.replace —— 取消/崩溃不再留下半个 GeoTIFF（规范 §12 raster window / §23）。
+from app.services.jobs.artifacts import atomic_output
+from app.services.jobs.cancellation import checkpoint
+
 
 # ─── Shared GDAL environment ────────────────────────────────────
 
@@ -211,9 +216,10 @@ def reclassify(
                 return ~np.isnan(arr)
             return arr != out_nodata
 
-        with rasterio.open(out_path, "w", **profile) as dst:
+        with atomic_output(out_path) as _tmp_out, rasterio.open(_tmp_out, "w", **profile) as dst:
             for row0 in range(0, src.height, _WINDOW_SIZE):
                 for col0 in range(0, src.width, _WINDOW_SIZE):
+                    checkpoint()
                     win = Window(
                         col0, row0,
                         min(_WINDOW_SIZE, src.width - col0),
@@ -424,10 +430,11 @@ def raster_calculator(
             profile = _gtiff_profile(src_a.profile, nodata=out_nodata, count=1)
             profile["dtype"] = result0.dtype
 
-            with rasterio.open(out_path, "w", **profile) as dst:
+            with atomic_output(out_path) as _tmp_out, rasterio.open(_tmp_out, "w", **profile) as dst:
                 dst.write(result0, 1, window=first_win)
                 _accumulate(result0)
                 for win in windows[1:]:
+                    checkpoint()
                     data_a_win = src_a.read(1, window=win)
                     res = _compute_window(data_a_win, _get_b_window(win, data_a_win))
                     dst.write(res, 1, window=win)

--- a/app/lib/geo_analysis/statistics.py
+++ b/app/lib/geo_analysis/statistics.py
@@ -11,6 +11,10 @@ from scipy.stats import norm
 from app.lib.geo_processor.core import GeoAnalysisResult
 from app.lib.geo_processor.core import to_utm_gdf
 from app.lib.geo_analysis._vector import extract_centroids
+# ADR-0052: 协作式取消检查点。cancellable() 在 chunk 边界读一次 contextvar，
+# 未绑定 token 时开销为零；用户取消后长循环立即抛 OperationCancelled 退出，
+# 真正释放 CPU 而不是只改 UI 状态。
+from app.services.jobs.cancellation import cancellable
 
 def _build_weights(gdf: gpd.GeoDataFrame, k: int = 8) -> sparse.coo_matrix:
     """Build spatial weights matrix using KNN via cKDTree.
@@ -223,7 +227,7 @@ def moran_i_narrated(geojson: dict, value_field: str) -> GeoAnalysisResult:
     rng = np.random.default_rng(42)
     perms = 99
     perm_is = []
-    for _ in range(perms):
+    for _ in cancellable(range(perms)):
         pv = rng.permutation(values)
         pz = pv - pv.mean()
         if sparse.issparse(w):
@@ -350,7 +354,7 @@ def hotspot_narrated(geojson: dict, value_field: str, distance_band: float = 0) 
     ).tolist()
 
     features = []
-    for i in range(len(gdf)):
+    for i in cancellable(range(len(gdf)), every=512):
         gi_star = float(gi_stars[i])
         p_val = float(p_vals[i])
         h_type = hotspot_types[i]
@@ -551,7 +555,7 @@ def cluster_narrated(
     gdf_wgs84 = gdf.to_crs("EPSG:4326")
     
     out_features = []
-    for i in range(len(gdf)):
+    for i in cancellable(range(len(gdf)), every=512):
         geom_wgs84 = gdf_wgs84.geometry.iloc[i]
         row = gdf.iloc[i]
         props = {k: v for k, v in row.items() if k != "geometry"}
@@ -647,7 +651,7 @@ def h3_lisa(h3_geojson: dict, value_field: str) -> GeoAnalysisResult:
     gdf_wgs84 = gdf.to_crs("EPSG:4326")
     
     out_features = []
-    for i in range(len(gdf)):
+    for i in cancellable(range(len(gdf)), every=512):
         geom_wgs84 = gdf_wgs84.geometry.iloc[i]
         row = gdf.iloc[i]
         props = {k: v for k, v in row.items() if k != "geometry"}
@@ -871,7 +875,7 @@ def st_dbscan_narrated(
     # 4. Format Output GeoJSON
     gdf_wgs84 = gdf_valid.to_crs("EPSG:4326")
     out_features = []
-    for i in range(n):
+    for i in cancellable(range(n), every=512):
         geom_wgs84 = gdf_wgs84.geometry.iloc[i]
         row = gdf_valid.iloc[i]
         props = {k: v for k, v in row.items() if k != "geometry"}

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from app.core.config import settings
 from app.core.database import Engine
 from app.core.exception import global_exception_handler
 from app.core.rate_limiter import get_rate_limiter
-from app.api.routes import health, map, chat, layer, report, task, upload, knowledge, ws, config, explorer, auth as auth_routes, static as static_routes, pi_tools, templates, raster as raster_routes, metrics, project as project_routes, data_fabric
+from app.api.routes import health, map, chat, layer, report, task, upload, knowledge, ws, config, explorer, auth as auth_routes, static as static_routes, pi_tools, templates, raster as raster_routes, metrics, project as project_routes, data_fabric, jobs as jobs_routes
 from app.tools.registry import ToolRegistry
 from app.tools import init_tools
 from app.services.chat_engine import ChatEngine
@@ -71,14 +71,20 @@ async def lifespan(app: FastAPI):
     # 通过 session_data 的 TTL 兜底，但 active 列表 + in-memory 单例需要主动扫。
     cleanup_task = asyncio.create_task(_periodic_session_cleanup())
 
+    # ADR-0052：stale job 清扫。worker 崩溃/被杀时 DB 里的 job 会永远停在
+    # running —— 用户面对一个永不结束的任务。这里周期性把心跳超时的 job
+    # 收敛为 stale（终态但可 retry）。
+    stale_sweep_task = asyncio.create_task(_periodic_stale_job_sweep())
+
     yield
 
     # 关闭后台清理任务
-    cleanup_task.cancel()
-    try:
-        await cleanup_task
-    except asyncio.CancelledError:
-        pass
+    for bg_task in (cleanup_task, stale_sweep_task):
+        bg_task.cancel()
+        try:
+            await bg_task
+        except asyncio.CancelledError:
+            pass
 
     # 输出工具调用 digest（top 累计 / top p99 / 错误），便于运维定位最慢工具
     try:
@@ -122,6 +128,44 @@ async def _periodic_session_cleanup(interval_seconds: int = 600) -> None:
             raise
         except Exception as e:  # noqa: BLE001
             logger.warning(f"[lifespan] session cleanup tick failed: {e}")
+
+
+async def _periodic_stale_job_sweep(interval_seconds: int = 60) -> None:
+    """ADR-0052：把心跳超时的 durable job 标记为 stale（规范 §25）。
+
+    最小可行方案：worker 在写进度时顺带刷新 heartbeat_at，本任务扫出
+    ``running/cancelling 且心跳早于 cutoff`` 的行并原子迁移到 stale。没有引入
+    分布式调度平台、lease 表或额外中间件 —— 只用已有的 DB 列。
+
+    多副本 API 同时扫是安全的：迁移是条件更新（WHERE status IN (...)），只有一个
+    副本能成功改到 stale，其余 rowcount=0。
+    """
+    import asyncio
+    import logging
+
+    from app.core.database import AsyncSessionLocal
+    from app.services.jobs import DurableJobStore
+
+    logger = logging.getLogger(__name__)
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            if AsyncSessionLocal is None:
+                continue
+            async with AsyncSessionLocal() as db:
+                swept = await DurableJobStore.sweep_stale(db)
+                # pending/queued 不会心跳，心跳预测器抓不到它们；提交路径在 create 与
+                # apply_async 之间崩溃、或 broker 丢消息时，job 会永远停在那里。
+                orphaned = await DurableJobStore.sweep_orphans(db)
+                if swept or orphaned:
+                    await db.commit()
+                    logger.warning(
+                        f"[lifespan] swept {swept} stale job(s), {orphaned} orphaned job(s)"
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[lifespan] stale job sweep tick failed: {e}")
 
 
 
@@ -211,6 +255,9 @@ app.include_router(layer.router, prefix="/api/v1", tags=["图层管理"])
 app.include_router(report.router, prefix="/api/v1", tags=["报告生成"])
 app.include_router(chat.router, prefix="/api/v1", tags=["AI对话"])
 app.include_router(map.router, prefix="/api/v1", tags=["地图管理"])
+# ADR-0052: 统一任务中心必须先注册 —— task.router 的 GET /tasks/{task_id}
+# 会把字面量 "jobs" 当成 task_id 匹配掉。
+app.include_router(jobs_routes.router, prefix="/api/v1", tags=["任务管理"])
 app.include_router(task.router, prefix="/api/v1", tags=["任务管理"])
 app.include_router(upload.router, prefix="/api/v1", tags=["数据上传"])
 app.include_router(knowledge.router, prefix="/api/v1", tags=["知识库管理"])

--- a/app/models/db_model.py
+++ b/app/models/db_model.py
@@ -89,18 +89,33 @@ class Layer(Base):
     creator = relationship("User", backref="layers", lazy="selectin")
 
 class AnalysisTask(Base):
-    """空间分析任务表"""
+    """统一 durable job 表（ADR-0052）。
+
+    原为「空间分析任务表」且无生产调用方。ADR-0052 把它演进成 Agent task /
+    空间分析 job / Celery job 的统一持久化事实源，而不是新建第二套 Job 表 ——
+    它已经具备 status CHECK、progress、retry_count、queued/started/completed
+    时间戳、org/creator 归属与 JSON 载荷列，缺的只是关联与取消/租约字段。
+
+    迁移：migrations/versions/0013_unified_durable_job_runtime.py（additive，
+    老数据行不需要改写）。
+    """
     __tablename__ = "analysis_tasks"
     
-    id = Column(BigInteger, primary_key=True)
-    org_id = Column(Integer, ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False)
+    # ADR-0052: SQLite 只把「INTEGER PRIMARY KEY」当 rowid 别名（即自增）；BIGINT 主键
+    # 不自增，插入时会 NOT NULL 失败。durable job 现在是热路径，必须能在本地
+    # SQLite 与生产 PostgreSQL 上都自增，故用 dialect variant。
+    id = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True)
+    # 归属由 creator_id + owner_token + session_id 三元组证明。
+    org_id = Column(Integer, ForeignKey("organizations.id", ondelete="CASCADE"), nullable=True)
     creator_id = Column(String(255), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     layer_id = Column(BigInteger, ForeignKey("layers.id", ondelete="SET NULL"), nullable=True)
     result_layer_id = Column(BigInteger, ForeignKey("layers.id", ondelete="SET NULL"), nullable=True)
     task_type = Column(String(50), nullable=False)
     parameters = Column(JSON, nullable=False)
     celery_task_id = Column(String(100), unique=True)
-    status = Column(String(20), default="pending", index=True)
+    # 注意：不要在这里加 index=True —— __table_args__ 里已有 idx_task_status，
+    # 两者会在 create_all 下生成两个内容相同的索引（写放大且无收益）。
+    status = Column(String(20), default="pending")
     progress = Column(Integer, default=0)
     progress_message = Column(String(255))
     result_summary = Column(JSON)
@@ -112,12 +127,53 @@ class AnalysisTask(Base):
     completed_at = Column(DateTime)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    # ── ADR-0052 统一 durable job 字段 ──────────────────────────────
+    #: 执行域：agent / analysis / workflow / explorer（JobKind）
+    job_kind = Column(String(20), nullable=True, default="analysis")
+    #: 展示名。前端任务中心的标题，不含用户原文（避免 §35 的原文泄漏面扩大）
+    display_name = Column(String(200), nullable=True)
+    #: 会话归属。匿名会话的权限证明链：session_id → Conversation.owner_token
+    session_id = Column(String(255), nullable=True)
+    #: 匿名归属令牌（镜像 Conversation.owner_token 的 SEC-08 模式）
+    owner_token = Column(String(64), nullable=True)
+    project_id = Column(String(255), nullable=True)
+    #: Agent 侧关联（形成 Agent Turn → Tool Step → Durable Job 链）
+    run_id = Column(String(64), nullable=True)
+    turn_id = Column(String(64), nullable=True)
+    tool_call_id = Column(String(128), nullable=True)
+    agent_task_id = Column(String(64), nullable=True)
+    agent_step_id = Column(String(32), nullable=True)
+    #: 幂等键。同一逻辑提交重复到达（SSE 重连 / 双击 / API retry）时复用同一行
+    idempotency_key = Column(String(128), nullable=True, unique=True)
+    #: 当前尝试序号（从 1 开始）。retry 创建新 attempt 而不是覆盖失败证据
+    attempt = Column(Integer, default=1)
+    #: 执行者标识（hostname:pid 或 celery worker 名），用于 stale 归因
+    worker_id = Column(String(128), nullable=True)
+    #: 取消请求的持久事实源 —— 进程重启不丢
+    cancel_requested_at = Column(DateTime, nullable=True)
+    #: worker 心跳。running 且心跳超时 → stale（规范 §25）
+    heartbeat_at = Column(DateTime, nullable=True)
+    #: 结果指针（artifact id / 存储路径），巨型结果不入 result_summary（规范 §38）
+    result_ref = Column(String(512), nullable=True)
+    #: 重跑描述符 {task, args, kwargs}。retry 靠它忠实重新入队 —— parameters 是
+    #: 脱敏+截断后的展示摘要，无法用于重跑。写入前经敏感键脱敏与体积上限校验，
+    #: 且**绝不**通过任何 API 返回（JobView 里没有这个字段）。
+    dispatch_spec = Column(JSON, nullable=True)
     
     __table_args__ = (
         Index("idx_task_status", "status"),
         Index("idx_task_org_status", "org_id", "status"),
         Index("idx_task_org_type_status", "org_id", "task_type", "status"),
-        CheckConstraint("status IN ('pending', 'queued', 'running', 'completed', 'failed', 'cancelled')", name="ck_task_status"),
+        # ADR-0052: 任务中心的三条主查询路径
+        Index("idx_task_session_created", "session_id", "created_at"),
+        Index("idx_task_creator_created", "creator_id", "created_at"),
+        Index("idx_task_status_heartbeat", "status", "heartbeat_at"),
+        Index("idx_task_agent_task", "agent_task_id"),
+        CheckConstraint(
+            "status IN ('pending', 'queued', 'running', 'cancelling', 'completed', 'failed', 'cancelled', 'stale')",
+            name="ck_task_status",
+        ),
         CheckConstraint("progress >= 0 AND progress <= 100", name="ck_task_progress"),
     )
 

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -545,13 +545,19 @@ class ChatExecutionEngine:
                     tool_result_msgs: list[str] = []
                     if len(tc_list) > 1:
                         tasks = [
-                            self.tool_pipeline.execute_tool_call(tc, session_id, task.id, executed_tools)
+                            self.tool_pipeline.execute_tool_call(
+                                tc, session_id, task.id, executed_tools,
+                                owner_id=user_id, owner_token=owner_token,
+                            )
                             for tc in tc_list
                         ]
                         exec_results = await asyncio.gather(*tasks, return_exceptions=True)
                     else:
                         exec_results = [
-                            await self.tool_pipeline.execute_tool_call(tc_list[0], session_id, task.id, executed_tools)
+                            await self.tool_pipeline.execute_tool_call(
+                                tc_list[0], session_id, task.id, executed_tools,
+                                owner_id=user_id, owner_token=owner_token,
+                            )
                         ]
 
                     for tc, exec_res in zip(tc_list, exec_results):
@@ -786,6 +792,8 @@ class ChatExecutionEngine:
                                 self.tool_pipeline.execute_tool_call(
                                     tc, session_id, task.id, executed_tools,
                                     pre_created_step=step,
+                                    owner_id=user_id,
+                                    owner_token=owner_token,
                                 )
                             )
                             pending_tools.append({
@@ -800,15 +808,43 @@ class ChatExecutionEngine:
                         task_to_pending = {p["task"]: p for p in pending_tools}
                         completion_results: dict[str, dict] = {}  # step.id -> {tc, msg_result_str}
 
+                        # ADR-0052 抢占式取消：以前只在「某个工具跑完之后」才检查
+                        # is_cancelled，所以用户点 Cancel 要等当前工具自然结束
+                        # （长 GIS 计算 30–60s）。现在把 token.wait() 一起放进
+                        # asyncio.wait —— 取消到达即刻 cancel 全部在飞任务，
+                        # CPU/worker 立即释放，而不是只把 UI 状态改成已取消。
+                        cancel_watch: Optional[asyncio.Task] = None
+                        if task.cancel_token is not None:
+                            cancel_watch = asyncio.create_task(task.cancel_token.wait())
+
                         try:
                             remaining: set[asyncio.Task] = set(all_tasks)
                             while remaining:
-                                done, remaining = await asyncio.wait(remaining, timeout=5.0)
-                                if not done:
+                                wait_set = set(remaining)
+                                if cancel_watch is not None:
+                                    wait_set.add(cancel_watch)
+                                done, _pending = await asyncio.wait(
+                                    wait_set, timeout=5.0, return_when=asyncio.FIRST_COMPLETED
+                                )
+
+                                if cancel_watch is not None and cancel_watch in done:
+                                    for r in remaining:
+                                        r.cancel()
+                                    await asyncio.gather(*remaining, return_exceptions=True)
+                                    remaining = set()
+                                    pf = _maybe_plan_finalized_event()
+                                    if pf:
+                                        yield pf
+                                    yield sse_event("task_cancelled", {"task_id": task.id})
+                                    return
+
+                                done_tools = done & remaining
+                                remaining -= done_tools
+                                if not done_tools:
                                     yield sse_event("keep_alive", {"message": "ping"})
                                     logger.debug("SSE Heartbeat sent for parallel tool wave")
                                     continue
-                                for t in done:
+                                for t in done_tools:
                                     p = task_to_pending[t]
                                     step = p["step"]
                                     tool_name = p["tool_name"]
@@ -885,6 +921,13 @@ class ChatExecutionEngine:
                                             "geojson_ref": outcome.geojson_ref,
                                             "session_id": session_id,
                                         }
+                                        # ADR-0052: 本步骤派生的后台 durable job —— 前端
+                                        # 据此把 GIS job 挂到该 tool step 下，而不是让
+                                        # agent task 与 Celery task 变成两条毫无关联的
+                                        # UI 条目。
+                                        bg_jobs = getattr(exec_res, "background_job_ids", None)
+                                        if bg_jobs:
+                                            step_payload["background_job_ids"] = list(bg_jobs)
                                         yield sse_event("step_result", step_payload)
                                         yield sse_event("tool_result", {"name": tool_name, "result": outcome.slim_event, "session_id": session_id})
 
@@ -910,6 +953,11 @@ class ChatExecutionEngine:
                                     t.cancel()
                             if all_tasks:
                                 await asyncio.gather(*all_tasks, return_exceptions=True)
+                            # ADR-0052: cancel_watch 是纯等待任务，正常路径永不完成，
+                            # 必须显式回收，否则每个工具 wave 泄漏一个 pending task。
+                            if cancel_watch is not None and not cancel_watch.done():
+                                cancel_watch.cancel()
+                                await asyncio.gather(cancel_watch, return_exceptions=True)
 
                         # Phase 3: 按原始 tc 顺序对齐 LLM 上下文 + 落库
                         for p in pending_tools:

--- a/app/services/chat/tool_pipeline.py
+++ b/app/services/chat/tool_pipeline.py
@@ -6,10 +6,12 @@ sentinel duplicate-loop protection, and LLM payload slimming.
 import json
 import time
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional, Callable
 
 from app.tools.registry import ToolRegistry
+from app.services.jobs.cancellation import OperationCancelled, use_token
+from app.services.jobs.context import JobOrigin, use_origin
 from app.services.task_tracker import TaskTracker, TaskStep
 from app.services.tool_dispatch_service import ToolDispatchService, ToolDispatchResult
 
@@ -25,6 +27,11 @@ class ToolExecutionResult:
     is_error: bool = False
     execution_time_ms: float = 0.0
     outcome: Optional[ToolDispatchResult] = None
+    #: ADR-0052：本次工具执行期间创建的 durable job id。执行引擎把它放进
+    #: step_result SSE，前端据此把后台 GIS job 挂到该 tool step 下。
+    background_job_ids: list[str] = field(default_factory=list)
+    #: 工具是否因取消而中止（区别于普通错误 —— 取消绝不触发 retry，规范 §17）
+    cancelled: bool = False
 
 
 class ToolExecutionPipeline:
@@ -49,6 +56,8 @@ class ToolExecutionPipeline:
         task_id: Optional[str] = None,
         executed_tools: Optional[set[tuple[str, str]]] = None,
         pre_created_step: Optional[TaskStep] = None,
+        owner_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
     ) -> ToolExecutionResult:
         """
         Execute a single tool call dictionary from LLM assistant message.
@@ -63,6 +72,8 @@ class ToolExecutionPipeline:
                 NOT open a second track_step — RUN-02 (deep-audit round 2) fixed
                 double step tracking that inflated task.steps 2x and desynced
                 step_id between SSE events and the tracker.
+            owner_id: 已认证用户 id（ADR-0052：工具派生的 durable job 归属）
+            owner_token: 匿名会话归属令牌（同上，匿名路径）
 
         Returns:
             ToolExecutionResult with raw_result (for frontend/events) and llm_payload (for LLM history)
@@ -92,51 +103,89 @@ class ToolExecutionPipeline:
         # use it directly instead of opening a second track_step.
         outcome: ToolDispatchResult
         is_error = False
+        cancelled = False
+
+        # ADR-0052: 取消 token 与 job 来源都通过 contextvar 传递。asyncio.to_thread
+        # （registry 执行同步工具的路径）会复制 context，所以 token 自动穿到工具
+        # 线程里，几十个 GIS 工具签名不用改。origin 让工具内部创建的 durable job
+        # 自动带上 session/owner/agent step 关联。
+        cancel_token = self.tracker.cancel_token_for(task_id) if task_id else None
+        origin = JobOrigin(
+            session_id=session_id or None,
+            owner_id=owner_id,
+            owner_token=owner_token,
+            agent_task_id=task_id,
+            agent_step_id=(pre_created_step.id if pre_created_step is not None else None),
+            tool_call_id=tool_call_id or None,
+            tool_name=tool_name,
+        )
 
         async def _dispatch() -> ToolDispatchResult:
-            if self.dispatch_fn is not None:
-                return await self.dispatch_fn(tc, session_id, sentinels)
-            return await self.dispatch_service.dispatch(tc, session_id, sentinels)
+            with use_token(cancel_token), use_origin(origin):
+                if self.dispatch_fn is not None:
+                    return await self.dispatch_fn(tc, session_id, sentinels)
+                return await self.dispatch_service.dispatch(tc, session_id, sentinels)
+
+        def _error_outcome(exc: BaseException) -> ToolDispatchResult:
+            err_msg = f"工具执行异常 ({type(exc).__name__}): {exc}"
+            return ToolDispatchResult(
+                status="error",
+                llm_payload=err_msg,
+                slim_event={"error": err_msg},
+                geojson_ref=None,
+                raw_result={"error": err_msg},
+                error_msg=err_msg,
+            )
+
+        def _cancelled_outcome() -> ToolDispatchResult:
+            # 取消不是「工具坏了」：给 LLM 一个明确的取消说明，且不产生 traceback
+            msg = "工具执行已被用户取消"
+            return ToolDispatchResult(
+                status="error",
+                llm_payload=msg,
+                slim_event={"cancelled": True, "message": msg},
+                geojson_ref=None,
+                raw_result={"cancelled": True, "message": msg},
+                error_msg=msg,
+            )
 
         if pre_created_step is not None:
             try:
                 outcome = await _dispatch()
+            except OperationCancelled:
+                # 协作式取消在 GIS 循环的 checkpoint 处抛出 —— 这是预期路径，
+                # 不打 error 日志、不当作工具故障
+                logger.info(f"[ToolPipeline] {tool_name} cancelled by user")
+                cancelled = True
+                outcome = _cancelled_outcome()
             except Exception as e:
                 logger.error(f"[ToolPipeline] Dispatch error for {tool_name}: {e}", exc_info=True)
-                err_msg = f"工具执行异常 ({type(e).__name__}): {e}"
-                outcome = ToolDispatchResult(
-                    status="error",
-                    llm_payload=err_msg,
-                    slim_event={"error": err_msg},
-                    geojson_ref=None,
-                    raw_result={"error": err_msg},
-                    error_msg=err_msg,
-                )
+                outcome = _error_outcome(e)
             is_error = (outcome.status == "error")
             pre_created_step.result = outcome.raw_result
             if is_error:
                 pre_created_step.error = str(outcome.raw_result)
+            pre_created_step.background_job_ids = list(origin.created_job_ids)
         else:
             async with self.tracker.track_step(task_id, tool_name, args_dict) as step:
+                if step is not None:
+                    origin.agent_step_id = step.id
                 try:
                     outcome = await _dispatch()
+                except OperationCancelled:
+                    logger.info(f"[ToolPipeline] {tool_name} cancelled by user")
+                    cancelled = True
+                    outcome = _cancelled_outcome()
                 except Exception as e:
                     logger.error(f"[ToolPipeline] Dispatch error for {tool_name}: {e}", exc_info=True)
-                    err_msg = f"工具执行异常 ({type(e).__name__}): {e}"
-                    outcome = ToolDispatchResult(
-                        status="error",
-                        llm_payload=err_msg,
-                        slim_event={"error": err_msg},
-                        geojson_ref=None,
-                        raw_result={"error": err_msg},
-                        error_msg=err_msg,
-                    )
+                    outcome = _error_outcome(e)
 
                 is_error = (outcome.status == "error")
                 if step is not None:
                     step.result = outcome.raw_result
                     if is_error:
                         step.error = str(outcome.raw_result)
+                    step.background_job_ids = list(origin.created_job_ids)
 
         elapsed_ms = (time.time() - start_time) * 1000
         return ToolExecutionResult(
@@ -147,5 +196,7 @@ class ToolExecutionPipeline:
             is_error=is_error,
             execution_time_ms=elapsed_ms,
             outcome=outcome,
+            background_job_ids=list(origin.created_job_ids),
+            cancelled=cancelled,
         )
 

--- a/app/services/jobs/__init__.py
+++ b/app/services/jobs/__init__.py
@@ -1,0 +1,141 @@
+"""统一 durable job 运行时（ADR-0052）。
+
+Agent Task → Tool Step → Durable Job → Worker → Artifact 一条链上的公共语义：
+生命周期状态机、贯穿式取消、持久化事实源、进度契约、脱敏与体积上限。
+
+    from app.services.jobs import JobStatus, DurableJobStore, checkpoint, durable_job
+"""
+from app.services.jobs.artifacts import atomic_output, discard_partial
+from app.services.jobs.cancellation import (
+    CancellationRegistry,
+    CancellationToken,
+    OperationCancelled,
+    cancellable,
+    checkpoint,
+    current_token,
+    is_cancelled,
+    registry,
+    use_token,
+)
+from app.services.jobs.context import (
+    JobOrigin,
+    current_origin,
+    new_run_id,
+    new_turn_id,
+    use_origin,
+)
+from app.services.jobs.lifecycle import (
+    ACTIVE_STATUSES,
+    ALLOWED_TRANSITIONS,
+    CANCELLABLE_STATUSES,
+    IMMUTABLE_STATUSES,
+    RETRYABLE_STATUSES,
+    TERMINAL_STATUSES,
+    InvalidJobTransition,
+    JobKind,
+    JobStatus,
+    can_transition,
+    coerce_status,
+    is_active,
+    is_cancellable,
+    is_retryable_status,
+    is_terminal,
+    sources_for,
+    validate_transition,
+)
+from app.services.jobs.progress import (
+    JobProgress,
+    ProgressReporter,
+    ProgressThrottle,
+)
+from app.services.jobs.store import (
+    DEFAULT_LIST_LIMIT,
+    DEFAULT_STALE_AFTER_S,
+    MAX_LIST_LIMIT,
+    DurableJobStore,
+    JobNotFound,
+    worker_identity,
+)
+from app.services.jobs.views import (
+    ACTIVE_POLL_INTERVAL_MS,
+    JobCancelResponse,
+    JobListResponse,
+    JobRetryResponse,
+    JobView,
+    build_list_response,
+    classify_job_id,
+    job_from_agent_task,
+    job_from_record,
+)
+from app.services.jobs.worker import (
+    AlreadyFinished,
+    DurableJobHandle,
+    durable_job,
+    finish_job,
+)
+
+__all__ = [
+    # lifecycle
+    "JobStatus",
+    "JobKind",
+    "InvalidJobTransition",
+    "ALLOWED_TRANSITIONS",
+    "TERMINAL_STATUSES",
+    "ACTIVE_STATUSES",
+    "CANCELLABLE_STATUSES",
+    "IMMUTABLE_STATUSES",
+    "RETRYABLE_STATUSES",
+    "can_transition",
+    "validate_transition",
+    "coerce_status",
+    "is_terminal",
+    "is_active",
+    "is_cancellable",
+    "is_retryable_status",
+    "sources_for",
+    # cancellation
+    "CancellationToken",
+    "CancellationRegistry",
+    "OperationCancelled",
+    "checkpoint",
+    "cancellable",
+    "current_token",
+    "use_token",
+    "is_cancelled",
+    "registry",
+    # context
+    "JobOrigin",
+    "current_origin",
+    "use_origin",
+    "new_run_id",
+    "new_turn_id",
+    # progress
+    "JobProgress",
+    "ProgressThrottle",
+    "ProgressReporter",
+    # store
+    "DurableJobStore",
+    "JobNotFound",
+    "worker_identity",
+    "DEFAULT_LIST_LIMIT",
+    "MAX_LIST_LIMIT",
+    "DEFAULT_STALE_AFTER_S",
+    # views
+    "ACTIVE_POLL_INTERVAL_MS",
+    "JobView",
+    "JobListResponse",
+    "JobCancelResponse",
+    "JobRetryResponse",
+    "job_from_record",
+    "job_from_agent_task",
+    "build_list_response",
+    "classify_job_id",
+    # worker
+    "durable_job",
+    "finish_job",
+    "DurableJobHandle",
+    "AlreadyFinished",
+    # artifacts
+    "atomic_output",
+    "discard_partial",
+]

--- a/app/services/jobs/artifacts.py
+++ b/app/services/jobs/artifacts.py
@@ -1,0 +1,73 @@
+"""原子产物提交（规范 §23 / §24）。
+
+长任务产生 raster / vector / image 时的问题：直接写最终路径意味着「取消或崩溃 =
+留下半个 GeoTIFF」，而且这个半成品和成功产物长得一模一样，后续步骤会把它当成有效
+输入。ADR-0052 统一改成：
+
+    temporary output  →  compute success  →  atomic finalize (os.replace)  →  ready
+
+失败/取消时删除临时文件；已经 finalize 的成功产物**绝不**删除。os.replace 在同一
+文件系统上是原子的，所以不存在「读到写了一半的最终文件」的窗口。
+"""
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import uuid
+from typing import Callable, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def atomic_output(
+    final_path: str,
+    *,
+    should_abort: Optional[Callable[[], bool]] = None,
+    suffix: str = "",
+) -> Iterator[str]:
+    """产出 ``final_path`` 的原子写入上下文，yield 临时路径。
+
+    Args:
+        final_path: 最终产物路径。只有在 with 块正常结束时才会出现。
+        should_abort: 可选回调；块结束时若返回 True 则丢弃产物（用于取消已到达但
+            计算刚好完成的竞态 —— 取消优先，绝不 finalize 一个已取消任务的产物）。
+        suffix: 临时文件额外后缀（同目录下写多个产物时区分用）。
+
+    Raises:
+        FileNotFoundError: 块结束时临时文件不存在（生产者什么都没写）。
+        RuntimeError: should_abort 判定应丢弃。
+    """
+    parent = os.path.dirname(final_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    temp_path = f"{final_path}.part-{uuid.uuid4().hex[:8]}{suffix}"
+
+    try:
+        yield temp_path
+    except BaseException:
+        _discard(temp_path)
+        raise
+
+    if not os.path.exists(temp_path):
+        raise FileNotFoundError(f"artifact producer wrote nothing: {temp_path}")
+
+    if should_abort is not None and should_abort():
+        _discard(temp_path)
+        raise RuntimeError(f"artifact discarded before finalize: {final_path}")
+
+    os.replace(temp_path, final_path)
+
+
+def _discard(path: str) -> None:
+    """删除临时文件。缺失/权限问题不向上抛 —— 清理不应掩盖真正的失败原因。"""
+    with contextlib.suppress(FileNotFoundError, OSError):
+        if os.path.isfile(path):
+            os.unlink(path)
+            logger.debug("[jobs] discarded partial artifact %s", path)
+
+
+def discard_partial(path: str) -> None:
+    """公开的临时产物清理入口（供 finally 块使用）。"""
+    _discard(path)

--- a/app/services/jobs/cancellation.py
+++ b/app/services/jobs/cancellation.py
@@ -1,0 +1,269 @@
+"""取消传播原语（ADR-0052）。
+
+原状态：``TaskTracker.cancel()`` 只翻一个内存 bool，chat 引擎在「每轮之间」和
+「每个工具完成之后」轮询它。后果是用户点 Cancel 后，正在跑的 NDVI / 缓冲区分析
+会一路算完（30–60s）才停 —— 取消只是 UI 状态，CPU 并没有释放。
+
+本模块提供贯穿式取消：
+
+    Task API → CancellationRegistry → CancellationToken
+                                        ├─ asyncio 侧：await token.wait() 立即唤醒，
+                                        │   执行引擎据此 preemptively cancel 在飞的
+                                        │   asyncio.Task（真正的抢占）
+                                        └─ 线程/CPU 侧：contextvar 携带 token，
+                                            GIS 循环在 checkpoint() 处协作退出
+
+为什么用 contextvar 而不是给每个工具加参数：``asyncio.to_thread``（registry 的同步
+工具执行路径）会 ``contextvars.copy_context()``，所以 token 能自动穿到工具线程里，
+不需要改动几十个 GIS 工具签名。token 用 ``threading.Event`` 承载状态，因此从 worker
+线程读写都是安全的。
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+import logging
+import threading
+import time
+from collections import OrderedDict
+from typing import Callable, Iterable, Iterator, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class OperationCancelled(Exception):
+    """协作式取消：工具/算法在 checkpoint 处观察到取消后抛出。
+
+    与 ``asyncio.CancelledError`` 区别开来 —— 后者是 asyncio 抢占，会被 asyncio
+    机制特殊对待（BaseException，不应被 ``except Exception`` 吞掉）。
+    OperationCancelled 是普通 Exception，允许中间层用 finally 清理临时文件，
+    再由 job 运行时统一收敛为 cancelled 终态。
+    """
+
+    def __init__(self, message: str = "operation cancelled", job_id: str | int | None = None):
+        self.job_id = job_id
+        super().__init__(message)
+
+
+class CancellationToken:
+    """线程安全 + asyncio 友好的取消信号。
+
+    ``cancel()`` 幂等：重复取消返回 False 且不重复触发回调（规范 §5 双重取消幂等）。
+    """
+
+    __slots__ = ("_job_id", "_event", "_reason", "_lock", "_callbacks", "_waiters", "_cancelled_at")
+
+    def __init__(self, job_id: str | int | None = None):
+        self._job_id = job_id
+        self._event = threading.Event()
+        self._reason: str | None = None
+        self._cancelled_at: float | None = None
+        self._lock = threading.Lock()
+        self._callbacks: list[Callable[[CancellationToken], None]] = []
+        # (loop, asyncio.Event) 对：跨线程 cancel 时用 call_soon_threadsafe 唤醒
+        self._waiters: list[tuple[asyncio.AbstractEventLoop, asyncio.Event]] = []
+
+    @property
+    def job_id(self) -> str | int | None:
+        return self._job_id
+
+    @property
+    def cancelled(self) -> bool:
+        return self._event.is_set()
+
+    @property
+    def reason(self) -> str | None:
+        return self._reason
+
+    @property
+    def cancelled_at(self) -> float | None:
+        """取消请求被观察到的单调时钟时刻，用于取消延迟度量。"""
+        return self._cancelled_at
+
+    def cancel(self, reason: str = "cancelled") -> bool:
+        """请求取消。首次调用返回 True，重复调用返回 False（幂等）。"""
+        with self._lock:
+            if self._event.is_set():
+                return False
+            self._reason = reason
+            self._cancelled_at = time.monotonic()
+            self._event.set()
+            callbacks = list(self._callbacks)
+            waiters = list(self._waiters)
+
+        for loop, ev in waiters:
+            try:
+                if loop.is_closed():
+                    continue
+                loop.call_soon_threadsafe(ev.set)
+            except RuntimeError:
+                # loop 已停止：等待者本身也活不下去了，忽略
+                continue
+        for cb in callbacks:
+            try:
+                cb(self)
+            except Exception:
+                logger.warning("[jobs] cancellation callback failed", exc_info=True)
+        return True
+
+    def raise_if_cancelled(self) -> None:
+        if self._event.is_set():
+            raise OperationCancelled(self._reason or "operation cancelled", job_id=self._job_id)
+
+    def add_callback(self, callback: Callable[[CancellationToken], None]) -> None:
+        """注册取消回调。若已取消则立即同步执行。"""
+        with self._lock:
+            if not self._event.is_set():
+                self._callbacks.append(callback)
+                return
+        try:
+            callback(self)
+        except Exception:
+            logger.warning("[jobs] cancellation callback failed", exc_info=True)
+
+    async def wait(self) -> None:
+        """等待取消发生。执行引擎用它抢占式打断在飞的工具任务。"""
+        if self._event.is_set():
+            return
+        loop = asyncio.get_running_loop()
+        ev = asyncio.Event()
+        with self._lock:
+            if self._event.is_set():
+                return
+            self._waiters.append((loop, ev))
+        try:
+            await ev.wait()
+        finally:
+            with self._lock:
+                self._waiters = [w for w in self._waiters if w[1] is not ev]
+
+    def link(self, child: "CancellationToken") -> None:
+        """父 token 取消时级联取消 child（agent task → 其派生的 durable job）。"""
+        self.add_callback(lambda parent: child.cancel(parent.reason or "parent cancelled"))
+
+    def __repr__(self) -> str:  # pragma: no cover - 诊断用
+        return f"<CancellationToken job={self._job_id} cancelled={self.cancelled}>"
+
+
+#: 当前执行上下文的取消 token。asyncio.to_thread 会复制 context，因此同步 GIS
+#: 工具在工作线程里也能读到它。
+CURRENT_TOKEN: contextvars.ContextVar[CancellationToken | None] = contextvars.ContextVar(
+    "webgis_current_cancellation_token", default=None
+)
+
+
+def current_token() -> CancellationToken | None:
+    return CURRENT_TOKEN.get()
+
+
+@contextlib.contextmanager
+def use_token(token: CancellationToken | None) -> Iterator[CancellationToken | None]:
+    """在 with 作用域内把 token 绑定到当前执行上下文。"""
+    reset = CURRENT_TOKEN.set(token)
+    try:
+        yield token
+    finally:
+        CURRENT_TOKEN.reset(reset)
+
+
+def is_cancelled() -> bool:
+    """当前上下文是否已被取消。无 token 时恒为 False。"""
+    token = CURRENT_TOKEN.get()
+    return bool(token and token.cancelled)
+
+
+def checkpoint() -> None:
+    """协作式取消检查点。已取消则抛 OperationCancelled，否则零开销返回。
+
+    放在长循环的安全边界（chunk / tile / feature batch / raster window 之间）：
+
+        for window in windows:
+            checkpoint()
+            process(window)
+
+    没有 token 时（普通同步请求路径）这就是一次 ContextVar.get()，可以放心撒。
+    """
+    token = CURRENT_TOKEN.get()
+    if token is not None and token.cancelled:
+        raise OperationCancelled(token.reason or "operation cancelled", job_id=token.job_id)
+
+
+def cancellable(iterable: Iterable[T], every: int = 1) -> Iterator[T]:
+    """包装迭代器，在每 ``every`` 个元素处插入 checkpoint()。
+
+    用于把已有的 ``for feature in features:`` 循环变成可取消循环而不改动循环体。
+    ``every > 1`` 用于单次迭代极短、checkpoint 相对开销不可忽略的场合。
+    """
+    if every < 1:
+        every = 1
+    for index, item in enumerate(iterable):
+        if index % every == 0:
+            checkpoint()
+        yield item
+
+
+class CancellationRegistry:
+    """进程内 job_id → token 映射。
+
+    这是「传信」通道而不是「事实源」：取消的持久事实是
+    ``analysis_tasks.cancel_requested_at``（见 store.request_cancel），registry 只负责
+    让本进程在飞的执行体立刻感知。因此 API 重启后 registry 为空并不丢取消语义 ——
+    worker 通过 DurableCancellationProbe 从 DB 读取。
+
+    LRU 有界，避免长期运行的 API 进程无限增长。
+    """
+
+    def __init__(self, max_entries: int = 2048):
+        self._max_entries = max_entries
+        self._tokens: OrderedDict[str, CancellationToken] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def register(self, key: str | int, token: CancellationToken | None = None) -> CancellationToken:
+        """获取或创建 key 对应的 token。已存在则返回原 token（保持幂等）。"""
+        skey = str(key)
+        with self._lock:
+            existing = self._tokens.get(skey)
+            if existing is not None:
+                self._tokens.move_to_end(skey)
+                return existing
+            tok = token or CancellationToken(job_id=skey)
+            self._tokens[skey] = tok
+            while len(self._tokens) > self._max_entries:
+                # 丢最旧的：它对应的执行体要么已结束，要么会在 DB 探针上观察取消
+                self._tokens.popitem(last=False)
+            return tok
+
+    def get(self, key: str | int) -> CancellationToken | None:
+        with self._lock:
+            return self._tokens.get(str(key))
+
+    def cancel(self, key: str | int, reason: str = "cancelled") -> bool:
+        """取消 key 对应的 token。key 未注册时返回 False。"""
+        token = self.get(key)
+        if token is None:
+            return False
+        return token.cancel(reason)
+
+    def is_cancelled(self, key: str | int) -> bool:
+        token = self.get(key)
+        return bool(token and token.cancelled)
+
+    def discard(self, key: str | int) -> None:
+        with self._lock:
+            self._tokens.pop(str(key), None)
+
+    def __len__(self) -> int:  # pragma: no cover - 诊断用
+        with self._lock:
+            return len(self._tokens)
+
+    def clear(self) -> None:
+        """清空 registry。用于测试里模拟进程重启。"""
+        with self._lock:
+            self._tokens.clear()
+
+
+#: 全局 registry。Task API 与执行引擎共用同一个实例。
+registry = CancellationRegistry()

--- a/app/services/jobs/context.py
+++ b/app/services/jobs/context.py
@@ -1,0 +1,97 @@
+"""Agent ↔ durable job 关联上下文（规范 §5 / §21）。
+
+目标形态：
+
+    Agent Turn
+     └─ Tool Step
+         └─ Durable Job
+
+原状态下 TaskTracker 的 ``task-xxxxxxxx`` 与 Celery 的 ``celery_task_id`` 是两个
+完全无关的命名空间 —— 前端会看到两条互不相干的条目，用户不知道那个「后台任务」属于
+刚才哪一步。
+
+这里用一个 contextvar 承载「我是谁派生出来的」：工具在执行期间创建 durable job 时，
+``DurableJobStore.create`` 自动把 session/owner/run/turn/tool_call/agent step 填进
+job 行，并把新 job id 追加到 ``created_job_ids``。工具管道在 dispatch 结束后读取该
+列表，把 ``background_job_ids`` 放进 ``step_result`` SSE，前端由此把后台 job 挂到
+对应的 tool step 下面。
+
+工具本身不需要改签名 —— 与 cancellation 一样走 contextvar，``asyncio.to_thread``
+会复制 context。
+"""
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import uuid
+from dataclasses import dataclass, field
+from typing import Iterator, Optional
+
+
+@dataclass
+class JobOrigin:
+    """一次工具执行的来源标识 + 该执行派生出的 durable job 收集器。"""
+
+    session_id: Optional[str] = None
+    owner_id: Optional[str] = None
+    owner_token: Optional[str] = None
+    org_id: Optional[int] = None
+    project_id: Optional[str] = None
+    run_id: Optional[str] = None
+    turn_id: Optional[str] = None
+    tool_call_id: Optional[str] = None
+    agent_task_id: Optional[str] = None
+    agent_step_id: Optional[str] = None
+    tool_name: Optional[str] = None
+    #: 本次执行期间创建的 durable job id（按创建顺序）
+    created_job_ids: list[str] = field(default_factory=list)
+
+    def record_job(self, job_id: str | int) -> None:
+        sid = str(job_id)
+        if sid not in self.created_job_ids:
+            self.created_job_ids.append(sid)
+
+    def child(self, **overrides) -> "JobOrigin":
+        """派生一个继承 owner/session 的子上下文（收集器不共享）。"""
+        data = {
+            "session_id": self.session_id,
+            "owner_id": self.owner_id,
+            "owner_token": self.owner_token,
+            "org_id": self.org_id,
+            "project_id": self.project_id,
+            "run_id": self.run_id,
+            "turn_id": self.turn_id,
+            "tool_call_id": self.tool_call_id,
+            "agent_task_id": self.agent_task_id,
+            "agent_step_id": self.agent_step_id,
+            "tool_name": self.tool_name,
+        }
+        data.update(overrides)
+        return JobOrigin(**data)
+
+
+CURRENT_ORIGIN: contextvars.ContextVar[Optional[JobOrigin]] = contextvars.ContextVar(
+    "webgis_current_job_origin", default=None
+)
+
+
+def current_origin() -> Optional[JobOrigin]:
+    return CURRENT_ORIGIN.get()
+
+
+@contextlib.contextmanager
+def use_origin(origin: Optional[JobOrigin]) -> Iterator[Optional[JobOrigin]]:
+    reset = CURRENT_ORIGIN.set(origin)
+    try:
+        yield origin
+    finally:
+        CURRENT_ORIGIN.reset(reset)
+
+
+def new_run_id() -> str:
+    """生成 run_id。与既有 ``wfrun_`` 风格保持一致的短前缀 id。"""
+    return f"run-{uuid.uuid4().hex[:12]}"
+
+
+def new_turn_id() -> str:
+    return f"turn-{uuid.uuid4().hex[:12]}"

--- a/app/services/jobs/lifecycle.py
+++ b/app/services/jobs/lifecycle.py
@@ -1,0 +1,192 @@
+"""Unified job lifecycle contract (ADR-0052).
+
+单一生命周期语义：Agent task / 空间分析 job / Celery worker job 共用同一套状态与
+同一套合法迁移。历史上有三套互不相通的 task state（内存 TaskTracker、
+analysis_tasks 表、TaskQueueService._task_owners），状态名与语义都不一致；这里把
+语义收敛到一处，并用显式迁移表挡住非法写入。
+
+状态名沿用 analysis_tasks 表原有 CHECK 值（pending/queued/running/completed/
+failed/cancelled），只新增两个必要状态 —— 这样迁移是 additive 的，老数据行不需要
+改写：
+
+    pending      已创建，尚未入队（= 规范里的 created）
+    queued       已交给 worker/队列
+    running      worker 正在执行
+    cancelling   已收到取消请求，worker 尚未确认（非终态）
+    cancelled    取消已生效（终态）
+    completed    成功（= 规范里的 succeeded）
+    failed       失败（终态）
+    stale        worker 失联，心跳超时被清扫（终态）
+
+关键不变式（见 test_job_lifecycle.py）：
+  1. 终态不可再迁移 —— late success 不能覆盖 cancelled。
+  2. cancelling 只能走向 cancelled/failed —— worker 若在 cancelling 期间跑完，
+     结果按取消处理，绝不回写 completed（规范 §14）。
+  3. failed/stale 只能通过显式新 attempt 回到 queued；cancelled 永不重试
+     （规范 §17：取消绝不能自动 retry）。
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class JobStatus(str, Enum):
+    """统一 job 状态。值与 analysis_tasks.status CHECK 约束一致。"""
+
+    pending = "pending"
+    queued = "queued"
+    running = "running"
+    cancelling = "cancelling"
+    cancelled = "cancelled"
+    completed = "completed"
+    failed = "failed"
+    stale = "stale"
+
+
+class JobKind(str, Enum):
+    """job 归属的执行域。决定前端图标/分组与可重试性默认值。"""
+
+    agent = "agent"          # Agent turn 级任务（原 TaskTracker task）
+    analysis = "analysis"    # 空间/遥感分析 job（Celery）
+    workflow = "workflow"    # WorkflowRun
+    explorer = "explorer"    # Explorer chain
+
+
+#: 终态集合：执行已结束，不再有 worker 在推进它。
+#: 注意「终态」≠「不可变」—— failed/stale 可以通过**显式新 attempt** 回到 queued
+#: （见 IMMUTABLE_STATUSES 与 DurableJobStore.start_retry）。
+TERMINAL_STATUSES: frozenset[JobStatus] = frozenset(
+    {JobStatus.cancelled, JobStatus.completed, JobStatus.failed, JobStatus.stale}
+)
+
+#: 永不可再迁移的状态。这是最强不变式：
+#:   * cancelled 不能被 worker 的 late success 改成 completed（规范 §14）；
+#:   * completed 不能被任何后续写入改掉。
+#: 取消也因此永远不会被 retry（规范 §17）—— cancelled 没有任何后继。
+IMMUTABLE_STATUSES: frozenset[JobStatus] = frozenset(
+    {JobStatus.cancelled, JobStatus.completed}
+)
+
+#: 可取消状态集合。
+CANCELLABLE_STATUSES: frozenset[JobStatus] = frozenset(
+    {JobStatus.pending, JobStatus.queued, JobStatus.running}
+)
+
+#: 允许通过新 attempt 重试的终态。cancelled 不在其中 —— 规范 §17。
+RETRYABLE_STATUSES: frozenset[JobStatus] = frozenset({JobStatus.failed, JobStatus.stale})
+
+#: 活跃（非终态）状态集合。前端轮询只在存在活跃 job 时进行。
+ACTIVE_STATUSES: frozenset[JobStatus] = frozenset(
+    {JobStatus.pending, JobStatus.queued, JobStatus.running, JobStatus.cancelling}
+)
+
+#: 显式迁移表。任何不在表中的 (from, to) 都是非法迁移。
+ALLOWED_TRANSITIONS: dict[JobStatus, frozenset[JobStatus]] = {
+    JobStatus.pending: frozenset(
+        {
+            JobStatus.queued,
+            JobStatus.running,
+            JobStatus.cancelling,
+            JobStatus.cancelled,
+            JobStatus.failed,
+        }
+    ),
+    JobStatus.queued: frozenset(
+        {
+            JobStatus.running,
+            JobStatus.cancelling,
+            JobStatus.cancelled,
+            JobStatus.failed,
+            JobStatus.stale,
+        }
+    ),
+    JobStatus.running: frozenset(
+        {
+            JobStatus.cancelling,
+            JobStatus.completed,
+            JobStatus.failed,
+            JobStatus.stale,
+        }
+    ),
+    # cancelling 绝不走向 completed：worker 的 late success 按取消收敛。
+    JobStatus.cancelling: frozenset({JobStatus.cancelled, JobStatus.failed}),
+    JobStatus.cancelled: frozenset(),
+    JobStatus.completed: frozenset(),
+    # failed/stale 只能经**显式新 attempt** 回到 queued（store.start_retry 会递增
+    # attempt 并保留首次失败的 error_trace）。直接 failed → running 是被禁止的。
+    JobStatus.failed: frozenset({JobStatus.queued}),
+    JobStatus.stale: frozenset({JobStatus.queued}),
+}
+
+
+class InvalidJobTransition(ValueError):
+    """非法状态迁移。携带 from/to 便于日志与测试断言。"""
+
+    def __init__(self, current: JobStatus, target: JobStatus, job_id: str | int | None = None):
+        self.current = current
+        self.target = target
+        self.job_id = job_id
+        where = f" job={job_id}" if job_id is not None else ""
+        super().__init__(f"illegal job transition {current.value} -> {target.value}{where}")
+
+
+def coerce_status(value: JobStatus | str | None) -> JobStatus:
+    """把 DB / API 传入的字符串收敛为 JobStatus。
+
+    未知值（例如未来版本写入的状态）按 pending 处理而非抛错，避免一行坏数据
+    让整个任务中心 500。
+    """
+    if isinstance(value, JobStatus):
+        return value
+    if not value:
+        return JobStatus.pending
+    try:
+        return JobStatus(str(value))
+    except ValueError:
+        return JobStatus.pending
+
+
+def is_terminal(status: JobStatus | str | None) -> bool:
+    return coerce_status(status) in TERMINAL_STATUSES
+
+
+def is_active(status: JobStatus | str | None) -> bool:
+    return coerce_status(status) in ACTIVE_STATUSES
+
+
+def can_transition(current: JobStatus | str | None, target: JobStatus | str) -> bool:
+    """target 是否是 current 的合法后继。同状态自迁移视为非法（调用方应走幂等分支）。"""
+    cur = coerce_status(current)
+    tgt = coerce_status(target)
+    return tgt in ALLOWED_TRANSITIONS.get(cur, frozenset())
+
+
+def validate_transition(
+    current: JobStatus | str | None,
+    target: JobStatus | str,
+    job_id: str | int | None = None,
+) -> JobStatus:
+    """校验并返回 target；非法则抛 InvalidJobTransition。"""
+    cur = coerce_status(current)
+    tgt = coerce_status(target)
+    if tgt not in ALLOWED_TRANSITIONS.get(cur, frozenset()):
+        raise InvalidJobTransition(cur, tgt, job_id)
+    return tgt
+
+
+def sources_for(target: JobStatus | str) -> frozenset[JobStatus]:
+    """能合法迁移到 target 的所有前驱状态。
+
+    store 层用它构造原子条件更新的 ``WHERE status IN (...)`` —— 迁移规则只在本
+    模块定义一次，避免各处手写状态列表逐渐漂移。
+    """
+    tgt = coerce_status(target)
+    return frozenset(src for src, allowed in ALLOWED_TRANSITIONS.items() if tgt in allowed)
+
+
+def is_cancellable(status: JobStatus | str | None) -> bool:
+    return coerce_status(status) in CANCELLABLE_STATUSES
+
+
+def is_retryable_status(status: JobStatus | str | None) -> bool:
+    return coerce_status(status) in RETRYABLE_STATUSES

--- a/app/services/jobs/progress.py
+++ b/app/services/jobs/progress.py
@@ -1,0 +1,208 @@
+"""统一进度语义与写入节流（规范 §19 / §20）。
+
+原状态：Celery 侧是 ``update_state(PROGRESS, {'progress': n})``（只存在于 Redis
+result backend），Agent 侧是 step_start/step_result 事件，两者没有共同契约，前端
+也拿不到统一百分比。
+
+统一契约（JobProgress）：
+
+    phase          当前阶段名（可空），如 "reproject" / "compute" / "finalize"
+    progress       0–100 整数，或 None 表示 indeterminate（不确定进度）
+    message        人类可读短消息
+    current_step   已完成步数（可空）
+    total_steps    总步数（可空）
+
+允许 ``progress=None``：不是所有 job 都能算出真实百分比，假装 99% 然后卡十分钟
+比 indeterminate 更糟（规范 §19 明令禁止）。
+
+节流：大循环不得每个 feature 写一次 DB。``ProgressThrottle`` 只在「进度变化 ≥1%」
+或「距上次写入 ≥500ms」时放行，终态与首次上报无条件放行 —— 保证 DB 写入速率有上界
+（规范 §20，基准见 tests/benchmarks/test_job_runtime_perf.py）。
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+#: 默认节流阈值。1% / 500ms 是规范给的起点；基准测试确认在 100k 次上报下
+#: DB 写入次数被压到两位数。
+DEFAULT_MIN_DELTA_PCT = 1.0
+DEFAULT_MIN_INTERVAL_S = 0.5
+
+
+@dataclass(frozen=True)
+class JobProgress:
+    """统一进度快照。"""
+
+    progress: Optional[int] = None
+    message: Optional[str] = None
+    phase: Optional[str] = None
+    current_step: Optional[int] = None
+    total_steps: Optional[int] = None
+
+    @property
+    def indeterminate(self) -> bool:
+        return self.progress is None
+
+    def clamped(self) -> "JobProgress":
+        """把 progress 收敛到 [0, 100]，满足 ck_task_progress CHECK 约束。"""
+        if self.progress is None:
+            return self
+        value = int(self.progress)
+        if value < 0:
+            value = 0
+        elif value > 100:
+            value = 100
+        if value == self.progress:
+            return self
+        return JobProgress(
+            progress=value,
+            message=self.message,
+            phase=self.phase,
+            current_step=self.current_step,
+            total_steps=self.total_steps,
+        )
+
+    def as_message(self) -> Optional[str]:
+        """合成落库用的 progress_message（analysis_tasks.progress_message 为 String(255)）。"""
+        parts: list[str] = []
+        if self.phase:
+            parts.append(f"[{self.phase}]")
+        if self.message:
+            parts.append(self.message)
+        if self.current_step is not None and self.total_steps:
+            parts.append(f"({self.current_step}/{self.total_steps})")
+        text = " ".join(parts).strip()
+        if not text:
+            return None
+        return text[:255]
+
+
+class ProgressThrottle:
+    """判断一次进度上报是否应该落库。
+
+    有状态、非线程安全 —— 每个 job 执行体持有自己的实例（执行体本身是单线程的）。
+    """
+
+    __slots__ = ("_min_delta", "_min_interval", "_last_pct", "_last_at", "_emitted", "_clock")
+
+    def __init__(
+        self,
+        min_delta_pct: float = DEFAULT_MIN_DELTA_PCT,
+        min_interval_s: float = DEFAULT_MIN_INTERVAL_S,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self._min_delta = float(min_delta_pct)
+        self._min_interval = float(min_interval_s)
+        self._last_pct: float | None = None
+        self._last_at: float | None = None
+        self._emitted = 0
+        self._clock = clock
+
+    @property
+    def emitted(self) -> int:
+        """已放行次数。基准测试用它断言 DB 写入速率有界。"""
+        return self._emitted
+
+    def should_emit(self, progress: int | None, *, force: bool = False) -> bool:
+        now = self._clock()
+
+        if force:
+            self._record(progress, now)
+            return True
+
+        # 首次上报总是放行 —— 让前端立刻看到 job 已开始推进
+        if self._last_at is None:
+            self._record(progress, now)
+            return True
+
+        # indeterminate 进度只能靠时间节流
+        if progress is None:
+            if now - self._last_at >= self._min_interval:
+                self._record(progress, now)
+                return True
+            return False
+
+        # 100% 是有意义的边界，总是放行
+        if progress >= 100:
+            self._record(progress, now)
+            return True
+
+        if self._last_pct is not None and abs(float(progress) - self._last_pct) >= self._min_delta:
+            self._record(progress, now)
+            return True
+
+        if now - self._last_at >= self._min_interval:
+            self._record(progress, now)
+            return True
+
+        return False
+
+    def _record(self, progress: int | None, now: float) -> None:
+        if progress is not None:
+            self._last_pct = float(progress)
+        self._last_at = now
+        self._emitted += 1
+
+    def reset(self) -> None:
+        self._last_pct = None
+        self._last_at = None
+        self._emitted = 0
+
+
+class ProgressReporter:
+    """把节流后的进度交给一个 sink 回调。
+
+    sink 由调用方决定：worker 侧写 DB + Celery ``update_state``，agent 侧发 SSE。
+    Reporter 本身不关心目的地，只保证「速率有界」和「终态必达」。
+    """
+
+    __slots__ = ("_sink", "_throttle", "_last")
+
+    def __init__(
+        self,
+        sink: Callable[[JobProgress], None],
+        throttle: ProgressThrottle | None = None,
+    ):
+        self._sink = sink
+        self._throttle = throttle or ProgressThrottle()
+        self._last: JobProgress | None = None
+
+    @property
+    def throttle(self) -> ProgressThrottle:
+        return self._throttle
+
+    @property
+    def last(self) -> JobProgress | None:
+        return self._last
+
+    def report(
+        self,
+        progress: int | None = None,
+        message: str | None = None,
+        *,
+        phase: str | None = None,
+        current_step: int | None = None,
+        total_steps: int | None = None,
+        force: bool = False,
+    ) -> bool:
+        """上报进度。返回是否真的落到了 sink。"""
+        snapshot = JobProgress(
+            progress=progress,
+            message=message,
+            phase=phase,
+            current_step=current_step,
+            total_steps=total_steps,
+        ).clamped()
+
+        if not self._throttle.should_emit(snapshot.progress, force=force):
+            return False
+
+        self._last = snapshot
+        self._sink(snapshot)
+        return True
+
+    def flush(self, progress: int | None = None, message: str | None = None, **kwargs) -> bool:
+        """无条件上报（终态/阶段边界用）。"""
+        return self.report(progress=progress, message=message, force=True, **kwargs)

--- a/app/services/jobs/redaction.py
+++ b/app/services/jobs/redaction.py
@@ -1,0 +1,257 @@
+"""job 载荷脱敏与体积上限（规范 §7 / §35 / §38）。
+
+durable job 行会被前端任务中心读取，而任务参数/结果里可能混进：完整 GeoJSON
+（50 MB 级）、raster 数组、signed URL、token、密码、原始 traceback。直接落库会
+同时踩三个坑：DB 行膨胀、任务列表查询变慢、凭据经任务中心泄漏。
+
+规则：
+  * 敏感 key 一律替换为 "[REDACTED]"（按 key 名匹配，大小写无关，子串命中）。
+  * 大型几何体（features / coordinates / 栅格数组）不落库，替换为摘要
+    ``{"__omitted__": "features", "count": N}``。
+  * 字符串截断；序列化后仍超上限则整体降级为 stub 摘要。
+  * 错误只留 "ExcType: 首行消息"，绝不落 traceback。
+
+这些函数是纯函数，无 IO，便于单测。
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+#: 参数摘要上限（序列化后字节）。
+MAX_PARAMETERS_BYTES = 8_192
+#: 结果摘要上限。比参数略宽 —— 结果里常有统计量与 bbox。
+MAX_RESULT_BYTES = 16_384
+#: 单个字符串字段截断长度。
+MAX_STRING_CHARS = 512
+#: 错误摘要长度。
+MAX_ERROR_CHARS = 500
+#: 递归深度上限，防御自引用/超深结构。
+MAX_DEPTH = 6
+#: 集合类字段保留的元素个数上限。
+MAX_SEQUENCE_ITEMS = 20
+
+REDACTED = "[REDACTED]"
+
+#: 命中即脱敏的 key 子串。覆盖规范 §35 点名的 credentials / signed URL / secret /
+#: token / password / auth header，以及 prompt 类原文。
+SENSITIVE_KEY_PARTS: tuple[str, ...] = (
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "credential",
+    "authorization",
+    "auth_header",
+    "api_key",
+    "apikey",
+    "access_key",
+    "private_key",
+    "signed_url",
+    "signature",
+    "cookie",
+    "session_token",
+    "owner_token",
+    "bearer",
+)
+
+#: 体积敏感、不做内容保留只做摘要的 key。
+BULK_KEYS: tuple[str, ...] = (
+    "features",
+    "coordinates",
+    "geojson",
+    "geometry",
+    "raster",
+    "array",
+    "image",
+    "image_base64",
+    "png",
+    "tiles",
+    "band_data",
+    "values",
+    "pixels",
+)
+
+
+def _is_sensitive(key: str) -> bool:
+    lowered = key.lower()
+    return any(part in lowered for part in SENSITIVE_KEY_PARTS)
+
+
+def _is_bulk(key: str) -> bool:
+    return key.lower() in BULK_KEYS
+
+
+def _summarize_bulk(key: str, value: Any) -> Any:
+    """把大对象替换成结构化摘要，保留对用户仍有意义的元信息。"""
+    if isinstance(value, (list, tuple)):
+        return {"__omitted__": key, "count": len(value)}
+    if isinstance(value, dict):
+        summary: dict[str, Any] = {"__omitted__": key}
+        # GeoJSON FeatureCollection 的 type/feature 数仍然值得展示
+        if isinstance(value.get("type"), str):
+            summary["type"] = value["type"]
+        feats = value.get("features")
+        if isinstance(feats, list):
+            summary["count"] = len(feats)
+        return summary
+    if isinstance(value, (str, bytes)):
+        return {"__omitted__": key, "bytes": len(value)}
+    return {"__omitted__": key}
+
+
+def _scrub(value: Any, depth: int = 0) -> Any:
+    if depth > MAX_DEPTH:
+        return "[TRUNCATED_DEPTH]"
+
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    if isinstance(value, bytes):
+        return {"__omitted__": "bytes", "bytes": len(value)}
+
+    if isinstance(value, str):
+        if len(value) > MAX_STRING_CHARS:
+            return value[:MAX_STRING_CHARS] + f"…[+{len(value) - MAX_STRING_CHARS} chars]"
+        return value
+
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for raw_key, raw_val in value.items():
+            key = str(raw_key)
+            if _is_sensitive(key):
+                out[key] = REDACTED
+            elif _is_bulk(key):
+                out[key] = _summarize_bulk(key, raw_val)
+            else:
+                out[key] = _scrub(raw_val, depth + 1)
+        return out
+
+    if isinstance(value, (list, tuple, set)):
+        items = list(value)
+        if len(items) > MAX_SEQUENCE_ITEMS:
+            head = [_scrub(v, depth + 1) for v in items[:MAX_SEQUENCE_ITEMS]]
+            return head + [{"__omitted__": "items", "count": len(items) - MAX_SEQUENCE_ITEMS}]
+        return [_scrub(v, depth + 1) for v in items]
+
+    # 其它类型（datetime / ORM 对象 / numpy 标量…）退化为可读字符串
+    return _scrub(str(value), depth + 1)
+
+
+def _fits(value: Any, max_bytes: int) -> bool:
+    try:
+        encoded = json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return False
+    return len(encoded.encode("utf-8")) <= max_bytes
+
+
+def _shrink_to_limit(scrubbed: Any, max_bytes: int, label: str) -> Any:
+    """逐级降级直到满足体积上限，保证落库大小有硬上界。"""
+    if _fits(scrubbed, max_bytes):
+        return scrubbed
+
+    # 第一级：只保留标量字段（丢掉所有嵌套结构）
+    if isinstance(scrubbed, dict):
+        flat = {
+            k: v
+            for k, v in scrubbed.items()
+            if v is None or isinstance(v, (bool, int, float)) or (isinstance(v, str) and len(v) <= 120)
+        }
+        flat["__truncated__"] = label
+        if _fits(flat, max_bytes):
+            return flat
+
+    # 第二级：只留一个 stub
+    return {"__truncated__": label, "note": "payload exceeded storage limit"}
+
+
+def safe_parameters(params: Any) -> dict[str, Any]:
+    """脱敏 + 限长的参数摘要，可直接写入 analysis_tasks.parameters。"""
+    scrubbed = _scrub(params if params is not None else {})
+    if not isinstance(scrubbed, dict):
+        scrubbed = {"value": scrubbed}
+    return _shrink_to_limit(scrubbed, MAX_PARAMETERS_BYTES, "parameters")
+
+
+def safe_result(result: Any) -> dict[str, Any] | None:
+    """脱敏 + 限长的结果摘要，可直接写入 analysis_tasks.result_summary。
+
+    巨型结果（完整 GeoJSON / raster）只留指针与统计量 —— 真实产物应通过
+    ``result_ref``（artifact id / 路径）引用，而不是塞进 task 行。
+    """
+    if result is None:
+        return None
+    scrubbed = _scrub(result)
+    if not isinstance(scrubbed, dict):
+        scrubbed = {"value": scrubbed}
+    return _shrink_to_limit(scrubbed, MAX_RESULT_BYTES, "result_summary")
+
+
+def safe_error(error: BaseException | str | None) -> str | None:
+    """单行错误摘要。绝不包含 traceback（规范 §7 / §10）。"""
+    if error is None:
+        return None
+    if isinstance(error, BaseException):
+        message = str(error).strip() or error.__class__.__name__
+        text = f"{error.__class__.__name__}: {message}"
+    else:
+        text = str(error).strip()
+    # traceback 是多行的 —— 只留第一行，杜绝 "Traceback (most recent call last)" 泄漏
+    text = text.splitlines()[0] if text else ""
+    if len(text) > MAX_ERROR_CHARS:
+        text = text[:MAX_ERROR_CHARS] + "…"
+    return text or None
+
+
+#: dispatch 描述符上限。它必须**忠实**可重跑，所以不做内容截断 —— 超限就整体丢弃，
+#: 让 retry 明确不可用，而不是留一份跑不起来的残缺参数。
+MAX_DISPATCH_BYTES = 4_096
+
+
+def _contains_sensitive_key(value: Any, depth: int = 0) -> bool:
+    """递归判断结构里是否出现敏感键名。"""
+    if depth > MAX_DEPTH:
+        return False
+    if isinstance(value, dict):
+        for key, val in value.items():
+            if _is_sensitive(str(key)):
+                return True
+            if _contains_sensitive_key(val, depth + 1):
+                return True
+        return False
+    if isinstance(value, (list, tuple, set)):
+        return any(_contains_sensitive_key(v, depth + 1) for v in value)
+    return False
+
+
+def safe_dispatch_spec(spec: Any) -> dict[str, Any] | None:
+    """校验并返回可用于重跑的 dispatch 描述符 ``{task, args, kwargs}``。
+
+    与 ``safe_parameters`` 不同，这里**不**截断内容（截断后的参数无法重跑），只做两件事：
+      1. 拒绝任何携带敏感键的 kwargs —— 凭据绝不落库（规范 §35）；
+      2. 超过体积上限就整体丢弃，并打上 ``__truncated__`` 标记，store 据此判定
+         该 job 不可重试，而不是提供一个必然失败的 retry。
+
+    该字段永不通过 API 返回（JobView 里没有它）。
+    """
+    if not isinstance(spec, dict):
+        return None
+    task = spec.get("task")
+    if not task or not isinstance(task, str):
+        return None
+
+    args = spec.get("args") or []
+    kwargs = spec.get("kwargs") or {}
+    if not isinstance(args, (list, tuple)) or not isinstance(kwargs, dict):
+        return None
+
+    # 递归筛查：args 里的嵌套 dict（例如一个带 properties.token 的 GeoJSON）
+    # 同样可能夹带凭据，只看顶层 kwargs 的 key 是不够的。
+    if _contains_sensitive_key(kwargs) or _contains_sensitive_key(list(args)):
+        return {"__truncated__": "dispatch_spec", "reason": "sensitive_argument"}
+
+    candidate: dict[str, Any] = {"task": task, "args": list(args), "kwargs": dict(kwargs)}
+    if not _fits(candidate, MAX_DISPATCH_BYTES):
+        return {"__truncated__": "dispatch_spec", "reason": "too_large"}
+    return candidate

--- a/app/services/jobs/store.py
+++ b/app/services/jobs/store.py
@@ -1,0 +1,1012 @@
+"""Durable job store（ADR-0052）。
+
+事实源在 PostgreSQL 的 ``analysis_tasks`` 表，不再是 ``TaskTracker._tasks`` 或
+``TaskQueueService._task_owners`` 这两个进程内 dict。API 重启后：
+
+  * 合法 owner 仍能查询自己的 job；
+  * 合法 owner 仍能取消自己的 job；
+  * 其他用户仍然 404。
+
+并发正确性靠**原子条件更新**而不是 read-modify-write：每次状态迁移都是
+
+    UPDATE analysis_tasks SET status=:target, ...
+     WHERE id=:id AND status IN (<legal predecessors of target>)
+
+合法前驱集合由 lifecycle.sources_for() 提供 —— 规则只定义一次。rowcount==0 说明
+状态已被别人改走（典型场景：API 取消与 worker 完成同时到达），调用方据此走幂等
+分支，而不是盲写覆盖。这直接杜绝了规范 §14 点名的 ``cancelled → completed``。
+
+同时提供 async（API 路径，AsyncSession）与 sync（Celery worker 路径，Session）两套
+入口。两套共享同一批语句构造函数，避免规则分叉。
+"""
+from __future__ import annotations
+
+import logging
+import os
+import socket
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Optional, Sequence
+
+from sqlalchemy import Select, and_, or_, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.models.db_model import AnalysisTask
+from app.services.jobs import redaction
+from app.services.jobs.lifecycle import (
+    ACTIVE_STATUSES,
+    JobKind,
+    JobStatus,
+    coerce_status,
+    is_terminal,
+    sources_for,
+)
+from app.services.jobs.progress import JobProgress
+
+logger = logging.getLogger(__name__)
+
+#: running job 心跳超时。超过此时长未心跳的 running/cancelling job 被判定 stale。
+#: 取 5 分钟：远大于正常心跳周期（30s），又不会让用户面对无限 running。
+DEFAULT_STALE_AFTER_S = 300
+#: 单次任务中心查询返回上限，防止无界扫描。
+DEFAULT_LIST_LIMIT = 50
+MAX_LIST_LIMIT = 200
+
+
+def _utcnow() -> datetime:
+    # DB 列是 naive DateTime（既有约定），统一存 naive UTC，避免混用导致比较异常
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+#: 未认证调用方在 auth 层被表示为字面量 "anonymous"（app/core/auth.py）。
+#: 它不是 users 表里的一行 —— 直接写进 creator_id 会在 PostgreSQL 上违反外键，
+#: 于是匿名用户根本无法创建 durable job（SQLite 因默认不校验 FK 而掩盖了这点）。
+#: 归属改由 owner_token + session_id 证明。
+_NON_OWNER_IDS = frozenset({"", "anonymous", "none", "null"})
+
+
+def normalize_owner_id(owner_id: Optional[str]) -> Optional[str]:
+    """把伪 owner id 收敛为 None。"""
+    if owner_id is None:
+        return None
+    text = str(owner_id).strip()
+    if not text or text.lower() in _NON_OWNER_IDS:
+        return None
+    return text
+
+
+def worker_identity() -> str:
+    """当前执行者标识。用于 stale 归因与日志。"""
+    return f"{socket.gethostname()}:{os.getpid()}"[:128]
+
+
+class JobNotFound(LookupError):
+    """job 不存在或不属于调用方。路由层统一转 404，不泄露存在性。"""
+
+
+def _ownership_predicate(owner_id: Optional[str], owner_token: Optional[str], session_ids: Sequence[str] | None):
+    """构造归属谓词。
+
+    三条合法证明链，任一命中即视为拥有：
+      1. creator_id == 已认证 user_id（登录用户自己的 job）
+      2. owner_token 精确匹配（匿名会话的能力令牌，镜像 SEC-08）
+      3. session_id ∈ 调用方已证明拥有的会话集合（由路由层用
+         require_owned_session / verify_session_owner 先证明）
+
+    三条都不成立时返回一个恒假谓词 —— 绝不退化成「无过滤」。
+    """
+    clauses = []
+    owner_id = normalize_owner_id(owner_id)
+    if owner_id:
+        clauses.append(AnalysisTask.creator_id == owner_id)
+    if owner_token:
+        clauses.append(AnalysisTask.owner_token == owner_token)
+    if session_ids:
+        clauses.append(AnalysisTask.session_id.in_(list(session_ids)))
+    if not clauses:
+        # 恒假：没有任何归属证明的调用方看不到任何 job
+        return AnalysisTask.id.is_(None)
+    return or_(*clauses)
+
+
+def _is_reusable(job: AnalysisTask) -> bool:
+    """幂等键命中时，这一行是否可以直接复用。
+
+    可复用：仍在推进中（未终态）——重复提交应当汇聚到它；或已成功完成 ——
+    重复提交本就该拿到同一个结果。
+
+    **不可**复用：cancelled / failed / stale。用户取消或失败之后再次请求同样的分析，
+    必须能真的跑起来；若复用旧行，提交路径会永远返回「已复用」而什么都不执行，而
+    cancelled 又永不可 retry —— 那是一个无法脱出的死胡同（除非改参数）。
+    """
+    status = coerce_status(job.status)
+    if not is_terminal(status):
+        return True
+    return status == JobStatus.completed
+
+
+class DurableJobStore:
+    """analysis_tasks 上的 durable job 仓储。全为静态方法，无自身状态。"""
+
+    # ── 构造 ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def build(
+        *,
+        task_type: str,
+        kind: JobKind | str = JobKind.analysis,
+        display_name: Optional[str] = None,
+        owner_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
+        org_id: Optional[int] = None,
+        session_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        parameters: Any = None,
+        idempotency_key: Optional[str] = None,
+        celery_task_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        turn_id: Optional[str] = None,
+        tool_call_id: Optional[str] = None,
+        agent_task_id: Optional[str] = None,
+        agent_step_id: Optional[str] = None,
+        max_retries: int = 3,
+        status: JobStatus = JobStatus.pending,
+        dispatch_spec: Optional[dict] = None,
+    ) -> AnalysisTask:
+        """构造（未持久化的）job 行。参数经脱敏与体积裁剪。"""
+        now = _utcnow()
+        kind_value = kind.value if isinstance(kind, JobKind) else str(kind)
+        return AnalysisTask(
+            task_type=task_type[:50],
+            job_kind=kind_value[:20],
+            display_name=(display_name or task_type)[:200],
+            creator_id=normalize_owner_id(owner_id),
+            owner_token=owner_token,
+            org_id=org_id,
+            session_id=session_id,
+            project_id=project_id,
+            parameters=redaction.safe_parameters(parameters),
+            idempotency_key=idempotency_key,
+            celery_task_id=celery_task_id,
+            run_id=run_id,
+            turn_id=turn_id,
+            tool_call_id=tool_call_id,
+            agent_task_id=agent_task_id,
+            agent_step_id=agent_step_id,
+            status=status.value,
+            progress=0,
+            attempt=1,
+            retry_count=0,
+            max_retries=max_retries,
+            created_at=now,
+            updated_at=now,
+            dispatch_spec=redaction.safe_dispatch_spec(dispatch_spec),
+        )
+
+    @staticmethod
+    async def create(db: AsyncSession, **kwargs) -> AnalysisTask:
+        """创建 durable job。
+
+        幂等：给了 ``idempotency_key`` 时，若已存在同键行则直接返回既有行 ——
+        SSE 重连 / 用户双击 / API retry 不会产生第二个 job，也不会重复执行不可逆
+        操作（规范 §16）。并发插入撞唯一约束时回滚并重读。
+        """
+        from app.services.jobs.context import current_origin
+
+        origin = current_origin()
+        if origin is not None:
+            kwargs.setdefault("session_id", origin.session_id)
+            kwargs.setdefault("owner_id", origin.owner_id)
+            kwargs.setdefault("owner_token", origin.owner_token)
+            kwargs.setdefault("org_id", origin.org_id)
+            kwargs.setdefault("project_id", origin.project_id)
+            kwargs.setdefault("run_id", origin.run_id)
+            kwargs.setdefault("turn_id", origin.turn_id)
+            kwargs.setdefault("tool_call_id", origin.tool_call_id)
+            kwargs.setdefault("agent_task_id", origin.agent_task_id)
+            kwargs.setdefault("agent_step_id", origin.agent_step_id)
+
+        idem = kwargs.get("idempotency_key")
+        if idem:
+            existing = await DurableJobStore.get_by_idempotency_key(db, idem)
+            if existing is not None:
+                if _is_reusable(existing):
+                    if origin is not None:
+                        origin.record_job(existing.id)
+                    return existing
+                # 终态且非成功：释放旧行的幂等键，让这次提交能建新行。
+                # 旧行保留（含 error_trace / attempt），是失败或取消的历史证据。
+                existing.idempotency_key = None
+                await db.flush()
+
+        job = DurableJobStore.build(**kwargs)
+        db.add(job)
+        try:
+            await db.flush()
+        except IntegrityError:
+            await db.rollback()
+            if idem:
+                existing = await DurableJobStore.get_by_idempotency_key(db, idem)
+                if existing is not None:
+                    if origin is not None:
+                        origin.record_job(existing.id)
+                    return existing
+            raise
+
+        if origin is not None:
+            origin.record_job(job.id)
+        logger.info(
+            "[jobs] created job_id=%s kind=%s type=%s session=%s agent_task=%s",
+            job.id, job.job_kind, job.task_type, job.session_id, job.agent_task_id,
+        )
+        return job
+
+    @staticmethod
+    def create_sync(db: Session, **kwargs) -> AnalysisTask:
+        """worker 侧同步创建（Celery 任务内部用 db_session）。"""
+        idem = kwargs.get("idempotency_key")
+        if idem:
+            existing = db.execute(
+                select(AnalysisTask).where(AnalysisTask.idempotency_key == idem)
+            ).scalar_one_or_none()
+            if existing is not None:
+                if _is_reusable(existing):
+                    return existing
+                # 见 create()：cancelled/failed 不可复用，否则重复提交永远是 no-op
+                existing.idempotency_key = None
+                db.flush()
+        job = DurableJobStore.build(**kwargs)
+        db.add(job)
+        try:
+            db.flush()
+        except IntegrityError:
+            db.rollback()
+            if idem:
+                existing = db.execute(
+                    select(AnalysisTask).where(AnalysisTask.idempotency_key == idem)
+                ).scalar_one_or_none()
+                if existing is not None:
+                    return existing
+            raise
+        return job
+
+    # ── 读取 ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _job_id_int(job_id: str | int) -> Optional[int]:
+        try:
+            return int(job_id)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    async def get(db: AsyncSession, job_id: str | int) -> Optional[AnalysisTask]:
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return None
+        return (
+            await db.execute(select(AnalysisTask).where(AnalysisTask.id == numeric))
+        ).scalar_one_or_none()
+
+    @staticmethod
+    def get_sync(db: Session, job_id: str | int) -> Optional[AnalysisTask]:
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return None
+        return db.execute(select(AnalysisTask).where(AnalysisTask.id == numeric)).scalar_one_or_none()
+
+    @staticmethod
+    async def get_by_idempotency_key(db: AsyncSession, key: str) -> Optional[AnalysisTask]:
+        return (
+            await db.execute(select(AnalysisTask).where(AnalysisTask.idempotency_key == key))
+        ).scalar_one_or_none()
+
+    @staticmethod
+    async def get_by_celery_id(db: AsyncSession, celery_task_id: str) -> Optional[AnalysisTask]:
+        if not celery_task_id:
+            return None
+        return (
+            await db.execute(
+                select(AnalysisTask).where(AnalysisTask.celery_task_id == celery_task_id)
+            )
+        ).scalar_one_or_none()
+
+    @staticmethod
+    async def get_for_owner(
+        db: AsyncSession,
+        job_id: str | int,
+        *,
+        owner_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
+        session_ids: Sequence[str] | None = None,
+    ) -> AnalysisTask:
+        """按归属读取。不存在或不属于调用方一律抛 JobNotFound（→ 404）。"""
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            raise JobNotFound(str(job_id))
+        stmt = select(AnalysisTask).where(
+            and_(
+                AnalysisTask.id == numeric,
+                _ownership_predicate(owner_id, owner_token, session_ids),
+            )
+        )
+        job = (await db.execute(stmt)).scalar_one_or_none()
+        if job is None:
+            raise JobNotFound(str(job_id))
+        return job
+
+    @staticmethod
+    def _list_stmt(
+        *,
+        owner_id: Optional[str],
+        owner_token: Optional[str],
+        session_ids: Sequence[str] | None,
+        active_only: bool,
+        agent_task_id: Optional[str],
+        limit: int,
+    ) -> Select:
+        stmt = select(AnalysisTask).where(
+            _ownership_predicate(owner_id, owner_token, session_ids)
+        )
+        if active_only:
+            stmt = stmt.where(AnalysisTask.status.in_([s.value for s in ACTIVE_STATUSES]))
+        if agent_task_id:
+            stmt = stmt.where(AnalysisTask.agent_task_id == agent_task_id)
+        return stmt.order_by(AnalysisTask.created_at.desc(), AnalysisTask.id.desc()).limit(limit)
+
+    @staticmethod
+    async def list_for_owner(
+        db: AsyncSession,
+        *,
+        owner_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
+        session_ids: Sequence[str] | None = None,
+        active_only: bool = False,
+        agent_task_id: Optional[str] = None,
+        limit: int = DEFAULT_LIST_LIMIT,
+    ) -> list[AnalysisTask]:
+        """归属范围内的 job 列表。始终有 limit 上界。"""
+        bounded = max(1, min(int(limit or DEFAULT_LIST_LIMIT), MAX_LIST_LIMIT))
+        stmt = DurableJobStore._list_stmt(
+            owner_id=owner_id,
+            owner_token=owner_token,
+            session_ids=session_ids,
+            active_only=active_only,
+            agent_task_id=agent_task_id,
+            limit=bounded,
+        )
+        return list((await db.execute(stmt)).scalars().all())
+
+    # ── 状态迁移（原子条件更新） ──────────────────────────────────
+
+    @staticmethod
+    def _transition_stmt(
+        job_id: int,
+        target: JobStatus,
+        *,
+        expected: Iterable[JobStatus] | None = None,
+        extra: Optional[dict[str, Any]] = None,
+    ):
+        allowed = list(expected) if expected is not None else list(sources_for(target))
+        values: dict[str, Any] = {"status": target.value, "updated_at": _utcnow()}
+        if extra:
+            values.update(extra)
+        return (
+            update(AnalysisTask)
+            .where(
+                and_(
+                    AnalysisTask.id == job_id,
+                    AnalysisTask.status.in_([s.value for s in allowed]),
+                )
+            )
+            .values(**values)
+        )
+
+    @staticmethod
+    async def transition(
+        db: AsyncSession,
+        job_id: str | int,
+        target: JobStatus,
+        *,
+        expected: Iterable[JobStatus] | None = None,
+        **fields: Any,
+    ) -> bool:
+        """原子迁移。成功返回 True；状态已被别人改走返回 False（不抛错）。"""
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return False
+        stmt = DurableJobStore._transition_stmt(numeric, target, expected=expected, extra=fields)
+        result = await db.execute(stmt)
+        changed = bool(result.rowcount)
+        if changed:
+            logger.info("[jobs] transition job_id=%s -> %s", numeric, target.value)
+        return changed
+
+    @staticmethod
+    def transition_sync(
+        db: Session,
+        job_id: str | int,
+        target: JobStatus,
+        *,
+        expected: Iterable[JobStatus] | None = None,
+        **fields: Any,
+    ) -> bool:
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return False
+        stmt = DurableJobStore._transition_stmt(numeric, target, expected=expected, extra=fields)
+        result = db.execute(stmt)
+        return bool(result.rowcount)
+
+    # ── 生命周期语义包装 ────────────────────────────────────────────
+
+    @staticmethod
+    async def mark_queued(db: AsyncSession, job_id: str | int, *, celery_task_id: Optional[str] = None) -> bool:
+        """pending → queued。
+
+        显式限定前驱为 pending：failed/stale → queued 是「重试」语义，必须走
+        ``start_retry``（它会递增 attempt），不能被普通入队悄悄绕过。
+        """
+        fields: dict[str, Any] = {"queued_at": _utcnow()}
+        if celery_task_id:
+            fields["celery_task_id"] = celery_task_id
+        return await DurableJobStore.transition(
+            db, job_id, JobStatus.queued, expected=[JobStatus.pending], **fields
+        )
+
+    @staticmethod
+    def mark_running_sync(db: Session, job_id: str | int, *, worker_id: Optional[str] = None) -> bool:
+        now = _utcnow()
+        return DurableJobStore.transition_sync(
+            db,
+            job_id,
+            JobStatus.running,
+            started_at=now,
+            heartbeat_at=now,
+            worker_id=(worker_id or worker_identity()),
+        )
+
+    @staticmethod
+    async def mark_running(db: AsyncSession, job_id: str | int, *, worker_id: Optional[str] = None) -> bool:
+        now = _utcnow()
+        return await DurableJobStore.transition(
+            db,
+            job_id,
+            JobStatus.running,
+            started_at=now,
+            heartbeat_at=now,
+            worker_id=(worker_id or worker_identity()),
+        )
+
+    @staticmethod
+    def _terminal_fields(now: datetime) -> dict[str, Any]:
+        return {"completed_at": now, "heartbeat_at": None}
+
+    @staticmethod
+    async def mark_succeeded(
+        db: AsyncSession,
+        job_id: str | int,
+        *,
+        result: Any = None,
+        result_ref: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> JobStatus:
+        """标记成功。返回实际落定的终态。
+
+        关键语义（规范 §14）：job 若已进入 ``cancelling``，worker 的 late success
+        **不会**写成 completed —— 迁移表里 cancelling 无法到 completed，这里改为
+        收敛到 cancelled 并返回 cancelled，调用方据此清理产物。
+        """
+        now = _utcnow()
+        ok = await DurableJobStore.transition(
+            db,
+            job_id,
+            JobStatus.completed,
+            progress=100,
+            progress_message=(message or "completed")[:255],
+            result_summary=redaction.safe_result(result),
+            result_ref=(result_ref[:512] if result_ref else None),
+            **DurableJobStore._terminal_fields(now),
+        )
+        if ok:
+            return JobStatus.completed
+
+        current, _started = await DurableJobStore._status_and_started_at(db, job_id)
+        if current == JobStatus.cancelling:
+            await DurableJobStore.confirm_cancelled(db, job_id, message="late success discarded after cancel")
+            logger.info("[jobs] late success discarded job_id=%s (cancelling → cancelled)", job_id)
+            # 确认可能被并发清扫抢先 —— 回报真实终态而不是假定 cancelled
+            final, _ = await DurableJobStore._status_and_started_at(db, job_id)
+            return final
+        logger.info("[jobs] mark_succeeded no-op job_id=%s already=%s", job_id, current.value)
+        return current
+
+    @staticmethod
+    def mark_succeeded_sync(
+        db: Session,
+        job_id: str | int,
+        *,
+        result: Any = None,
+        result_ref: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> JobStatus:
+        now = _utcnow()
+        ok = DurableJobStore.transition_sync(
+            db,
+            job_id,
+            JobStatus.completed,
+            progress=100,
+            progress_message=(message or "completed")[:255],
+            result_summary=redaction.safe_result(result),
+            result_ref=(result_ref[:512] if result_ref else None),
+            **DurableJobStore._terminal_fields(now),
+        )
+        if ok:
+            return JobStatus.completed
+        current = DurableJobStore._status_sync(db, job_id)
+        if current == JobStatus.cancelling:
+            DurableJobStore.confirm_cancelled_sync(db, job_id, message="late success discarded after cancel")
+            return DurableJobStore._status_sync(db, job_id)
+        return current
+
+    @staticmethod
+    async def mark_failed(
+        db: AsyncSession,
+        job_id: str | int,
+        *,
+        error: BaseException | str | None = None,
+        message: Optional[str] = None,
+    ) -> bool:
+        return await DurableJobStore.transition(
+            db,
+            job_id,
+            JobStatus.failed,
+            error_trace=redaction.safe_error(error),
+            progress_message=(message or redaction.safe_error(error) or "failed")[:255],
+            **DurableJobStore._terminal_fields(_utcnow()),
+        )
+
+    @staticmethod
+    def mark_failed_sync(
+        db: Session,
+        job_id: str | int,
+        *,
+        error: BaseException | str | None = None,
+        message: Optional[str] = None,
+    ) -> bool:
+        return DurableJobStore.transition_sync(
+            db,
+            job_id,
+            JobStatus.failed,
+            error_trace=redaction.safe_error(error),
+            progress_message=(message or redaction.safe_error(error) or "failed")[:255],
+            **DurableJobStore._terminal_fields(_utcnow()),
+        )
+
+    # ── 取消 ────────────────────────────────────────────────────────
+
+    @staticmethod
+    async def request_cancel(db: AsyncSession, job_id: str | int) -> tuple[bool, JobStatus]:
+        """请求取消。返回 (是否发生了状态变化, 当前状态)。
+
+        幂等（规范 §5）：重复取消不报错 —— 第二次返回 (False, cancelling/cancelled)。
+        终态 job 取消是 no-op，绝不把 completed 改回 cancelling。
+        """
+        now = _utcnow()
+        changed = await DurableJobStore.transition(
+            db,
+            job_id,
+            JobStatus.cancelling,
+            cancel_requested_at=now,
+            progress_message="cancelling",
+        )
+        # 只读列、不经身份映射：批量 UPDATE 之后 session 里可能仍持有这一行的旧 ORM
+        # 对象，而 expire_on_commit=False + synchronize_session='evaluate' 会让它
+        # 携带被就地改写过的属性。基于那种对象做判断会得出错误结论。
+        current, started_at = await DurableJobStore._status_and_started_at(db, job_id)
+
+        # pending job 没有 worker 会去确认取消 —— 直接落 cancelled 终态
+        if changed and current == JobStatus.cancelling and started_at is None:
+            if await DurableJobStore.confirm_cancelled(db, job_id, message="cancelled before start"):
+                return True, JobStatus.cancelled
+        return changed, current
+
+    @staticmethod
+    async def attach_celery_task(db: AsyncSession, job_id: str | int, celery_task_id: str) -> bool:
+        """只回填 celery_task_id（async 版本，retry 重新入队后用）。"""
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None or not celery_task_id:
+            return False
+        result = await db.execute(
+            update(AnalysisTask)
+            .where(AnalysisTask.id == numeric)
+            .values(celery_task_id=celery_task_id, updated_at=_utcnow())
+        )
+        return bool(result.rowcount)
+
+    @staticmethod
+    def set_celery_task_id_sync(db: Session, job_id: str | int, celery_task_id: str) -> bool:
+        """只回填 celery_task_id，不触碰 status。
+
+        入队后 worker 可能已经把状态推到 running/completed，此时任何状态迁移都会
+        失败；但标识列必须写进去，否则旧的 `/tasks/status/{celery_task_id}` 端点
+        永远查不到这个 job。
+        """
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None or not celery_task_id:
+            return False
+        result = db.execute(
+            update(AnalysisTask)
+            .where(AnalysisTask.id == numeric)
+            .values(celery_task_id=celery_task_id, updated_at=_utcnow())
+        )
+        return bool(result.rowcount)
+
+    @staticmethod
+    async def _status_and_started_at(
+        db: AsyncSession, job_id: str | int
+    ) -> tuple[JobStatus, Optional[datetime]]:
+        """列级读取当前状态与 started_at，绕过 ORM 身份映射。"""
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return JobStatus.pending, None
+        row = (
+            await db.execute(
+                select(AnalysisTask.status, AnalysisTask.started_at).where(
+                    AnalysisTask.id == numeric
+                )
+            )
+        ).first()
+        if row is None:
+            return JobStatus.pending, None
+        return coerce_status(row[0]), row[1]
+
+    @staticmethod
+    def _status_sync(db: Session, job_id: str | int) -> JobStatus:
+        """列级读取当前状态（worker 侧）。"""
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return JobStatus.pending
+        row = db.execute(
+            select(AnalysisTask.status).where(AnalysisTask.id == numeric)
+        ).first()
+        return coerce_status(row[0] if row else None)
+
+    @staticmethod
+    def request_cancel_sync(db: Session, job_id: str | int) -> tuple[bool, JobStatus]:
+        """worker 侧请求取消。与 async 版本语义一致，含 pending 直落终态分支。"""
+        now = _utcnow()
+        changed = DurableJobStore.transition_sync(
+            db,
+            job_id,
+            JobStatus.cancelling,
+            cancel_requested_at=now,
+            progress_message="cancelling",
+        )
+        numeric = DurableJobStore._job_id_int(job_id)
+        row = None
+        if numeric is not None:
+            row = db.execute(
+                select(AnalysisTask.status, AnalysisTask.started_at).where(
+                    AnalysisTask.id == numeric
+                )
+            ).first()
+        current = coerce_status(row[0] if row else None)
+        started_at = row[1] if row else None
+        if changed and current == JobStatus.cancelling and started_at is None:
+            if DurableJobStore.confirm_cancelled_sync(db, job_id, message="cancelled before start"):
+                return True, JobStatus.cancelled
+        return changed, current
+
+    @staticmethod
+    async def confirm_cancelled(
+        db: AsyncSession, job_id: str | int, *, message: Optional[str] = None
+    ) -> bool:
+        """worker 确认取消已生效 → cancelled 终态。"""
+        return await DurableJobStore.transition(
+            db,
+            job_id,
+            JobStatus.cancelled,
+            progress_message=(message or "cancelled")[:255],
+            **DurableJobStore._terminal_fields(_utcnow()),
+        )
+
+    @staticmethod
+    def confirm_cancelled_sync(
+        db: Session, job_id: str | int, *, message: Optional[str] = None
+    ) -> bool:
+        return DurableJobStore.transition_sync(
+            db,
+            job_id,
+            JobStatus.cancelled,
+            progress_message=(message or "cancelled")[:255],
+            **DurableJobStore._terminal_fields(_utcnow()),
+        )
+
+    @staticmethod
+    def is_cancel_requested_sync(db: Session, job_id: str | int) -> bool:
+        """worker 侧读取持久取消事实。API 重启不影响它。"""
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return False
+        row = db.execute(
+            select(AnalysisTask.cancel_requested_at, AnalysisTask.status).where(
+                AnalysisTask.id == numeric
+            )
+        ).first()
+        if row is None:
+            return False
+        cancel_requested_at, status = row
+        return cancel_requested_at is not None or coerce_status(status) in (
+            JobStatus.cancelling,
+            JobStatus.cancelled,
+        )
+
+    # ── 进度 / 心跳 ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _progress_values(snapshot: JobProgress) -> dict[str, Any]:
+        values: dict[str, Any] = {"updated_at": _utcnow(), "heartbeat_at": _utcnow()}
+        if snapshot.progress is not None:
+            values["progress"] = snapshot.progress
+        msg = snapshot.as_message()
+        if msg is not None:
+            values["progress_message"] = msg
+        return values
+
+    @staticmethod
+    def _progress_stmt(job_id: int, snapshot: JobProgress):
+        # 只更新未终结的 job：stale progress 绝不覆盖终态（规范 §50）
+        return (
+            update(AnalysisTask)
+            .where(
+                and_(
+                    AnalysisTask.id == job_id,
+                    AnalysisTask.status.in_([s.value for s in ACTIVE_STATUSES]),
+                )
+            )
+            .values(**DurableJobStore._progress_values(snapshot))
+        )
+
+    @staticmethod
+    async def update_progress(db: AsyncSession, job_id: str | int, snapshot: JobProgress) -> bool:
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return False
+        result = await db.execute(DurableJobStore._progress_stmt(numeric, snapshot.clamped()))
+        return bool(result.rowcount)
+
+    @staticmethod
+    def update_progress_sync(db: Session, job_id: str | int, snapshot: JobProgress) -> bool:
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return False
+        result = db.execute(DurableJobStore._progress_stmt(numeric, snapshot.clamped()))
+        return bool(result.rowcount)
+
+    @staticmethod
+    def heartbeat_sync(db: Session, job_id: str | int) -> bool:
+        numeric = DurableJobStore._job_id_int(job_id)
+        if numeric is None:
+            return False
+        result = db.execute(
+            update(AnalysisTask)
+            .where(
+                and_(
+                    AnalysisTask.id == numeric,
+                    AnalysisTask.status.in_([s.value for s in ACTIVE_STATUSES]),
+                )
+            )
+            .values(heartbeat_at=_utcnow())
+        )
+        return bool(result.rowcount)
+
+    # ── stale 清扫（worker crash 恢复，规范 §25） ──────────────────
+
+    @staticmethod
+    def _stale_predicate(cutoff: datetime):
+        # running/cancelling 且（心跳超时 或 从未心跳但启动已久）
+        return and_(
+            AnalysisTask.status.in_([JobStatus.running.value, JobStatus.cancelling.value]),
+            or_(
+                AnalysisTask.heartbeat_at < cutoff,
+                and_(AnalysisTask.heartbeat_at.is_(None), AnalysisTask.started_at < cutoff),
+            ),
+        )
+
+    #: pending/queued 的「从未被取走」判定阈值。远大于正常入队延迟，
+    #: 避免把只是排队较久的 job 误判成孤儿。
+    ORPHAN_AFTER_S = 3600
+
+    @staticmethod
+    def _orphan_predicate(cutoff: datetime):
+        """从未被 worker 取走的 job。
+
+        pending/queued 不会心跳，所以心跳预测器永远抓不到它们。它们的产生场景很实在：
+        提交路径在 create 与 apply_async 之间崩溃、broker 丢消息、retry 落库后
+        send_task 之前进程退出。此时 job 会永远停在 pending/queued —— 而 queued 不
+        可重试，用户除了取消无路可走。
+        """
+        return and_(
+            AnalysisTask.status.in_([JobStatus.pending.value, JobStatus.queued.value]),
+            AnalysisTask.created_at < cutoff,
+        )
+
+    @staticmethod
+    async def sweep_orphans(
+        db: AsyncSession, *, orphan_after_s: int | None = None, limit: int = 100
+    ) -> int:
+        """把长时间没人执行的 pending/queued job 收敛为 failed（可重试）。"""
+        seconds = orphan_after_s if orphan_after_s is not None else DurableJobStore.ORPHAN_AFTER_S
+        cutoff = _utcnow() - timedelta(seconds=seconds)
+        rows = list(
+            (
+                await db.execute(
+                    select(AnalysisTask).where(DurableJobStore._orphan_predicate(cutoff)).limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        swept = 0
+        for job in rows:
+            ok = await DurableJobStore.transition(
+                db,
+                job.id,
+                JobStatus.failed,
+                expected=[JobStatus.pending, JobStatus.queued],
+                progress_message="never picked up by a worker",
+                error_trace="job orphaned: never picked up by a worker",
+                **DurableJobStore._terminal_fields(_utcnow()),
+            )
+            if ok:
+                swept += 1
+                logger.warning("[jobs] orphaned job_id=%s created_at=%s", job.id, job.created_at)
+        return swept
+
+    @staticmethod
+    async def has_active_for_owner(
+        db: AsyncSession,
+        *,
+        owner_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
+        session_ids: Sequence[str] | None = None,
+    ) -> bool:
+        """归属范围内是否存在活跃 job（不受列表 limit 截断影响）。
+
+        任务中心用它决定要不要继续轮询：若只看被 limit 截断的那一页，当活跃 job 比
+        50 条更旧时会误判「没有活跃任务」→ 前端停止轮询 → 正在跑的任务卡住不动。
+        """
+        stmt = (
+            select(AnalysisTask.id)
+            .where(_ownership_predicate(owner_id, owner_token, session_ids))
+            .where(AnalysisTask.status.in_([s.value for s in ACTIVE_STATUSES]))
+            .limit(1)
+        )
+        return (await db.execute(stmt)).first() is not None
+
+    @staticmethod
+    async def find_stale(
+        db: AsyncSession, *, stale_after_s: int = DEFAULT_STALE_AFTER_S, limit: int = 100
+    ) -> list[AnalysisTask]:
+        cutoff = _utcnow() - timedelta(seconds=stale_after_s)
+        stmt = select(AnalysisTask).where(DurableJobStore._stale_predicate(cutoff)).limit(limit)
+        return list((await db.execute(stmt)).scalars().all())
+
+    @staticmethod
+    async def sweep_stale(
+        db: AsyncSession, *, stale_after_s: int = DEFAULT_STALE_AFTER_S, limit: int = 100
+    ) -> int:
+        """把心跳超时的 running job 标记为 stale。返回处理条数。
+
+        stale 是终态但可 retry（新 attempt），所以「worker 挂了」不会让用户永远看到
+        running，也不会丢掉重跑的可能。
+        """
+        stale_jobs = await DurableJobStore.find_stale(db, stale_after_s=stale_after_s, limit=limit)
+        swept = 0
+        for job in stale_jobs:
+            current = coerce_status(job.status)
+            if current == JobStatus.cancelling:
+                # worker 在确认取消之前就没了：用户的意图是取消，且已经没有执行体
+                # 在推进它 —— 收敛到 cancelled 才是真话。
+                # （若这里也写 stale，job 会变成「可重试」，等于给被取消的任务开了
+                # 一条重跑后门，违反规范 §17。）
+                ok = await DurableJobStore.confirm_cancelled(
+                    db, job.id, message="cancelled (worker heartbeat lost)"
+                )
+                target = JobStatus.cancelled
+            else:
+                ok = await DurableJobStore.transition(
+                    db,
+                    job.id,
+                    JobStatus.stale,
+                    progress_message="worker heartbeat lost",
+                    error_trace="job marked stale: worker heartbeat lost",
+                    **DurableJobStore._terminal_fields(_utcnow()),
+                )
+                target = JobStatus.stale
+            if ok:
+                swept += 1
+                logger.warning(
+                    "[jobs] swept job_id=%s -> %s worker=%s started_at=%s",
+                    job.id, target.value, job.worker_id, job.started_at,
+                )
+        return swept
+
+    # ── 重试（显式新 attempt，规范 §17/§18） ─────────────────────
+
+    @staticmethod
+    async def start_retry(db: AsyncSession, job_id: str | int) -> tuple[bool, str]:
+        """把 failed/stale job 重新入队为新 attempt。
+
+        返回 (是否成功, 原因)。拒绝条件：
+          * cancelled —— 取消绝不自动/手动转 retry（规范 §17）
+          * 非 failed/stale 终态或仍活跃
+          * retry_count 已达 max_retries
+        """
+        job = await DurableJobStore.get(db, job_id)
+        if job is None:
+            return False, "not_found"
+        current = coerce_status(job.status)
+        if current == JobStatus.cancelled:
+            return False, "cancelled_jobs_are_never_retried"
+        if current not in (JobStatus.failed, JobStatus.stale):
+            return False, f"not_retryable_from_{current.value}"
+        if (job.retry_count or 0) >= (job.max_retries or 0):
+            return False, "max_retries_exhausted"
+
+        # 没有 dispatch 描述符就无法忠实重跑 —— 与其把状态改成 queued 却永远没有
+        # 执行体（用户看到一个永不推进的任务），不如明确拒绝（规范 §9：只有 retry
+        # 真正可靠时才提供）。
+        if not job.dispatch_spec or not isinstance(job.dispatch_spec, dict):
+            return False, "no_dispatch_spec"
+        if job.dispatch_spec.get("__truncated__"):
+            # 描述符因携带敏感参数或体积超限被丢弃 —— 无法忠实重跑
+            return False, "dispatch_spec_unusable"
+        if not job.dispatch_spec.get("task"):
+            return False, "no_dispatch_spec"
+
+        ok = await DurableJobStore.transition(
+            db,
+            job_id,
+            JobStatus.queued,
+            expected=[JobStatus.failed, JobStatus.stale],
+            attempt=(job.attempt or 1) + 1,
+            retry_count=(job.retry_count or 0) + 1,
+            queued_at=_utcnow(),
+            started_at=None,
+            completed_at=None,
+            cancel_requested_at=None,
+            heartbeat_at=None,
+            progress=0,
+            progress_message="requeued for retry",
+            # 保留 error_trace：不覆盖第一次失败的证据（规范 §18）
+        )
+        return ok, ("requeued" if ok else "state_changed_concurrently")
+
+    # ── 归属（替代进程内 _task_owners） ────────────────────────────
+
+    @staticmethod
+    async def verify_celery_owner(
+        db: AsyncSession,
+        celery_task_id: str,
+        *,
+        owner_id: Optional[str] = None,
+        owner_token: Optional[str] = None,
+        session_ids: Sequence[str] | None = None,
+    ) -> bool:
+        """基于 durable 行验证 celery task 归属。API 重启后依然有效。"""
+        if not celery_task_id:
+            return False
+        stmt = select(AnalysisTask.id).where(
+            and_(
+                AnalysisTask.celery_task_id == celery_task_id,
+                _ownership_predicate(owner_id, owner_token, session_ids),
+            )
+        )
+        return (await db.execute(stmt)).first() is not None
+
+    @staticmethod
+    def is_terminal_job(job: AnalysisTask) -> bool:
+        return is_terminal(job.status)

--- a/app/services/jobs/submit.py
+++ b/app/services/jobs/submit.py
@@ -1,0 +1,179 @@
+"""Agent 工具 → durable job 提交桥（规范 §21 / §22）。
+
+同步工具（跑在 registry 的线程池里）用这里的 ``submit_durable_job`` 把重计算交给
+Celery，并同时得到一个 durable job 行。它做四件事：
+
+  1. 从 contextvar 里的 JobOrigin 取出 session/owner/agent step 关联，写进 job 行 ——
+     前端因此能把后台 GIS job 挂到对应 tool step 下，而不是看到两条无关条目。
+  2. 幂等：同一逻辑提交（用户双击 / SSE 重连 / API retry）复用同一行、不重复入队。
+  3. 把 job_id 作为参数传给 Celery 任务，worker 据此写进度、读取消、落终态。
+  4. 把 celery_task_id 回填到 job 行，让旧的 `/tasks/status/{celery_task_id}` 端点
+     和新任务中心指向同一个逻辑执行。
+
+「什么算重操作」由调用方决定 —— 规范 §22 明确不要求所有 GIS 工具都 Celery 化。
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, Optional
+
+from app.services.jobs.context import current_origin
+from app.services.jobs.lifecycle import JobKind, JobStatus
+from app.services.jobs.store import DurableJobStore
+from app.tools._utils import db_session
+
+logger = logging.getLogger(__name__)
+
+
+def build_execution_key(task_type: str, session_id: Optional[str], params: dict[str, Any]) -> str:
+    """稳定的幂等键：(task_type, session, 规范化参数) 的摘要。
+
+    只用于 durable/background 提交 —— 不给所有工具硬编码 hash（规范 §16）。
+    参数用 sort_keys 序列化，保证 dict 顺序不影响键。
+    """
+    payload = json.dumps(params, sort_keys=True, ensure_ascii=False, default=str)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+    return f"{task_type}:{session_id or '-'}:{digest}"
+
+
+def submit_durable_job(
+    *,
+    celery_task,
+    task_type: str,
+    display_name: str,
+    params: dict[str, Any],
+    task_args: tuple = (),
+    task_kwargs: Optional[dict[str, Any]] = None,
+    kind: JobKind = JobKind.analysis,
+    session_id: Optional[str] = None,
+    idempotent: bool = True,
+    max_retries: int = 3,
+) -> dict[str, Any]:
+    """创建 durable job 并入队 Celery 任务。
+
+    Args:
+        celery_task: Celery task 对象（会以 ``job_id=`` 关键字额外接收 job id）。
+        task_type: 落库的 task_type（≤50 字符）。
+        display_name: 任务中心展示名。
+        params: 用于幂等键与参数摘要的业务参数（会脱敏后落库）。
+        task_args / task_kwargs: 传给 Celery 任务的参数。
+        idempotent: 是否启用幂等键。不可逆且可能被重复触发的操作应保持 True。
+
+    Returns:
+        工具可直接返回给 LLM 的 dict：``{status, job_id, task_id, message, idempotent_reuse}``。
+    """
+    origin = current_origin()
+    effective_session = session_id or (origin.session_id if origin else None)
+    idem_key = (
+        build_execution_key(task_type, effective_session, params) if idempotent else None
+    )
+
+    dispatch_spec = {
+        "task": celery_task.name,
+        "args": list(task_args),
+        "kwargs": dict(task_kwargs or {}),
+    }
+
+    with db_session() as db:
+        job = DurableJobStore.create_sync(
+            db,
+            dispatch_spec=dispatch_spec,
+            task_type=task_type,
+            kind=kind,
+            display_name=display_name,
+            parameters=params,
+            session_id=effective_session,
+            owner_id=(origin.owner_id if origin else None),
+            owner_token=(origin.owner_token if origin else None),
+            org_id=(origin.org_id if origin else None),
+            project_id=(origin.project_id if origin else None),
+            run_id=(origin.run_id if origin else None),
+            turn_id=(origin.turn_id if origin else None),
+            tool_call_id=(origin.tool_call_id if origin else None),
+            agent_task_id=(origin.agent_task_id if origin else None),
+            agent_step_id=(origin.agent_step_id if origin else None),
+            idempotency_key=idem_key,
+            max_retries=max_retries,
+        )
+        job_id = int(job.id)
+        existing_celery_id = job.celery_task_id
+        already_terminal = DurableJobStore.is_terminal_job(job)
+        db.commit()
+
+    if origin is not None:
+        origin.record_job(job_id)
+
+    # 幂等复用：已入队或已完成的 job 不再重复提交，避免重复写分析资产
+    if existing_celery_id or already_terminal:
+        logger.info(
+            "[jobs] reusing durable job_id=%s (celery=%s terminal=%s)",
+            job_id, existing_celery_id, already_terminal,
+        )
+        return {
+            "status": "analysis_task_reused",
+            "job_id": str(job_id),
+            "task_id": existing_celery_id,
+            "idempotent_reuse": True,
+            "message": f"{display_name} 已在执行或已完成，复用同一后台任务（job {job_id}）。",
+        }
+
+    kwargs = dict(task_kwargs or {})
+    kwargs["job_id"] = job_id
+
+    # 先**原子认领**（pending → queued），只有认领成功的调用方才真正入队。
+    # 顺序颠倒会留一个 TOCTOU 窗口：两个并发的相同提交都看到 celery_task_id 为空、
+    # 都 apply_async，于是同一个 job 收到两条消息 → 重复执行不可逆的 GIS 操作。
+    with db_session() as db:
+        claimed = DurableJobStore.transition_sync(
+            db, job_id, JobStatus.queued, expected=[JobStatus.pending]
+        )
+        db.commit()
+
+    if not claimed:
+        with db_session() as db:
+            current = DurableJobStore.get_sync(db, job_id)
+            existing_celery_id = current.celery_task_id if current else None
+        logger.info("[jobs] job_id=%s already claimed by a concurrent submit", job_id)
+        return {
+            "status": "analysis_task_reused",
+            "job_id": str(job_id),
+            "task_id": existing_celery_id,
+            "idempotent_reuse": True,
+            "message": f"{display_name} 已在执行中，复用同一后台任务（job {job_id}）。",
+        }
+
+    try:
+        async_result = celery_task.apply_async(args=list(task_args), kwargs=kwargs)
+    except Exception as exc:
+        # 入队失败：把 job 落成 failed，否则它会永远停在 queued 且没有执行体
+        # （stale 清扫只覆盖 running/cancelling）。
+        logger.error("[jobs] enqueue failed job_id=%s: %s", job_id, exc)
+        with db_session() as db:
+            DurableJobStore.mark_failed_sync(db, job_id, error=exc, message="enqueue failed")
+            db.commit()
+        raise
+
+    # 回填 celery_task_id。worker 可能已经把状态推到 running/completed，所以这里
+    # 不做状态迁移，只更新标识列 —— 否则旧的 /tasks/status/{celery_task_id}
+    # 端点会永远查不到这个 job。
+    with db_session() as db:
+        DurableJobStore.set_celery_task_id_sync(db, job_id, async_result.id)
+        db.commit()
+
+    logger.info(
+        "[jobs] queued job_id=%s celery=%s type=%s agent_task=%s",
+        job_id, async_result.id, task_type,
+        (origin.agent_task_id if origin else None),
+    )
+    return {
+        "status": "analysis_task_started",
+        "job_id": str(job_id),
+        "task_id": async_result.id,
+        "idempotent_reuse": False,
+        "message": (
+            f"{display_name} 已作为后台任务启动（job {job_id}）。"
+            "可在任务中心查看进度，也可随时取消。"
+        ),
+    }

--- a/app/services/jobs/views.py
+++ b/app/services/jobs/views.py
@@ -1,0 +1,195 @@
+"""任务中心对外视图（规范 §10 / §35）。
+
+前端只拿到「安全摘要」：不含 Celery traceback、worker 内部信息、DB 实现细节、原始
+用户 prompt、凭据或完整 GeoJSON。同一个 JobView 同时承载 durable job 与内存 agent
+task，前端因此只需要处理一种形状。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from app.models.db_model import AnalysisTask
+from app.services.jobs.lifecycle import (
+    JobStatus,
+    coerce_status,
+    is_active,
+    is_cancellable,
+    is_retryable_status,
+)
+
+
+def _iso(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
+
+class JobView(BaseModel):
+    """统一 job 视图。"""
+
+    id: str = Field(description="durable job id，或 agent task id（task-xxxxxxxx）")
+    kind: str = Field(description="agent | analysis | workflow | explorer")
+    name: str = Field(description="展示名。不含用户原始请求原文")
+    status: str = Field(description="pending|queued|running|cancelling|completed|failed|cancelled|stale")
+    progress: Optional[int] = Field(default=None, description="0–100；null 表示不确定进度")
+    message: Optional[str] = None
+    cancellable: bool = False
+    retryable: bool = False
+    active: bool = False
+    attempt: int = 1
+    session_id: Optional[str] = None
+    project_id: Optional[str] = None
+    #: 关联的 agent task（durable job 由哪个 agent 任务派生）
+    agent_task_id: Optional[str] = None
+    agent_step_id: Optional[str] = None
+    #: agent task 派生出的后台 job（形成 Turn → Step → Job 链）
+    background_job_ids: list[str] = Field(default_factory=list)
+    error: Optional[str] = Field(default=None, description="单行错误摘要，绝不含 traceback")
+    result_ref: Optional[str] = Field(default=None, description="结果指针（artifact id / 路径）")
+    step_count: int = 0
+    created_at: Optional[str] = None
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    cancel_requested_at: Optional[str] = None
+
+
+class JobListResponse(BaseModel):
+    jobs: list[JobView]
+    #: 是否仍有活跃 job。前端据此决定要不要继续轮询（规范 §32：无活跃 job → 0 轮询）
+    has_active: bool = False
+    #: 建议的下次轮询间隔（毫秒）。null 表示不要再轮询
+    poll_after_ms: Optional[int] = None
+
+
+class JobCancelResponse(BaseModel):
+    id: str
+    status: str
+    #: 本次调用是否真的改变了状态。重复取消返回 False 但仍是 200（幂等）
+    cancel_requested: bool
+    cancelling: bool = False
+
+
+class JobRetryResponse(BaseModel):
+    id: str
+    status: str
+    retried: bool
+    reason: str
+    attempt: int = 1
+
+
+#: 建议轮询间隔。有活跃 job 时 3s —— 复用 SSE 之外的轻量兜底，不引入 websocket。
+ACTIVE_POLL_INTERVAL_MS = 3000
+
+
+def job_from_record(record: AnalysisTask) -> JobView:
+    """durable 行 → JobView。只读安全字段。"""
+    status = coerce_status(record.status)
+    # error_trace 已在写入侧脱敏为单行；此处再兜一层，杜绝历史行的多行 traceback 泄漏
+    error = None
+    if record.error_trace:
+        error = str(record.error_trace).splitlines()[0][:500]
+
+    return JobView(
+        id=str(record.id),
+        kind=str(record.job_kind or "analysis"),
+        name=str(record.display_name or record.task_type or "job"),
+        status=status.value,
+        progress=(None if record.progress is None else int(record.progress)),
+        message=record.progress_message,
+        cancellable=is_cancellable(status),
+        retryable=(
+            is_retryable_status(status) and (record.retry_count or 0) < (record.max_retries or 0)
+        ),
+        active=is_active(status),
+        attempt=int(record.attempt or 1),
+        session_id=record.session_id,
+        project_id=record.project_id,
+        agent_task_id=record.agent_task_id,
+        agent_step_id=record.agent_step_id,
+        error=error,
+        result_ref=record.result_ref,
+        created_at=_iso(record.created_at),
+        started_at=_iso(record.started_at),
+        finished_at=_iso(record.completed_at),
+        cancel_requested_at=_iso(record.cancel_requested_at),
+    )
+
+
+#: 内存 agent task 状态 → 统一 JobStatus。
+_AGENT_STATUS_MAP: dict[str, JobStatus] = {
+    "running": JobStatus.running,
+    "completed": JobStatus.completed,
+    "failed": JobStatus.failed,
+    "cancelled": JobStatus.cancelled,
+}
+
+
+def job_from_agent_task(task: Any, *, background_job_ids: list[str] | None = None) -> JobView:
+    """内存 TaskInfo → JobView。
+
+    ``name`` 用步骤数/工具名合成，**不**回传 ``original_request`` 原文 —— 旧
+    ``/tasks/{id}`` 端点为兼容仍返回原文，但统一视图不扩大泄漏面（规范 §35）。
+    """
+    raw_status = getattr(getattr(task, "status", None), "value", None) or str(
+        getattr(task, "status", "running")
+    )
+    status = _AGENT_STATUS_MAP.get(raw_status, JobStatus.running)
+    steps = list(getattr(task, "steps", []) or [])
+    cancelling = bool(getattr(task, "_cancelled", False)) and status == JobStatus.running
+    if cancelling:
+        status = JobStatus.cancelling
+
+    last_tool = None
+    for step in reversed(steps):
+        tool = getattr(step, "tool", None)
+        if tool:
+            last_tool = tool
+            break
+
+    error = None
+    for step in reversed(steps):
+        if getattr(step, "error", None):
+            error = str(step.error).splitlines()[0][:500]
+            break
+
+    return JobView(
+        id=str(getattr(task, "id", "")),
+        kind="agent",
+        name=(f"AI 任务 · {last_tool}" if last_tool else "AI 任务"),
+        status=status.value,
+        # agent task 没有真实百分比 —— 明确 indeterminate，而不是编一个假的 99%
+        progress=(100 if status == JobStatus.completed else None),
+        message=(f"{len(steps)} 个步骤" if steps else None),
+        cancellable=is_cancellable(status),
+        retryable=False,
+        active=is_active(status),
+        session_id=getattr(task, "session_id", None) or None,
+        background_job_ids=list(background_job_ids or []),
+        error=error,
+        step_count=len(steps),
+        created_at=_iso(getattr(task, "created_at", None)),
+        started_at=_iso(getattr(task, "created_at", None)),
+        finished_at=_iso(getattr(task, "finished_at", None)),
+    )
+
+
+def build_list_response(jobs: list[JobView]) -> JobListResponse:
+    has_active = any(job.active for job in jobs)
+    return JobListResponse(
+        jobs=jobs,
+        has_active=has_active,
+        poll_after_ms=(ACTIVE_POLL_INTERVAL_MS if has_active else None),
+    )
+
+
+AgentOrDurable = Literal["agent", "durable"]
+
+
+def classify_job_id(job_id: str) -> AgentOrDurable:
+    """区分 agent task id（``task-xxxxxxxx``）与 durable job id（数字）。"""
+    return "agent" if str(job_id).startswith("task-") else "durable"

--- a/app/services/jobs/worker.py
+++ b/app/services/jobs/worker.py
@@ -1,0 +1,438 @@
+"""Worker 侧 durable job 运行时（规范 §12 / §17 / §23 / §24 / §25）。
+
+一个 Celery 任务体包起来长这样：
+
+    @celery_app.task(bind=True, name="...")
+    def run_ndvi_analysis(self, raster_path, ...):
+        with durable_job(self, job_id, task_type="ndvi") as job:
+            for i, window in enumerate(windows):
+                job.checkpoint()                     # 协作式取消
+                job.progress(i * 100 // n, "计算中")  # 节流后落库
+                ...
+            with job.artifact(out_path) as tmp:      # 原子 finalize
+                write_geotiff(tmp)
+            return {...}
+
+它负责的事：
+  * 取消：DB 里的 ``cancel_requested_at`` 是持久事实源，探针按节流周期轮询它并驱动
+    一个 CancellationToken；token 通过 contextvar 传给下游 GIS 代码，
+    ``checkpoint()`` 在安全边界抛 OperationCancelled。**先协作、后 revoke、
+    hard terminate 只作为有界最后手段** —— 不再拿 terminate=True 当唯一取消手段。
+  * 进度：ProgressReporter 节流写库，DB 写入速率有上界。
+  * 心跳：进度写入顺带刷新 heartbeat_at；长时间无进度也按周期刷新。stale 清扫据此
+    识别挂掉的 worker，避免永远 running。
+  * 终态：正常返回 → completed；OperationCancelled → cancelled；异常 → failed，
+    错误只落单行摘要。已 cancelling 时的 late success 收敛为 cancelled（§14）。
+  * 重复执行防护：acks_late 下 broker 可能重投消息；进入时若 job 已是终态则直接
+    跳过执行（返回 AlreadyFinished），不会重复 finalize 产物（§16）。
+  * 产物：``job.artifact(path)`` 写 ``path.part-<uuid>`` 再 os.replace，成功才可见；
+    取消/失败时删除临时文件，绝不留下半个 GeoTIFF 或 status=ready 的损坏资产。
+"""
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator, Optional
+
+from app.services.jobs.artifacts import atomic_output
+from app.services.jobs.cancellation import (
+    CancellationToken,
+    OperationCancelled,
+    use_token,
+)
+from app.services.jobs.lifecycle import JobStatus, coerce_status, is_terminal
+from app.services.jobs.progress import JobProgress, ProgressReporter, ProgressThrottle
+from app.services.jobs.store import DurableJobStore
+
+logger = logging.getLogger(__name__)
+
+#: 取消探针轮询周期。500ms 足够让用户感知「点了就停」，又不会把 DB 打满。
+CANCEL_POLL_INTERVAL_S = 0.5
+#: 无进度时的心跳周期。远小于 DEFAULT_STALE_AFTER_S(300s)。
+HEARTBEAT_INTERVAL_S = 30.0
+
+
+class AlreadyFinished(Exception):
+    """job 已处于终态，本次投递应被忽略（重复投递防护）。"""
+
+
+@dataclass
+class _JobRuntimeState:
+    observed_cancel_at: Optional[float] = None
+    last_heartbeat_at: float = 0.0
+    checkpoints: int = 0
+
+
+class DurableJobHandle:
+    """暴露给任务体的运行时句柄。"""
+
+    def __init__(
+        self,
+        job_id: str | int,
+        token: CancellationToken,
+        reporter: ProgressReporter,
+        *,
+        cancel_probe: Callable[[], bool] | None = None,
+        state: _JobRuntimeState | None = None,
+        watchdog: Any = None,
+    ):
+        self.job_id = str(job_id)
+        self.token = token
+        self._reporter = reporter
+        self._cancel_probe = cancel_probe
+        self._state = state or _JobRuntimeState()
+        self._temp_paths: set[str] = set()
+        #: 看门狗（可选，测试可为 None）。暴露出来便于断言 DB 轮询/心跳次数。
+        self.watchdog = watchdog
+
+    # ── 取消 ────────────────────────────────────────────────────────
+
+    @property
+    def cancelled(self) -> bool:
+        return self.token.cancelled
+
+    def poll_cancel(self) -> bool:
+        """主动拉一次持久取消事实（受探针内部节流约束）。"""
+        if self._cancel_probe is not None:
+            return self._cancel_probe()
+        return self.token.cancelled
+
+    def checkpoint(self) -> None:
+        """安全边界取消检查点。已取消则抛 OperationCancelled。
+
+        这里**不**主动读 DB —— 看门狗线程已经在按周期推送取消事实，checkpoint 只需
+        读一次内存标志。因此检查点可以撒得很密（每个 chunk），开销依然可忽略。
+        """
+        self._state.checkpoints += 1
+        if self.token.cancelled:
+            if self._state.observed_cancel_at is None:
+                self._state.observed_cancel_at = time.monotonic()
+            raise OperationCancelled(self.token.reason or "job cancelled", job_id=self.job_id)
+
+    def ensure_not_cancelled(self) -> None:
+        """**强制**读一次持久取消事实后再检查 —— 用于不可逆副作用之前。
+
+        ``checkpoint()`` 只读内存 token（便宜、可密集调用），代价是取消可能还没被
+        看门狗推过来。所以在「注册资产 / 提交产物 / 写不可逆记录」这类点上必须用
+        本方法：它同步查一次 DB，确保不会给一个已被取消的 job 留下副作用
+        （规范 §23 —— cancelled 的任务不得留下 status=ready 的资产）。
+
+        每个 job 只会在少数几个关键点调用，DB 开销可忽略。
+        """
+        if self._cancel_probe is not None:
+            self._cancel_probe()
+        self._state.checkpoints += 1
+        if self.token.cancelled:
+            if self._state.observed_cancel_at is None:
+                self._state.observed_cancel_at = time.monotonic()
+            raise OperationCancelled(self.token.reason or "job cancelled", job_id=self.job_id)
+
+    @property
+    def checkpoints(self) -> int:
+        """已执行的检查点次数。取消延迟测试用它断言「取消后不再跑后续 chunk」。"""
+        return self._state.checkpoints
+
+    def chunks(self, iterable, every: int = 1) -> Iterator:
+        """把循环变成可取消循环。"""
+        if every < 1:
+            every = 1
+        for index, item in enumerate(iterable):
+            if index % every == 0:
+                self.checkpoint()
+            yield item
+
+    # ── 进度 ────────────────────────────────────────────────────────
+
+    def progress(
+        self,
+        value: int | None = None,
+        message: str | None = None,
+        *,
+        phase: str | None = None,
+        current_step: int | None = None,
+        total_steps: int | None = None,
+        force: bool = False,
+    ) -> bool:
+        return self._reporter.report(
+            progress=value,
+            message=message,
+            phase=phase,
+            current_step=current_step,
+            total_steps=total_steps,
+            force=force,
+        )
+
+    @property
+    def progress_writes(self) -> int:
+        """实际落库的进度写入次数。基准测试用它断言写入速率有界。"""
+        return self._reporter.throttle.emitted
+
+    # ── 产物 ────────────────────────────────────────────────────────
+
+    @contextlib.contextmanager
+    def artifact(self, final_path: str) -> Iterator[str]:
+        """原子产物提交：temporary output → 成功 → os.replace → ready。
+
+        失败/取消时删除临时文件，绝不把半成品暴露为最终路径。已存在的成功产物
+        不会被删除（清理只针对本次的 .part 文件）。
+        """
+        # should_abort: 取消可能在计算刚结束、finalize 之前到达 —— 取消优先
+        with atomic_output(final_path, should_abort=lambda: self.token.cancelled) as temp_path:
+            self._temp_paths.add(temp_path)
+            try:
+                yield temp_path
+            except BaseException:
+                self._temp_paths.discard(temp_path)
+                raise
+        self._temp_paths.discard(temp_path)
+
+    def track_temp(self, path: str) -> str:
+        """登记一个由任务体自行创建的临时路径，交给运行时兜底清理。"""
+        self._temp_paths.add(path)
+        return path
+
+    def _discard(self, path: str) -> None:
+        self._temp_paths.discard(path)
+        with contextlib.suppress(FileNotFoundError, OSError):
+            if os.path.isfile(path):
+                os.unlink(path)
+
+    def cleanup_temps(self) -> None:
+        """清理所有尚未 finalize 的临时文件（finally 路径调用）。"""
+        for path in list(self._temp_paths):
+            self._discard(path)
+
+
+class _CancelWatchdog:
+    """后台看门狗线程：把「持久取消事实」**推**给 token，并独立维持心跳。
+
+    为什么必须推而不是拉：探针若只在任务体调用 ``job.checkpoint()`` 时才读 DB，那么
+    一段不可中断的 numpy/rasterio 调用期间（NDVI 就是一次 ``np.divide``）没人会去看
+    DB —— 用户点了取消，计算仍然跑到自然结束，CPU 根本没被释放。那正是 ADR-0052
+    要消除的「取消只是 UI 状态」。
+
+    看门狗按固定周期轮询 DB 并点燃 token，于是散布在 GIS 库里的模块级
+    ``jobs.checkpoint()``（它只读 contextvar 里的 token，不碰 DB）真正生效 ——
+    栅格窗口循环、要素批循环都能在下一个检查点退出。
+
+    它同时按 ``HEARTBEAT_INTERVAL_S`` 刷新 heartbeat_at：心跳不能依赖进度上报，
+    否则一个长时间进度不变的 job 会被 stale 清扫误判成「worker 已死」，跑完的结果
+    反而被丢弃。
+    """
+
+    def __init__(
+        self,
+        job_id: str | int,
+        token: CancellationToken,
+        session_factory: Callable[[], Any],
+        *,
+        poll_interval: float = CANCEL_POLL_INTERVAL_S,
+        heartbeat_interval: float = HEARTBEAT_INTERVAL_S,
+    ):
+        self._job_id = job_id
+        self._token = token
+        self._session_factory = session_factory
+        self._poll_interval = max(0.01, poll_interval)
+        self._heartbeat_interval = heartbeat_interval
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.db_polls = 0
+        self.heartbeats = 0
+
+    def start(self) -> None:
+        self._thread = threading.Thread(
+            target=self._run, name=f"job-watchdog-{self._job_id}", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+    def poll_once(self) -> bool:
+        """立即读一次持久取消事实并在命中时点燃 token。返回是否已取消。"""
+        if self._token.cancelled:
+            return True
+        try:
+            with self._session_factory() as db:
+                requested = DurableJobStore.is_cancel_requested_sync(db, self._job_id)
+            self.db_polls += 1
+        except Exception:
+            logger.warning("[jobs] cancel probe failed job_id=%s", self._job_id, exc_info=True)
+            return False
+        if requested:
+            self._token.cancel("cancel requested (durable)")
+            logger.info("[jobs] cancel observed by worker job_id=%s", self._job_id)
+            return True
+        return False
+
+    def _heartbeat(self) -> None:
+        try:
+            with self._session_factory() as db:
+                DurableJobStore.heartbeat_sync(db, self._job_id)
+                db.commit()
+            self.heartbeats += 1
+        except Exception:
+            logger.warning("[jobs] heartbeat failed job_id=%s", self._job_id, exc_info=True)
+
+    def _run(self) -> None:
+        last_heartbeat = time.monotonic()
+        while not self._stop.wait(self._poll_interval):
+            if self.poll_once():
+                return  # token 已点燃，无需继续轮询
+            now = time.monotonic()
+            if now - last_heartbeat >= self._heartbeat_interval:
+                last_heartbeat = now
+                self._heartbeat()
+
+
+def _default_session_factory():
+    from app.tools._utils import db_session
+
+    return db_session()
+
+
+@contextlib.contextmanager
+def durable_job(
+    job_id: str | int,
+    *,
+    worker_id: Optional[str] = None,
+    session_factory: Callable[[], Any] | None = None,
+    progress_throttle: ProgressThrottle | None = None,
+    cancel_interval: float = CANCEL_POLL_INTERVAL_S,
+    celery_task: Any = None,
+) -> Iterator[DurableJobHandle]:
+    """durable job 执行上下文。
+
+    Args:
+        job_id: durable job（analysis_tasks.id）。
+        worker_id: 执行者标识，默认 hostname:pid。
+        session_factory: 返回同步 Session 的上下文管理器工厂，默认 ``db_session``。
+        progress_throttle: 覆盖默认 1%/500ms 节流（测试用）。
+        cancel_interval: 取消探针轮询周期。
+        celery_task: bind=True 的 Celery task 实例；给了就同步 update_state，
+            保持既有 ``/tasks/status/{celery_task_id}`` 端点的进度语义不变。
+
+    Raises:
+        AlreadyFinished: job 已终态（重复投递），任务体不应执行。
+    """
+    factory = session_factory or _default_session_factory
+    token = CancellationToken(job_id=str(job_id))
+    state = _JobRuntimeState(last_heartbeat_at=time.monotonic())
+
+    # 入口守卫：重复投递 / 已被取消的 job 不执行任务体。
+    # pending|queued → running 的迁移本身就是「认领」动作：它是条件更新，所以
+    # 两个 worker 拿到同一条消息时只有一个能成功，另一个 rowcount=0 → 直接放弃。
+    # 这挡住了 acks_late 下 broker 重投导致的重复执行（规范 §16）。
+    with factory() as db:
+        record = DurableJobStore.get_sync(db, job_id)
+        if record is None:
+            raise AlreadyFinished(f"job {job_id} not found")
+        status = coerce_status(record.status)
+        if is_terminal(status):
+            logger.info("[jobs] skip duplicate delivery job_id=%s status=%s", job_id, status.value)
+            raise AlreadyFinished(f"job {job_id} already {status.value}")
+        if status == JobStatus.cancelling or record.cancel_requested_at is not None:
+            DurableJobStore.confirm_cancelled_sync(db, job_id, message="cancelled before execution")
+            db.commit()
+            raise AlreadyFinished(f"job {job_id} cancelled before execution")
+        claimed = DurableJobStore.mark_running_sync(db, job_id, worker_id=worker_id)
+        db.commit()
+    if not claimed:
+        # 认领失败：别人已经在跑（running），或取消刚好插进来。绝不重复执行。
+        with factory() as db:
+            current = coerce_status(
+                getattr(DurableJobStore.get_sync(db, job_id), "status", None)
+            )
+        logger.info("[jobs] claim failed job_id=%s status=%s", job_id, current.value)
+        raise AlreadyFinished(f"job {job_id} could not be claimed (status={current.value})")
+
+    watchdog = _CancelWatchdog(job_id, token, factory, poll_interval=cancel_interval)
+
+    def _sink(snapshot: JobProgress) -> None:
+        try:
+            with factory() as db:
+                DurableJobStore.update_progress_sync(db, job_id, snapshot)
+                db.commit()
+        except Exception:
+            logger.warning("[jobs] progress write failed job_id=%s", job_id, exc_info=True)
+        state.last_heartbeat_at = time.monotonic()
+        if celery_task is not None:
+            with contextlib.suppress(Exception):
+                celery_task.update_state(
+                    state="PROGRESS",
+                    meta={
+                        "progress": snapshot.progress if snapshot.progress is not None else 0,
+                        "message": snapshot.as_message() or "",
+                        "job_id": str(job_id),
+                    },
+                )
+
+    reporter = ProgressReporter(_sink, throttle=progress_throttle or ProgressThrottle())
+    handle = DurableJobHandle(
+        job_id, token, reporter, cancel_probe=watchdog.poll_once, state=state, watchdog=watchdog
+    )
+
+    logger.info("[jobs] started job_id=%s worker=%s", job_id, worker_id or "-")
+    watchdog.start()
+    try:
+        with use_token(token):
+            yield handle
+    except OperationCancelled:
+        handle.cleanup_temps()
+        with factory() as db:
+            DurableJobStore.confirm_cancelled_sync(db, job_id, message="cancelled by user")
+            db.commit()
+        latency = None
+        if token.cancelled_at is not None and state.observed_cancel_at is not None:
+            latency = state.observed_cancel_at - token.cancelled_at
+        logger.info(
+            "[jobs] cancelled job_id=%s checkpoints=%s observe_latency_s=%s",
+            job_id, state.checkpoints, (f"{latency:.3f}" if latency is not None else "-"),
+        )
+        raise
+    except BaseException as exc:
+        handle.cleanup_temps()
+        # 取消期间抛出的其它异常（例如底层库把取消翻译成自己的异常）按取消收敛
+        if token.cancelled:
+            with factory() as db:
+                DurableJobStore.confirm_cancelled_sync(db, job_id, message="cancelled by user")
+                db.commit()
+        else:
+            with factory() as db:
+                # cancelling → failed 也是合法迁移；若此刻已被取消确认，rowcount=0
+                # 且状态保持 cancelled（终态不被覆盖）。
+                DurableJobStore.mark_failed_sync(db, job_id, error=exc)
+                db.commit()
+            logger.warning("[jobs] failed job_id=%s error=%s", job_id, type(exc).__name__)
+        raise
+    else:
+        handle.cleanup_temps()
+    finally:
+        # 看门狗是守护线程，但必须在任务体结束时立刻停 —— 否则每个 job 留一个线程
+        # 持续轮询 DB，长跑 worker 会累积成连接池压力。
+        watchdog.stop()
+
+
+def finish_job(
+    job_id: str | int,
+    *,
+    result: Any = None,
+    result_ref: Optional[str] = None,
+    session_factory: Callable[[], Any] | None = None,
+) -> JobStatus:
+    """把 job 落成成功终态，返回实际终态。
+
+    与 ``durable_job`` 分开是因为：任务体正常返回后才知道结果，而 ``cancelling``
+    期间的 late success 必须被丢弃 —— 该判定在 store.mark_succeeded 里做。
+    """
+    factory = session_factory or _default_session_factory
+    with factory() as db:
+        status = DurableJobStore.mark_succeeded_sync(db, job_id, result=result, result_ref=result_ref)
+        db.commit()
+    return status

--- a/app/services/nature_resource_analyzer.py
+++ b/app/services/nature_resource_analyzer.py
@@ -9,6 +9,7 @@ import rasterio
 from typing import Dict, Optional
 import uuid
 import time
+from app.services.jobs.artifacts import atomic_output
 
 logger = logging.getLogger(__name__)
 
@@ -128,8 +129,11 @@ class NatureResourceAnalyzer:
                 filename = f"NDVI_{int(time.time())}_{uuid.uuid4().hex[:6]}.tif"
                 result_path = os.path.join(output_dir, filename)
 
-                with rasterio.open(result_path, 'w', **meta) as dst:
-                    dst.write(ndvi.astype(np.float32), 1)
+                # ADR-0052: 先写临时文件再原子 os.replace —— 取消/崩溃不会留下一个
+                # 看起来正常、其实只写了一半的 NDVI GeoTIFF（规范 §23）。
+                with atomic_output(result_path) as tmp_path:
+                    with rasterio.open(tmp_path, 'w', **meta) as dst:
+                        dst.write(ndvi.astype(np.float32), 1)
 
                 return {
                     "success": True,

--- a/app/services/spatial_tasks.py
+++ b/app/services/spatial_tasks.py
@@ -20,6 +20,14 @@ from app.services.nature_resource_analyzer import NatureResourceAnalyzer
 from app.services.rs.spectral_engine import SpectralRasterEngine
 from app.models.upload import UploadRecord
 from app.tools._utils import db_session
+from app.services.jobs.worker import AlreadyFinished, durable_job, finish_job
+from app.services.jobs.cancellation import OperationCancelled
+from app.services.jobs.store import DurableJobStore
+from celery.exceptions import SoftTimeLimitExceeded
+# ADR-0052: 协作式取消检查点。cancellable() 在 chunk 边界读一次 contextvar，
+# 未绑定 token 时开销为零；用户取消后长循环立即抛 OperationCancelled 退出，
+# 真正释放 CPU 而不是只改 UI 状态。
+from app.services.jobs.cancellation import cancellable
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +40,7 @@ logger = logging.getLogger(__name__)
 def _extract_heatmap_points(features: List[Dict]) -> tuple[list, list]:
     """Extract valid (lon, lat) points from GeoJSON features."""
     points = []
-    for f in features or []:
+    for f in cancellable(features or [], every=512):
         if not isinstance(f, dict):
             continue
         geom = f.get("geometry") or {}
@@ -181,15 +189,121 @@ def run_ndvi_analysis(
     nir_band: Optional[int] = None,
     red_band: Optional[int] = None,
     session_id: Optional[str] = None,
+    job_id: Optional[int] = None,
 ):
     """从本地 GeoTIFF 计算 NDVI 并持久化为资产。
 
     薄包装层，所有计算下沉到 NatureResourceAnalyzer.calculate_ndvi。
     NDVI 是 CPU 密集型操作（大栅格 reproject + 数组运算），
     严格走 Celery worker 隔离，遵循 V2.0 计算隔离不变式。
+
+    ADR-0052：``job_id`` 存在时走 durable job 运行时 —— 进度落库（节流）、取消从
+    DB 读取并在 checkpoint 处生效、终态由状态机守卫（cancelling 期间的 late
+    success 收敛为 cancelled）、重复投递被入口守卫拒绝。``job_id=None`` 保留旧
+    行为，兼容未迁移的调用方。
+    """
+    if job_id is None:
+        return _run_ndvi_legacy(self, raster_path, nir_band, red_band, session_id)
+
+    try:
+        with durable_job(job_id, celery_task=self) as job:
+            job.progress(10, "校验路径并读取影像元信息", phase="read")
+            job.checkpoint()
+            result = NatureResourceAnalyzer.calculate_ndvi(
+                tif_path=raster_path,
+                red_band=red_band,
+                nir_band=nir_band,
+            )
+            if not result.get("success"):
+                raise RuntimeError(result.get("error", "NDVI calculation failed"))
+
+            # 取消可能在计算期间到达。注册资产是不可逆副作用，所以这里用
+            # ensure_not_cancelled（强制读一次 DB）而不是 checkpoint（只读内存
+            # token）—— 否则「取消已落库但看门狗还没轮询到」的瞬间会给一个已取消
+            # 的 job 留下资产记录（规范 §23）。
+            job.ensure_not_cancelled()
+            job.progress(80, "入库登记分析资产", phase="persist")
+            # job_id 传进去，让「取消检查」与「资产 INSERT」落在同一个事务里 ——
+            # 否则取消可能挤在检查与 commit 之间，给已取消的 job 留下一条 ready 资产。
+            asset_id = _persist_ndvi_asset(result, session_id, job_id=job_id)
+            payload = {
+                "asset_id": asset_id,
+                "result_path": result["result_path"],
+                "filename": result["filename"],
+                "stats": result.get("stats", {}),
+                "bbox": result.get("bbox"),
+            }
+
+        status = finish_job(job_id, result=payload, result_ref=result["result_path"])
+        return {
+            "success": status.value == "completed",
+            "job_id": str(job_id),
+            "status": status.value,
+            "data": payload,
+            "status_desc": "NDVI 分析完成，结果已入库。可通过 list_analysis_assets 查询。",
+        }
+    except AlreadyFinished as e:
+        # 重复投递（acks_late 下 broker 可能重投）或提交前已被取消
+        logger.info(f"run_ndvi_analysis skipped: {e}")
+        return {"success": False, "skipped": True, "job_id": str(job_id), "error": str(e)}
+    except OperationCancelled:
+        logger.info(f"run_ndvi_analysis cancelled job_id={job_id}")
+        return {"success": False, "cancelled": True, "job_id": str(job_id)}
+    except SoftTimeLimitExceeded:
+        # durable_job 已在 finally 里清掉临时产物并把 job 标成 failed。这里必须
+        # 重新抛出：SoftTimeLimitExceeded 是 Exception 的子类，被下面的通用分支
+        # 吞掉会让 Celery 以为任务正常返回，超时语义与统计全部失效。
+        logger.warning(f"run_ndvi_analysis soft time limit exceeded job_id={job_id}")
+        raise
+    except Exception as e:
+        logger.error(f"run_ndvi_analysis failed: {e}", exc_info=True)
+        return {"success": False, "job_id": str(job_id), "error": str(e)}
+
+
+def _persist_ndvi_asset(
+    result: dict, session_id: Optional[str], job_id: Optional[int] = None
+) -> Optional[int]:
+    """把 NDVI 产物登记进 UploadRecord 资产表。失败不阻断任务（file-only 降级）。
+
+    ``job_id`` 给定时，在**同一个事务内**先确认没有取消请求再插入 —— 资产登记是
+    不可逆副作用，规范 §23 要求已取消的任务不得留下 status=ready 的资产。
     """
     try:
-        self.update_state(state='PROGRESS', meta={'progress': 10, 'message': '校验路径并读取影像元信息'})
+        with db_session() as db:
+            if job_id is not None and DurableJobStore.is_cancel_requested_sync(db, job_id):
+                raise OperationCancelled("cancelled before asset registration", job_id=job_id)
+            record = UploadRecord(
+                filename=result["result_path"],
+                original_name=result["filename"],
+                file_type="raster",
+                format="geotiff",  # ck_upload_format 不接受 "tif"
+                crs=result.get("crs", "EPSG:4326"),
+                geometry_type="raster_analysis",
+                feature_count=0,
+                bbox=result.get("bbox"),
+                file_size=os.path.getsize(result["result_path"]) if os.path.exists(result["result_path"]) else 0,
+                session_id=session_id,
+            )
+            db.add(record)
+            db.flush()
+            return record.id
+    except OperationCancelled:
+        raise  # 取消不是「登记失败」—— 必须上抛让 durable_job 收敛为 cancelled
+    except Exception as db_err:
+        logger.warning(f"NDVI asset persist failed (continuing with file-only): {db_err}")
+        return None
+
+
+def _run_ndvi_legacy(
+    task,
+    raster_path: str,
+    nir_band: Optional[int],
+    red_band: Optional[int],
+    session_id: Optional[str],
+):
+    """ADR-0052 之前的 NDVI 路径。无 durable job 时的兼容分支。"""
+    try:
+        task.update_state(state='PROGRESS', meta={'progress': 10, 'message': '校验路径并读取影像元信息'})
         result = NatureResourceAnalyzer.calculate_ndvi(
             tif_path=raster_path,
             red_band=red_band,
@@ -199,7 +313,7 @@ def run_ndvi_analysis(
         if not result.get("success"):
             return {"success": False, "error": result.get("error", "NDVI calculation failed")}
 
-        self.update_state(state='PROGRESS', meta={'progress': 80, 'message': '入库登记分析资产'})
+        task.update_state(state='PROGRESS', meta={'progress': 80, 'message': '入库登记分析资产'})
 
         # 将分析结果落入 UploadRecord 资产表，便于 list_analysis_assets 查询
         try:
@@ -208,7 +322,7 @@ def run_ndvi_analysis(
                     filename=result["result_path"],
                     original_name=result["filename"],
                     file_type="raster",
-                    format="tif",
+                    format="geotiff",  # ck_upload_format 不接受 "tif"
                     crs=result.get("crs", "EPSG:4326"),
                     geometry_type="raster_analysis",
                     feature_count=0,

--- a/app/services/task_queue.py
+++ b/app/services/task_queue.py
@@ -29,6 +29,18 @@ celery_app.conf.update(
     enable_utc=True,
     task_track_started=True,
     task_time_limit=3600,  # 1小时超时
+    # ADR-0052: worker 崩溃语义。
+    #   acks_late=True             → 执行完成后才 ack
+    #   reject_on_worker_lost=False→ 不主动 requeue：重投会重复执行不可逆的 GIS
+    #                                操作。durable job 的入口守卫拒绝重复投递
+    #                                （已终态直接跳过），stale 清扫负责把「worker
+    #                                没了但状态仍是 running」的 job 收敛为 stale，
+    #                                用户因此不会永远看到 running。
+    task_acks_late=True,
+    task_reject_on_worker_lost=False,
+    # 软超时留出清理窗口：任务体能在 SoftTimeLimitExceeded 时删掉临时产物，
+    # 而不是被硬杀后留下半个 GeoTIFF。
+    task_soft_time_limit=3300,
 )
 
 # 自动发现任务
@@ -88,15 +100,25 @@ class TaskQueueService:
 
     @staticmethod
     def get_task_status(task_id: str) -> dict:
-        """查询任务状态（审计 S34：不返回 traceback 给客户端）"""
-        result = celery_app.AsyncResult(task_id)
-        info = result.info
-        return {
-            "task_id": task_id,
-            "status": result.status,
-            "result": result.result if result.ready() else None,
-            "progress": info.get("progress", 0) if isinstance(info, dict) else 0,
-        }
+        """查询任务状态（审计 S34：不返回 traceback 给客户端）。
+
+        ADR-0052：结果后端不可用时优雅降级。没有 Redis 时 backend 是
+        DisabledBackend，读 AsyncResult 会抛 AttributeError —— 之前这会让
+        `/tasks/status/{id}` 直接 500。现在返回 UNKNOWN，让调用方（以及新任务中心）
+        改用 durable job 行作为事实源。
+        """
+        try:
+            result = celery_app.AsyncResult(task_id)
+            info = result.info
+            return {
+                "task_id": task_id,
+                "status": result.status,
+                "result": result.result if result.ready() else None,
+                "progress": info.get("progress", 0) if isinstance(info, dict) else 0,
+            }
+        except Exception as e:  # noqa: BLE001 —— 后端不可用不应让端点 500
+            logger.warning(f"Celery result backend unavailable for {task_id}: {e}")
+            return {"task_id": task_id, "status": "UNKNOWN", "result": None, "progress": 0}
 
     @staticmethod
     def revoke_task(task_id: str) -> bool:

--- a/app/services/task_tracker.py
+++ b/app/services/task_tracker.py
@@ -299,7 +299,12 @@ class TaskTracker:
             asyncio 工具任务（见 execution_engine 的并行 wave 循环）；
           * token 经 contextvar 传入同步 GIS 代码（asyncio.to_thread 会复制
             context），长循环在 ``jobs.checkpoint()`` 处协作退出；
-          * token 级联到本 turn 派生的 durable job，worker 侧也会观察到取消。
+          * 本 turn 派生的 durable job 的**进程内** token 一并点燃，所以同进程的
+            执行体（eager Celery、线程池工具）立即感知。
+
+        注意：跨进程 worker 依赖的是 DB 里的 ``cancel_requested_at``，那需要一次
+        数据库写入，不在本方法职责内 —— 由 Task API 的取消端点负责持久化，worker
+        的看门狗从 DB 读到它。
 
         幂等：重复取消返回 True 但不重复点燃 token（规范 §5）。
         """
@@ -313,6 +318,9 @@ class TaskTracker:
         token = task.cancel_token or cancellation_registry.register(task_id)
         task.cancel_token = token
         token.cancel("cancelled by user")
+        # 级联到本 turn 派生的 durable job（仅进程内 token；持久化见上方说明）
+        for job_id in task.background_job_ids:
+            cancellation_registry.cancel(job_id, "parent agent task cancelled")
         return True
 
     def cancel_token_for(self, task_id: str) -> CancellationToken | None:

--- a/app/services/task_tracker.py
+++ b/app/services/task_tracker.py
@@ -1,12 +1,21 @@
 """TaskTracker - 任务状态跟踪器
 
 根据 docs/superpower/specs/2026-04-08-task-planning-react-design.md 设计实现
+
+ADR-0052 之后 TaskTracker 不再是任务的**持久事实源** —— 它是「本进程内正在跑的
+agent turn」的热态视图，durable 事实在 analysis_tasks 表（见 app/services/jobs）。
+同时每个 task 现在持有一个 CancellationToken：``cancel()`` 会点燃它，执行引擎
+``await token.wait()`` 从而**抢占式**打断在飞的工具，而不是等当前工具自然跑完；
+token 还通过 contextvar 传进同步 GIS 代码，让长循环能在 checkpoint 处协作退出。
 """
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
+
+from app.services.jobs.cancellation import CancellationToken
+from app.services.jobs.cancellation import registry as cancellation_registry
 
 
 class StepStatus(str, Enum):
@@ -35,6 +44,9 @@ class TaskStep:
     error: str | None = None
     started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     finished_at: datetime | None = None
+    #: ADR-0052：本步骤派生出的 durable job id。前端据此把后台 GIS job 挂到
+    #: 对应 tool step 下面，形成 Agent Turn → Tool Step → Durable Job 链。
+    background_job_ids: list[str] = field(default_factory=list)
 
     @property
     def is_error(self) -> bool:
@@ -53,6 +65,19 @@ class TaskInfo:
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     finished_at: datetime | None = None
     _cancelled: bool = field(default=False, repr=False)  # 内部取消标志
+    #: ADR-0052：贯穿式取消信号。cancel() 点燃它 → 执行引擎抢占在飞工具，
+    #: 同步 GIS 循环在 checkpoint 处退出。
+    cancel_token: CancellationToken | None = field(default=None, repr=False)
+
+    @property
+    def background_job_ids(self) -> list[str]:
+        """本 task 全部步骤派生的 durable job id（按出现顺序去重）。"""
+        seen: list[str] = []
+        for step in self.steps:
+            for job_id in step.background_job_ids:
+                if job_id not in seen:
+                    seen.append(job_id)
+        return seen
 
 
 class _TrackStepContext:
@@ -135,6 +160,7 @@ class TaskTracker:
             id=task_id,
             session_id=session_id,
             original_request=request,
+            cancel_token=cancellation_registry.register(task_id),
         )
         self._tasks[task_id] = task
 
@@ -187,6 +213,8 @@ class TaskTracker:
         """Remove a task and its bookkeeping; drop now-empty session keys."""
         self._tasks.pop(tid, None)
         self._step_counters.pop(tid, None)
+        # ADR-0052: token 随 task 一起回收，避免 registry 随进程寿命单调增长
+        cancellation_registry.discard(tid)
         for sid, ids in list(self._session_tasks.items()):
             if tid in ids:
                 ids.remove(tid)
@@ -261,13 +289,19 @@ class TaskTracker:
         # 可选：记录失败原因到任务中
 
     def cancel(self, task_id: str) -> bool:
-        """取消任务（cooperative - 不会打断正在执行的 tool）。
+        """取消任务。点燃 CancellationToken，取消随即贯穿整条执行路径。
 
-        审计 M7：cancel 仅设置 _cancelled 标志，由 chat_engine 在每轮/每步
-        之间轮询 is_cancelled 决定是否退出。正在执行的单个 tool（如 NDVI 计算、
-        LLM 流式调用）会跑到自然完成才检查标志。完整 preemptive cancel 需要把
-        asyncio.Event 透传到每个 tool 的 dispatch 路径，是独立重构工作。
-        用户感知：长任务点 cancel 后可能等 30-60s 才真正停。
+        ADR-0052 之前这里只翻一个 bool，chat 引擎在「每轮之间 / 每个工具完成之后」
+        轮询它 —— 正在跑的 NDVI 或缓冲区分析会一路算完（30–60s）才停，CPU 并没有
+        被释放。现在：
+
+          * 执行引擎 ``await token.wait()``，取消到达即 **抢占式** cancel 在飞的
+            asyncio 工具任务（见 execution_engine 的并行 wave 循环）；
+          * token 经 contextvar 传入同步 GIS 代码（asyncio.to_thread 会复制
+            context），长循环在 ``jobs.checkpoint()`` 处协作退出；
+          * token 级联到本 turn 派生的 durable job，worker 侧也会观察到取消。
+
+        幂等：重复取消返回 True 但不重复点燃 token（规范 §5）。
         """
         task = self._tasks.get(task_id)
         if not task:
@@ -276,7 +310,19 @@ class TaskTracker:
         task.status = TaskStatus.cancelled
         task._cancelled = True
         task.finished_at = datetime.now(timezone.utc)
+        token = task.cancel_token or cancellation_registry.register(task_id)
+        task.cancel_token = token
+        token.cancel("cancelled by user")
         return True
+
+    def cancel_token_for(self, task_id: str) -> CancellationToken | None:
+        """取回 task 的取消 token（工具管道用它绑定执行上下文）。"""
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        if task.cancel_token is None:
+            task.cancel_token = cancellation_registry.register(task_id)
+        return task.cancel_token
 
     def is_cancelled(self, task_id: str) -> bool:
         """检查任务是否已取消"""

--- a/app/services/tool_dispatch_service.py
+++ b/app/services/tool_dispatch_service.py
@@ -41,6 +41,8 @@ from app.tools.registry import ToolRegistry
 from app.utils.security import sanitize_error_msg
 from app.utils.geojson import geojson_bbox
 
+from app.services.jobs.cancellation import OperationCancelled
+
 logger = logging.getLogger(__name__)
 
 
@@ -218,6 +220,9 @@ class ToolDispatchService:
         # 2. 执行（registry 内部全权处理 ref 解析、校验、异常捕获与自愈）
         try:
             result = await self._registry.dispatch(tool_name, tool_args_raw, session_id=session_id)
+        except OperationCancelled:
+            # ADR-0052：取消上抛给工具管道处理（它会记成「已取消」而非工具故障）
+            raise
         except Exception as e:
             from app.tools._utils import std_error_response
             error_msg = sanitize_error_msg(str(e))

--- a/app/tools/nature_resources.py
+++ b/app/tools/nature_resources.py
@@ -7,6 +7,7 @@ from typing import Optional
 from pydantic import BaseModel, Field
 from app.tools.registry import ToolRegistry, tool
 from app.services.spatial_tasks import run_ndvi_analysis
+from app.services.jobs.submit import submit_durable_job
 from app.tools._utils import db_session
 
 logger = logging.getLogger(__name__)
@@ -37,13 +38,20 @@ def register_nature_resource_tools(registry: ToolRegistry):
               "\n关键约束：raster_path 必须是 list_uploaded_data 返回过的路径；任务异步，返回 task_id 后需轮询。"
           ))
     def analyze_vegetation_index(raster_path: str, nir_band: Optional[int] = None, red_band: Optional[int] = None, session_id: Optional[str] = None) -> dict:
-        # 触发 Celery 异步任务
-        task = run_ndvi_analysis.delay(raster_path, nir_band, red_band, session_id)
-        return {
-            "status": "analysis_task_started",
-            "task_id": task.id,
-            "message": "植被指数 (NDVI) 分析任务已启动。这是后台异步计算，完成后结果会自动推送到地图并进入你的资产库。"
-        }
+        # ADR-0052: 重计算走 durable job —— 返回 job_id 让用户能在任务中心看到进度
+        # 并随时取消；幂等键防止双击/重连提交两次同样的分析。
+        return submit_durable_job(
+            celery_task=run_ndvi_analysis,
+            task_type="ndvi",
+            display_name="NDVI 植被指数分析",
+            params={
+                "raster_path": raster_path,
+                "nir_band": nir_band,
+                "red_band": red_band,
+            },
+            task_args=(raster_path, nir_band, red_band, session_id),
+            session_id=session_id,
+        )
 
     @tool(registry, name="list_analysis_assets",
           tier=2, domains=["raster"],

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -12,6 +12,8 @@ from enum import Enum
 from app.services.session_data import session_data_manager
 from app.lib.geo_processor.core import GeoAnalysisResult
 
+from app.services.jobs.cancellation import OperationCancelled
+
 logger = logging.getLogger(__name__)
 
 
@@ -445,6 +447,12 @@ class ToolRegistry:
                 error_type="FileNotFoundError",
                 correction_hint=f"Error: File {str(e)} not found. Please ensure the path is correct."
             )
+        except OperationCancelled:
+            # ADR-0052：用户取消不是「工具坏了」。这里必须上抛，否则通用兜底会把它
+            # 变成一个 TOOL_ERROR 结果 —— 工具管道的取消分支永远不会触发，LLM 会
+            # 收到「工具执行异常」而不是「已被用户取消」，且取消有可能被当作可重试
+            # 的失败对待。
+            raise
         except Exception as e:
             logger.exception(f"Tool execution failed: {name}")
             return std_error_response(

--- a/docs/adr/0052-unified-durable-job-runtime.md
+++ b/docs/adr/0052-unified-durable-job-runtime.md
@@ -1,0 +1,185 @@
+# ADR-0052：统一 Durable Job 运行时与取消生命周期
+
+- 状态：Accepted
+- 日期：2026-08-12
+- 关联：ADR-0013（工具 dispatch 收敛）、ADR-0024（ToolExecutionPipeline 深模块）、
+  审计 S33/S34（任务 API 跨租户）、SEC-08（匿名会话 owner_token）
+
+## 背景：三套互不相通的任务状态
+
+改动前系统里同时存在三份「任务状态」，语义与生命周期都不一致：
+
+```
+TaskTracker._tasks          进程内 dict     Agent turn 的步骤热态，重启即失
+AnalysisTask (analysis_tasks) PostgreSQL 表  有完整状态机与进度列，但零生产调用方
+TaskQueueService._task_owners 进程内 class dict  Celery 任务归属的唯一事实源
+```
+
+由此产生的具体缺陷（全部在代码里核实过，不是推测）：
+
+1. **取消只是 UI 状态。** `TaskTracker.cancel()` 只翻一个 bool，chat 引擎在「每轮之间」
+   和「每个工具完成之后」轮询它。正在跑的 NDVI 或缓冲区分析会一路算完（30–60s）
+   才停 —— CPU、worker、内存都没有被释放。原 docstring 自己也承认了这点。
+2. **API 重启丢任务归属。** `_task_owners` 是进程内 dict：API 一重启，合法用户查
+   自己的 Celery 任务也是 404，更取消不了；多副本部署下「注册在哪个 pod 就只有那个
+   pod 认」。
+3. **Agent 任务与后台 job 毫无关联。** `task-xxxxxxxx` 与 `celery_task_id` 是两个独立
+   命名空间，前端只能显示两条互不相干的条目。
+4. **worker 崩溃 = 永久 running。** 没有心跳、没有租约、没有清扫，DB 里的
+   `status=running` 永远不会变。
+5. **进度契约分裂。** Celery 侧是 `update_state(PROGRESS)`（只存在于 Redis result
+   backend），Agent 侧是 `step_start/step_result` 事件，前端拿不到统一百分比。
+6. **产物不是原子的。** NDVI 直接写最终路径，取消或崩溃会留下一个看起来正常、其实
+   只写了一半的 GeoTIFF。
+
+## 决策
+
+**演进 `AnalysisTask` 为统一 durable job 记录，而不是新建第二套 Job 表。**
+
+它已经具备状态 CHECK、`progress`、`retry_count`、queued/started/completed 时间戳、
+`org_id`/`creator_id` 归属与 JSON 载荷列 —— 缺的只是「关联」与「取消/租约」字段。
+迁移 `0013_unified_durable_job_runtime` 因此是 additive 的：只加列/索引 + 放宽两处
+约束，老数据行不需要改写。
+
+### 1. 单一生命周期契约（`app/services/jobs/lifecycle.py`）
+
+```
+pending → queued → running → completed
+                     ↓  ↘
+              cancelling   failed / stale
+                     ↓
+                cancelled
+```
+
+状态名沿用表原有 CHECK 值，只新增 `cancelling`（取消中，非终态）与 `stale`
+（worker 失联）。两条最强不变式由显式迁移表保证：
+
+- **`cancelled` 与 `completed` 没有任何后继**（`IMMUTABLE_STATUSES`）。worker 的
+  late success 不可能覆盖 cancelled；取消也因此永远不会被 retry。
+- **`cancelling` 只能走向 `cancelled`/`failed`**。worker 若在取消期间跑完，结果按
+  取消处理并丢弃产物。
+
+`failed`/`stale` 是终态但**可重试** —— 只能经显式新 attempt 回到 `queued`，
+`attempt` 递增且保留首次失败的 `error_trace` 作为证据。
+
+### 2. 并发安全靠原子条件更新，不靠 read-modify-write
+
+每次迁移都是
+
+```sql
+UPDATE analysis_tasks SET status = :target, ...
+ WHERE id = :id AND status IN (<target 的合法前驱>)
+```
+
+合法前驱集合由 `lifecycle.sources_for()` 统一提供，规则只定义一次。`rowcount == 0`
+说明状态已被别人改走，调用方据此走幂等分支而不是盲写覆盖。这直接消灭了
+`cancelled → completed`、重复 finalize、以及迟到进度复活终态三类竞态。
+
+批量 UPDATE 之后的读取一律走**列级 SELECT**，不复用 ORM 身份映射里的对象 ——
+`expire_on_commit=False` 加上 `synchronize_session='evaluate'` 会让一次失败的条件
+更新在内存里改写掉那一行的属性，基于它做判断会得出错误结论。
+
+### 3. 取消贯穿执行路径（`cancellation.py` + `worker.py`）
+
+```
+Task API → 落库 cancel_requested_at（持久事实）
+         → CancellationRegistry 点燃本进程 token
+              ├─ asyncio 侧：执行引擎 await token.wait()，取消到达即抢占式
+              │   cancel 在飞的工具任务（不再等当前工具自然结束）
+              └─ 线程/CPU 侧：token 经 contextvar 传入同步 GIS 代码
+                  （asyncio.to_thread 会复制 context，几十个工具签名不用改），
+                  长循环在 jobs.checkpoint() 处协作退出
+
+跨进程 worker → 后台看门狗线程按 500ms 轮询 DB 并**推**送取消给 token
+```
+
+看门狗必须是「推」而不是「拉」：探针如果只在任务体调用 `checkpoint()` 时才读 DB，
+一段不可中断的 numpy 调用期间没人会去看 DB，取消依旧要等计算跑完 —— 那就退回到了
+「取消只是 UI 状态」。看门狗同时按 30s 刷新 `heartbeat_at`，因为心跳不能依赖进度
+上报（进度是节流的，长时间不变的 job 会被误判为 worker 已死）。
+
+不可逆副作用之前用 `ensure_not_cancelled()`（强制读一次 DB）而不是 `checkpoint()`
+（只读内存 token），避免「取消已落库但看门狗还没轮询到」的瞬间给已取消的 job 留下
+资产记录。
+
+**取消是先协作、后 revoke，hard terminate 只作为有界最后手段** —— `terminate=True`
+不再是所有任务的第一取消手段。
+
+### 4. 归属持久化
+
+`_task_owners` 降级为快路径缓存，durable 行才是事实源。归属有三条证明链，任一命中
+即可：`creator_id == 已认证 user_id`、`owner_token` 精确匹配（镜像 SEC-08 的匿名
+能力令牌）、`session_id ∈ 调用方已证明拥有的会话`。三条都不成立时归属谓词是**恒假**，
+绝不退化成无过滤全表扫描。
+
+auth 层的字面量 `"anonymous"` 在写入前归一化为 `NULL` —— 它不是 `users` 表里的一行，
+直接写 `creator_id` 会在 PostgreSQL 上违反外键，匿名用户于是完全无法创建 durable job
+（SQLite 因默认不校验外键而会掩盖这个问题）。
+
+### 5. Agent Turn → Tool Step → Durable Job
+
+`JobOrigin` 经 contextvar 承载「我是谁派生出来的」。工具在执行期间创建 durable job
+时自动带上 session/owner/run/turn/tool_call/agent step 关联，新 job id 回流到该
+step，并出现在 `step_result` SSE 的 `background_job_ids` 里。前端因此把后台 GIS job
+挂到对应步骤下面，而不是显示两条无关条目。
+
+### 6. 进度契约与写入速率上界
+
+统一为 `{phase, progress, message, current_step, total_steps}`，并**允许
+`progress = null` 表示不确定进度** —— 不是所有 job 都能算出真实百分比，假装 99% 然后
+卡十分钟比 indeterminate 更糟。节流规则「进度变化 ≥1% 或距上次 ≥500ms」把 10 万次
+上报压到约 100 次落库（基准见下）。
+
+### 7. 产物原子提交
+
+```
+temporary output → compute success → os.replace → ready
+```
+
+失败/取消删除临时文件，已 finalize 的成功产物绝不删除。覆盖 NDVI 输出、
+`raster_math` 的窗口写入循环，以及 `DurableJobHandle.artifact()`。
+
+### 8. 重试只在真正可靠时提供
+
+`retry` 必须**真的**把任务重新交给 worker —— 只改状态而不入队会留下一个永不推进的
+job，比不提供 retry 更糟。为此在提交时持久化 `dispatch_spec`（`{task, args, kwargs}`）：
+`parameters` 是脱敏+截断后的展示摘要，无法用于重跑。`dispatch_spec` 携带敏感键或
+超过体积上限时整体丢弃并标记不可用，此时 retry 明确拒绝而不是假装成功。该字段
+**永不**通过 API 返回。
+
+## 拒绝的方案
+
+- **新建 `Job` 表。** `AnalysisTask` 已有 70% 需要的列，再建一套会立刻产生第四份
+  任务状态 —— 正是本 ADR 要消灭的问题。
+- **`reject_on_worker_lost=True`（worker 丢失时重投）。** 重投会重复执行不可逆的 GIS
+  操作。改为 `acks_late=True` + 不重投，重复投递由 job 的「认领」语义
+  （`pending|queued → running` 条件更新只有一个能成功）挡住，worker 真死掉的 job
+  由 stale 清扫收敛。
+- **Temporal / Airflow / Kafka / 新微服务。** 目标是让现有 Celery + PostgreSQL 组合
+  可靠，不是引入新的调度平台。
+- **把所有 GIS 工具 Celery 化。** 短操作直接 await 更快也更简单；只有重操作走
+  durable job（阈值由调用方决定）。
+- **新 websocket 通道。** SSE 仍是主推送路径；任务中心只在浏览器刷新后用**有界**轮询
+  兜底（无活跃 job → 0 请求，tab 隐藏 → 暂停，连续失败 → 停止）。
+
+## 后果
+
+正面：
+
+- 取消真正释放算力（基准：取消后 10000 个 chunk 只执行 51 个，省下 99.49%）。
+- API 重启后合法 owner 仍可查询与取消自己的任务；其他用户仍然 404。
+- worker 崩溃不再导致永久 running。
+- 进度写入速率有硬上界（10 万次上报 → 100 次落库）。
+- 巨型结果与凭据不进 task 行；任务中心响应约 478 B/job。
+
+代价与已知限制：
+
+- `analysis_tasks` 多了 17 列（全部 nullable）。
+- 每个 running job 多一个看门狗线程与约 2 次/秒的 DB 轮询。
+- **stale 检测有延迟**：心跳超时 300s + 清扫周期 60s，所以 worker 崩溃后用户最多
+  会看到约 5 分钟的「执行中」。这是有意的保守取值（避免误判活着的慢 job）。
+- **不可中断的原子计算无法被打断**：一次巨大的 `np.divide` 内部没有检查点，取消只能
+  在它返回后生效。要更细的粒度需要把波段运算改成分块循环，属于后续工作。
+- **跨进程真实 worker 未在本地验证**：环境缺少 Redis，Celery 走 eager 模式，
+  测试覆盖的是任务体全部代码路径与 durable 状态机，**不覆盖** broker 重投、
+  revoke/terminate 与 prefork 隔离。相关测试文件已显式标注这一点。

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -191,6 +191,8 @@ export default function Home() {
           aiStatus={aiStatus}
           onSend={handleSend}
           accentColor={reactiveAccentColor}
+          sessionId={sessionId}
+          ownerToken={sessionTokenRef.current}
           onPlanAction={handlePlanAction}
         />
 

--- a/frontend/components/sidebar/left-sidebar.tsx
+++ b/frontend/components/sidebar/left-sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MessageCircle, Layers, Printer, Triangle, Folder, Database } from 'lucide-react';
+import { MessageCircle, Layers, Printer, Triangle, Folder, Database, ListChecks } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import { ChatTab } from '@/components/sidebar/chat-tab';
@@ -9,6 +9,7 @@ import { AnalysisTab } from '@/components/sidebar/analysis-tab';
 import { MapStudioTab } from '@/components/sidebar/map-studio-tab';
 import { ProjectTab } from '@/components/sidebar/project-tab';
 import { DataSourcesTab } from '@/components/sidebar/data-sources-tab';
+import { TasksTab } from '@/components/sidebar/tasks-tab';
 import type { AiStatus, LeftTab } from '@/lib/store/hud-types';
 
 export interface LeftSidebarProps {
@@ -24,6 +25,10 @@ export interface LeftSidebarProps {
   aiStatus: AiStatus;
   onSend: (text: string) => void;
   accentColor?: string;
+  /** ADR-0052 任务中心：durable job 按 session 归属查询，需要当前 session */
+  sessionId?: string | null;
+  /** 匿名会话的归属令牌（SEC-08）。任务中心据此证明 job 归属 */
+  ownerToken?: string | null;
   /** Plan Mode: 由 page.tsx 注入 — 用户在 PlanProposalCard 上点按钮时回调 */
   onPlanAction?: (planId: string, action: 'approve' | 'revise' | 'reject') => void;
 }
@@ -41,9 +46,10 @@ const TAB_DEFS: TabDef[] = [
   { key: 'analysis', icon: Triangle, label: '分析' },
   { key: 'data_sources', icon: Database, label: '数据织网' },
   { key: 'export_layout', icon: Printer, label: '制图工坊' },
+  { key: 'tasks', icon: ListChecks, label: '任务' },
 ];
 
-export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#16a34a', onPlanAction }: LeftSidebarProps) {
+export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#16a34a', sessionId, ownerToken, onPlanAction }: LeftSidebarProps) {
   const activeTab = useHudStore((s) => s.activeLeftTab);
   const setActiveTab = useHudStore((s) => s.setActiveLeftTab);
   const sidebarWidth = useHudStore((s) => s.sidebarWidth);
@@ -121,6 +127,9 @@ export function LeftSidebar({ open, messages, aiStatus, onSend, accentColor = '#
         {activeTab === 'analysis' && <AnalysisTab onSend={onSend} />}
         {activeTab === 'data_sources' && <DataSourcesTab />}
         {(activeTab === 'export_layout' || activeTab === 'exports') && <MapStudioTab />}
+        {activeTab === 'tasks' && (
+          <TasksTab sessionId={sessionId} ownerToken={ownerToken} accentColor={accentColor} />
+        )}
       </div>
     </aside>
   );

--- a/frontend/components/sidebar/tasks-tab.test.tsx
+++ b/frontend/components/sidebar/tasks-tab.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import type { JobView } from '@/lib/api/jobs';
+import { TasksTab } from './tasks-tab';
+
+// 只 mock 数据 hook：渲染、状态映射、取消 UX 是被测逻辑本身。
+const hook = vi.hoisted(() => ({ useJobCenter: vi.fn() }));
+
+vi.mock('@/lib/hooks/use-job-center', () => ({
+  useJobCenter: hook.useJobCenter,
+}));
+
+function job(overrides: Partial<JobView> = {}): JobView {
+  return {
+    id: 'job-1',
+    kind: 'analysis',
+    name: 'NDVI 植被指数分析',
+    status: 'running',
+    progress: 42,
+    message: '计算中',
+    cancellable: true,
+    retryable: false,
+    active: true,
+    attempt: 1,
+    session_id: 'sess-a',
+    project_id: null,
+    agent_task_id: null,
+    agent_step_id: null,
+    background_job_ids: [],
+    error: null,
+    result_ref: null,
+    step_count: 0,
+    created_at: '2026-08-12T00:00:00Z',
+    started_at: '2026-08-12T00:00:00Z',
+    finished_at: null,
+    cancel_requested_at: null,
+    ...overrides,
+  };
+}
+
+const cancel = vi.fn();
+const retry = vi.fn();
+const refresh = vi.fn();
+
+function mockCenter(jobs: JobView[], cancelling: string[] = [], error: string | null = null) {
+  hook.useJobCenter.mockReturnValue({
+    jobs,
+    loading: false,
+    error,
+    hasActive: jobs.some((j) => j.active),
+    cancelling: new Set(cancelling),
+    refresh,
+    cancel,
+    retry,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCenter([]);
+});
+
+describe('TasksTab — 渲染', () => {
+  it('空状态提示随 session 存在性变化', () => {
+    const { rerender } = render(<TasksTab sessionId={null} />);
+    expect(screen.getByText('开始一次对话后即可查看任务')).toBeInTheDocument();
+
+    rerender(<TasksTab sessionId="sess-a" />);
+    expect(screen.getByText('暂无后台任务')).toBeInTheDocument();
+  });
+
+  it('显示任务名、类型、进度与消息', () => {
+    mockCenter([job()]);
+    render(<TasksTab sessionId="sess-a" />);
+
+    expect(screen.getByText('NDVI 植被指数分析')).toBeInTheDocument();
+    expect(screen.getByText(/空间分析/)).toBeInTheDocument();
+    expect(screen.getByText('计算中')).toBeInTheDocument();
+    expect(screen.getByText('42%')).toBeInTheDocument();
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '42');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('progress=null 显示为不确定进度，而不是假百分比', () => {
+    mockCenter([job({ progress: null, message: '排队中' })]);
+    render(<TasksTab sessionId="sess-a" />);
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('job-indeterminate-job-1')).toBeInTheDocument();
+  });
+
+  it('显示 attempt 与来源步骤（Turn → Step → Job 链）', () => {
+    mockCenter([job({ attempt: 2, agent_step_id: 'step-3' })]);
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.getByText(/第 2 次尝试/)).toBeInTheDocument();
+    expect(screen.getByText(/来自 step-3/)).toBeInTheDocument();
+  });
+
+  it('展示单行错误摘要', () => {
+    mockCenter([
+      job({ status: 'failed', active: false, cancellable: false, error: 'ValueError: invalid CRS' }),
+    ]);
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.getByText('ValueError: invalid CRS')).toBeInTheDocument();
+  });
+
+  it('活跃与已结束任务分组展示', () => {
+    mockCenter([job({ id: 'a' }), job({ id: 'b', status: 'completed', active: false })]);
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.getByText('已结束')).toBeInTheDocument();
+    expect(screen.getByTestId('job-card-a')).toBeInTheDocument();
+    expect(screen.getByTestId('job-card-b')).toBeInTheDocument();
+  });
+
+  it('展示错误横幅', () => {
+    mockCenter([], [], '任务中心请求失败');
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.getByText('任务中心请求失败')).toBeInTheDocument();
+  });
+});
+
+describe('TasksTab — 状态标签映射（规范 §29）', () => {
+  const cases: Array<[JobView['status'], string, boolean]> = [
+    ['pending', '待入队', true],
+    ['queued', '排队中', true],
+    ['running', '执行中', true],
+    ['cancelling', '取消中…', true],
+    ['completed', '已完成', false],
+    ['failed', '失败', false],
+    ['cancelled', '已取消', false],
+    ['stale', '已中断', false],
+  ];
+
+  it.each(cases)('%s → %s', (status, label, active) => {
+    mockCenter([job({ status, active, cancellable: active && status !== 'cancelling' })]);
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});
+
+describe('TasksTab — 取消 UX（规范 §30）', () => {
+  it('点击取消调用 cancel', () => {
+    mockCenter([job()]);
+    render(<TasksTab sessionId="sess-a" />);
+    fireEvent.click(screen.getByRole('button', { name: /取消 NDVI/ }));
+    expect(cancel).toHaveBeenCalledWith('job-1');
+  });
+
+  it('取消进行中时显示「取消中…」且按钮禁用，绝不直接显示已取消', () => {
+    mockCenter([job()], ['job-1']);
+    render(<TasksTab sessionId="sess-a" />);
+
+    expect(screen.getByText('取消中…')).toBeInTheDocument();
+    expect(screen.queryByText('已取消')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /取消 NDVI/ })).toBeDisabled();
+  });
+
+  it('后端确认终态后才显示已取消', () => {
+    mockCenter([job({ status: 'cancelled', active: false, cancellable: false })]);
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.getByText('已取消')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /取消 NDVI/ })).not.toBeInTheDocument();
+  });
+
+  it('不可取消的任务不显示取消按钮', () => {
+    mockCenter([job({ status: 'completed', active: false, cancellable: false })]);
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.queryByRole('button', { name: /取消/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('TasksTab — 重试', () => {
+  it('可重试任务显示重试按钮并调用 retry', () => {
+    mockCenter([
+      job({ status: 'failed', active: false, cancellable: false, retryable: true }),
+    ]);
+    render(<TasksTab sessionId="sess-a" />);
+    fireEvent.click(screen.getByRole('button', { name: /重试 NDVI/ }));
+    expect(retry).toHaveBeenCalledWith('job-1');
+  });
+
+  it('已取消任务不显示重试按钮（取消绝不重试）', () => {
+    mockCenter([
+      job({ status: 'cancelled', active: false, cancellable: false, retryable: false }),
+    ]);
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.queryByRole('button', { name: /重试/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('TasksTab — 结果与刷新', () => {
+  it('终态任务展示结果文件名', () => {
+    mockCenter([
+      job({
+        status: 'completed',
+        active: false,
+        cancellable: false,
+        result_ref: '/data/analysis_results/NDVI_123.tif',
+      }),
+    ]);
+    render(<TasksTab sessionId="sess-a" />);
+    expect(screen.getByText('NDVI_123.tif')).toBeInTheDocument();
+  });
+
+  it('点击刷新调用 refresh', () => {
+    mockCenter([]);
+    render(<TasksTab sessionId="sess-a" />);
+    fireEvent.click(screen.getByRole('button', { name: '刷新' }));
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('把 session 与 ownerToken 传给数据 hook', () => {
+    mockCenter([]);
+    render(<TasksTab sessionId="sess-a" ownerToken="tok-a" />);
+    expect(hook.useJobCenter).toHaveBeenCalledWith({
+      sessionId: 'sess-a',
+      ownerToken: 'tok-a',
+    });
+  });
+});

--- a/frontend/components/sidebar/tasks-tab.tsx
+++ b/frontend/components/sidebar/tasks-tab.tsx
@@ -1,0 +1,263 @@
+/**
+ * 任务中心 / Running Jobs（ADR-0052，规范 §28 / §29 / §30）。
+ *
+ * 轻量面板，不改动既有 UI 结构：作为左侧栏的一个 tab，形状沿用 ops-log-tab 的
+ * 活动流模式，进度条沿用 explorer-progress-panel 的 a11y 实现。
+ *
+ * 同时显示 agent task 与后台 durable GIS job；后者会标出它属于哪个 agent 步骤，
+ * 因此用户不会看到两条互不相关的条目。
+ */
+'use client';
+
+import { RotateCcw, X } from 'lucide-react';
+import { useMemo } from 'react';
+
+import type { JobStatus, JobView } from '@/lib/api/jobs';
+import { useJobCenter } from '@/lib/hooks/use-job-center';
+
+interface TasksTabProps {
+  sessionId?: string | null;
+  ownerToken?: string | null;
+  accentColor?: string;
+}
+
+const STATUS_LABELS: Record<JobStatus, string> = {
+  pending: '待入队',
+  queued: '排队中',
+  running: '执行中',
+  cancelling: '取消中…',
+  completed: '已完成',
+  failed: '失败',
+  cancelled: '已取消',
+  stale: '已中断',
+};
+
+const STATUS_COLORS: Record<JobStatus, string> = {
+  pending: 'text-white/50',
+  queued: 'text-blue-300',
+  running: 'text-blue-400',
+  cancelling: 'text-yellow-400',
+  completed: 'text-green-400',
+  failed: 'text-red-400',
+  cancelled: 'text-gray-400',
+  stale: 'text-orange-400',
+};
+
+const KIND_LABELS: Record<string, string> = {
+  agent: 'AI 任务',
+  analysis: '空间分析',
+  workflow: '工作流',
+  explorer: '数据探索',
+};
+
+/** 已运行时长。终态用 finished-started，活跃用 now-started。 */
+function formatElapsed(job: JobView, now: number): string {
+  const startedAt = job.started_at ?? job.created_at;
+  if (!startedAt) return '—';
+  const start = new Date(startedAt).getTime();
+  if (Number.isNaN(start)) return '—';
+  const end = job.finished_at ? new Date(job.finished_at).getTime() : now;
+  const seconds = Math.max(0, Math.round((end - start) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+function JobCard({
+  job,
+  isCancelling,
+  onCancel,
+  onRetry,
+  now,
+}: {
+  job: JobView;
+  isCancelling: boolean;
+  onCancel: (id: string) => void;
+  onRetry: (id: string) => void;
+  now: number;
+}) {
+  // 「取消中」以本地乐观状态或后端状态任一为准；但「已取消」只认后端终态
+  const displayStatus: JobStatus =
+    isCancelling && job.active && job.status !== 'cancelling' ? 'cancelling' : job.status;
+  const showProgress = job.active && job.progress !== null;
+  const indeterminate = job.active && job.progress === null;
+
+  return (
+    <div
+      className="rounded-lg border border-white/10 bg-white/5 p-3 backdrop-blur-sm"
+      data-testid={`job-card-${job.id}`}
+      aria-busy={job.active}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-white/90">{job.name}</div>
+          <div className="mt-0.5 text-xs text-white/40">
+            {KIND_LABELS[job.kind] ?? job.kind}
+            {job.attempt > 1 && ` · 第 ${job.attempt} 次尝试`}
+            {job.agent_step_id && ` · 来自 ${job.agent_step_id}`}
+          </div>
+        </div>
+        <span
+          role="status"
+          aria-live="polite"
+          className={`shrink-0 text-xs ${STATUS_COLORS[displayStatus]}`}
+        >
+          {STATUS_LABELS[displayStatus]}
+        </span>
+      </div>
+
+      {showProgress && (
+        <div className="mt-2">
+          <div
+            className="h-1.5 overflow-hidden rounded-full bg-white/10"
+            role="progressbar"
+            aria-valuenow={job.progress ?? 0}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${job.name} 进度`}
+          >
+            <div
+              className="h-1.5 rounded-full bg-blue-400 transition-all duration-500"
+              style={{ width: `${job.progress ?? 0}%` }}
+            />
+          </div>
+          <div className="mt-1 flex justify-between text-xs text-white/50">
+            <span className="truncate">{job.message ?? ''}</span>
+            <span className="shrink-0 pl-2">{job.progress}%</span>
+          </div>
+        </div>
+      )}
+
+      {indeterminate && (
+        // 不确定进度：明确显示为「进行中」而不是编造一个 99% 然后卡住
+        <div className="mt-2 text-xs text-white/50" data-testid={`job-indeterminate-${job.id}`}>
+          {job.message ?? '进行中…'}
+        </div>
+      )}
+
+      {job.error && <div className="mt-2 text-xs text-red-400">{job.error}</div>}
+
+      <div className="mt-2 flex items-center justify-between text-xs text-white/40">
+        <span>已用 {formatElapsed(job, now)}</span>
+        <div className="flex items-center gap-2">
+          {job.result_ref && !job.active && (
+            <span className="max-w-[10rem] truncate text-white/50" title={job.result_ref}>
+              {job.result_ref.split('/').pop()}
+            </span>
+          )}
+          {job.cancellable && (
+            <button
+              type="button"
+              onClick={() => onCancel(job.id)}
+              disabled={isCancelling || displayStatus === 'cancelling'}
+              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-white/60 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-40"
+              aria-label={`取消 ${job.name}`}
+            >
+              <X className="h-3 w-3" />
+              取消
+            </button>
+          )}
+          {job.retryable && (
+            <button
+              type="button"
+              onClick={() => onRetry(job.id)}
+              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+              aria-label={`重试 ${job.name}`}
+            >
+              <RotateCcw className="h-3 w-3" />
+              重试
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TasksTab({ sessionId, ownerToken, accentColor = '#16a34a' }: TasksTabProps) {
+  const { jobs, error, hasActive, cancelling, refresh, cancel, retry } = useJobCenter({
+    sessionId,
+    ownerToken,
+  });
+
+  // 单次读取的时钟基准：同一渲染内所有卡片用同一个 now，避免逐张 Date.now()
+  // 造成「已用时长」互相错开一两秒
+  const now = Date.now();
+
+  const { active, finished } = useMemo(() => {
+    const a: JobView[] = [];
+    const f: JobView[] = [];
+    for (const job of jobs) (job.active ? a : f).push(job);
+    return { active: a, finished: f };
+  }, [jobs]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex items-center justify-between border-b border-white/10 px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-white/80">任务中心</span>
+          {hasActive && (
+            <span
+              className="h-1.5 w-1.5 animate-pulse rounded-full"
+              style={{ backgroundColor: accentColor }}
+              aria-hidden
+            />
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          className="rounded px-1.5 py-0.5 text-xs text-white/50 transition-colors hover:bg-white/10 hover:text-white"
+        >
+          刷新
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mx-3 mt-2 rounded border border-red-500/30 bg-red-500/10 px-2 py-1 text-xs text-red-300"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 space-y-2 overflow-y-auto p-3">
+        {jobs.length === 0 && (
+          <div className="pt-8 text-center text-xs text-white/40">
+            {sessionId ? '暂无后台任务' : '开始一次对话后即可查看任务'}
+          </div>
+        )}
+
+        {active.map((job) => (
+          <JobCard
+            key={job.id}
+            job={job}
+            isCancelling={cancelling.has(job.id)}
+            onCancel={cancel}
+            onRetry={retry}
+            now={now}
+          />
+        ))}
+
+        {finished.length > 0 && active.length > 0 && (
+          <div className="pt-2 text-xs text-white/30">已结束</div>
+        )}
+
+        {finished.map((job) => (
+          <JobCard
+            key={job.id}
+            job={job}
+            isCancelling={cancelling.has(job.id)}
+            onCancel={cancel}
+            onRetry={retry}
+            now={now}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default TasksTab;

--- a/frontend/lib/api/jobs.ts
+++ b/frontend/lib/api/jobs.ts
@@ -1,0 +1,156 @@
+/**
+ * 统一任务中心 API 客户端（ADR-0052）。
+ *
+ * 对应后端 `/api/v1/tasks/jobs*`。同一个 JobView 形状同时承载 agent task 与
+ * durable GIS job，所以任务中心只需处理一种类型。
+ *
+ * 走 `apiFetch`（lib/api/transport）而不是裸 fetch —— 由它统一处理超时、
+ * X-Request-ID、ApiError 归一化与 ownerToken → X-Session-Token 头。
+ */
+import { apiFetch } from './transport';
+
+/** 后端 JobStatus。cancelling/stale 是 ADR-0052 新增语义。 */
+export type JobStatus =
+  | 'pending'
+  | 'queued'
+  | 'running'
+  | 'cancelling'
+  | 'completed'
+  | 'failed'
+  | 'cancelled'
+  | 'stale';
+
+export type JobKind = 'agent' | 'analysis' | 'workflow' | 'explorer';
+
+export interface JobView {
+  id: string;
+  kind: JobKind | string;
+  name: string;
+  status: JobStatus;
+  /** 0–100；null 表示不确定进度（后端明确不编造假百分比） */
+  progress: number | null;
+  message: string | null;
+  cancellable: boolean;
+  retryable: boolean;
+  active: boolean;
+  attempt: number;
+  session_id: string | null;
+  project_id: string | null;
+  agent_task_id: string | null;
+  agent_step_id: string | null;
+  /** agent task 派生出的后台 durable job（Turn → Step → Job 链） */
+  background_job_ids: string[];
+  /** 单行错误摘要。后端保证不含 traceback */
+  error: string | null;
+  result_ref: string | null;
+  step_count: number;
+  created_at: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  cancel_requested_at: string | null;
+}
+
+export interface JobListResponse {
+  jobs: JobView[];
+  /** 是否仍有活跃 job。false → 前端停止轮询（规范 §32） */
+  has_active: boolean;
+  /** 后端建议的下次轮询间隔；null 表示不要再轮询 */
+  poll_after_ms: number | null;
+}
+
+export interface JobCancelResponse {
+  id: string;
+  status: JobStatus;
+  /** 本次调用是否真的改变了状态。重复取消为 false，但仍是 200（幂等） */
+  cancel_requested: boolean;
+  cancelling: boolean;
+}
+
+export interface JobRetryResponse {
+  id: string;
+  status: JobStatus;
+  retried: boolean;
+  reason: string;
+  attempt: number;
+}
+
+export interface ListJobsOptions {
+  sessionId?: string | null;
+  activeOnly?: boolean;
+  limit?: number;
+  ownerToken?: string | null;
+  signal?: AbortSignal;
+}
+
+/** 未终结状态集合。前端据此决定 UI 与是否继续轮询。 */
+export const ACTIVE_JOB_STATUSES: readonly JobStatus[] = [
+  'pending',
+  'queued',
+  'running',
+  'cancelling',
+];
+
+export function isJobActive(status: JobStatus): boolean {
+  return ACTIVE_JOB_STATUSES.includes(status);
+}
+
+export async function listJobs(options: ListJobsOptions = {}): Promise<JobListResponse> {
+  const params = new URLSearchParams();
+  if (options.sessionId) params.set('session_id', options.sessionId);
+  if (options.activeOnly) params.set('active_only', 'true');
+  if (options.limit) params.set('limit', String(options.limit));
+  const qs = params.toString();
+
+  return apiFetch<JobListResponse>(`/api/v1/tasks/jobs${qs ? `?${qs}` : ''}`, {
+    method: 'GET',
+    ownerToken: options.ownerToken ?? undefined,
+    signal: options.signal,
+    label: 'Task center API error',
+  });
+}
+
+export async function getJob(
+  jobId: string,
+  options: { ownerToken?: string | null; signal?: AbortSignal } = {},
+): Promise<JobView> {
+  return apiFetch<JobView>(`/api/v1/tasks/jobs/${encodeURIComponent(jobId)}`, {
+    method: 'GET',
+    ownerToken: options.ownerToken ?? undefined,
+    signal: options.signal,
+    label: 'Task detail API error',
+  });
+}
+
+/**
+ * 请求取消 job。后端幂等：重复取消返回 200 且 cancel_requested=false。
+ *
+ * 注意返回的 status 可能仍是 `cancelling` —— UI 必须显示「取消中…」而不是直接
+ * 显示「已取消」，只有后端到达终态才算取消完成（规范 §30）。
+ */
+export async function cancelJob(
+  jobId: string,
+  options: { ownerToken?: string | null; signal?: AbortSignal } = {},
+): Promise<JobCancelResponse> {
+  return apiFetch<JobCancelResponse>(`/api/v1/tasks/jobs/${encodeURIComponent(jobId)}`, {
+    method: 'DELETE',
+    ownerToken: options.ownerToken ?? undefined,
+    signal: options.signal,
+    label: 'Task cancel API error',
+  });
+}
+
+/** 重试 failed/stale job（新 attempt）。被取消的 job 后端会拒绝。 */
+export async function retryJob(
+  jobId: string,
+  options: { ownerToken?: string | null; signal?: AbortSignal } = {},
+): Promise<JobRetryResponse> {
+  return apiFetch<JobRetryResponse>(
+    `/api/v1/tasks/jobs/${encodeURIComponent(jobId)}/retry`,
+    {
+      method: 'POST',
+      ownerToken: options.ownerToken ?? undefined,
+      signal: options.signal,
+      label: 'Task retry API error',
+    },
+  );
+}

--- a/frontend/lib/api/task.ts
+++ b/frontend/lib/api/task.ts
@@ -4,6 +4,10 @@
  * F-FE-3 migration: previously raw fetch + plain Error with status only.
  * Now routes through the shared transport (typed ApiError, abort, timeout,
  * request id). GETs go through the Fast Path (in-flight dedup + 5s LRU).
+ *
+ * ADR-0052: 统一任务中心请用 `lib/api/jobs.ts` —— JobView 同时承载 agent task 与
+ * durable GIS job。这里保留的三个函数对应后端未删除的旧端点（expand-contract），
+ * 仅做 transport 迁移，不承担新任务中心的职责。
  */
 
 import { apiFetch } from './transport';

--- a/frontend/lib/hooks/use-job-center.test.ts
+++ b/frontend/lib/hooks/use-job-center.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import type { JobListResponse, JobView } from '@/lib/api/jobs';
+import { useJobCenter } from './use-job-center';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+// 只 mock API 层：轮询调度、陈旧响应保护、取消 UX 都是被测逻辑本身。
+const api = vi.hoisted(() => ({
+  listJobs: vi.fn(),
+  cancelJob: vi.fn(),
+  retryJob: vi.fn(),
+}));
+
+vi.mock('@/lib/api/jobs', () => ({
+  listJobs: api.listJobs,
+  cancelJob: api.cancelJob,
+  retryJob: api.retryJob,
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+function job(overrides: Partial<JobView> = {}): JobView {
+  return {
+    id: 'job-1',
+    kind: 'analysis',
+    name: 'NDVI 分析',
+    status: 'running',
+    progress: 40,
+    message: '计算中',
+    cancellable: true,
+    retryable: false,
+    active: true,
+    attempt: 1,
+    session_id: 'sess-a',
+    project_id: null,
+    agent_task_id: null,
+    agent_step_id: null,
+    background_job_ids: [],
+    error: null,
+    result_ref: null,
+    step_count: 0,
+    created_at: '2026-08-12T00:00:00Z',
+    started_at: '2026-08-12T00:00:01Z',
+    finished_at: null,
+    cancel_requested_at: null,
+    ...overrides,
+  };
+}
+
+function listResponse(jobs: JobView[]): JobListResponse {
+  const hasActive = jobs.some((j) => j.active);
+  return { jobs, has_active: hasActive, poll_after_ms: hasActive ? 3000 : null };
+}
+
+// fake timers 下 testing-library 的 waitFor 不会推进定时器 —— 用显式 flush
+// 冲刷 microtask + 定时器队列，测试因此完全确定，不依赖真实时间。
+async function flush(ms = 0): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+    // hook 的一次拉取跨多个 await（请求 + setState + 排下一次轮询），
+    // 多冲刷几轮 microtask 队列让状态完全落定。
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+  });
+}
+
+let hidden = false;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  hidden = false;
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+  api.listJobs.mockResolvedValue(listResponse([]));
+  api.cancelJob.mockResolvedValue({
+    id: 'job-1',
+    status: 'cancelling',
+    cancel_requested: true,
+    cancelling: true,
+  });
+  api.retryJob.mockResolvedValue({
+    id: 'job-1',
+    status: 'queued',
+    retried: true,
+    reason: 'requeued',
+    attempt: 2,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ── 加载 / 恢复 ──────────────────────────────────────────────────────────
+
+describe('useJobCenter — 恢复与加载', () => {
+  it('挂载时拉取一次（浏览器刷新后恢复任务中心）', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job()]));
+    const { result } = renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+
+    await flush();
+    expect(result.current.jobs).toHaveLength(1);
+    expect(api.listJobs).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'sess-a' }),
+    );
+    expect(result.current.hasActive).toBe(true);
+  });
+
+  it('没有 session 时不发请求（无归属证明）', async () => {
+    renderHook(() => useJobCenter({ sessionId: null }));
+    await flush();
+    expect(api.listJobs).not.toHaveBeenCalled();
+  });
+
+  it('enabled=false 时不发请求（面板收起不打后端）', async () => {
+    renderHook(() => useJobCenter({ sessionId: 'sess-a', enabled: false }));
+    await flush();
+    expect(api.listJobs).not.toHaveBeenCalled();
+  });
+
+  it('暴露请求错误', async () => {
+    api.listJobs.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+    await flush();
+    expect(result.current.error).toBe('boom');
+  });
+});
+
+// ── 轮询生命周期（规范 §32） ─────────────────────────────────────────────
+
+describe('useJobCenter — 轮询边界', () => {
+  it('无活跃 job → 0 轮询', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job({ status: 'completed', active: false })]));
+    renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+    await flush();
+    expect(api.listJobs).toHaveBeenCalledTimes(1);
+
+    await flush(30_000);
+    expect(api.listJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('有活跃 job → 按间隔继续轮询', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job()]));
+    renderHook(() => useJobCenter({ sessionId: 'sess-a', pollIntervalMs: 1000 }));
+    await flush();
+    expect(api.listJobs).toHaveBeenCalledTimes(1);
+
+    await flush(3500);
+    expect(api.listJobs.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('tab 隐藏时暂停轮询，重新可见时立刻补一次', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job()]));
+    renderHook(() => useJobCenter({ sessionId: 'sess-a', pollIntervalMs: 1000 }));
+    await flush();
+    expect(api.listJobs).toHaveBeenCalledTimes(1);
+
+    hidden = true;
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    const pausedAt = api.listJobs.mock.calls.length;
+    await flush(10_000);
+    expect(api.listJobs.mock.calls.length).toBe(pausedAt);
+
+    hidden = false;
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(api.listJobs.mock.calls.length).toBeGreaterThan(pausedAt);
+  });
+
+  it('连续失败达到上限后停止轮询（有界重试）', async () => {
+    api.listJobs.mockRejectedValue(new Error('down'));
+    renderHook(() => useJobCenter({ sessionId: 'sess-a', pollIntervalMs: 10 }));
+
+    await flush(5_000);
+    // 最多 MAX_CONSECUTIVE_ERRORS 次后不再排下一次
+    expect(api.listJobs.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  it('卸载时 abort 在飞请求并停止定时器', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job()]));
+    const { unmount } = renderHook(() =>
+      useJobCenter({ sessionId: 'sess-a', pollIntervalMs: 100 }),
+    );
+    await flush();
+    expect(api.listJobs).toHaveBeenCalledTimes(1);
+
+    const signal = api.listJobs.mock.calls[0][0].signal as AbortSignal;
+    await act(async () => {
+      unmount();
+    });
+    expect(signal.aborted).toBe(true);
+
+    const afterUnmount = api.listJobs.mock.calls.length;
+    await flush(5_000);
+    expect(api.listJobs.mock.calls.length).toBe(afterUnmount);
+  });
+});
+
+// ── 会话切换污染防护（Scenario 10） ──────────────────────────────────────
+
+describe('useJobCenter — 会话切换', () => {
+  it('切换 session 立刻清空旧任务', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job()]));
+    const { result, rerender } = renderHook(
+      ({ sid }: { sid: string }) => useJobCenter({ sessionId: sid }),
+      { initialProps: { sid: 'sess-a' } },
+    );
+    await flush();
+    expect(result.current.jobs).toHaveLength(1);
+
+    api.listJobs.mockResolvedValue(listResponse([]));
+    await act(async () => {
+      rerender({ sid: 'sess-b' });
+    });
+    expect(result.current.jobs).toHaveLength(0);
+  });
+
+  it('旧 session 的迟到响应不得写进新 session 的 UI', async () => {
+    // 第一次请求慢，切换 session 后才 resolve
+    let resolveOld: (v: JobListResponse) => void = () => {};
+    api.listJobs.mockImplementationOnce(
+      () => new Promise<JobListResponse>((res) => { resolveOld = res; }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ sid }: { sid: string }) => useJobCenter({ sessionId: sid }),
+      { initialProps: { sid: 'sess-a' } },
+    );
+    await flush();
+
+    api.listJobs.mockResolvedValue(listResponse([]));
+    await act(async () => {
+      rerender({ sid: 'sess-b' });
+    });
+
+    await act(async () => {
+      resolveOld(listResponse([job({ id: 'stale-job', session_id: 'sess-a' })]));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.jobs.find((j) => j.id === 'stale-job')).toBeUndefined();
+  });
+
+  it('切换 session 时 abort 旧请求', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job()]));
+    const { rerender } = renderHook(
+      ({ sid }: { sid: string }) => useJobCenter({ sessionId: sid }),
+      { initialProps: { sid: 'sess-a' } },
+    );
+    await flush();
+    expect(api.listJobs).toHaveBeenCalled();
+    const signal = api.listJobs.mock.calls[0][0].signal as AbortSignal;
+
+    await act(async () => {
+      rerender({ sid: 'sess-b' });
+    });
+    expect(signal.aborted).toBe(true);
+  });
+});
+
+// ── 取消 UX（规范 §30） ──────────────────────────────────────────────────
+
+describe('useJobCenter — 取消', () => {
+  it('取消后立即进入「取消中」，而不是直接显示已取消', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job()]));
+    const { result } = renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+    await flush();
+    expect(result.current.jobs).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.cancel('job-1');
+    });
+
+    expect(api.cancelJob).toHaveBeenCalledWith('job-1', expect.anything());
+    expect(result.current.cancelling.has('job-1')).toBe(true);
+    // 后端仍是 cancelling → UI 不得宣称已取消
+    expect(result.current.jobs[0].status).not.toBe('cancelled');
+  });
+
+  it('后端确认终态后退出「取消中」', async () => {
+    api.listJobs.mockResolvedValueOnce(listResponse([job()]));
+    const { result } = renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+    await flush();
+    expect(result.current.jobs).toHaveLength(1);
+
+    api.listJobs.mockResolvedValue(
+      listResponse([job({ status: 'cancelled', active: false, cancellable: false })]),
+    );
+    await act(async () => {
+      await result.current.cancel('job-1');
+    });
+
+    await flush();
+    expect(result.current.cancelling.has('job-1')).toBe(false);
+    expect(result.current.jobs[0].status).toBe('cancelled');
+  });
+
+  it('取消失败时回滚乐观状态并暴露错误', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job()]));
+    api.cancelJob.mockRejectedValue(new Error('cancel failed'));
+    const { result } = renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+    await flush();
+    expect(result.current.jobs).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.cancel('job-1');
+    });
+
+    expect(result.current.cancelling.has('job-1')).toBe(false);
+    expect(result.current.error).toBe('cancel failed');
+    expect(result.current.jobs[0].status).toBe('running');
+  });
+
+  it('重复取消是幂等的（后端 cancel_requested=false 不算错误）', async () => {
+    api.listJobs.mockResolvedValue(listResponse([job({ status: 'cancelling' })]));
+    api.cancelJob.mockResolvedValue({
+      id: 'job-1',
+      status: 'cancelling',
+      cancel_requested: false,
+      cancelling: true,
+    });
+    const { result } = renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+    await flush();
+    expect(result.current.jobs).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.cancel('job-1');
+      await result.current.cancel('job-1');
+    });
+    expect(result.current.error).toBeNull();
+  });
+});
+
+// ── 重试 ────────────────────────────────────────────────────────────────
+
+describe('useJobCenter — 重试', () => {
+  it('重试成功后刷新列表', async () => {
+    api.listJobs.mockResolvedValue(
+      listResponse([job({ status: 'failed', active: false, retryable: true })]),
+    );
+    const { result } = renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+    await flush();
+    expect(result.current.jobs).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.retry('job-1');
+    });
+    expect(api.retryJob).toHaveBeenCalledWith('job-1', expect.anything());
+    expect(result.current.error).toBeNull();
+  });
+
+  it('后端拒绝重试时展示原因（取消不得重试）', async () => {
+    api.listJobs.mockResolvedValue(
+      listResponse([job({ status: 'cancelled', active: false })]),
+    );
+    api.retryJob.mockResolvedValue({
+      id: 'job-1',
+      status: 'cancelled',
+      retried: false,
+      reason: 'cancelled_jobs_are_never_retried',
+      attempt: 1,
+    });
+    const { result } = renderHook(() => useJobCenter({ sessionId: 'sess-a' }));
+    await flush();
+    expect(result.current.jobs).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.retry('job-1');
+    });
+    expect(result.current.error).toContain('cancelled_jobs_are_never_retried');
+  });
+});

--- a/frontend/lib/hooks/use-job-center.ts
+++ b/frontend/lib/hooks/use-job-center.ts
@@ -1,0 +1,277 @@
+/**
+ * 任务中心数据源（ADR-0052，规范 §27 / §31 / §32）。
+ *
+ * 设计约束：
+ *   * **不引入新的 websocket 系统**，也不做高频轮询。SSE 仍然是主推送通道；
+ *     这里只提供「浏览器刷新 / 重连后恢复后台 job」所需的轻量兜底轮询。
+ *   * 轮询生命周期严格有界：
+ *       - 没有活跃 job → 完全停止（0 请求），只在用户操作或会话切换时再拉一次；
+ *       - tab 隐藏 → 暂停，重新可见时立刻补一次；
+ *       - 组件卸载 / session 切换 → abort 在飞请求；
+ *       - 连续失败达到上限 → 停止轮询并暴露错误，不无限重试打后端。
+ *   * 陈旧响应保护：每次请求带一个自增 requestId 与当时的 sessionId，回来时若
+ *     两者与当前状态不符则整份丢弃 —— 旧 session 的任务绝不会写进新 session 的
+ *     UI（规范 Scenario 10）。
+ */
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { cancelJob, listJobs, retryJob, type JobView } from '@/lib/api/jobs';
+import { ApiError } from '@/lib/api/transport';
+
+/** 有活跃 job 时的轮询间隔。后端也会通过 poll_after_ms 建议，取两者较大值。 */
+export const DEFAULT_POLL_INTERVAL_MS = 3000;
+/** tab 隐藏时不轮询；重新可见时立即补一次。 */
+export const MAX_CONSECUTIVE_ERRORS = 3;
+
+export interface UseJobCenterOptions {
+  sessionId?: string | null;
+  ownerToken?: string | null;
+  /** 关闭轮询（面板收起时传 false，避免看不见的面板还在打后端） */
+  enabled?: boolean;
+  pollIntervalMs?: number;
+}
+
+export interface UseJobCenterResult {
+  jobs: JobView[];
+  loading: boolean;
+  error: string | null;
+  hasActive: boolean;
+  /** 已提交取消请求、后端尚未确认终态的 job id（UI 显示「取消中…」） */
+  cancelling: Set<string>;
+  refresh: () => Promise<void>;
+  cancel: (jobId: string) => Promise<void>;
+  retry: (jobId: string) => Promise<void>;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error && err.message) return err.message;
+  return '任务中心请求失败';
+}
+
+export function useJobCenter(options: UseJobCenterOptions = {}): UseJobCenterResult {
+  const { sessionId = null, ownerToken = null, enabled = true } = options;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  const [jobs, setJobs] = useState<JobView[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cancelling, setCancelling] = useState<Set<string>>(new Set());
+  // 每次拉取尝试后自增，驱动「排下一次轮询」的调度 effect。
+  // 用它而不是直接依赖 jobs：拉取失败时 jobs 不变，但仍需要（有界地）重排。
+  const [pollTick, setPollTick] = useState(0);
+
+  // 请求代次 + 当时的 session：用于丢弃陈旧响应
+  const generationRef = useRef(0);
+  // 会话轮次：**只**在 session 切换或卸载时递增。cancel/retry 的守卫必须用它而不是
+  // generationRef —— 后者每次拉取都自增，会把「刚刚由本次操作触发的刷新」误判成陈旧。
+  const epochRef = useRef(0);
+  const sessionRef = useRef<string | null>(sessionId);
+  const abortRef = useRef<AbortController | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const errorCountRef = useRef(0);
+  const mountedRef = useRef(true);
+  // 后端建议的下次间隔（poll_after_ms）
+  const serverIntervalRef = useRef<number | null>(null);
+
+  const hasActive = useMemo(() => jobs.some((job) => job.active), [jobs]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const fetchOnce = useCallback(async () => {
+    if (!enabled) return;
+    // 没有 session 就没有归属证明，后端会返回空列表 —— 干脆不发请求
+    if (!sessionId) {
+      setJobs([]);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const generation = ++generationRef.current;
+    const requestSession = sessionId;
+    setLoading(true);
+    try {
+      const data = await listJobs({
+        sessionId: requestSession,
+        ownerToken,
+        signal: controller.signal,
+      });
+      // 陈旧响应保护：代次落后，或 session 已切换 → 整份丢弃
+      if (generation !== generationRef.current) return;
+      if (sessionRef.current !== requestSession) return;
+      if (!mountedRef.current) return;
+
+      setJobs(data.jobs ?? []);
+      serverIntervalRef.current = data.poll_after_ms ?? null;
+      setError(null);
+      errorCountRef.current = 0;
+
+      // 后端已确认终态 → 从「取消中」集合里移除
+      setCancelling((prev) => {
+        if (prev.size === 0) return prev;
+        const next = new Set(prev);
+        for (const job of data.jobs ?? []) {
+          if (!job.active) next.delete(job.id);
+        }
+        return next.size === prev.size ? prev : next;
+      });
+    } catch (err) {
+      if (controller.signal.aborted) return; // 主动取消不算错误
+      if (generation !== generationRef.current || !mountedRef.current) return;
+      // 404 = 调用方对这个 session 无归属证明（典型场景：刷新后恢复匿名会话，
+      // ownerToken 还没从后端取回）。这是「没有可见任务」而不是故障 —— 显示成
+      // 红色错误横幅只会让用户困惑。
+      if (err instanceof ApiError && err.status === 404) {
+        setJobs([]);
+        setError(null);
+        errorCountRef.current = 0;
+        return;
+      }
+      errorCountRef.current += 1;
+      setError(errorMessage(err));
+    } finally {
+      if (generation === generationRef.current && mountedRef.current) {
+        setLoading(false);
+        setPollTick((tick) => tick + 1);
+      }
+    }
+  }, [enabled, sessionId, ownerToken]);
+
+  // session 切换：立刻丢弃旧数据，避免旧 session 的任务短暂显示在新 session 下
+  useEffect(() => {
+    sessionRef.current = sessionId;
+    generationRef.current += 1;
+    epochRef.current += 1;
+    abortRef.current?.abort();
+    setJobs([]);
+    setCancelling(new Set());
+    setError(null);
+    errorCountRef.current = 0;
+  }, [sessionId]);
+
+  // 首次挂载 / 依赖变化时拉一次。浏览器刷新后任务中心据此恢复。
+  // 注意这个 effect 不依赖 jobs —— 否则每次拉取结果变化都会立刻再拉一次。
+  useEffect(() => {
+    mountedRef.current = true;
+    if (!enabled || !sessionId) return;
+    void fetchOnce();
+  }, [enabled, sessionId, ownerToken, fetchOnce]);
+
+  // 轮询调度：只**排下一次**，自身从不立即请求。
+  // 停止条件（规范 §32）：无活跃 job / tab 隐藏 / 连续失败超上限 / 无 session。
+  useEffect(() => {
+    if (!enabled || !sessionId) return;
+    if (!hasActive) return;                                  // 无活跃 job → 0 轮询
+    if (errorCountRef.current >= MAX_CONSECUTIVE_ERRORS) return;  // 有界重试
+    if (typeof document !== 'undefined' && document.hidden) return;  // 隐藏 → 暂停
+
+    const interval = Math.max(pollIntervalMs, serverIntervalRef.current ?? 0);
+    timerRef.current = setTimeout(() => {
+      void fetchOnce();
+    }, interval);
+    return clearTimer;
+  }, [enabled, sessionId, hasActive, pollIntervalMs, pollTick, fetchOnce, clearTimer]);
+
+  // tab 重新可见：给一次重试机会并立刻补一次（补拉会 bump pollTick 重启调度）
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const onVisibility = () => {
+      if (document.hidden) {
+        clearTimer();
+        return;
+      }
+      if (!enabled || !sessionId) return;
+      errorCountRef.current = 0;
+      void fetchOnce();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [enabled, sessionId, fetchOnce, clearTimer]);
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      clearTimer();
+      abortRef.current?.abort();
+    },
+    [clearTimer],
+  );
+
+  const cancel = useCallback(
+    async (jobId: string) => {
+      // 卸载/切换 session 后到达的响应不得再写 UI（与 fetchOnce 同样的守卫）
+      const epoch = epochRef.current;
+      const isStale = () => !mountedRef.current || epoch !== epochRef.current;
+
+      // 乐观进入「取消中」—— 但绝不直接显示「已取消」：只有后端到达终态才算
+      setCancelling((prev) => new Set(prev).add(jobId));
+      try {
+        const res = await cancelJob(jobId, { ownerToken });
+        if (isStale()) return;
+        setJobs((prev) =>
+          prev.map((job) => (job.id === jobId ? { ...job, status: res.status, active: res.cancelling || job.active } : job)),
+        );
+        if (!res.cancelling) {
+          // 后端已终态（或本就终态）→ 退出「取消中」显示
+          setCancelling((prev) => {
+            const next = new Set(prev);
+            next.delete(jobId);
+            return next;
+          });
+        }
+        await fetchOnce();
+      } catch (err) {
+        if (isStale()) return;
+        // 取消失败：回滚乐观状态并暴露错误（规范 §30）
+        setCancelling((prev) => {
+          const next = new Set(prev);
+          next.delete(jobId);
+          return next;
+        });
+        setError(errorMessage(err));
+      }
+    },
+    [ownerToken, fetchOnce],
+  );
+
+  const retry = useCallback(
+    async (jobId: string) => {
+      const epoch = epochRef.current;
+      const isStale = () => !mountedRef.current || epoch !== epochRef.current;
+      try {
+        const res = await retryJob(jobId, { ownerToken });
+        if (isStale()) return;
+        errorCountRef.current = 0;
+        // 先刷新再写错误：fetchOnce 成功时会清空 error，若顺序颠倒，
+        // 「无法重试」的原因会被立刻擦掉，用户看不到为什么被拒绝。
+        await fetchOnce();
+        if (isStale()) return;
+        if (!res.retried) setError(`无法重试：${res.reason}`);
+      } catch (err) {
+        if (isStale()) return;
+        setError(errorMessage(err));
+      }
+    },
+    [ownerToken, fetchOnce],
+  );
+
+  return {
+    jobs,
+    loading,
+    error,
+    hasActive,
+    cancelling,
+    refresh: fetchOnce,
+    cancel,
+    retry,
+  };
+}

--- a/frontend/lib/store/hud-types.ts
+++ b/frontend/lib/store/hud-types.ts
@@ -70,7 +70,7 @@ export interface CausalEntry {
   mapState?: Record<string, unknown>;
 }
 
-export type LeftTab = 'chat' | 'project' | 'layers' | 'analysis' | 'ops' | 'exports' | 'assets' | 'export_layout' | 'data_sources';
+export type LeftTab = 'chat' | 'project' | 'layers' | 'analysis' | 'ops' | 'exports' | 'assets' | 'export_layout' | 'data_sources' | 'tasks';
 export type SettingsTab = 'llm' | 'skills' | 'rag' | 'layers' | 'map' | 'system';
 
 export interface SkillEntry {

--- a/frontend/lib/types/agent-events.ts
+++ b/frontend/lib/types/agent-events.ts
@@ -12,6 +12,11 @@ export interface StepResultEvent {
   geojson_ref?: string;
   tool?: string;
   name?: string;
+  /**
+   * ADR-0052: 本 tool step 派生出的后台 durable job id。
+   * 任务中心据此把后台 GIS job 挂到对应步骤下，用户不会看到两条互不相关的条目。
+   */
+  background_job_ids?: string[];
 }
 
 export interface TokenEvent {

--- a/migrations/versions/0013_unified_durable_job_runtime.py
+++ b/migrations/versions/0013_unified_durable_job_runtime.py
@@ -1,0 +1,196 @@
+"""Unified durable job runtime: extend analysis_tasks into the durable job record
+
+ADR-0052。additive 迁移：只加列/索引 + 放宽两处约束，不删列、不改写老数据行。
+现有 analysis_tasks 行升级后依然合法（新列全部 nullable 或有 server_default）。
+
+放宽的两处约束：
+  1. org_id 由 NOT NULL 改为 nullable —— 匿名/个人会话产生的 job 没有组织归属，
+     归属由 creator_id + owner_token + session_id 证明。
+  2. ck_task_status 增加 'cancelling'（取消中，非终态）与 'stale'（worker 失联）。
+
+SQLite 说明：SQLite 无法 ALTER 约束，必须重建表。这里用
+``batch_alter_table(copy_from=<反射得到的表>)`` —— SQLAlchemy 不反射 SQLite 的 CHECK
+约束，所以重建会隐式丢掉全部 CHECK，我们随后显式重建 ck_task_status（新定义）与
+ck_task_progress（原定义）。PostgreSQL 走逐条 DDL + IF NOT EXISTS，可重复执行。
+
+Revision ID: 0013_unified_durable_job_runtime
+Revises: 0012_add_composite_indexes_pd_wr
+Create Date: 2026-08-12
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import context, op
+
+# revision identifiers, used by Alembic.
+revision: str = "0013_unified_durable_job_runtime"
+down_revision: Union[str, Sequence[str], None] = "0012_add_composite_indexes_pd_wr"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "analysis_tasks"
+
+
+def _is_sqlite() -> bool:
+    """Detect if the target database is SQLite."""
+    return context.get_context().dialect.name == "sqlite"
+
+
+#: (column_name, 类型键, server_default)。全部 nullable，老行无需回填。
+#: 类型键经 _TYPE_MAP / _PG_TYPES 按方言渲染 —— PostgreSQL 没有 DATETIME 类型，
+#: 直接把 SQLite 的类型名拼进 DDL 会让整个 upgrade 失败。
+NEW_COLUMNS: tuple[tuple[str, str, str | None], ...] = (
+    ("job_kind", "VARCHAR(20)", "analysis"),
+    ("display_name", "VARCHAR(200)", None),
+    ("session_id", "VARCHAR(255)", None),
+    ("owner_token", "VARCHAR(64)", None),
+    ("project_id", "VARCHAR(255)", None),
+    ("run_id", "VARCHAR(64)", None),
+    ("turn_id", "VARCHAR(64)", None),
+    ("tool_call_id", "VARCHAR(128)", None),
+    ("agent_task_id", "VARCHAR(64)", None),
+    ("agent_step_id", "VARCHAR(32)", None),
+    ("idempotency_key", "VARCHAR(128)", None),
+    ("attempt", "INTEGER", "1"),
+    ("worker_id", "VARCHAR(128)", None),
+    ("cancel_requested_at", "DATETIME", None),
+    ("heartbeat_at", "DATETIME", None),
+    ("result_ref", "VARCHAR(512)", None),
+    ("dispatch_spec", "JSON", None),
+)
+
+#: PostgreSQL 的类型名映射（其余键与 SQLite 同名）。
+_PG_TYPES: dict[str, str] = {
+    "DATETIME": "TIMESTAMP",
+    "JSON": "JSON",
+}
+
+
+def _pg_type(type_key: str) -> str:
+    return _PG_TYPES.get(type_key, type_key)
+
+
+_TYPE_MAP: dict[str, sa.types.TypeEngine] = {
+    "VARCHAR(20)": sa.String(length=20),
+    "VARCHAR(32)": sa.String(length=32),
+    "VARCHAR(64)": sa.String(length=64),
+    "VARCHAR(128)": sa.String(length=128),
+    "VARCHAR(200)": sa.String(length=200),
+    "VARCHAR(255)": sa.String(length=255),
+    "VARCHAR(512)": sa.String(length=512),
+    "INTEGER": sa.Integer(),
+    "DATETIME": sa.DateTime(),
+    "JSON": sa.JSON(),
+}
+
+#: 任务中心的查询路径 + stale 清扫路径。
+NEW_INDEXES: tuple[tuple[str, list[str], bool], ...] = (
+    ("idx_task_session_created", ["session_id", "created_at"], False),
+    ("idx_task_creator_created", ["creator_id", "created_at"], False),
+    ("idx_task_status_heartbeat", ["status", "heartbeat_at"], False),
+    ("idx_task_agent_task", ["agent_task_id"], False),
+    ("uq_analysis_tasks_idempotency_key", ["idempotency_key"], True),
+)
+
+OLD_STATUS_CHECK = "status IN ('pending', 'queued', 'running', 'completed', 'failed', 'cancelled')"
+NEW_STATUS_CHECK = (
+    "status IN ('pending', 'queued', 'running', 'cancelling', "
+    "'completed', 'failed', 'cancelled', 'stale')"
+)
+PROGRESS_CHECK = "progress >= 0 AND progress <= 100"
+
+
+def _reflected_table() -> sa.Table:
+    """反射当前 analysis_tasks 结构，供 batch_alter_table 重建使用。"""
+    meta = sa.MetaData()
+    return sa.Table(TABLE, meta, autoload_with=op.get_bind())
+
+
+def upgrade() -> None:
+    if _is_sqlite():
+        with op.batch_alter_table(TABLE, copy_from=_reflected_table(), schema=None) as batch_op:
+            for name, type_key, default in NEW_COLUMNS:
+                batch_op.add_column(
+                    sa.Column(name, _TYPE_MAP[type_key], nullable=True, server_default=default)
+                )
+            batch_op.alter_column("org_id", existing_type=sa.Integer(), nullable=True)
+            # e46935cd5dd1 只在 PostgreSQL 分支执行了 creator_id DROP NOT NULL，
+            # SQLite 分支漏了 —— 模型声明 nullable=True 但本地 SQLite 仍是 NOT NULL。
+            # 匿名会话的 job 没有 creator_id，这里把 SQLite 对齐到模型。
+            batch_op.alter_column("creator_id", existing_type=sa.String(length=255), nullable=True)
+            # SQLite 的 BIGINT 主键不是 rowid 别名（不自增）。durable job 现在是热
+            # 路径，必须能自增插入 —— 重建时把 id 收敛为 INTEGER PRIMARY KEY。
+            # PostgreSQL 分支不需要（BIGSERIAL 已有序列）。
+            batch_op.alter_column(
+                "id",
+                existing_type=sa.BigInteger(),
+                type_=sa.Integer(),
+                existing_nullable=False,
+                autoincrement=True,
+            )
+            # 重建被反射丢弃的 CHECK：status 用新定义，progress 保持原定义
+            batch_op.create_check_constraint("ck_task_status", NEW_STATUS_CHECK)
+            batch_op.create_check_constraint("ck_task_progress", PROGRESS_CHECK)
+        for index_name, columns, unique in NEW_INDEXES:
+            op.create_index(index_name, TABLE, columns, unique=unique)
+        return
+
+    # PostgreSQL
+    for name, type_key, default in NEW_COLUMNS:
+        default_sql = f" DEFAULT '{default}'" if default is not None else ""
+        op.execute(
+            f"ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS {name} "
+            f"{_pg_type(type_key)}{default_sql}"
+        )
+
+    op.execute(f"ALTER TABLE {TABLE} ALTER COLUMN org_id DROP NOT NULL")
+
+    op.execute(f"ALTER TABLE {TABLE} DROP CONSTRAINT IF EXISTS ck_task_status")
+    op.execute(f"ALTER TABLE {TABLE} ADD CONSTRAINT ck_task_status CHECK ({NEW_STATUS_CHECK})")
+
+    for index_name, columns, unique in NEW_INDEXES:
+        cols = ", ".join(columns)
+        kind = "UNIQUE INDEX" if unique else "INDEX"
+        op.execute(f"CREATE {kind} IF NOT EXISTS {index_name} ON {TABLE} ({cols})")
+
+
+def downgrade() -> None:
+    """回滚到 0012。
+
+    cancelling/stale 状态的行归一化为 failed —— 否则旧 ck_task_status 无法重建。
+    org_id 的 NOT NULL 只在确实没有 NULL 行时恢复：期间产生过的匿名 job 不能被删除
+    （规范 §39：迁移不得要求删除现有 task 数据）。
+    """
+    op.execute(f"UPDATE {TABLE} SET status = 'failed' WHERE status IN ('cancelling', 'stale')")
+
+    # 先删依赖新列的索引，再删列
+    for index_name, _columns, _unique in reversed(NEW_INDEXES):
+        if _is_sqlite():
+            op.drop_index(index_name, table_name=TABLE)
+        else:
+            op.execute(f"DROP INDEX IF EXISTS {index_name}")
+
+    if _is_sqlite():
+        with op.batch_alter_table(TABLE, copy_from=_reflected_table(), schema=None) as batch_op:
+            for name, _type_key, _default in reversed(NEW_COLUMNS):
+                batch_op.drop_column(name)
+            batch_op.create_check_constraint("ck_task_status", OLD_STATUS_CHECK)
+            batch_op.create_check_constraint("ck_task_progress", PROGRESS_CHECK)
+        return
+
+    op.execute(f"ALTER TABLE {TABLE} DROP CONSTRAINT IF EXISTS ck_task_status")
+    op.execute(f"ALTER TABLE {TABLE} ADD CONSTRAINT ck_task_status CHECK ({OLD_STATUS_CHECK})")
+
+    for name, _type_key, _default in reversed(NEW_COLUMNS):
+        op.execute(f"ALTER TABLE {TABLE} DROP COLUMN IF EXISTS {name}")
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM analysis_tasks WHERE org_id IS NULL) THEN
+                ALTER TABLE analysis_tasks ALTER COLUMN org_id SET NOT NULL;
+            END IF;
+        END $$;
+        """
+    )

--- a/tests/benchmarks/test_job_runtime_perf.py
+++ b/tests/benchmarks/test_job_runtime_perf.py
@@ -1,0 +1,328 @@
+"""Durable job runtime 的确定性性能基准（ADR-0052，规范 §37）。
+
+这些不是墙钟计时基准 —— 它们断言**行为量**，因此在任何机器上结果一致：
+
+  cancelled_chunked_cpu_work   取消后实际执行的 chunk 数（证明 CPU 真的释放了）
+  progress_write_rate          10 万次上报对应的 DB 写入次数（写入速率有上界）
+  task_summary_query           1000 条 job 的任务中心查询（单查询、有界返回）
+  running_job_poll_payload     轮询响应体大小（前端兜底轮询的带宽成本）
+  job_transition_contention    高并发状态迁移下的胜出者数量（正好 1）
+
+跑：pytest -m perf tests/benchmarks/test_job_runtime_perf.py
+"""
+import asyncio
+import json
+import time
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.db_model import Base
+from app.services.jobs import (
+    DurableJobStore,
+    JobProgress,
+    JobStatus,
+    ProgressThrottle,
+    coerce_status,
+)
+from app.services.jobs.cancellation import (
+    CancellationToken,
+    OperationCancelled,
+    cancellable,
+    use_token,
+)
+from app.services.jobs.views import build_list_response, job_from_record
+
+pytestmark = pytest.mark.perf
+
+
+@pytest_asyncio.fixture
+async def session_factory(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'perf.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(bind=engine, expire_on_commit=False)
+    await engine.dispose()
+
+
+# ── 1. cancelled_chunked_cpu_work ──────────────────────────────────
+
+
+def test_bench_cancelled_chunked_cpu_work():
+    """取消后必须**不再**执行后续 chunk —— 这是「取消不只是 UI 状态」的量化证据。
+
+    before（ADR-0052 之前）：取消只翻内存 bool，工具内部无检查点，
+                              10_000 个 chunk 全部跑完。
+    after ：第 50 个 chunk 后取消 → 实际执行 ≤ 52。
+    """
+    total_chunks = 10_000
+    cancel_after = 50
+    token = CancellationToken("bench")
+    executed = 0
+
+    with use_token(token):
+        with pytest.raises(OperationCancelled):
+            for i in cancellable(range(total_chunks)):
+                executed += 1
+                # 每个 chunk 模拟一点真实计算
+                sum(x * x for x in range(50))
+                if i == cancel_after:
+                    token.cancel("user cancelled")
+
+    assert executed <= cancel_after + 2, executed
+    saved_ratio = 1 - executed / total_chunks
+    assert saved_ratio > 0.99, f"仅省下 {saved_ratio:.2%} 的计算"
+    print(f"\n[bench] cancelled_chunked_cpu_work: executed={executed}/{total_chunks} "
+          f"saved={saved_ratio:.2%}")
+
+
+def test_bench_checkpoint_overhead_is_negligible_without_token():
+    """未绑定 token 时 checkpoint 必须近乎零成本 —— 普通请求路径也会经过这些循环。
+
+    断言的是「相对开销有上界」而不是绝对耗时，避免机器差异导致 flaky。
+    """
+    n = 200_000
+
+    start = time.perf_counter()
+    for _ in range(n):
+        pass
+    baseline = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in cancellable(range(n)):
+        pass
+    instrumented = time.perf_counter() - start
+
+    overhead_per_iter_us = (instrumented - baseline) / n * 1e6
+    assert overhead_per_iter_us < 5.0, f"{overhead_per_iter_us:.3f} µs/iter"
+    print(f"\n[bench] checkpoint overhead: {overhead_per_iter_us:.3f} µs/iter")
+
+
+# ── 2. progress_write_rate ─────────────────────────────────────────
+
+
+def test_bench_progress_write_rate_is_bounded():
+    """规范 §20：10 万次进度上报的 DB 写入次数必须是两位数。
+
+    before：每次迭代一次 update_state / DB 写 → 100_000 次写。
+    after ：1% / 500ms 节流 → ≈101 次。
+    """
+    reports = 100_000
+    now = [0.0]
+    throttle = ProgressThrottle(min_delta_pct=1.0, min_interval_s=0.5, clock=lambda: now[0])
+
+    for i in range(reports):
+        now[0] += 0.0001  # 模拟 10s 总时长
+        throttle.should_emit(i * 100 // reports)
+
+    assert throttle.emitted <= 120, throttle.emitted
+    print(f"\n[bench] progress_write_rate: {throttle.emitted} writes / {reports} reports "
+          f"({throttle.emitted / reports:.4%})")
+
+
+@pytest.mark.asyncio
+async def test_bench_progress_writes_never_touch_terminal_jobs(session_factory):
+    """终态 job 上的进度写入必须 0 命中 —— 否则 stale progress 会复活终态。"""
+    async with session_factory() as db:
+        job = await DurableJobStore.create(db, task_type="bench", owner_id="u", parameters={})
+        await db.commit()
+        await DurableJobStore.mark_queued(db, job.id)
+        await DurableJobStore.mark_running(db, job.id)
+        await DurableJobStore.mark_succeeded(db, job.id, result={})
+        await db.commit()
+
+        hits = 0
+        for i in range(200):
+            if await DurableJobStore.update_progress(db, job.id, JobProgress(progress=i % 100)):
+                hits += 1
+        await db.commit()
+
+    assert hits == 0
+    print("\n[bench] terminal-job progress writes: 0/200 (as required)")
+
+
+# ── 3. task_summary_query ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bench_1000_task_summary_query(session_factory):
+    """1000 条 job 下的任务中心查询：单次查询、返回条数有界。
+
+    重点不是毫秒数，而是「不会随任务总量线性膨胀返回体」。
+    """
+    total = 1000
+    async with session_factory() as db:
+        for i in range(total):
+            await DurableJobStore.create(
+                db,
+                task_type="bench",
+                owner_id="user-a",
+                session_id="sess-a",
+                display_name=f"job {i}",
+                parameters={"i": i},
+            )
+        await db.commit()
+
+    async with session_factory() as db:
+        start = time.perf_counter()
+        rows = await DurableJobStore.list_for_owner(db, owner_id="user-a", limit=50)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+    assert len(rows) == 50, "返回条数必须被 limit 钳住"
+    print(f"\n[bench] 1000_task_summary_query: {elapsed_ms:.1f} ms for 50/{total} rows")
+
+
+@pytest.mark.asyncio
+async def test_bench_list_limit_cannot_be_raised_by_caller(session_factory):
+    """调用方不能通过超大 limit 拉全表 —— MAX_LIST_LIMIT 是硬上界。"""
+    async with session_factory() as db:
+        for i in range(300):
+            await DurableJobStore.create(
+                db, task_type="bench", owner_id="user-a", parameters={"i": i}
+            )
+        await db.commit()
+
+    async with session_factory() as db:
+        rows = await DurableJobStore.list_for_owner(db, owner_id="user-a", limit=100_000)
+    assert len(rows) <= 200
+    print(f"\n[bench] list hard cap: requested 100000, got {len(rows)}")
+
+
+# ── 4. running_job_poll_payload ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bench_running_job_poll_payload_size(session_factory):
+    """轮询响应体必须小 —— 前端每 3s 一次，体积直接决定带宽成本。
+
+    同时验证巨型参数/结果不会被塞进响应（规范 §38）。
+    """
+    async with session_factory() as db:
+        for i in range(20):
+            job = await DurableJobStore.create(
+                db,
+                task_type="ndvi",
+                owner_id="user-a",
+                session_id="sess-a",
+                display_name=f"NDVI 分析 {i}",
+                parameters={
+                    "features": [{"geometry": {"coordinates": [[1, 2]] * 100}}] * 5000,
+                    "token": "secret",
+                },
+            )
+            await db.commit()
+            await DurableJobStore.mark_queued(db, job.id)
+            await DurableJobStore.mark_running(db, job.id)
+            await DurableJobStore.update_progress(
+                db, job.id, JobProgress(progress=42, message="计算中", phase="compute")
+            )
+        await db.commit()
+
+        rows = await DurableJobStore.list_for_owner(db, owner_id="user-a", active_only=True)
+
+    response = build_list_response([job_from_record(r) for r in rows])
+    payload = response.model_dump_json()
+    size = len(payload.encode("utf-8"))
+
+    assert response.has_active is True
+    assert size < 20_000, f"20 个活跃 job 的轮询响应 {size} 字节，过大"
+    assert "secret" not in payload
+    assert "coordinates" not in payload
+    print(f"\n[bench] running_job_poll_payload: {size} bytes for {len(rows)} active jobs "
+          f"({size / max(1, len(rows)):.0f} B/job)")
+
+
+# ── 5. job_transition_contention ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bench_job_transition_contention(session_factory):
+    """N 个并发写入者争抢同一个终态迁移，胜出者必须正好 1 个。
+
+    这是「cancelled → completed」和「重复 finalize」两类缺陷的量化闸门。
+    """
+    writers = 32
+    async with session_factory() as db:
+        job = await DurableJobStore.create(db, task_type="bench", owner_id="u", parameters={})
+        await db.commit()
+        await DurableJobStore.mark_queued(db, job.id)
+        await DurableJobStore.mark_running(db, job.id)
+        await db.commit()
+        job_id = job.id
+
+    ready = asyncio.Event()
+
+    async def contend(index: int) -> bool:
+        async with session_factory() as db:
+            await ready.wait()
+            won = await DurableJobStore.transition(
+                db, job_id, JobStatus.completed, progress=100, result_summary={"w": index}
+            )
+            await db.commit()
+            return won
+
+    tasks = [asyncio.create_task(contend(i)) for i in range(writers)]
+    start = time.perf_counter()
+    ready.set()
+    results = await asyncio.gather(*tasks)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    winners = results.count(True)
+    assert winners == 1, f"{writers} 个并发写入者中有 {winners} 个胜出（应为 1）"
+
+    async with session_factory() as db:
+        fresh = await DurableJobStore.get(db, job_id)
+        assert coerce_status(fresh.status) is JobStatus.completed
+    print(f"\n[bench] job_transition_contention: {winners}/{writers} winner in {elapsed_ms:.1f} ms")
+
+
+@pytest.mark.asyncio
+async def test_bench_cancel_vs_complete_contention(session_factory):
+    """取消与完成对撞：终态必须唯一且确定，绝不留在 cancelling 悬挂态。"""
+    rounds = 16
+    outcomes: dict[str, int] = {}
+
+    for r in range(rounds):
+        async with session_factory() as db:
+            job = await DurableJobStore.create(
+                db, task_type="bench", owner_id="u", parameters={"r": r}
+            )
+            await db.commit()
+            await DurableJobStore.mark_queued(db, job.id)
+            await DurableJobStore.mark_running(db, job.id)
+            await db.commit()
+            job_id = job.id
+
+        ready = asyncio.Event()
+
+        async def do_cancel():
+            async with session_factory() as db:
+                await ready.wait()
+                await DurableJobStore.request_cancel(db, job_id)
+                await db.commit()
+
+        async def do_complete():
+            async with session_factory() as db:
+                await ready.wait()
+                await DurableJobStore.mark_succeeded(db, job_id, result={"ok": True})
+                await db.commit()
+
+        t1 = asyncio.create_task(do_cancel())
+        t2 = asyncio.create_task(do_complete())
+        ready.set()
+        await asyncio.gather(t1, t2, return_exceptions=True)
+
+        async with session_factory() as db:
+            fresh = await DurableJobStore.get(db, job_id)
+            final = coerce_status(fresh.status)
+        outcomes[final.value] = outcomes.get(final.value, 0) + 1
+        assert final in (JobStatus.completed, JobStatus.cancelled, JobStatus.cancelling), final
+
+    # cancelling 是非终态：若对撞后停在这里，说明取消确认路径漏了
+    hung = outcomes.get("cancelling", 0)
+    assert hung == 0, f"{hung}/{rounds} 轮停在 cancelling 悬挂态"
+    print(f"\n[bench] cancel_vs_complete over {rounds} rounds: {json.dumps(outcomes)}")

--- a/tests/jobs/test_job_agent_bridge.py
+++ b/tests/jobs/test_job_agent_bridge.py
@@ -1,0 +1,305 @@
+"""Agent Turn → Tool Step → Durable Job 关联，以及取消贯穿工具管道（ADR-0052）。
+
+覆盖规范 §21（agent 与后台 job 不是两条无关 UI 条目）、§11（取消贯穿到工具实现）、
+Scenario 1（短工具正常完成）、Scenario 2（重工具创建 durable job）、
+Scenario 3（取消真正停止计算）。
+"""
+import asyncio
+
+import pytest
+
+from app.services.chat.tool_pipeline import ToolExecutionPipeline
+from app.services.jobs.cancellation import checkpoint, current_token
+from app.services.jobs.context import JobOrigin, current_origin, use_origin
+from app.services.task_tracker import TaskTracker
+from app.services.tool_dispatch_service import ToolDispatchResult
+
+
+def _tc(name: str, args: str = "{}") -> dict:
+    return {"id": f"call-{name}", "function": {"name": name, "arguments": args}}
+
+
+def _ok(payload=None) -> ToolDispatchResult:
+    return ToolDispatchResult(
+        status="ok",
+        llm_payload="done",
+        slim_event={"ok": True},
+        geojson_ref=None,
+        raw_result=payload or {"ok": True},
+        error_msg=None,
+    )
+
+
+def _pipeline(dispatch_fn, tracker=None) -> ToolExecutionPipeline:
+    class _Registry:
+        pass
+
+    return ToolExecutionPipeline(
+        registry=_Registry(), tracker=tracker or TaskTracker(), dispatch_fn=dispatch_fn
+    )
+
+
+# ── Scenario 1：短工具正常完成 ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_short_tool_completes_normally():
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "帮我算个缓冲区")
+
+    async def dispatch(tc, session_id, sentinels):
+        return _ok({"features": 3})
+
+    pipeline = _pipeline(dispatch, tracker)
+    result = await pipeline.execute_tool_call(_tc("buffer"), "sess-1", task.id)
+
+    assert result.is_error is False
+    assert result.cancelled is False
+    assert result.background_job_ids == []
+    assert len(task.steps) == 1
+    assert task.steps[0].status.value == "completed"
+
+
+# ── 取消 token 贯穿 ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_token_is_bound_during_dispatch():
+    """规范 §11：token 必须一路传到工具实现，而不是只在 step 之间检查。"""
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    seen: list[object] = []
+
+    async def dispatch(tc, session_id, sentinels):
+        seen.append(current_token())
+        return _ok()
+
+    await _pipeline(dispatch, tracker).execute_tool_call(_tc("t"), "sess-1", task.id)
+    assert seen[0] is task.cancel_token
+    assert current_token() is None, "dispatch 结束后必须还原上下文"
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_tool_at_checkpoint():
+    """Scenario 3：取消后工具在 checkpoint 处退出，剩余 chunk 不再执行。"""
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "重计算")
+    executed: list[int] = []
+
+    async def dispatch(tc, session_id, sentinels):
+        # 模拟一个分块 GIS 循环
+        for i in range(100):
+            checkpoint()
+            executed.append(i)
+            if i == 3:
+                tracker.cancel(task.id)
+        return _ok()
+
+    result = await _pipeline(dispatch, tracker).execute_tool_call(_tc("heavy"), "sess-1", task.id)
+
+    assert len(executed) <= 5, f"取消后仍执行了 {len(executed)}/100 个 chunk"
+    assert result.cancelled is True
+    assert result.is_error is True
+    assert result.raw_result["cancelled"] is True
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_not_reported_as_tool_failure_payload():
+    """取消给 LLM 的说明必须是「已取消」而不是一个异常堆栈。"""
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    tracker.cancel(task.id)
+
+    async def dispatch(tc, session_id, sentinels):
+        checkpoint()
+        return _ok()
+
+    result = await _pipeline(dispatch, tracker).execute_tool_call(_tc("t"), "sess-1", task.id)
+    assert result.cancelled is True
+    assert "取消" in result.llm_payload
+    assert "Traceback" not in result.llm_payload
+
+
+@pytest.mark.asyncio
+async def test_ordinary_tool_error_is_not_marked_cancelled():
+    """普通工具异常必须与取消区分开 —— 取消绝不能触发 retry（规范 §17）。"""
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+
+    async def dispatch(tc, session_id, sentinels):
+        raise ValueError("bad crs")
+
+    result = await _pipeline(dispatch, tracker).execute_tool_call(_tc("t"), "sess-1", task.id)
+    assert result.is_error is True
+    assert result.cancelled is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_token_is_shared_across_steps_of_same_task():
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    assert tracker.cancel_token_for(task.id) is task.cancel_token
+    tracker.cancel(task.id)
+    assert task.cancel_token.cancelled is True
+    assert tracker.is_cancelled(task.id) is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_is_idempotent_at_tracker_level():
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    assert tracker.cancel(task.id) is True
+    assert tracker.cancel(task.id) is True  # 幂等：仍返回 True，不重复点燃
+    assert tracker.cancel("task-unknown") is False
+
+
+def test_dropped_task_releases_its_token():
+    """token 必须随 task 一起回收，否则 registry 随进程寿命单调增长。"""
+    from app.services.jobs.cancellation import registry as cancellation_registry
+
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    assert cancellation_registry.get(task.id) is not None
+    tracker._drop_task(task.id)  # noqa: SLF001 —— 泄漏断言需要触发内部回收
+    assert cancellation_registry.get(task.id) is None
+
+
+# ── Scenario 2：agent ↔ durable job 关联 ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_origin_is_bound_with_agent_linkage():
+    """工具执行期间 JobOrigin 必须带齐 session/owner/agent step 关联。"""
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "算 NDVI")
+    step = tracker.start_step(task.id, "analyze_vegetation_index", {})
+    captured: list[JobOrigin] = []
+
+    async def dispatch(tc, session_id, sentinels):
+        captured.append(current_origin())
+        return _ok()
+
+    await _pipeline(dispatch, tracker).execute_tool_call(
+        _tc("analyze_vegetation_index"),
+        "sess-1",
+        task.id,
+        pre_created_step=step,
+        owner_id="user-a",
+        owner_token="tok-a",
+    )
+
+    origin = captured[0]
+    assert origin.session_id == "sess-1"
+    assert origin.owner_id == "user-a"
+    assert origin.owner_token == "tok-a"
+    assert origin.agent_task_id == task.id
+    assert origin.agent_step_id == step.id
+    assert origin.tool_call_id == "call-analyze_vegetation_index"
+    assert origin.tool_name == "analyze_vegetation_index"
+
+
+@pytest.mark.asyncio
+async def test_background_job_ids_flow_to_step_and_result():
+    """规范 §21：工具创建的 durable job 挂到该 tool step，并出现在执行结果里。"""
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "算 NDVI")
+    step = tracker.start_step(task.id, "analyze_vegetation_index", {})
+
+    async def dispatch(tc, session_id, sentinels):
+        # 模拟工具内部提交 durable job（submit_durable_job 会做同样的事）
+        current_origin().record_job(4242)
+        return _ok({"job_id": "4242"})
+
+    result = await _pipeline(dispatch, tracker).execute_tool_call(
+        _tc("analyze_vegetation_index"), "sess-1", task.id, pre_created_step=step
+    )
+
+    assert result.background_job_ids == ["4242"]
+    assert step.background_job_ids == ["4242"]
+    assert task.background_job_ids == ["4242"]
+
+
+@pytest.mark.asyncio
+async def test_background_job_ids_recorded_without_pre_created_step():
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+
+    async def dispatch(tc, session_id, sentinels):
+        current_origin().record_job("7")
+        return _ok()
+
+    result = await _pipeline(dispatch, tracker).execute_tool_call(_tc("t"), "sess-1", task.id)
+    assert result.background_job_ids == ["7"]
+    assert task.steps[0].background_job_ids == ["7"]
+
+
+def test_task_background_job_ids_are_deduped_in_order():
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    s1 = tracker.start_step(task.id, "a", {})
+    s2 = tracker.start_step(task.id, "b", {})
+    s1.background_job_ids = ["1", "2"]
+    s2.background_job_ids = ["2", "3"]
+    assert task.background_job_ids == ["1", "2", "3"]
+
+
+def test_origin_record_job_is_idempotent():
+    origin = JobOrigin()
+    origin.record_job(1)
+    origin.record_job("1")
+    assert origin.created_job_ids == ["1"]
+
+
+def test_origin_child_inherits_owner_but_not_collector():
+    parent = JobOrigin(session_id="s", owner_id="u", agent_task_id="task-1")
+    parent.record_job("9")
+    child = parent.child(tool_name="other")
+    assert child.session_id == "s"
+    assert child.owner_id == "u"
+    assert child.agent_task_id == "task-1"
+    assert child.tool_name == "other"
+    assert child.created_job_ids == []
+
+
+def test_use_origin_restores_previous():
+    assert current_origin() is None
+    outer = JobOrigin(session_id="outer")
+    with use_origin(outer):
+        assert current_origin() is outer
+        with use_origin(JobOrigin(session_id="inner")):
+            assert current_origin().session_id == "inner"
+        assert current_origin() is outer
+    assert current_origin() is None
+
+
+# ── 并行 wave 中的取消隔离 ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_parallel_tools_share_task_token():
+    """同一 turn 的并行工具共享 token：取消一次全部停。"""
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    started = asyncio.Event()
+    executed: dict[str, int] = {"a": 0, "b": 0}
+
+    async def dispatch(tc, session_id, sentinels):
+        name = tc["function"]["name"]
+        for _ in range(100):
+            checkpoint()
+            executed[name] += 1
+            started.set()
+            await asyncio.sleep(0)
+        return _ok()
+
+    pipeline = _pipeline(dispatch, tracker)
+    tasks = [
+        asyncio.create_task(pipeline.execute_tool_call(_tc("a"), "sess-1", task.id)),
+        asyncio.create_task(pipeline.execute_tool_call(_tc("b"), "sess-1", task.id)),
+    ]
+    await started.wait()
+    tracker.cancel(task.id)
+    results = await asyncio.gather(*tasks)
+
+    assert all(r.cancelled for r in results)
+    assert executed["a"] < 100 and executed["b"] < 100

--- a/tests/jobs/test_job_agent_bridge.py
+++ b/tests/jobs/test_job_agent_bridge.py
@@ -9,7 +9,13 @@ import asyncio
 import pytest
 
 from app.services.chat.tool_pipeline import ToolExecutionPipeline
-from app.services.jobs.cancellation import checkpoint, current_token
+from app.services.jobs.cancellation import (
+    CancellationToken,
+    OperationCancelled,
+    checkpoint,
+    current_token,
+    use_token,
+)
 from app.services.jobs.context import JobOrigin, current_origin, use_origin
 from app.services.task_tracker import TaskTracker
 from app.services.tool_dispatch_service import ToolDispatchResult
@@ -303,3 +309,92 @@ async def test_parallel_tools_share_task_token():
 
     assert all(r.cancelled for r in results)
     assert executed["a"] < 100 and executed["b"] < 100
+
+
+# ── 真实 registry 路径的取消（round-3 审计） ────────────────────────
+# 上面的测试都注入了 dispatch_fn，因此绕过了 ToolRegistry 与 ToolDispatchService
+# 的异常兜底。生产路径不是这样：真实工具经 registry → to_thread 执行，两层通用
+# ``except Exception`` 曾把 OperationCancelled 降级成 TOOL_ERROR —— 取消于是被
+# 当成「工具坏了」，管道的取消分支永远不触发。这些测试守住真实路径。
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates_through_real_registry():
+    """同步工具在工作线程里被取消时，取消必须穿透 registry 的异常兜底。"""
+    from app.tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+    executed: list[int] = []
+    token = CancellationToken("job-registry")
+
+    def heavy_tool(chunks: int = 100) -> dict:
+        # 真实同步工具：registry 会用 asyncio.to_thread 执行它
+        for i in range(chunks):
+            checkpoint()
+            executed.append(i)
+            if i == 3:
+                token.cancel("cancelled by user")
+        return {"done": True}
+
+    registry.register(
+        name="heavy_tool",
+        description="test tool",
+        func=heavy_tool,
+        parameters={"type": "object", "properties": {"chunks": {"type": "integer"}}},
+    )
+
+    with use_token(token):
+        with pytest.raises(OperationCancelled):
+            await registry.dispatch("heavy_tool", {"chunks": 100})
+
+    assert len(executed) <= 5, f"取消后仍执行了 {len(executed)}/100 个 chunk"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_marks_registry_cancellation_as_cancelled_not_error():
+    """经真实 ToolDispatchService 时，取消必须被记成「已取消」而非工具故障。"""
+    from app.services.tool_dispatch_service import ToolDispatchService
+    from app.tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+
+    def cancelled_tool() -> dict:
+        checkpoint()
+        return {"unreachable": True}
+
+    registry.register(
+        name="cancelled_tool",
+        description="test tool",
+        func=cancelled_tool,
+        parameters={"type": "object", "properties": {}},
+    )
+
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    tracker.cancel(task.id)  # 取消先到
+
+    pipeline = ToolExecutionPipeline(
+        registry=registry,
+        tracker=tracker,
+        dispatch_service=ToolDispatchService(registry=registry),
+    )
+    result = await pipeline.execute_tool_call(_tc("cancelled_tool"), "sess-1", task.id)
+
+    assert result.cancelled is True, "真实 registry 路径下取消必须被识别"
+    assert "取消" in result.llm_payload
+    assert "OperationCancelled" not in result.llm_payload
+
+
+def test_cancel_cascades_to_derived_durable_jobs():
+    """agent turn 取消必须级联到它派生的 durable job（进程内 token）。"""
+    from app.services.jobs.cancellation import registry as cancellation_registry
+
+    tracker = TaskTracker()
+    task = tracker.create("sess-1", "req")
+    step = tracker.start_step(task.id, "analyze_vegetation_index", {})
+    step.background_job_ids = ["4242"]
+    child = cancellation_registry.register("4242")
+
+    assert child.cancelled is False
+    tracker.cancel(task.id)
+    assert child.cancelled is True, "派生 durable job 的 token 未被级联取消"

--- a/tests/jobs/test_job_api.py
+++ b/tests/jobs/test_job_api.py
@@ -1,0 +1,601 @@
+"""统一任务中心 API 端到端（ADR-0052）。
+
+覆盖规范 §41 的回归场景：API 重启恢复（Scenario 6）、跨租户隔离（Scenario 9）、
+双重取消幂等（Scenario 5）、取消不 retry（Scenario 12）、旧端点兼容、
+以及 durable job 与 agent task 的统一视图。
+
+真实 SQLite + 真实路由 + 真实 auth 依赖，不 mock 掉被测语义。
+"""
+import os
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-job-api-32-chars-okay")
+os.environ.setdefault("ENV", "development")
+
+
+@pytest_asyncio.fixture
+async def app_and_db(tmp_path, monkeypatch):
+    from fastapi import FastAPI
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.api.routes import chat as chat_routes
+    from app.api.routes import jobs as jobs_routes
+    from app.api.routes import task as task_routes
+    from app.core import rate_limiter as rl_mod
+    from app.core.database import get_async_db
+    from app.models.db_model import Base
+    from app.tools import _utils
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'job_api.db'}"
+    engine = create_async_engine(db_url, connect_args={"check_same_thread": False})
+    session_factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async def override_get_async_db():
+        async with session_factory() as s:
+            yield s
+
+    @asynccontextmanager
+    async def override_async_db_session():
+        async with session_factory() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    monkeypatch.setattr(_utils, "async_db_session", override_async_db_session)
+    monkeypatch.setattr("app.api.routes.chat.async_db_session", override_async_db_session)
+
+    class _NoOpLimiter:
+        async def is_allowed(self, key, max_requests, window_seconds):
+            return True
+
+    async def _stub_get_rate_limiter():
+        return _NoOpLimiter()
+
+    monkeypatch.setattr(rl_mod, "get_rate_limiter", _stub_get_rate_limiter)
+
+    app = FastAPI()
+    # 与 main.py 一致：jobs 必须先注册，否则 /tasks/{task_id} 会吃掉 "jobs"
+    app.include_router(jobs_routes.router, prefix="/api/v1")
+    app.include_router(task_routes.router, prefix="/api/v1")
+    app.include_router(chat_routes.router, prefix="/api/v1")
+    app.dependency_overrides[get_async_db] = override_get_async_db
+    try:
+        yield app, session_factory
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(app_and_db):
+    app, _ = app_and_db
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def db(app_and_db):
+    _, factory = app_and_db
+    async with factory() as s:
+        yield s
+
+
+@pytest_asyncio.fixture
+async def tenants(db):
+    """两个租户，各有一个 Conversation。归属链：session_id → Conversation.user_id。"""
+    from app.core.auth import hash_password
+    from app.models.db_model import Conversation, User
+
+    made = {}
+    for name in ("a", "b"):
+        user = User(
+            id=str(uuid.uuid4()),
+            username=f"user_{name}",
+            email=f"{name}@example.com",
+            password_hash=hash_password("pw-12345678"),
+            role="editor",
+            is_active=True,
+        )
+        db.add(user)
+        conv = Conversation(id=f"sess-{name}", user_id=user.id, title=f"会话 {name}")
+        db.add(conv)
+        made[f"user_{name}"] = user
+        made[f"conv_{name}"] = conv
+    await db.commit()
+    return made
+
+
+def _auth(user) -> dict:
+    from app.core.auth import create_access_token
+
+    token = create_access_token({"sub": user.id, "username": user.username, "role": user.role})
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_job(db, *, owner, session_id, status=None, **overrides):
+    from app.services.jobs import DurableJobStore, JobStatus
+
+    params = {
+        "task_type": "ndvi",
+        "display_name": "NDVI 植被指数分析",
+        "owner_id": (owner.id if owner is not None else None),
+        "session_id": session_id,
+        "parameters": {"raster_path": "/data/a.tif", "token": "SECRET"},
+        "dispatch_spec": {
+            "task": "app.services.spatial_tasks.run_ndvi_analysis",
+            "args": ["/data/a.tif"],
+            "kwargs": {},
+        },
+    }
+    params.update(overrides)
+    job = await DurableJobStore.create(db, **params)
+    await db.commit()
+    if status in (JobStatus.queued, JobStatus.running, JobStatus.completed, JobStatus.failed):
+        await DurableJobStore.mark_queued(db, job.id, celery_task_id=f"celery-{job.id}")
+    if status in (JobStatus.running, JobStatus.completed, JobStatus.failed):
+        await DurableJobStore.mark_running(db, job.id)
+    if status is JobStatus.completed:
+        await DurableJobStore.mark_succeeded(db, job.id, result={"mean": 0.4}, result_ref="/data/out.tif")
+    if status is JobStatus.failed:
+        await DurableJobStore.mark_failed(db, job.id, error=ValueError("invalid CRS"))
+    await db.commit()
+    return job
+
+
+# ── 列表 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_returns_owner_scoped_jobs(client, db, tenants):
+    from app.services.jobs import JobStatus
+
+    await _make_job(db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running)
+
+    resp = await client.get(
+        "/api/v1/tasks/jobs?session_id=sess-a", headers=_auth(tenants["user_a"])
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["jobs"]) == 1
+    job = body["jobs"][0]
+    assert job["kind"] == "analysis"
+    assert job["name"] == "NDVI 植被指数分析"
+    assert job["status"] == "running"
+    assert job["cancellable"] is True
+    assert job["active"] is True
+    assert body["has_active"] is True
+    assert body["poll_after_ms"] == 3000
+
+
+@pytest.mark.asyncio
+async def test_no_active_jobs_tells_frontend_to_stop_polling(client, db, tenants):
+    """规范 §32：无活跃 job → 前端 0 轮询。后端必须主动告知。"""
+    from app.services.jobs import JobStatus
+
+    await _make_job(db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.completed)
+    resp = await client.get(
+        "/api/v1/tasks/jobs?session_id=sess-a", headers=_auth(tenants["user_a"])
+    )
+    body = resp.json()
+    assert body["has_active"] is False
+    assert body["poll_after_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_response_never_leaks_secrets_or_traceback(client, db, tenants):
+    """规范 §35 / §10：参数凭据与 traceback 不得出现在响应里。"""
+    from app.services.jobs import JobStatus
+
+    await _make_job(db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.failed)
+    resp = await client.get(
+        "/api/v1/tasks/jobs?session_id=sess-a", headers=_auth(tenants["user_a"])
+    )
+    raw = resp.text
+    assert "SECRET" not in raw
+    assert "Traceback" not in raw
+    job = resp.json()["jobs"][0]
+    assert job["error"] == "ValueError: invalid CRS"
+    # 统一视图不回传原始参数
+    assert "parameters" not in job
+
+
+@pytest.mark.asyncio
+async def test_active_only_filter(client, db, tenants):
+    from app.services.jobs import JobStatus
+
+    await _make_job(db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running)
+    await _make_job(db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.completed)
+
+    resp = await client.get(
+        "/api/v1/tasks/jobs?session_id=sess-a&active_only=true", headers=_auth(tenants["user_a"])
+    )
+    jobs = resp.json()["jobs"]
+    assert len(jobs) == 1
+    assert jobs[0]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_list_requires_proven_session_ownership(client, db, tenants):
+    """Scenario 9：拿别人的 session_id 查列表必须 404，不能返回对方任务。"""
+    from app.services.jobs import JobStatus
+
+    await _make_job(db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running)
+    resp = await client.get(
+        "/api/v1/tasks/jobs?session_id=sess-a", headers=_auth(tenants["user_b"])
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_without_session_scopes_to_authenticated_user(client, db, tenants):
+    """不带 session_id 时按 creator_id 收敛，绝不返回别人的 job。"""
+    from app.services.jobs import JobStatus
+
+    await _make_job(db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running)
+    await _make_job(db, owner=tenants["user_b"], session_id="sess-b", status=JobStatus.running)
+
+    resp = await client.get("/api/v1/tasks/jobs", headers=_auth(tenants["user_a"]))
+    assert resp.status_code == 200
+    jobs = resp.json()["jobs"]
+    assert len(jobs) == 1
+    assert jobs[0]["session_id"] == "sess-a"
+
+
+# ── 单条读取 ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_job_by_owner(client, db, tenants):
+    from app.services.jobs import JobStatus
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.completed
+    )
+    resp = await client.get(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"]))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(job.id)
+    assert body["status"] == "completed"
+    assert body["result_ref"] == "/data/out.tif"
+    assert body["progress"] == 100
+
+
+@pytest.mark.asyncio
+async def test_get_job_cross_tenant_is_404(client, db, tenants):
+    from app.services.jobs import JobStatus
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running
+    )
+    resp = await client.get(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_b"]))
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent_job_is_404(client, tenants):
+    resp = await client.get("/api/v1/tasks/jobs/999999", headers=_auth(tenants["user_a"]))
+    assert resp.status_code == 404
+    resp = await client.get("/api/v1/tasks/jobs/not-a-number", headers=_auth(tenants["user_a"]))
+    assert resp.status_code == 404
+
+
+# ── 取消 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_running_job_reports_cancelling(client, db, tenants):
+    """规范 §30：后端未终态时状态必须是 cancelling，而不是直接 cancelled。"""
+    from app.services.jobs import JobStatus
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running
+    )
+    resp = await client.delete(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"]))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "cancelling"
+    assert body["cancel_requested"] is True
+    assert body["cancelling"] is True
+
+
+@pytest.mark.asyncio
+async def test_double_cancel_is_idempotent(client, db, tenants):
+    """Scenario 5：重复取消 200 且不报错，cancel_requested 转为 False。"""
+    from app.services.jobs import JobStatus
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running
+    )
+    first = await client.delete(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"]))
+    second = await client.delete(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"]))
+    assert first.status_code == second.status_code == 200
+    assert first.json()["cancel_requested"] is True
+    assert second.json()["cancel_requested"] is False
+    assert second.json()["status"] == "cancelling"
+
+
+@pytest.mark.asyncio
+async def test_cancel_persists_durable_fact(client, db, tenants):
+    """取消必须落库 —— 这是 worker 在另一个进程也能观察到取消的前提。"""
+    from app.services.jobs import DurableJobStore, JobStatus
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running
+    )
+    await client.delete(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"]))
+
+    async with db.begin_nested():
+        pass
+    fresh = await DurableJobStore.get(db, job.id)
+    await db.refresh(fresh)
+    assert fresh.cancel_requested_at is not None
+
+
+@pytest.mark.asyncio
+async def test_cancel_cross_tenant_is_404_and_does_not_cancel(client, db, tenants):
+    """Scenario 9：user B 不能取消 user A 的任务。"""
+    from app.services.jobs import DurableJobStore, coerce_status
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=None
+    )
+    from app.services.jobs import JobStatus
+
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+
+    resp = await client.delete(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_b"]))
+    assert resp.status_code == 404
+
+    fresh = await DurableJobStore.get(db, job.id)
+    await db.refresh(fresh)
+    assert coerce_status(fresh.status) is JobStatus.running
+    assert fresh.cancel_requested_at is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_completed_job_is_noop(client, db, tenants):
+    from app.services.jobs import JobStatus
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.completed
+    )
+    resp = await client.delete(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"]))
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "completed"
+    assert resp.json()["cancel_requested"] is False
+
+
+# ── 重试 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_job_reenqueues_and_creates_new_attempt(
+    client, db, tenants, monkeypatch
+):
+    """retry 必须**真的**把任务重新交给 worker。
+
+    只把状态改成 queued 而不入队会留下一个永不推进的 job —— 比不提供 retry 更糟。
+    这里断言 send_task 被调用，且带上了同一个 job_id（新 attempt 复用同一逻辑 job）。
+    """
+    from app.services.jobs import JobStatus
+
+    sent: list[dict] = []
+
+    class _Result:
+        id = "celery-retry-1"
+
+    def fake_send_task(name, args=None, kwargs=None, **_):
+        sent.append({"name": name, "args": args, "kwargs": kwargs})
+        return _Result()
+
+    monkeypatch.setattr("app.api.routes.jobs.celery_app.send_task", fake_send_task)
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.failed
+    )
+    resp = await client.post(
+        f"/api/v1/tasks/jobs/{job.id}/retry", headers=_auth(tenants["user_a"])
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["retried"] is True
+    assert body["status"] == "queued"
+    assert body["attempt"] == 2
+
+    assert len(sent) == 1, "retry 必须真的重新入队"
+    assert sent[0]["name"] == "app.services.spatial_tasks.run_ndvi_analysis"
+    assert sent[0]["kwargs"]["job_id"] == int(job.id)
+
+    from app.services.jobs import DurableJobStore
+
+    fresh = await DurableJobStore.get(db, job.id)
+    await db.refresh(fresh)
+    assert fresh.celery_task_id == "celery-retry-1", "新 attempt 的 celery id 必须回填"
+
+
+@pytest.mark.asyncio
+async def test_retry_without_dispatch_spec_is_refused(client, db, tenants):
+    """无法忠实重跑时明确拒绝，而不是把 job 改成 queued 后永远挂着。"""
+    from app.services.jobs import JobStatus
+
+    job = await _make_job(
+        db,
+        owner=tenants["user_a"],
+        session_id="sess-a",
+        status=JobStatus.failed,
+        dispatch_spec=None,
+    )
+    resp = await client.post(
+        f"/api/v1/tasks/jobs/{job.id}/retry", headers=_auth(tenants["user_a"])
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["retried"] is False
+    assert body["reason"] == "no_dispatch_spec"
+    assert body["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_job_retry_is_refused(client, db, tenants):
+    """Scenario 12 / 规范 §17：取消绝不能被 retry。"""
+    from app.services.jobs import JobStatus
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running
+    )
+    await client.delete(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"]))
+
+    from app.services.jobs import DurableJobStore
+
+    await DurableJobStore.confirm_cancelled(db, job.id)
+    await db.commit()
+
+    resp = await client.post(
+        f"/api/v1/tasks/jobs/{job.id}/retry", headers=_auth(tenants["user_a"])
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["retried"] is False
+    assert body["reason"] == "cancelled_jobs_are_never_retried"
+    assert body["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_retry_cross_tenant_is_404(client, db, tenants):
+    from app.services.jobs import JobStatus
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.failed
+    )
+    resp = await client.post(
+        f"/api/v1/tasks/jobs/{job.id}/retry", headers=_auth(tenants["user_b"])
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_agent_task_retry_is_rejected(client, tenants):
+    resp = await client.post(
+        "/api/v1/tasks/jobs/task-abc12345/retry", headers=_auth(tenants["user_a"])
+    )
+    assert resp.status_code in (400, 404)
+
+
+# ── Scenario 6：API 重启恢复 ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_job_survives_api_restart(client, db, tenants):
+    """Scenario 6 / 规范 §26：清空全部进程内状态后，合法 owner 仍能查询与取消。
+
+    这里显式清空 CancellationRegistry 与 TaskQueueService._task_owners —— 它们是
+    ADR-0052 之前唯一的「事实源」。现在事实在 DB，所以清空后语义不变。
+    """
+    from app.services.jobs import JobStatus, registry as cancellation_registry
+    from app.services.task_queue import TaskQueueService
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running
+    )
+
+    # 模拟 API 重启：进程内状态全部丢失
+    cancellation_registry.clear()
+    TaskQueueService._task_owners.clear()
+
+    got = await client.get(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"]))
+    assert got.status_code == 200, "重启后合法 owner 必须仍能查询自己的任务"
+    assert got.json()["status"] == "running"
+
+    cancelled = await client.delete(
+        f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_a"])
+    )
+    assert cancelled.status_code == 200, "重启后合法 owner 必须仍能取消自己的任务"
+    assert cancelled.json()["cancel_requested"] is True
+
+    # 其他用户仍然 404
+    other = await client.get(f"/api/v1/tasks/jobs/{job.id}", headers=_auth(tenants["user_b"]))
+    assert other.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_celery_status_endpoint_survives_api_restart(client, db, tenants):
+    """旧 `/tasks/status/{celery_task_id}` 端点也必须扛住重启。
+
+    ADR-0052 之前它唯一的归属事实源是进程内 dict —— 重启后合法用户也 404。
+    """
+    from app.services.jobs import JobStatus
+    from app.services.task_queue import TaskQueueService
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running
+    )
+    celery_id = f"celery-{job.id}"
+
+    TaskQueueService._task_owners.clear()  # 模拟重启
+
+    resp = await client.get(
+        f"/api/v1/tasks/status/{celery_id}", headers=_auth(tenants["user_a"])
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # durable 行补充的字段：即使 Celery result backend 不可用也能读到进度
+    assert body["job_id"] == str(job.id)
+    assert body["durable_status"] == "running"
+
+    denied = await client.get(
+        f"/api/v1/tasks/status/{celery_id}", headers=_auth(tenants["user_b"])
+    )
+    assert denied.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_celery_revoke_requests_durable_cancel(client, db, tenants):
+    """旧 revoke 端点现在也走「先协作取消、后 revoke」。"""
+    from app.services.jobs import DurableJobStore, JobStatus, coerce_status
+
+    job = await _make_job(
+        db, owner=tenants["user_a"], session_id="sess-a", status=JobStatus.running
+    )
+    celery_id = f"celery-{job.id}"
+
+    resp = await client.delete(
+        f"/api/v1/tasks/status/{celery_id}", headers=_auth(tenants["user_a"])
+    )
+    assert resp.status_code == 200
+
+    fresh = await DurableJobStore.get(db, job.id)
+    await db.refresh(fresh)
+    assert coerce_status(fresh.status) is JobStatus.cancelling
+    assert fresh.cancel_requested_at is not None
+
+
+# ── 旧端点兼容（expand-contract） ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_legacy_task_list_endpoint_still_requires_session_id(client, tenants):
+    """审计 S33 的契约不能被本次改动放宽。"""
+    resp = await client.get("/api/v1/tasks", headers=_auth(tenants["user_a"]))
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_legacy_and_unified_routes_coexist(client, db, tenants):
+    """`/tasks/jobs` 不能被 `/tasks/{task_id}` 吃掉（路由注册顺序）。"""
+    resp = await client.get(
+        "/api/v1/tasks/jobs?session_id=sess-a", headers=_auth(tenants["user_a"])
+    )
+    assert resp.status_code == 200
+    assert "jobs" in resp.json()

--- a/tests/jobs/test_job_cancellation.py
+++ b/tests/jobs/test_job_cancellation.py
@@ -1,0 +1,300 @@
+"""取消传播原语（ADR-0052）。
+
+重点验证「取消不只是 UI 状态」：token 在线程间可见、经 contextvar 穿进同步代码、
+长循环在 checkpoint 处**提前**退出（跑掉的 chunk 数远小于总数）。
+"""
+import asyncio
+import threading
+import time
+
+import pytest
+
+from app.services.jobs.cancellation import (
+    CancellationRegistry,
+    CancellationToken,
+    OperationCancelled,
+    cancellable,
+    checkpoint,
+    current_token,
+    is_cancelled,
+    use_token,
+)
+
+
+# ── token 基本语义 ──────────────────────────────────────────────────
+
+
+def test_cancel_is_idempotent():
+    """重复取消返回 False 且不重复触发回调（规范 §5：double cancel 幂等）。"""
+    token = CancellationToken("job-1")
+    fired: list[str] = []
+    token.add_callback(lambda t: fired.append(t.reason or ""))
+
+    assert token.cancel("first") is True
+    assert token.cancel("second") is False
+    assert token.cancelled is True
+    assert token.reason == "first"  # 首个原因胜出，不被后续覆盖
+    assert fired == ["first"]
+
+
+def test_raise_if_cancelled():
+    token = CancellationToken("job-2")
+    token.raise_if_cancelled()  # 未取消时是 no-op
+    token.cancel("stop")
+    with pytest.raises(OperationCancelled) as exc:
+        token.raise_if_cancelled()
+    assert exc.value.job_id == "job-2"
+
+
+def test_add_callback_after_cancel_fires_immediately():
+    token = CancellationToken()
+    token.cancel()
+    fired: list[bool] = []
+    token.add_callback(lambda _t: fired.append(True))
+    assert fired == [True]
+
+
+def test_callback_exception_does_not_break_cancel():
+    """一个坏回调不能让取消半途而废 —— 否则取消会变得不可靠。"""
+    token = CancellationToken()
+    fired: list[str] = []
+
+    def bad(_t):
+        raise RuntimeError("boom")
+
+    token.add_callback(bad)
+    token.add_callback(lambda _t: fired.append("ok"))
+    assert token.cancel() is True
+    assert token.cancelled is True
+    assert fired == ["ok"]
+
+
+def test_link_cascades_to_child():
+    """agent task 取消要级联到它派生的 durable job。"""
+    parent = CancellationToken("agent")
+    child = CancellationToken("job")
+    parent.link(child)
+    assert child.cancelled is False
+    parent.cancel("user cancelled")
+    assert child.cancelled is True
+    assert "user cancelled" in (child.reason or "")
+
+
+def test_token_is_visible_across_threads():
+    """token 用 threading.Event 承载 —— 工作线程里的 GIS 代码必须能看到取消。"""
+    token = CancellationToken()
+    observed = threading.Event()
+
+    def worker():
+        for _ in range(2000):
+            if token.cancelled:
+                observed.set()
+                return
+            time.sleep(0.001)
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    token.cancel()
+    assert observed.wait(timeout=5.0) is True
+    t.join(timeout=5.0)
+
+
+# ── asyncio 抢占 ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wait_returns_immediately_when_already_cancelled():
+    token = CancellationToken()
+    token.cancel()
+    await asyncio.wait_for(token.wait(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_wakes_up_on_cancel():
+    """执行引擎靠这个把取消变成抢占：无需等在飞工具自然结束。"""
+    token = CancellationToken()
+    waiter = asyncio.create_task(token.wait())
+    await asyncio.sleep(0)
+    assert not waiter.done()
+    token.cancel()
+    await asyncio.wait_for(waiter, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_wakes_up_when_cancelled_from_another_thread():
+    """真实场景：cancel 来自 API 请求线程，等待者在事件循环里。"""
+    token = CancellationToken()
+    waiter = asyncio.create_task(token.wait())
+    await asyncio.sleep(0)
+    threading.Thread(target=token.cancel, daemon=True).start()
+    await asyncio.wait_for(waiter, timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_waiters_are_cleaned_up_after_wait():
+    """等待者用完必须摘掉，否则每个工具 wave 泄漏一个 asyncio.Event。"""
+    token = CancellationToken()
+    task = asyncio.create_task(token.wait())
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    assert token._waiters == []  # noqa: SLF001 —— 泄漏断言必须看内部状态
+
+
+# ── contextvar 传播 + checkpoint ────────────────────────────────────
+
+
+def test_checkpoint_is_noop_without_token():
+    """没有 token 时 checkpoint 必须零副作用 —— 普通请求路径也会经过这些循环。"""
+    assert current_token() is None
+    assert is_cancelled() is False
+    checkpoint()
+
+
+def test_use_token_binds_and_restores():
+    token = CancellationToken()
+    assert current_token() is None
+    with use_token(token):
+        assert current_token() is token
+    assert current_token() is None
+
+
+def test_checkpoint_raises_inside_bound_context():
+    token = CancellationToken("job-9")
+    with use_token(token):
+        checkpoint()
+        token.cancel("stop")
+        assert is_cancelled() is True
+        with pytest.raises(OperationCancelled):
+            checkpoint()
+
+
+@pytest.mark.asyncio
+async def test_token_propagates_into_to_thread():
+    """关键机制：asyncio.to_thread 复制 context，所以同步 GIS 工具无需改签名。
+
+    registry 的同步工具执行路径正是 to_thread —— 这条断言保证取消能到达那里。
+    """
+    token = CancellationToken()
+    token.cancel("stop")
+
+    def sync_gis_work():
+        checkpoint()  # 应当在工作线程里抛出
+        return "should not reach"
+
+    with use_token(token):
+        with pytest.raises(OperationCancelled):
+            await asyncio.to_thread(sync_gis_work)
+
+
+@pytest.mark.asyncio
+async def test_sibling_asyncio_tasks_have_independent_tokens():
+    """并行工具 wave 里，取消一个工具不应影响另一个（context 是每 task 复制的）。"""
+    token_a = CancellationToken("a")
+    token_b = CancellationToken("b")
+    results: dict[str, str] = {}
+
+    async def run(name: str, token: CancellationToken):
+        with use_token(token):
+            await asyncio.sleep(0.01)
+            try:
+                checkpoint()
+                results[name] = "ok"
+            except OperationCancelled:
+                results[name] = "cancelled"
+
+    token_a.cancel()
+    await asyncio.gather(run("a", token_a), run("b", token_b))
+    assert results == {"a": "cancelled", "b": "ok"}
+
+
+# ── 取消延迟：真正停止计算而不是跑完 ────────────────────────────────
+
+
+def test_cancellable_loop_stops_early():
+    """规范 §13：100 个 chunk，第 5 个后取消 → 实际执行应 ≤ 7 而不是 100。"""
+    token = CancellationToken()
+    executed: list[int] = []
+
+    with use_token(token):
+        with pytest.raises(OperationCancelled):
+            for i in cancellable(range(100)):
+                executed.append(i)
+                if i == 5:
+                    token.cancel("user cancelled")
+
+    assert len(executed) <= 7, f"取消后仍执行了 {len(executed)} 个 chunk"
+    assert len(executed) >= 6  # 第 5 个必须已完成，取消不应回滚已完成工作
+
+
+def test_cancellable_every_n_bounds_overshoot():
+    """every=N 时超跑量必须 ≤ N —— 检查点稀疏化不能让取消失控。"""
+    token = CancellationToken()
+    executed: list[int] = []
+    every = 10
+
+    with use_token(token):
+        with pytest.raises(OperationCancelled):
+            for i in cancellable(range(1000), every=every):
+                executed.append(i)
+                if i == 15:
+                    token.cancel()
+
+    assert len(executed) <= 16 + every
+
+
+def test_cancellable_completes_normally_without_cancel():
+    token = CancellationToken()
+    with use_token(token):
+        assert list(cancellable(range(50))) == list(range(50))
+
+
+def test_cancellable_normalizes_bad_every():
+    token = CancellationToken()
+    with use_token(token):
+        assert list(cancellable(range(5), every=0)) == list(range(5))
+
+
+# ── registry ────────────────────────────────────────────────────────
+
+
+def test_registry_register_is_idempotent():
+    reg = CancellationRegistry()
+    first = reg.register("job-1")
+    second = reg.register("job-1")
+    assert first is second
+
+
+def test_registry_cancel_unknown_key_returns_false():
+    """API 重启后 registry 为空 —— 取消不能因此报错（持久事实在 DB）。"""
+    reg = CancellationRegistry()
+    assert reg.cancel("never-seen") is False
+    assert reg.is_cancelled("never-seen") is False
+
+
+def test_registry_cancel_and_discard():
+    reg = CancellationRegistry()
+    token = reg.register("job-2")
+    assert reg.cancel("job-2") is True
+    assert token.cancelled is True
+    assert reg.is_cancelled("job-2") is True
+    reg.discard("job-2")
+    assert reg.get("job-2") is None
+
+
+def test_registry_is_lru_bounded():
+    """长寿命 API 进程不能让 registry 无限增长。"""
+    reg = CancellationRegistry(max_entries=8)
+    for i in range(40):
+        reg.register(f"job-{i}")
+    assert len(reg) == 8
+    assert reg.get("job-0") is None      # 最旧的被淘汰
+    assert reg.get("job-39") is not None  # 最新的仍在
+
+
+def test_registry_accepts_int_keys():
+    """durable job id 是整数 —— registry 必须按字符串统一。"""
+    reg = CancellationRegistry()
+    token = reg.register(42)
+    assert reg.get("42") is token
+    assert reg.cancel(42) is True

--- a/tests/jobs/test_job_celery_e2e.py
+++ b/tests/jobs/test_job_celery_e2e.py
@@ -1,0 +1,421 @@
+"""真实 Celery 任务 + submit 桥的端到端测试（ADR-0052）。
+
+审计发现：`durable_job` 句柄和状态机测得很扎实，但**真正的 Celery 任务体**
+（`run_ndvi_analysis`）和**提交桥**（`submit_durable_job`）此前零覆盖 —— 而集成层
+恰恰是取消、心跳、幂等、重复投递等语义真正生效的地方。
+
+诚实说明测试真实性（规范 §47）：
+  * 这些测试是 **worker simulation**：Celery 以 eager 模式（`USE_REDIS=false`）在
+    当前进程内同步执行任务体，不存在真实的 broker、独立 worker 进程或 prefork 池。
+  * 真实的是：任务体全部代码路径、durable job 状态机、DB 读写、看门狗线程、
+    取消传播、原子产物落盘。
+  * 不真实的是：跨进程投递、broker 重投、revoke/terminate、prefork 隔离。
+    需要本地 Redis + `celery worker` 才能覆盖那些（环境缺少 Redis 时无法执行）。
+"""
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.db_model import Base
+from app.services.jobs import (
+    DurableJobStore,
+    JobKind,
+    JobStatus,
+    coerce_status,
+)
+from app.services.jobs.context import JobOrigin, use_origin
+from app.services.jobs.submit import build_execution_key, submit_durable_job
+
+
+@pytest.fixture
+def job_db(tmp_path, monkeypatch):
+    """把 `db_session`（工具/worker 用的同步会话）指向临时 SQLite。"""
+    engine = create_engine(f"sqlite:///{tmp_path / 'e2e.db'}")
+    Base.metadata.create_all(engine)
+    Sess = sessionmaker(bind=engine)
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def fake_db_session():
+        db = Sess()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    # submit / worker / spatial_tasks 各自 import 了同一个名字，全部替换
+    monkeypatch.setattr("app.tools._utils.db_session", fake_db_session)
+    monkeypatch.setattr("app.services.jobs.submit.db_session", fake_db_session)
+    monkeypatch.setattr("app.services.spatial_tasks.db_session", fake_db_session)
+    monkeypatch.setattr(
+        "app.services.jobs.worker._default_session_factory", fake_db_session
+    )
+    yield {"factory": fake_db_session, "Sess": Sess}
+    engine.dispose()
+
+
+# ── submit 桥 ───────────────────────────────────────────────────────
+
+
+def test_submit_creates_durable_job_and_enqueues(job_db):
+    """Scenario 2：agent 重工具创建 durable job 并入队。"""
+    calls: list[dict] = []
+
+    class _FakeTask:
+        name = "tests.fake_task"
+
+        def apply_async(self, args=None, kwargs=None, **_):
+            calls.append({"args": args, "kwargs": kwargs})
+
+            class _R:
+                id = "celery-abc"
+
+            return _R()
+
+    origin = JobOrigin(
+        session_id="sess-a",
+        owner_id="user-a",
+        agent_task_id="task-1234",
+        agent_step_id="step-1",
+        tool_call_id="call-1",
+    )
+    with use_origin(origin):
+        result = submit_durable_job(
+            celery_task=_FakeTask(),
+            task_type="ndvi",
+            display_name="NDVI 分析",
+            params={"raster_path": "/data/a.tif"},
+            task_args=("/data/a.tif",),
+            session_id="sess-a",
+        )
+
+    assert result["status"] == "analysis_task_started"
+    assert result["task_id"] == "celery-abc"
+    job_id = int(result["job_id"])
+
+    # job_id 回流给 agent step（Turn → Step → Job 链）
+    assert origin.created_job_ids == [str(job_id)]
+
+    # Celery 收到了 job_id
+    assert calls[0]["kwargs"]["job_id"] == job_id
+
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_id)
+        assert coerce_status(job.status) is JobStatus.queued
+        assert job.celery_task_id == "celery-abc"
+        assert job.session_id == "sess-a"
+        assert job.creator_id == "user-a"
+        assert job.agent_task_id == "task-1234"
+        assert job.agent_step_id == "step-1"
+        assert job.dispatch_spec["task"] == "tests.fake_task"
+
+
+def test_submit_is_idempotent_for_duplicate_requests(job_db):
+    """规范 §16 / Scenario 5 前置：双击 / SSE 重连不得提交两次。"""
+    enqueued: list[str] = []
+
+    class _FakeTask:
+        name = "tests.fake_task"
+
+        def apply_async(self, args=None, kwargs=None, **_):
+            enqueued.append("sent")
+
+            class _R:
+                id = f"celery-{len(enqueued)}"
+
+            return _R()
+
+    def submit():
+        return submit_durable_job(
+            celery_task=_FakeTask(),
+            task_type="ndvi",
+            display_name="NDVI 分析",
+            params={"raster_path": "/data/a.tif"},
+            task_args=("/data/a.tif",),
+            session_id="sess-a",
+        )
+
+    first = submit()
+    second = submit()
+
+    assert first["job_id"] == second["job_id"], "同一逻辑提交必须复用同一个 job"
+    assert second["idempotent_reuse"] is True
+    assert len(enqueued) == 1, "不得重复入队（会重复执行不可逆的 GIS 操作）"
+
+
+def test_submit_marks_job_failed_when_enqueue_raises(job_db):
+    """broker 挂了：job 不能永远停在 pending（stale 清扫不覆盖 pending）。"""
+
+    class _BrokenTask:
+        name = "tests.broken"
+
+        def apply_async(self, args=None, kwargs=None, **_):
+            raise RuntimeError("broker unreachable")
+
+    with pytest.raises(RuntimeError):
+        submit_durable_job(
+            celery_task=_BrokenTask(),
+            task_type="ndvi",
+            display_name="NDVI 分析",
+            params={"raster_path": "/data/a.tif"},
+            session_id="sess-a",
+        )
+
+    with job_db["Sess"]() as db:
+        from app.models.db_model import AnalysisTask
+
+        jobs = db.query(AnalysisTask).all()
+        assert len(jobs) == 1
+        assert coerce_status(jobs[0].status) is JobStatus.failed
+
+
+def test_execution_key_is_stable_and_discriminating():
+    a = build_execution_key("ndvi", "sess-a", {"path": "/x.tif", "band": 4})
+    b = build_execution_key("ndvi", "sess-a", {"band": 4, "path": "/x.tif"})
+    assert a == b, "dict 顺序不应改变幂等键"
+
+    assert a != build_execution_key("ndvi", "sess-b", {"path": "/x.tif", "band": 4})
+    assert a != build_execution_key("ndvi", "sess-a", {"path": "/y.tif", "band": 4})
+    assert a != build_execution_key("ndwi", "sess-a", {"path": "/x.tif", "band": 4})
+
+
+# ── 真实 Celery 任务体（eager 模式，worker simulation） ──────────────
+
+
+def _make_ndvi_job(job_db, **overrides) -> int:
+    params = {
+        "task_type": "ndvi",
+        "kind": JobKind.analysis,
+        "owner_id": "user-a",
+        "session_id": "sess-a",
+        "parameters": {"raster_path": "/data/a.tif"},
+    }
+    params.update(overrides)
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.create_sync(db, **params)
+        DurableJobStore.transition_sync(
+            db, job.id, JobStatus.queued, expected=[JobStatus.pending]
+        )
+        db.commit()
+        return int(job.id)
+
+
+def test_ndvi_task_completes_and_records_progress(job_db, monkeypatch, tmp_path):
+    """任务体走通 durable job：running → 进度 → completed + result_ref。"""
+    from app.services import spatial_tasks
+
+    out = tmp_path / "NDVI_out.tif"
+    out.write_bytes(b"GEOTIFF")
+
+    monkeypatch.setattr(
+        spatial_tasks.NatureResourceAnalyzer,
+        "calculate_ndvi",
+        staticmethod(
+            lambda **kw: {
+                "success": True,
+                "result_path": str(out),
+                "filename": "NDVI_out.tif",
+                "stats": {"mean": 0.42},
+                "bbox": [0, 0, 1, 1],
+                "crs": "EPSG:4326",
+            }
+        ),
+    )
+
+    job_id = _make_ndvi_job(job_db)
+    result = spatial_tasks.run_ndvi_analysis(
+        "/data/a.tif", None, None, "sess-a", job_id=job_id
+    )
+
+    assert result["success"] is True
+    assert result["job_id"] == str(job_id)
+    assert result["data"]["result_path"] == str(out)
+
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_id)
+        assert coerce_status(job.status) is JobStatus.completed
+        assert job.progress == 100
+        assert job.result_ref == str(out)
+        assert job.worker_id, "worker_id 必须落库供 stale 归因"
+        # 结果摘要只留统计量，不含巨型数据
+        assert job.result_summary["stats"]["mean"] == 0.42
+
+
+def test_ndvi_task_cancelled_before_execution_does_no_work(job_db, monkeypatch):
+    """取消在 worker 拿到任务之前到达 → 计算一次都不跑，也不注册资产。"""
+    from app.services import spatial_tasks
+
+    called: list[int] = []
+
+    def _should_not_run(**kw):
+        called.append(1)
+        return {"success": True}
+
+    monkeypatch.setattr(
+        spatial_tasks.NatureResourceAnalyzer, "calculate_ndvi", staticmethod(_should_not_run)
+    )
+
+    job_id = _make_ndvi_job(job_db)
+    with job_db["Sess"]() as db:
+        DurableJobStore.request_cancel_sync(db, job_id)
+        db.commit()
+
+    result = spatial_tasks.run_ndvi_analysis(
+        "/data/a.tif", None, None, "sess-a", job_id=job_id
+    )
+
+    assert called == [], "已取消的 job 不得执行任务体"
+    assert result["skipped"] is True
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_id)
+        assert coerce_status(job.status) is JobStatus.cancelled
+
+
+def test_ndvi_task_cancelled_mid_compute_discards_asset(job_db, monkeypatch, tmp_path):
+    """取消在计算期间到达：不注册资产，终态为 cancelled（规范 §14/§23）。"""
+    from app.services import spatial_tasks
+
+    out = tmp_path / "NDVI_mid.tif"
+
+    def _compute_then_cancel(**kw):
+        # 计算过程中用户点了取消（持久事实写进 DB）
+        with job_db["factory"]() as db:
+            DurableJobStore.request_cancel_sync(db, job_holder["id"])
+            db.commit()
+        out.write_bytes(b"GEOTIFF")
+        return {
+            "success": True,
+            "result_path": str(out),
+            "filename": "NDVI_mid.tif",
+            "stats": {"mean": 0.1},
+            "bbox": [0, 0, 1, 1],
+            "crs": "EPSG:4326",
+        }
+
+    monkeypatch.setattr(
+        spatial_tasks.NatureResourceAnalyzer,
+        "calculate_ndvi",
+        staticmethod(_compute_then_cancel),
+    )
+
+    job_holder = {"id": _make_ndvi_job(job_db)}
+    result = spatial_tasks.run_ndvi_analysis(
+        "/data/a.tif", None, None, "sess-a", job_id=job_holder["id"]
+    )
+
+    assert result.get("cancelled") is True
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_holder["id"])
+        assert coerce_status(job.status) is JobStatus.cancelled
+        assert job.result_summary is None, "已取消的 job 不得保留结果"
+
+        from app.models.upload import UploadRecord
+
+        assert db.query(UploadRecord).count() == 0, "已取消的 job 不得注册资产"
+
+
+def test_ndvi_task_failure_is_recorded_without_traceback(job_db, monkeypatch):
+    from app.services import spatial_tasks
+
+    monkeypatch.setattr(
+        spatial_tasks.NatureResourceAnalyzer,
+        "calculate_ndvi",
+        staticmethod(lambda **kw: {"success": False, "error": "无法确定波段索引"}),
+    )
+
+    job_id = _make_ndvi_job(job_db)
+    result = spatial_tasks.run_ndvi_analysis(
+        "/data/a.tif", None, None, "sess-a", job_id=job_id
+    )
+
+    assert result["success"] is False
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_id)
+        assert coerce_status(job.status) is JobStatus.failed
+        assert "波段索引" in job.error_trace
+        assert "Traceback" not in job.error_trace
+        assert "\n" not in job.error_trace
+
+
+def test_ndvi_task_duplicate_delivery_does_not_recompute(job_db, monkeypatch, tmp_path):
+    """acks_late 下 broker 可能重投：第二次投递不得重复计算或重复注册资产。"""
+    from app.services import spatial_tasks
+
+    out = tmp_path / "NDVI_dup.tif"
+    out.write_bytes(b"GEOTIFF")
+    computes: list[int] = []
+
+    def _compute(**kw):
+        computes.append(1)
+        return {
+            "success": True,
+            "result_path": str(out),
+            "filename": "NDVI_dup.tif",
+            "stats": {"mean": 0.3},
+            "bbox": [0, 0, 1, 1],
+            "crs": "EPSG:4326",
+        }
+
+    monkeypatch.setattr(
+        spatial_tasks.NatureResourceAnalyzer, "calculate_ndvi", staticmethod(_compute)
+    )
+
+    job_id = _make_ndvi_job(job_db)
+    first = spatial_tasks.run_ndvi_analysis("/data/a.tif", None, None, "sess-a", job_id=job_id)
+    second = spatial_tasks.run_ndvi_analysis("/data/a.tif", None, None, "sess-a", job_id=job_id)
+
+    assert first["success"] is True
+    assert second.get("skipped") is True
+    assert len(computes) == 1, "重投不得重复计算"
+
+    with job_db["Sess"]() as db:
+        from app.models.upload import UploadRecord
+
+        assert db.query(UploadRecord).count() == 1, "重投不得重复注册资产"
+
+
+def test_ndvi_legacy_path_without_job_id_still_works(job_db, monkeypatch, tmp_path):
+    """兼容：未迁移的调用方（无 job_id）保持原行为。"""
+    from app.services import spatial_tasks
+
+    out = tmp_path / "NDVI_legacy.tif"
+    out.write_bytes(b"GEOTIFF")
+    monkeypatch.setattr(
+        spatial_tasks.NatureResourceAnalyzer,
+        "calculate_ndvi",
+        staticmethod(
+            lambda **kw: {
+                "success": True,
+                "result_path": str(out),
+                "filename": "NDVI_legacy.tif",
+                "stats": {"mean": 0.5},
+                "bbox": [0, 0, 1, 1],
+                "crs": "EPSG:4326",
+            }
+        ),
+    )
+
+    result = spatial_tasks.run_ndvi_analysis("/data/a.tif", None, None, "sess-a")
+    assert result["success"] is True
+    assert result["data"]["result_path"] == str(out)
+    assert "job_id" not in result  # 旧形状不变
+
+
+def test_ndvi_task_missing_job_row_is_skipped(job_db, monkeypatch):
+    """job 行不存在（被清理/错误 id）时安全跳过，不抛给 Celery。"""
+    from app.services import spatial_tasks
+
+    monkeypatch.setattr(
+        spatial_tasks.NatureResourceAnalyzer,
+        "calculate_ndvi",
+        staticmethod(lambda **kw: {"success": True}),
+    )
+    result = spatial_tasks.run_ndvi_analysis(
+        "/data/a.tif", None, None, "sess-a", job_id=999999
+    )
+    assert result["skipped"] is True

--- a/tests/jobs/test_job_lifecycle.py
+++ b/tests/jobs/test_job_lifecycle.py
@@ -1,0 +1,147 @@
+"""统一 job 生命周期状态机（ADR-0052）。
+
+这些断言是整个 durable job 运行时的安全基线：一旦迁移表被人「顺手放宽」，
+late success 覆盖 cancelled / 取消后自动 retry 这类缺陷就会重新出现。
+"""
+import pytest
+
+from app.services.jobs.lifecycle import (
+    ACTIVE_STATUSES,
+    ALLOWED_TRANSITIONS,
+    IMMUTABLE_STATUSES,
+    TERMINAL_STATUSES,
+    InvalidJobTransition,
+    JobStatus,
+    can_transition,
+    coerce_status,
+    is_active,
+    is_cancellable,
+    is_retryable_status,
+    is_terminal,
+    sources_for,
+    validate_transition,
+)
+
+
+def test_immutable_statuses_have_no_successors():
+    """cancelled / completed 永不可再迁移 —— 这是「cancelled 不被 late success
+    覆盖」和「取消永不 retry」两条不变式的共同根。"""
+    for status in IMMUTABLE_STATUSES:
+        assert ALLOWED_TRANSITIONS[status] == frozenset(), status
+
+
+def test_failed_and_stale_are_terminal_but_retryable():
+    """failed/stale 是终态（没有 worker 在跑）但可经显式新 attempt 回 queued。
+
+    唯一后继必须是 queued —— 直接回 running 会绕过 attempt 递增。
+    """
+    assert JobStatus.failed in TERMINAL_STATUSES
+    assert JobStatus.stale in TERMINAL_STATUSES
+    assert JobStatus.failed not in IMMUTABLE_STATUSES
+    assert JobStatus.stale not in IMMUTABLE_STATUSES
+    assert ALLOWED_TRANSITIONS[JobStatus.failed] == frozenset({JobStatus.queued})
+    assert ALLOWED_TRANSITIONS[JobStatus.stale] == frozenset({JobStatus.queued})
+
+
+@pytest.mark.parametrize(
+    "current,target",
+    [
+        (JobStatus.cancelled, JobStatus.completed),   # 规范 §14 明令禁止
+        (JobStatus.cancelled, JobStatus.running),
+        (JobStatus.cancelled, JobStatus.queued),      # 取消绝不 retry（规范 §17）
+        (JobStatus.completed, JobStatus.running),
+        (JobStatus.completed, JobStatus.failed),
+        (JobStatus.failed, JobStatus.running),        # 只能经新 attempt 回 queued
+        (JobStatus.cancelling, JobStatus.completed),  # cancelling 期间的成功不算成功
+        (JobStatus.stale, JobStatus.completed),
+    ],
+)
+def test_forbidden_transitions(current, target):
+    assert can_transition(current, target) is False
+    with pytest.raises(InvalidJobTransition):
+        validate_transition(current, target)
+
+
+@pytest.mark.parametrize(
+    "current,target",
+    [
+        (JobStatus.pending, JobStatus.queued),
+        (JobStatus.pending, JobStatus.cancelled),
+        (JobStatus.queued, JobStatus.running),
+        (JobStatus.queued, JobStatus.stale),
+        (JobStatus.running, JobStatus.cancelling),
+        (JobStatus.running, JobStatus.completed),
+        (JobStatus.running, JobStatus.failed),
+        (JobStatus.running, JobStatus.stale),
+        (JobStatus.cancelling, JobStatus.cancelled),
+        (JobStatus.cancelling, JobStatus.failed),
+        (JobStatus.failed, JobStatus.queued),  # 显式新 attempt
+        (JobStatus.stale, JobStatus.queued),
+    ],
+)
+def test_allowed_transitions(current, target):
+    assert can_transition(current, target) is True
+    assert validate_transition(current, target) is target
+
+
+def test_self_transition_is_not_allowed():
+    """同状态自迁移一律非法 —— 调用方必须走幂等分支而不是重复写。"""
+    for status in JobStatus:
+        assert can_transition(status, status) is False
+
+
+def test_sources_for_matches_transition_table():
+    """sources_for 是 store 构造原子条件更新的唯一来源，必须与迁移表严格一致。"""
+    for target in JobStatus:
+        expected = {src for src, allowed in ALLOWED_TRANSITIONS.items() if target in allowed}
+        assert sources_for(target) == frozenset(expected), target
+
+
+def test_completed_only_reachable_from_running():
+    """成功只能来自 running。queued 直接跳 completed 会绕过 started_at 记录。"""
+    assert sources_for(JobStatus.completed) == frozenset({JobStatus.running})
+
+
+def test_cancelled_never_reachable_from_success_or_failure():
+    assert JobStatus.completed not in sources_for(JobStatus.cancelled)
+    assert JobStatus.failed not in sources_for(JobStatus.cancelled)
+
+
+def test_active_and_terminal_partition_all_statuses():
+    """每个状态必须恰好属于 active 或 terminal 之一，不能有归类真空。"""
+    assert ACTIVE_STATUSES.isdisjoint(TERMINAL_STATUSES)
+    assert ACTIVE_STATUSES | TERMINAL_STATUSES == frozenset(JobStatus)
+
+
+def test_cancellable_excludes_cancelling_and_terminal():
+    """cancelling 不再可取消（重复取消走幂等分支而不是再次迁移）。"""
+    assert is_cancellable(JobStatus.pending)
+    assert is_cancellable(JobStatus.queued)
+    assert is_cancellable(JobStatus.running)
+    assert not is_cancellable(JobStatus.cancelling)
+    for status in TERMINAL_STATUSES:
+        assert not is_cancellable(status)
+
+
+def test_retryable_statuses_exclude_cancelled():
+    assert is_retryable_status(JobStatus.failed)
+    assert is_retryable_status(JobStatus.stale)
+    assert not is_retryable_status(JobStatus.cancelled)
+    assert not is_retryable_status(JobStatus.completed)
+    assert not is_retryable_status(JobStatus.running)
+
+
+def test_coerce_status_tolerates_unknown_values():
+    """未来版本写入的未知状态不能让整个任务中心 500。"""
+    assert coerce_status("running") is JobStatus.running
+    assert coerce_status(JobStatus.failed) is JobStatus.failed
+    assert coerce_status(None) is JobStatus.pending
+    assert coerce_status("") is JobStatus.pending
+    assert coerce_status("some_future_status") is JobStatus.pending
+
+
+def test_is_terminal_is_active_helpers():
+    assert is_terminal("completed") and is_terminal("cancelled") and is_terminal("stale")
+    assert not is_terminal("cancelling")
+    assert is_active("cancelling") and is_active("queued")
+    assert not is_active("failed")

--- a/tests/jobs/test_job_migration.py
+++ b/tests/jobs/test_job_migration.py
@@ -1,0 +1,238 @@
+"""迁移 0013 的结构守卫（ADR-0052）。
+
+为什么需要这个文件：所有 job 测试都用 ``Base.metadata.create_all`` 建表，**没有任何
+测试执行过真正的 Alembic 迁移**。这正是典型的 false-green —— 审计里发现的
+「PostgreSQL 上 `DATETIME` 类型不存在导致 upgrade 整体失败」就完全逃过了绿灯测试。
+
+这里做三件事：
+  1. 在真实 SQLite 上跑 upgrade head → 断言新列/约束/索引确实存在；
+  2. 断言老数据行在 upgrade + downgrade 往返后仍然存在（规范 §39：不得要求删数据）；
+  3. 对 PostgreSQL 分支做**静态**校验：确保 DDL 里不出现非 PG 类型名。
+     （本地无 PG 实例，所以不做真实执行 —— 明确标注为静态检查，不谎称集成验证。）
+"""
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = REPO_ROOT / "migrations" / "versions" / "0013_unified_durable_job_runtime.py"
+
+#: 迁移必须新增的列（与 db_model.AnalysisTask 的 ADR-0052 字段一致）
+EXPECTED_COLUMNS = {
+    "job_kind",
+    "display_name",
+    "session_id",
+    "owner_token",
+    "project_id",
+    "run_id",
+    "turn_id",
+    "tool_call_id",
+    "agent_task_id",
+    "agent_step_id",
+    "idempotency_key",
+    "attempt",
+    "worker_id",
+    "cancel_requested_at",
+    "heartbeat_at",
+    "result_ref",
+    "dispatch_spec",
+}
+
+EXPECTED_INDEXES = {
+    "idx_task_session_created",
+    "idx_task_creator_created",
+    "idx_task_status_heartbeat",
+    "idx_task_agent_task",
+    "uq_analysis_tasks_idempotency_key",
+}
+
+#: 升级前就存在的索引，重建表时不能丢
+PRESERVED_INDEXES = {"idx_task_status", "idx_task_org_status", "idx_task_org_type_status"}
+
+
+def _alembic(db_path: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=REPO_ROOT,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "DATABASE_URL": f"sqlite:///{db_path}",
+            "JWT_SECRET_KEY": "test-secret-migration-32-chars-okay",
+            "USE_REDIS": "false",
+            "HOME": str(Path.home()),
+        },
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+def _columns(db_path: Path, table: str) -> set[str]:
+    with sqlite3.connect(db_path) as conn:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _indexes(db_path: Path, table: str) -> set[str]:
+    with sqlite3.connect(db_path) as conn:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?", (table,)
+            )
+        }
+
+
+def _table_sql(db_path: Path, table: str) -> str:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name=?", (table,)
+        ).fetchone()
+    return row[0] if row else ""
+
+
+@pytest.fixture
+def migrated_db(tmp_path):
+    """真实执行 alembic upgrade head 的 SQLite 数据库。"""
+    if shutil.which(sys.executable) is None:  # pragma: no cover
+        pytest.skip("python executable unavailable")
+    db_path = tmp_path / "migration.db"
+    result = _alembic(db_path, "upgrade", "head")
+    if result.returncode != 0:
+        pytest.fail(f"alembic upgrade head failed:\n{result.stdout}\n{result.stderr}")
+    return db_path
+
+
+def test_upgrade_adds_all_durable_job_columns(migrated_db):
+    columns = _columns(migrated_db, "analysis_tasks")
+    missing = EXPECTED_COLUMNS - columns
+    assert not missing, f"迁移缺少列: {sorted(missing)}"
+
+
+def test_upgrade_creates_new_indexes_and_preserves_old_ones(migrated_db):
+    indexes = _indexes(migrated_db, "analysis_tasks")
+    assert not EXPECTED_INDEXES - indexes, f"缺少新索引: {sorted(EXPECTED_INDEXES - indexes)}"
+    # 重建表（SQLite 无法 ALTER 约束）时不能把升级前的索引弄丢
+    assert not PRESERVED_INDEXES - indexes, (
+        f"重建表丢失了原有索引: {sorted(PRESERVED_INDEXES - indexes)}"
+    )
+
+
+def test_upgrade_widens_status_check_and_relaxes_nullability(migrated_db):
+    """cancelling/stale 必须被 CHECK 接受；org_id/creator_id 必须可为 NULL。"""
+    with sqlite3.connect(migrated_db) as conn:
+        for status in ("pending", "queued", "running", "cancelling", "completed", "failed", "cancelled", "stale"):
+            conn.execute(
+                "INSERT INTO analysis_tasks (org_id, creator_id, task_type, parameters, status, progress)"
+                " VALUES (NULL, NULL, 't', '{}', ?, 0)",
+                (status,),
+            )
+        conn.commit()
+
+        # 未知状态仍必须被拒绝 —— CHECK 是放宽而不是取消
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO analysis_tasks (org_id, task_type, parameters, status, progress)"
+                " VALUES (NULL, 't', '{}', 'bogus_status', 0)"
+            )
+        # progress 上下界约束不能在重建中丢掉
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO analysis_tasks (org_id, task_type, parameters, status, progress)"
+                " VALUES (NULL, 't', '{}', 'running', 101)"
+            )
+
+
+def test_upgrade_makes_primary_key_autoincrement_on_sqlite(migrated_db):
+    """BIGINT 主键在 SQLite 上不自增 —— durable job 是热路径，必须能自增插入。"""
+    assert "id INTEGER NOT NULL" in _table_sql(migrated_db, "analysis_tasks")
+    with sqlite3.connect(migrated_db) as conn:
+        conn.execute(
+            "INSERT INTO analysis_tasks (org_id, task_type, parameters, status, progress)"
+            " VALUES (NULL, 't', '{}', 'pending', 0)"
+        )
+        conn.commit()
+        assert conn.execute("SELECT id FROM analysis_tasks").fetchone()[0] is not None
+
+
+def test_downgrade_preserves_existing_rows(tmp_path):
+    """规范 §39：迁移不得要求删除现有 task 数据。"""
+    db_path = tmp_path / "roundtrip.db"
+    assert _alembic(db_path, "upgrade", "head").returncode == 0
+
+    with sqlite3.connect(db_path) as conn:
+        for status in ("running", "cancelling", "stale", "completed"):
+            conn.execute(
+                "INSERT INTO analysis_tasks (org_id, task_type, parameters, status, progress)"
+                " VALUES (NULL, 't', '{}', ?, 0)",
+                (status,),
+            )
+        conn.commit()
+
+    down = _alembic(db_path, "downgrade", "0012_add_composite_indexes_pd_wr")
+    assert down.returncode == 0, f"downgrade failed:\n{down.stdout}\n{down.stderr}"
+
+    columns = _columns(db_path, "analysis_tasks")
+    assert not (EXPECTED_COLUMNS & columns), "downgrade 未移除新列"
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT status FROM analysis_tasks ORDER BY id").fetchall()
+    assert len(rows) == 4, "downgrade 丢了数据行"
+    # cancelling/stale 在旧 CHECK 下不合法 —— 归一化为 failed 而不是删行
+    statuses = [r[0] for r in rows]
+    assert statuses.count("failed") == 2
+    assert "running" in statuses and "completed" in statuses
+
+
+def test_upgrade_is_reapplicable_after_downgrade(tmp_path):
+    db_path = tmp_path / "reapply.db"
+    assert _alembic(db_path, "upgrade", "head").returncode == 0
+    assert _alembic(db_path, "downgrade", "0012_add_composite_indexes_pd_wr").returncode == 0
+    again = _alembic(db_path, "upgrade", "head")
+    assert again.returncode == 0, f"re-upgrade failed:\n{again.stdout}\n{again.stderr}"
+    assert not EXPECTED_COLUMNS - _columns(db_path, "analysis_tasks")
+
+
+def test_full_downgrade_to_base_succeeds(tmp_path):
+    db_path = tmp_path / "tobase.db"
+    assert _alembic(db_path, "upgrade", "head").returncode == 0
+    result = _alembic(db_path, "downgrade", "base")
+    assert result.returncode == 0, f"downgrade base failed:\n{result.stdout}\n{result.stderr}"
+
+
+# ── PostgreSQL 分支的静态校验 ───────────────────────────────────────
+# 本地没有 PG 实例，所以这里只做静态检查，**不**声称做了 PG 集成验证。
+
+
+def test_postgres_branch_uses_valid_postgres_types():
+    """PG 没有 DATETIME 类型 —— 直接把 SQLite 类型名拼进 DDL 会让 upgrade 整体失败。
+
+    这个守卫存在的原因：审计发现过正是这个缺陷，而所有测试都走 create_all，
+    完全没碰迁移，因此一路绿灯。
+    """
+    source = MIGRATION.read_text(encoding="utf-8")
+    assert "_PG_TYPES" in source, "迁移必须显式做方言类型映射"
+    assert '"DATETIME": "TIMESTAMP"' in source, "DATETIME 必须在 PG 分支映射为 TIMESTAMP"
+    assert "_pg_type(type_key)" in source, "PG 的 ADD COLUMN 必须经过类型映射"
+
+    # 拼接 DDL 的那一行不得直接使用未映射的 type_key
+    assert "ADD COLUMN IF NOT EXISTS {name} {type_key}" not in source
+
+
+def test_postgres_branch_ddl_is_idempotent():
+    """PG DDL 必须可重复执行（IF NOT EXISTS / IF EXISTS）。"""
+    source = MIGRATION.read_text(encoding="utf-8")
+    assert "ADD COLUMN IF NOT EXISTS" in source
+    # 索引 DDL 是 f-string 拼的（普通索引 / UNIQUE 共用一条语句）
+    assert "IF NOT EXISTS {index_name}" in source, "索引创建必须是 IF NOT EXISTS"
+    assert "DROP INDEX IF EXISTS" in source
+    assert "DROP CONSTRAINT IF EXISTS ck_task_status" in source
+
+
+def test_migration_declares_expected_revision_chain():
+    source = MIGRATION.read_text(encoding="utf-8")
+    assert 'revision: str = "0013_unified_durable_job_runtime"' in source
+    assert '"0012_add_composite_indexes_pd_wr"' in source

--- a/tests/jobs/test_job_redaction_progress.py
+++ b/tests/jobs/test_job_redaction_progress.py
@@ -1,0 +1,316 @@
+"""载荷脱敏、体积上限与统一进度契约（ADR-0052，规范 §19/§20/§35/§38）。"""
+import json
+
+import pytest
+
+from app.services.jobs.progress import (
+    JobProgress,
+    ProgressReporter,
+    ProgressThrottle,
+)
+from app.services.jobs.redaction import (
+    MAX_PARAMETERS_BYTES,
+    safe_dispatch_spec,
+    MAX_RESULT_BYTES,
+    REDACTED,
+    safe_error,
+    safe_parameters,
+    safe_result,
+)
+
+
+def _size(value) -> int:
+    return len(json.dumps(value, ensure_ascii=False, default=str).encode("utf-8"))
+
+
+# ── 脱敏 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "password", "passwd", "api_key", "apiKey", "secret", "client_secret",
+        "token", "access_token", "session_token", "owner_token", "authorization",
+        "auth_header", "credential", "credentials", "signed_url", "signature",
+        "cookie", "private_key", "access_key", "bearer_token",
+    ],
+)
+def test_sensitive_keys_are_redacted(key):
+    """凭据绝不落库、绝不经任务中心回传（规范 §35）。"""
+    out = safe_parameters({key: "super-secret-value"})
+    assert out[key] == REDACTED
+    assert "super-secret-value" not in json.dumps(out)
+
+
+def test_redaction_is_case_insensitive_and_substring_based():
+    out = safe_parameters({"AWS_SECRET_ACCESS_KEY": "x", "userTokenValue": "y"})
+    assert out["AWS_SECRET_ACCESS_KEY"] == REDACTED
+    assert out["userTokenValue"] == REDACTED
+
+
+def test_nested_sensitive_keys_are_redacted():
+    out = safe_parameters({"cfg": {"inner": {"api_key": "leak-me"}}})
+    assert "leak-me" not in json.dumps(out)
+
+
+def test_bulk_geometry_is_summarized_not_stored():
+    """规范 §38：50MB GeoJSON 绝不写进 task 行，只留摘要。"""
+    features = [{"type": "Feature", "geometry": {"coordinates": [[i, i]] * 50}} for i in range(20_000)]
+    out = safe_parameters({"features": features, "crs": "EPSG:4326"})
+    assert out["features"] == {"__omitted__": "features", "count": 20_000}
+    assert out["crs"] == "EPSG:4326"
+    assert _size(out) <= MAX_PARAMETERS_BYTES
+
+
+def test_geojson_featurecollection_keeps_useful_metadata():
+    """摘要仍保留对用户有意义的元信息（类型、要素数）。"""
+    out = safe_result({"geojson": {"type": "FeatureCollection", "features": [{}] * 1234}})
+    assert out["geojson"]["type"] == "FeatureCollection"
+    assert out["geojson"]["count"] == 1234
+
+
+def test_result_size_is_hard_bounded(caplog):
+    """无论输入多大，序列化后必须落在硬上界内。"""
+    monster = {f"key_{i}": "x" * 400 for i in range(500)}
+    out = safe_result(monster)
+    assert _size(out) <= MAX_RESULT_BYTES
+    assert "__truncated__" in out
+
+
+def test_parameters_size_is_hard_bounded():
+    monster = {f"k{i}": {"nested": ["v" * 200] * 5} for i in range(400)}
+    out = safe_parameters(monster)
+    assert _size(out) <= MAX_PARAMETERS_BYTES
+
+
+def test_long_strings_are_truncated_with_marker():
+    out = safe_parameters({"note": "a" * 5000})
+    assert len(out["note"]) < 5000
+    assert "chars]" in out["note"]
+
+
+def test_long_sequences_are_capped():
+    out = safe_parameters({"ids": list(range(500))})
+    assert len(out["ids"]) <= 21
+    assert out["ids"][-1]["__omitted__"] == "items"
+
+
+def test_bytes_are_not_embedded():
+    out = safe_parameters({"blob": b"\x00" * 4096})
+    assert out["blob"] == {"__omitted__": "bytes", "bytes": 4096}
+
+
+def test_deep_structures_are_depth_limited():
+    node = {"leaf": 1}
+    for _ in range(40):
+        node = {"child": node}
+    out = safe_parameters(node)
+    assert _size(out) <= MAX_PARAMETERS_BYTES
+    assert "TRUNCATED_DEPTH" in json.dumps(out)
+
+
+def test_non_dict_payloads_are_wrapped():
+    assert safe_parameters("just a string")["value"] == "just a string"
+    assert safe_parameters(None) == {}
+    assert safe_result(None) is None
+    assert safe_result([1, 2, 3])["value"] == [1, 2, 3]
+
+
+def test_safe_error_never_contains_traceback():
+    """规范 §10：raw traceback 不得泄漏给前端。"""
+    multiline = 'Traceback (most recent call last):\n  File "x.py", line 1\n    boom\nValueError: bad'
+    out = safe_error(multiline)
+    assert "\n" not in out
+    assert out.startswith("Traceback (most recent call last):")  # 只留首行，不含栈帧
+    assert "x.py" not in out
+
+
+def test_safe_error_from_exception():
+    out = safe_error(ValueError("invalid CRS"))
+    assert out == "ValueError: invalid CRS"
+
+
+def test_safe_error_handles_empty_and_none():
+    assert safe_error(None) is None
+    assert safe_error("") is None
+    assert safe_error(RuntimeError()) == "RuntimeError: RuntimeError"
+
+
+def test_safe_error_is_length_bounded():
+    out = safe_error("x" * 5000)
+    assert len(out) <= 501
+
+
+# ── 进度契约 ────────────────────────────────────────────────────────
+
+
+def test_progress_clamped_to_valid_range():
+    assert JobProgress(progress=150).clamped().progress == 100
+    assert JobProgress(progress=-5).clamped().progress == 0
+    assert JobProgress(progress=None).clamped().progress is None
+    snap = JobProgress(progress=50)
+    assert snap.clamped() is snap  # 已合法则不复制
+
+
+def test_indeterminate_progress_is_explicit():
+    """规范 §19：允许 progress=null，禁止编造假百分比。"""
+    snap = JobProgress(progress=None, message="处理中")
+    assert snap.indeterminate is True
+
+
+def test_progress_message_composition_and_length():
+    snap = JobProgress(progress=10, message="重投影", phase="reproject", current_step=2, total_steps=7)
+    msg = snap.as_message()
+    assert msg == "[reproject] 重投影 (2/7)"
+    long = JobProgress(message="x" * 500).as_message()
+    assert len(long) <= 255  # progress_message 是 String(255)
+
+
+def test_progress_message_none_when_empty():
+    assert JobProgress(progress=5).as_message() is None
+
+
+# ── 节流 ────────────────────────────────────────────────────────────
+
+
+def test_throttle_first_report_always_emits():
+    t = ProgressThrottle(min_delta_pct=10, min_interval_s=100, clock=lambda: 0.0)
+    assert t.should_emit(0) is True
+
+
+def test_throttle_suppresses_sub_threshold_updates():
+    now = [0.0]
+    t = ProgressThrottle(min_delta_pct=5.0, min_interval_s=100.0, clock=lambda: now[0])
+    assert t.should_emit(0) is True
+    assert t.should_emit(1) is False
+    assert t.should_emit(3) is False
+    assert t.should_emit(5) is True  # 达到 5% delta
+
+
+def test_throttle_time_based_release_for_stuck_progress():
+    """进度长时间不变也要偶尔刷一次 —— 心跳靠它维持。"""
+    now = [0.0]
+    t = ProgressThrottle(min_delta_pct=50.0, min_interval_s=1.0, clock=lambda: now[0])
+    assert t.should_emit(10) is True
+    assert t.should_emit(11) is False
+    now[0] = 2.0
+    assert t.should_emit(11) is True
+
+
+def test_throttle_always_emits_hundred_percent():
+    now = [0.0]
+    t = ProgressThrottle(min_delta_pct=90.0, min_interval_s=999.0, clock=lambda: now[0])
+    assert t.should_emit(0) is True
+    assert t.should_emit(50) is False
+    assert t.should_emit(100) is True
+
+
+def test_throttle_force_bypasses_all_limits():
+    now = [0.0]
+    t = ProgressThrottle(min_delta_pct=99.0, min_interval_s=999.0, clock=lambda: now[0])
+    t.should_emit(0)
+    assert t.should_emit(1, force=True) is True
+
+
+def test_throttle_indeterminate_uses_time_only():
+    now = [0.0]
+    t = ProgressThrottle(min_interval_s=1.0, clock=lambda: now[0])
+    assert t.should_emit(None) is True
+    assert t.should_emit(None) is False
+    now[0] = 1.5
+    assert t.should_emit(None) is True
+
+
+def test_throttle_bounds_write_rate_for_hot_loop():
+    """规范 §20：10 万次上报必须被压到两位数写入。"""
+    now = [0.0]
+    t = ProgressThrottle(min_delta_pct=1.0, min_interval_s=0.5, clock=lambda: now[0])
+    for i in range(100_000):
+        t.should_emit(i * 100 // 100_000)
+    assert t.emitted <= 110, t.emitted
+
+
+def test_throttle_reset():
+    t = ProgressThrottle(clock=lambda: 0.0)
+    t.should_emit(10)
+    t.reset()
+    assert t.emitted == 0
+    assert t.should_emit(10) is True
+
+
+def test_reporter_only_forwards_released_updates():
+    now = [0.0]
+    seen: list[JobProgress] = []
+    reporter = ProgressReporter(
+        seen.append, ProgressThrottle(min_delta_pct=10.0, min_interval_s=999.0, clock=lambda: now[0])
+    )
+    assert reporter.report(0, "start") is True
+    assert reporter.report(2, "tick") is False
+    assert reporter.report(20, "tick") is True
+    assert [s.progress for s in seen] == [0, 20]
+    assert reporter.last.progress == 20
+
+
+def test_reporter_flush_always_forwards():
+    seen: list[JobProgress] = []
+    reporter = ProgressReporter(
+        seen.append, ProgressThrottle(min_delta_pct=99.0, min_interval_s=999.0, clock=lambda: 0.0)
+    )
+    reporter.report(0)
+    assert reporter.flush(1, "terminal") is True
+    assert len(seen) == 2
+
+
+def test_reporter_clamps_before_sink():
+    seen: list[JobProgress] = []
+    reporter = ProgressReporter(seen.append)
+    reporter.report(9999, "over")
+    assert seen[0].progress == 100
+
+
+# ── dispatch 描述符（round-2 审计） ─────────────────────────────────
+
+
+def test_dispatch_spec_roundtrips_faithfully():
+    """重跑描述符必须**不**被截断 —— 截断后的参数无法忠实重跑。"""
+    spec = {"task": "app.tasks.ndvi", "args": ["/data/a.tif", 4, None], "kwargs": {"session_id": "s"}}
+    out = safe_dispatch_spec(spec)
+    assert out == spec
+
+
+def test_dispatch_spec_rejects_top_level_sensitive_kwarg():
+    out = safe_dispatch_spec({"task": "t", "args": [], "kwargs": {"api_key": "leak"}})
+    assert out["__truncated__"] == "dispatch_spec"
+    assert "leak" not in json.dumps(out)
+
+
+def test_dispatch_spec_rejects_nested_sensitive_kwarg():
+    """嵌套结构里的凭据同样不得落库（只筛顶层 key 是不够的）。"""
+    out = safe_dispatch_spec(
+        {"task": "t", "args": [], "kwargs": {"cfg": {"inner": {"password": "leak"}}}}
+    )
+    assert out["__truncated__"] == "dispatch_spec"
+    assert "leak" not in json.dumps(out)
+
+
+def test_dispatch_spec_rejects_sensitive_key_inside_args():
+    """args 是位置参数，但里面的 dict 也可能夹带凭据。"""
+    out = safe_dispatch_spec(
+        {"task": "t", "args": [{"properties": {"access_token": "leak"}}], "kwargs": {}}
+    )
+    assert out["__truncated__"] == "dispatch_spec"
+    assert "leak" not in json.dumps(out)
+
+
+def test_dispatch_spec_rejects_oversized_payload():
+    out = safe_dispatch_spec({"task": "t", "args": [["x" * 200] * 200], "kwargs": {}})
+    assert out["__truncated__"] == "dispatch_spec"
+    assert out["reason"] == "too_large"
+
+
+def test_dispatch_spec_rejects_malformed_input():
+    assert safe_dispatch_spec(None) is None
+    assert safe_dispatch_spec({"args": []}) is None
+    assert safe_dispatch_spec({"task": ""}) is None
+    assert safe_dispatch_spec({"task": "t", "args": "not-a-list"}) is None
+    assert safe_dispatch_spec({"task": "t", "kwargs": "not-a-dict"}) is None

--- a/tests/jobs/test_job_store.py
+++ b/tests/jobs/test_job_store.py
@@ -1,0 +1,929 @@
+"""Durable job store：原子迁移、竞态、归属隔离、stale 清扫、幂等（ADR-0052）。
+
+竞态用 asyncio.Event / barrier 编排，不用 sleep 猜时序（规范 §42）。
+"""
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.db_model import AnalysisTask, Base
+from app.services.jobs import (
+    DurableJobStore,
+    JobKind,
+    JobNotFound,
+    JobProgress,
+    JobStatus,
+    coerce_status,
+)
+
+
+def _naive_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@pytest_asyncio.fixture
+async def engine(tmp_path):
+    eng = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):
+    return async_sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def db(session_factory):
+    async with session_factory() as s:
+        yield s
+
+
+async def _job(db, **overrides):
+    params = {
+        "task_type": "ndvi",
+        "kind": JobKind.analysis,
+        "owner_id": "user-a",
+        "session_id": "sess-a",
+        "parameters": {"raster_path": "/data/a.tif"},
+        # retry 必须能忠实重跑 —— 没有 dispatch 描述符时 store 会拒绝重试
+        "dispatch_spec": {
+            "task": "app.services.spatial_tasks.run_ndvi_analysis",
+            "args": ["/data/a.tif"],
+            "kwargs": {},
+        },
+    }
+    params.update(overrides)
+    job = await DurableJobStore.create(db, **params)
+    await db.commit()
+    return job
+
+
+# ── 创建 / 幂等 ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_sets_defaults(db):
+    job = await _job(db)
+    assert job.id is not None, "BigInteger 主键在 SQLite 上必须自增（dialect variant）"
+    assert coerce_status(job.status) is JobStatus.pending
+    assert job.attempt == 1
+    assert job.retry_count == 0
+    assert job.progress == 0
+    assert job.job_kind == "analysis"
+
+
+@pytest.mark.asyncio
+async def test_create_is_idempotent_by_key(db):
+    """规范 §16：SSE 重连 / 双击 / API retry 不得产生第二个 job。"""
+    first = await _job(db, idempotency_key="k-1")
+    second = await DurableJobStore.create(
+        db, task_type="ndvi", owner_id="user-a", idempotency_key="k-1"
+    )
+    await db.commit()
+    assert second.id == first.id
+
+    rows = (await db.execute(AnalysisTask.__table__.select())).fetchall()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_without_key_allows_multiple(db):
+    """没有幂等键时不去重 —— 不给所有工具硬编码 hash（规范 §16）。"""
+    a = await _job(db)
+    b = await _job(db)
+    assert a.id != b.id
+
+
+@pytest.mark.asyncio
+async def test_parameters_are_redacted_and_bounded(db):
+    """凭据不落库，巨型几何体只留摘要（规范 §35 / §38）。"""
+    job = await _job(
+        db,
+        parameters={
+            "token": "super-secret",
+            "signed_url": "https://x/y?sig=abc",
+            "features": [{"geometry": {}} for _ in range(5000)],
+            "raster_path": "/data/a.tif",
+        },
+    )
+    assert job.parameters["token"] == "[REDACTED]"
+    assert job.parameters["signed_url"] == "[REDACTED]"
+    assert job.parameters["features"]["count"] == 5000
+    assert job.parameters["raster_path"] == "/data/a.tif"
+
+
+# ── 原子迁移 ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_happy_path_transitions(db):
+    job = await _job(db)
+    assert await DurableJobStore.mark_queued(db, job.id, celery_task_id="celery-1") is True
+    assert await DurableJobStore.mark_running(db, job.id) is True
+    assert await DurableJobStore.mark_succeeded(db, job.id, result={"mean": 0.4}) is JobStatus.completed
+    await db.commit()
+
+    fresh = await DurableJobStore.get(db, job.id)
+    assert coerce_status(fresh.status) is JobStatus.completed
+    assert fresh.progress == 100
+    assert fresh.completed_at is not None
+    assert fresh.heartbeat_at is None  # 终态清空心跳，避免被 stale 清扫误判
+
+
+@pytest.mark.asyncio
+async def test_illegal_transition_returns_false_without_writing(db):
+    """非法迁移不抛错、不写库 —— 调用方据 False 走幂等分支。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_failed(db, job.id, error=ValueError("bad crs"))
+    await db.commit()
+
+    # failed → running 被禁止
+    assert await DurableJobStore.transition(db, job.id, JobStatus.running) is False
+    fresh = await DurableJobStore.get(db, job.id)
+    assert coerce_status(fresh.status) is JobStatus.failed
+
+
+@pytest.mark.asyncio
+async def test_mark_queued_rejects_failed_predecessor(db):
+    """failed → queued 必须走 start_retry（递增 attempt），不能被普通入队绕过。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_failed(db, job.id, error="boom")
+    await db.commit()
+    assert await DurableJobStore.mark_queued(db, job.id) is False
+
+
+@pytest.mark.asyncio
+async def test_transition_on_unknown_job_returns_false(db):
+    assert await DurableJobStore.transition(db, 999999, JobStatus.running) is False
+    assert await DurableJobStore.transition(db, "not-a-number", JobStatus.running) is False
+
+
+# ── 取消语义 ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_running_job_goes_to_cancelling(db):
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+
+    changed, status = await DurableJobStore.request_cancel(db, job.id)
+    await db.commit()
+    assert changed is True
+    assert status is JobStatus.cancelling
+    fresh = await DurableJobStore.get(db, job.id)
+    assert fresh.cancel_requested_at is not None
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_job_terminates_immediately(db):
+    """没有 worker 会去确认取消的 job（未 started）直接落 cancelled。"""
+    job = await _job(db)
+    changed, status = await DurableJobStore.request_cancel(db, job.id)
+    await db.commit()
+    assert changed is True
+    assert status is JobStatus.cancelled
+
+
+@pytest.mark.asyncio
+async def test_double_cancel_is_idempotent(db):
+    """规范 Scenario 5。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+
+    first = await DurableJobStore.request_cancel(db, job.id)
+    second = await DurableJobStore.request_cancel(db, job.id)
+    third = await DurableJobStore.request_cancel(db, job.id)
+    await db.commit()
+
+    assert first == (True, JobStatus.cancelling)
+    assert second == (False, JobStatus.cancelling)
+    assert third == (False, JobStatus.cancelling)
+
+
+@pytest.mark.asyncio
+async def test_cancel_completed_job_is_noop(db):
+    """终态不得被取消改写 —— completed 永远是 completed。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_succeeded(db, job.id, result={})
+    await db.commit()
+
+    changed, status = await DurableJobStore.request_cancel(db, job.id)
+    await db.commit()
+    assert changed is False
+    assert status is JobStatus.completed
+
+
+@pytest.mark.asyncio
+async def test_late_success_does_not_overwrite_cancellation(db):
+    """规范 §14 / Scenario 4：cancelled 不能被 worker 的迟到成功改成 completed。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.request_cancel(db, job.id)
+    await db.commit()
+
+    # worker 在观察到取消之前跑完了 —— 结果必须被丢弃
+    status = await DurableJobStore.mark_succeeded(db, job.id, result={"mean": 0.9})
+    await db.commit()
+    assert status is JobStatus.cancelled
+
+    fresh = await DurableJobStore.get(db, job.id)
+    assert coerce_status(fresh.status) is JobStatus.cancelled
+    assert fresh.result_summary is None, "已取消的 job 不应保留结果"
+
+
+@pytest.mark.asyncio
+async def test_late_success_after_confirmed_cancel_is_noop(db):
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.request_cancel(db, job.id)
+    await DurableJobStore.confirm_cancelled(db, job.id)
+    await db.commit()
+
+    status = await DurableJobStore.mark_succeeded(db, job.id, result={"mean": 0.9})
+    await db.commit()
+    assert status is JobStatus.cancelled
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cancel_and_complete_yields_single_terminal(session_factory):
+    """竞态：API 取消与 worker 完成同时到达（各自独立 session/事务）。
+
+    结果必须是单一确定终态，且绝不是「先 cancelled 后又 completed」。
+    用 Event 编排而不是 sleep 猜时序。
+    """
+    async with session_factory() as setup:
+        job = await DurableJobStore.create(
+            setup, task_type="ndvi", owner_id="user-a", session_id="sess-a", parameters={}
+        )
+        await setup.commit()
+        await DurableJobStore.mark_queued(setup, job.id)
+        await DurableJobStore.mark_running(setup, job.id)
+        await setup.commit()
+        job_id = job.id
+
+    ready = asyncio.Event()
+
+    async def canceller():
+        async with session_factory() as s:
+            await ready.wait()
+            result = await DurableJobStore.request_cancel(s, job_id)
+            await s.commit()
+            return result
+
+    async def completer():
+        async with session_factory() as s:
+            await ready.wait()
+            status = await DurableJobStore.mark_succeeded(s, job_id, result={"ok": True})
+            await s.commit()
+            return status
+
+    task_c = asyncio.create_task(canceller())
+    task_d = asyncio.create_task(completer())
+    ready.set()
+    await asyncio.gather(task_c, task_d, return_exceptions=True)
+
+    async with session_factory() as s:
+        fresh = await DurableJobStore.get(s, job_id)
+        final = coerce_status(fresh.status)
+
+    # 两种合法收敛：worker 先赢 → completed；取消先赢 → cancelled。
+    # 非法的是 cancelling（悬挂）或先 cancelled 再被改成 completed。
+    assert final in (JobStatus.completed, JobStatus.cancelled), final
+
+
+@pytest.mark.asyncio
+async def test_duplicate_completion_only_applies_once(session_factory):
+    """重复完成（broker 重投 / worker 重试）只能有一次真正写入。
+
+    注意 ``mark_succeeded`` 对「已经是 completed」的 job 返回 completed（幂等读），
+    所以不能靠返回值计数 —— 要断言的是「只有一次条件更新命中」以及「结果不被后来
+    者改写」。
+    """
+    async with session_factory() as s:
+        job = await DurableJobStore.create(s, task_type="ndvi", owner_id="u", parameters={})
+        await s.commit()
+        await DurableJobStore.mark_queued(s, job.id)
+        await DurableJobStore.mark_running(s, job.id)
+        await s.commit()
+        job_id = job.id
+
+    async def complete(value):
+        async with session_factory() as s:
+            # 直接用底层原子迁移，才能观察到「谁真的写成功了」
+            won = await DurableJobStore.transition(
+                s,
+                job_id,
+                JobStatus.completed,
+                progress=100,
+                result_summary={"v": value},
+                completed_at=_naive_utc(),
+            )
+            await s.commit()
+            return won
+
+    winners = await asyncio.gather(*(complete(i) for i in range(5)))
+    assert winners.count(True) == 1, "并发完成必须只有一个写入者胜出"
+
+    async with session_factory() as s:
+        fresh = await DurableJobStore.get(s, job_id)
+        assert coerce_status(fresh.status) is JobStatus.completed
+        stored = fresh.result_summary["v"]
+
+    # 胜出者写入的结果不得被后续重复投递改写
+    async with session_factory() as s:
+        assert await DurableJobStore.mark_succeeded(s, job_id, result={"v": 999}) is JobStatus.completed
+        await s.commit()
+    async with session_factory() as s:
+        assert (await DurableJobStore.get(s, job_id)).result_summary["v"] == stored
+
+
+# ── 进度 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_progress_updates_active_job(db):
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+
+    ok = await DurableJobStore.update_progress(
+        db, job.id, JobProgress(progress=42, message="计算中", phase="compute")
+    )
+    await db.commit()
+    assert ok is True
+    fresh = await DurableJobStore.get(db, job.id)
+    assert fresh.progress == 42
+    assert "[compute]" in fresh.progress_message
+    assert fresh.heartbeat_at is not None
+
+
+@pytest.mark.asyncio
+async def test_stale_progress_cannot_overwrite_terminal_status(db):
+    """规范 §50：迟到的进度写入不得复活已终结的 job。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.request_cancel(db, job.id)
+    await DurableJobStore.confirm_cancelled(db, job.id)
+    await db.commit()
+
+    ok = await DurableJobStore.update_progress(db, job.id, JobProgress(progress=77, message="late"))
+    await db.commit()
+    assert ok is False
+    fresh = await DurableJobStore.get(db, job.id)
+    assert coerce_status(fresh.status) is JobStatus.cancelled
+    assert fresh.progress != 77
+
+
+@pytest.mark.asyncio
+async def test_progress_is_clamped_to_check_constraint(db):
+    """progress 必须落在 [0,100] —— 否则触发 ck_task_progress 让整个任务失败。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+
+    await DurableJobStore.update_progress(db, job.id, JobProgress(progress=500))
+    await db.commit()
+    assert (await DurableJobStore.get(db, job.id)).progress == 100
+
+    await DurableJobStore.update_progress(db, job.id, JobProgress(progress=-20))
+    await db.commit()
+    assert (await DurableJobStore.get(db, job.id)).progress == 0
+
+
+# ── 归属隔离 ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_owner_scoped_read(db):
+    """规范 Scenario 9 / §34：user B 看不到 user A 的 job（且 404 语义）。"""
+    job = await _job(db, owner_id="user-a")
+    got = await DurableJobStore.get_for_owner(db, job.id, owner_id="user-a")
+    assert got.id == job.id
+
+    with pytest.raises(JobNotFound):
+        await DurableJobStore.get_for_owner(db, job.id, owner_id="user-b")
+
+
+@pytest.mark.asyncio
+async def test_no_ownership_proof_sees_nothing(db):
+    """三条归属证明链都缺失时必须是「恒假」，绝不能退化成无过滤全表扫。"""
+    await _job(db, owner_id="user-a")
+    assert await DurableJobStore.list_for_owner(db) == []
+    with pytest.raises(JobNotFound):
+        await DurableJobStore.get_for_owner(db, 1)
+
+
+@pytest.mark.asyncio
+async def test_owner_token_proves_ownership_for_anonymous(db):
+    """匿名会话靠 owner_token（镜像 SEC-08），没有 creator_id 也能拥有 job。"""
+    job = await _job(db, owner_id=None, owner_token="tok-a")
+    got = await DurableJobStore.get_for_owner(db, job.id, owner_token="tok-a")
+    assert got.id == job.id
+    with pytest.raises(JobNotFound):
+        await DurableJobStore.get_for_owner(db, job.id, owner_token="tok-b")
+
+
+@pytest.mark.asyncio
+async def test_list_is_scoped_and_bounded(db):
+    for i in range(5):
+        await _job(db, owner_id="user-a", session_id="sess-a", task_type=f"t{i}")
+    for i in range(3):
+        await _job(db, owner_id="user-b", session_id="sess-b", task_type=f"u{i}")
+
+    mine = await DurableJobStore.list_for_owner(db, owner_id="user-a")
+    assert len(mine) == 5
+    assert {j.creator_id for j in mine} == {"user-a"}
+
+    theirs = await DurableJobStore.list_for_owner(db, owner_id="user-b")
+    assert len(theirs) == 3
+
+    limited = await DurableJobStore.list_for_owner(db, owner_id="user-a", limit=2)
+    assert len(limited) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_limit_is_capped(db):
+    """limit 必须有硬上界，防止无界扫描。"""
+    await _job(db, owner_id="user-a")
+    got = await DurableJobStore.list_for_owner(db, owner_id="user-a", limit=10_000)
+    assert len(got) == 1  # 不报错，且内部 clamp 到 MAX_LIST_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_active_only_filter(db):
+    active = await _job(db, owner_id="user-a")
+    await DurableJobStore.mark_queued(db, active.id)
+    await DurableJobStore.mark_running(db, active.id)
+    done = await _job(db, owner_id="user-a")
+    await DurableJobStore.mark_queued(db, done.id)
+    await DurableJobStore.mark_running(db, done.id)
+    await DurableJobStore.mark_succeeded(db, done.id, result={})
+    await db.commit()
+
+    only_active = await DurableJobStore.list_for_owner(db, owner_id="user-a", active_only=True)
+    assert [j.id for j in only_active] == [active.id]
+
+
+@pytest.mark.asyncio
+async def test_verify_celery_owner_is_durable(db):
+    """API 重启后（内存 owner map 清空）合法用户仍能凭 durable 行证明归属。"""
+    job = await _job(db, owner_id="user-a")
+    await DurableJobStore.mark_queued(db, job.id, celery_task_id="celery-xyz")
+    await db.commit()
+
+    assert await DurableJobStore.verify_celery_owner(db, "celery-xyz", owner_id="user-a") is True
+    assert await DurableJobStore.verify_celery_owner(db, "celery-xyz", owner_id="user-b") is False
+    assert await DurableJobStore.verify_celery_owner(db, "celery-xyz") is False
+    assert await DurableJobStore.verify_celery_owner(db, "") is False
+
+
+# ── stale 清扫（worker crash 恢复） ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sweep_stale_marks_heartbeat_timeout(db):
+    """规范 §25 / Scenario 7：worker 没了，job 不能永远 running。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+
+    # 模拟 worker 失联：心跳退回到很久以前
+    fresh = await DurableJobStore.get(db, job.id)
+    fresh.heartbeat_at = _naive_utc() - timedelta(seconds=900)
+    await db.commit()
+
+    swept = await DurableJobStore.sweep_stale(db, stale_after_s=300)
+    await db.commit()
+    assert swept == 1
+    after = await DurableJobStore.get(db, job.id)
+    assert coerce_status(after.status) is JobStatus.stale
+
+
+@pytest.mark.asyncio
+async def test_sweep_stale_leaves_healthy_jobs_alone(db):
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+
+    assert await DurableJobStore.sweep_stale(db, stale_after_s=300) == 0
+    assert coerce_status((await DurableJobStore.get(db, job.id)).status) is JobStatus.running
+
+
+@pytest.mark.asyncio
+async def test_sweep_stale_ignores_terminal_jobs(db):
+    """已完成的 job 不能被清扫改成 stale。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_succeeded(db, job.id, result={})
+    await db.commit()
+
+    assert await DurableJobStore.sweep_stale(db, stale_after_s=0) == 0
+    assert coerce_status((await DurableJobStore.get(db, job.id)).status) is JobStatus.completed
+
+
+@pytest.mark.asyncio
+async def test_sweep_stale_catches_never_heartbeated_job(db):
+    """启动很久但一次心跳都没写的 job 也要能被识别。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+    fresh = await DurableJobStore.get(db, job.id)
+    fresh.heartbeat_at = None
+    fresh.started_at = _naive_utc() - timedelta(seconds=900)
+    await db.commit()
+
+    assert await DurableJobStore.sweep_stale(db, stale_after_s=300) == 1
+
+
+# ── 重试 ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retry_creates_new_attempt_and_keeps_error(db):
+    """规范 §18：重试是新 attempt，不覆盖第一次失败的证据。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_failed(db, job.id, error=ConnectionError("STAC timeout"))
+    await db.commit()
+
+    ok, reason = await DurableJobStore.start_retry(db, job.id)
+    await db.commit()
+    assert (ok, reason) == (True, "requeued")
+
+    fresh = await DurableJobStore.get(db, job.id)
+    assert coerce_status(fresh.status) is JobStatus.queued
+    assert fresh.attempt == 2
+    assert fresh.retry_count == 1
+    assert "STAC timeout" in fresh.error_trace  # 首次失败证据保留
+    assert fresh.cancel_requested_at is None
+    assert fresh.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_job_is_never_retried(db):
+    """规范 §17 / Scenario 12：取消绝不能转成 retry。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.request_cancel(db, job.id)
+    await DurableJobStore.confirm_cancelled(db, job.id)
+    await db.commit()
+
+    ok, reason = await DurableJobStore.start_retry(db, job.id)
+    await db.commit()
+    assert ok is False
+    assert reason == "cancelled_jobs_are_never_retried"
+    assert coerce_status((await DurableJobStore.get(db, job.id)).status) is JobStatus.cancelled
+
+
+@pytest.mark.asyncio
+async def test_retry_rejects_running_job(db):
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+    ok, reason = await DurableJobStore.start_retry(db, job.id)
+    assert ok is False
+    assert reason == "not_retryable_from_running"
+
+
+@pytest.mark.asyncio
+async def test_retry_respects_max_retries(db):
+    job = await _job(db, max_retries=1)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_failed(db, job.id, error="boom")
+    await db.commit()
+
+    assert (await DurableJobStore.start_retry(db, job.id))[0] is True
+    await db.commit()
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_failed(db, job.id, error="boom again")
+    await db.commit()
+
+    ok, reason = await DurableJobStore.start_retry(db, job.id)
+    assert ok is False
+    assert reason == "max_retries_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_stale_job_can_be_retried(db):
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+    fresh = await DurableJobStore.get(db, job.id)
+    fresh.heartbeat_at = _naive_utc() - timedelta(seconds=900)
+    await db.commit()
+    await DurableJobStore.sweep_stale(db, stale_after_s=300)
+    await db.commit()
+
+    ok, reason = await DurableJobStore.start_retry(db, job.id)
+    await db.commit()
+    assert (ok, reason) == (True, "requeued")
+    assert (await DurableJobStore.get(db, job.id)).attempt == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_retry_only_one_wins(session_factory):
+    """并发重试不得把 attempt 加两次或产生两次执行。"""
+    async with session_factory() as s:
+        job = await DurableJobStore.create(
+            s,
+            task_type="ndvi",
+            owner_id="u",
+            parameters={},
+            dispatch_spec={"task": "t", "args": [], "kwargs": {}},
+        )
+        await s.commit()
+        await DurableJobStore.mark_queued(s, job.id)
+        await DurableJobStore.mark_running(s, job.id)
+        await DurableJobStore.mark_failed(s, job.id, error="boom")
+        await s.commit()
+        job_id = job.id
+
+    async def retry():
+        async with session_factory() as s:
+            ok, reason = await DurableJobStore.start_retry(s, job_id)
+            await s.commit()
+            return ok
+
+    results = await asyncio.gather(*(retry() for _ in range(4)))
+    assert results.count(True) == 1
+
+    async with session_factory() as s:
+        fresh = await DurableJobStore.get(s, job_id)
+        assert fresh.attempt == 2
+
+
+# ── worker 侧同步入口 ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_is_cancel_requested_sync_reads_durable_fact(db, engine):
+    """worker 从 DB 读取取消 —— 与「取消请求落在哪个进程」无关。"""
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.request_cancel(db, job.id)
+    await db.commit()
+    job_id = job.id
+
+    # 用同步 sqlite 连接模拟 worker 进程
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    sync_url = str(engine.url).replace("sqlite+aiosqlite", "sqlite")
+    sync_engine = create_engine(sync_url)
+    Sess = sessionmaker(bind=sync_engine)
+    try:
+        with Sess() as s:
+            assert DurableJobStore.is_cancel_requested_sync(s, job_id) is True
+            assert DurableJobStore.is_cancel_requested_sync(s, 99999) is False
+    finally:
+        sync_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_retry_refused_without_dispatch_spec(db):
+    """规范 §9：只有 retry 真正可靠时才提供。
+
+    没有 dispatch 描述符就无法忠实重新入队 —— 此时必须明确拒绝，而不是把状态改成
+    queued 却永远没有执行体（那样用户会看到一个永不推进的任务）。
+    """
+    job = await _job(db, dispatch_spec=None)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_failed(db, job.id, error="boom")
+    await db.commit()
+
+    ok, reason = await DurableJobStore.start_retry(db, job.id)
+    assert ok is False
+    assert reason == "no_dispatch_spec"
+    assert coerce_status((await DurableJobStore.get(db, job.id)).status) is JobStatus.failed
+
+
+@pytest.mark.asyncio
+async def test_dispatch_spec_with_sensitive_argument_is_rejected(db):
+    """凭据绝不落库：带敏感 kwarg 的描述符被标记不可用，因此该 job 不可重试。"""
+    job = await _job(
+        db,
+        dispatch_spec={"task": "t", "args": [], "kwargs": {"api_key": "leak-me"}},
+    )
+    await db.commit()
+    assert "leak-me" not in str(job.dispatch_spec)
+    assert job.dispatch_spec["__truncated__"] == "dispatch_spec"
+
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.mark_failed(db, job.id, error="boom")
+    await db.commit()
+    ok, reason = await DurableJobStore.start_retry(db, job.id)
+    assert ok is False
+    assert reason == "dispatch_spec_unusable"
+
+
+@pytest.mark.asyncio
+async def test_sweep_converges_cancelling_job_to_cancelled(db):
+    """worker 在确认取消前失联：job 必须收敛到 cancelled，绝不能永久停在 cancelling。
+
+    也不能收敛到 stale —— stale 是可重试的，那等于给被取消的任务开了一条重跑后门
+    （规范 §17）。
+    """
+    job = await _job(db)
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await DurableJobStore.request_cancel(db, job.id)
+    await db.commit()
+    assert coerce_status((await DurableJobStore.get(db, job.id)).status) is JobStatus.cancelling
+
+    fresh = await DurableJobStore.get(db, job.id)
+    fresh.heartbeat_at = _naive_utc() - timedelta(seconds=900)
+    await db.commit()
+
+    swept = await DurableJobStore.sweep_stale(db, stale_after_s=300)
+    await db.commit()
+    assert swept == 1
+    after = await DurableJobStore.get(db, job.id)
+    assert coerce_status(after.status) is JobStatus.cancelled
+
+    ok, reason = await DurableJobStore.start_retry(db, job.id)
+    assert ok is False
+    assert reason == "cancelled_jobs_are_never_retried"
+
+
+@pytest.mark.asyncio
+async def test_anonymous_owner_id_is_normalized_to_null(db):
+    """auth 层的字面量 "anonymous" 不是 users 表里的一行 —— 直接写 creator_id
+    会在 PostgreSQL 上违反外键，匿名用户于是完全无法创建 durable job。"""
+    job = await _job(db, owner_id="anonymous", owner_token="tok-anon")
+    assert job.creator_id is None
+    # 归属仍然成立（靠 owner_token）
+    got = await DurableJobStore.get_for_owner(db, job.id, owner_token="tok-anon")
+    assert got.id == job.id
+    # 而 "anonymous" 不能当作一个真实 owner 去匹配别人的行
+    assert await DurableJobStore.list_for_owner(db, owner_id="anonymous") == []
+
+
+# ── 幂等复用策略（round-2 审计） ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancelled_job_does_not_block_resubmission(db):
+    """取消后再次请求同样的分析必须能真的跑起来。
+
+    幂等键若无条件复用旧行，提交路径会永远返回「已复用」而什么都不执行 —— 而
+    cancelled 又永不可 retry，于是形成一个除了改参数无法脱出的死胡同。
+    """
+    first = await _job(db, idempotency_key="ndvi:sess-a:abc")
+    await DurableJobStore.mark_queued(db, first.id)
+    await DurableJobStore.mark_running(db, first.id)
+    await DurableJobStore.request_cancel(db, first.id)
+    await DurableJobStore.confirm_cancelled(db, first.id)
+    await db.commit()
+
+    second = await DurableJobStore.create(
+        db, task_type="ndvi", owner_id="user-a", idempotency_key="ndvi:sess-a:abc"
+    )
+    await db.commit()
+
+    assert second.id != first.id, "取消后的重新提交必须创建新 job"
+    # 旧行保留为历史证据，只是让出了幂等键
+    old = await DurableJobStore.get(db, first.id)
+    assert coerce_status(old.status) is JobStatus.cancelled
+    assert old.idempotency_key is None
+
+
+@pytest.mark.asyncio
+async def test_failed_job_does_not_block_resubmission(db):
+    first = await _job(db, idempotency_key="k-failed")
+    await DurableJobStore.mark_queued(db, first.id)
+    await DurableJobStore.mark_running(db, first.id)
+    await DurableJobStore.mark_failed(db, first.id, error="boom")
+    await db.commit()
+
+    second = await DurableJobStore.create(
+        db, task_type="ndvi", owner_id="user-a", idempotency_key="k-failed"
+    )
+    await db.commit()
+    assert second.id != first.id
+
+
+@pytest.mark.asyncio
+async def test_inflight_and_completed_jobs_are_still_reused(db):
+    """在飞与已成功的 job 仍然必须被复用 —— 否则双击会跑两次。"""
+    running = await _job(db, idempotency_key="k-running")
+    await DurableJobStore.mark_queued(db, running.id)
+    await DurableJobStore.mark_running(db, running.id)
+    await db.commit()
+    again = await DurableJobStore.create(
+        db, task_type="ndvi", owner_id="user-a", idempotency_key="k-running"
+    )
+    assert again.id == running.id
+
+    done = await _job(db, idempotency_key="k-done")
+    await DurableJobStore.mark_queued(db, done.id)
+    await DurableJobStore.mark_running(db, done.id)
+    await DurableJobStore.mark_succeeded(db, done.id, result={})
+    await db.commit()
+    reused = await DurableJobStore.create(
+        db, task_type="ndvi", owner_id="user-a", idempotency_key="k-done"
+    )
+    assert reused.id == done.id
+
+
+# ── 孤儿 job 清扫（round-2 审计） ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orphaned_pending_job_is_swept_to_failed(db):
+    """pending/queued 不会心跳 —— 提交路径崩溃留下的 job 必须另有出路。"""
+    job = await _job(db)
+    fresh = await DurableJobStore.get(db, job.id)
+    fresh.created_at = _naive_utc() - timedelta(seconds=7200)
+    await db.commit()
+
+    swept = await DurableJobStore.sweep_orphans(db, orphan_after_s=3600)
+    await db.commit()
+    assert swept == 1
+    after = await DurableJobStore.get(db, job.id)
+    assert coerce_status(after.status) is JobStatus.failed
+    # failed 可重试，因此没有丢掉任何合法结局
+    assert after.dispatch_spec is not None
+
+
+@pytest.mark.asyncio
+async def test_orphan_sweep_leaves_recent_and_running_jobs_alone(db):
+    recent = await _job(db)
+    running = await _job(db)
+    await DurableJobStore.mark_queued(db, running.id)
+    await DurableJobStore.mark_running(db, running.id)
+    await db.commit()
+
+    assert await DurableJobStore.sweep_orphans(db, orphan_after_s=3600) == 0
+    assert coerce_status((await DurableJobStore.get(db, recent.id)).status) is JobStatus.pending
+    assert coerce_status((await DurableJobStore.get(db, running.id)).status) is JobStatus.running
+
+
+# ── has_active 不受列表截断影响（round-2 审计） ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_has_active_is_independent_of_list_limit(db):
+    """活跃 job 比一页更旧时，不能误判「无活跃任务」让前端停止轮询。"""
+    old_running = await _job(db, owner_id="user-a", session_id="sess-a")
+    await DurableJobStore.mark_queued(db, old_running.id)
+    await DurableJobStore.mark_running(db, old_running.id)
+    await db.commit()
+
+    # 之后再塞一批已完成的 job，把活跃那条挤出第一页
+    for _ in range(5):
+        done = await _job(db, owner_id="user-a", session_id="sess-a")
+        await DurableJobStore.mark_queued(db, done.id)
+        await DurableJobStore.mark_running(db, done.id)
+        await DurableJobStore.mark_succeeded(db, done.id, result={})
+    await db.commit()
+
+    page = await DurableJobStore.list_for_owner(db, owner_id="user-a", limit=2)
+    assert all(coerce_status(j.status) is JobStatus.completed for j in page)
+    assert await DurableJobStore.has_active_for_owner(db, owner_id="user-a") is True
+
+
+@pytest.mark.asyncio
+async def test_has_active_respects_ownership(db):
+    job = await _job(db, owner_id="user-a")
+    await DurableJobStore.mark_queued(db, job.id)
+    await DurableJobStore.mark_running(db, job.id)
+    await db.commit()
+    assert await DurableJobStore.has_active_for_owner(db, owner_id="user-a") is True
+    assert await DurableJobStore.has_active_for_owner(db, owner_id="user-b") is False
+    assert await DurableJobStore.has_active_for_owner(db) is False

--- a/tests/jobs/test_job_worker.py
+++ b/tests/jobs/test_job_worker.py
@@ -1,0 +1,414 @@
+"""Worker 侧 durable job 运行时：协作取消、进度节流、原子产物、重复投递防护。
+
+用真实 SQLite（同步 Session，与 Celery worker 相同的访问方式）+ 真实临时文件，
+不 mock 掉被测语义。
+"""
+import os
+import time
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.db_model import Base
+from app.services.jobs import (
+    AlreadyFinished,
+    DurableJobStore,
+    JobKind,
+    JobStatus,
+    OperationCancelled,
+    ProgressThrottle,
+    coerce_status,
+    durable_job,
+    finish_job,
+)
+from app.services.jobs.artifacts import atomic_output
+
+
+@pytest.fixture
+def worker_env(tmp_path):
+    """同步 engine + session_factory，模拟 Celery worker 的 db_session。"""
+    engine = create_engine(f"sqlite:///{tmp_path / 'worker.db'}")
+    Base.metadata.create_all(engine)
+    Sess = sessionmaker(bind=engine)
+
+    class _Factory:
+        def __call__(self):
+            return Sess()
+
+    factory = _Factory()
+
+    def make_job(**overrides) -> int:
+        params = {
+            "task_type": "ndvi",
+            "kind": JobKind.analysis,
+            "owner_id": "user-a",
+            "session_id": "sess-a",
+            "parameters": {"raster_path": "/data/a.tif"},
+            "dispatch_spec": {
+                "task": "app.services.spatial_tasks.run_ndvi_analysis",
+                "args": ["/data/a.tif"],
+                "kwargs": {},
+            },
+        }
+        params.update(overrides)
+        with Sess() as db:
+            job = DurableJobStore.create_sync(db, **params)
+            DurableJobStore.transition_sync(
+                db, job.id, JobStatus.queued, expected=[JobStatus.pending]
+            )
+            db.commit()
+            return int(job.id)
+
+    def status_of(job_id: int) -> JobStatus:
+        with Sess() as db:
+            return coerce_status(DurableJobStore.get_sync(db, job_id).status)
+
+    def record(job_id: int):
+        with Sess() as db:
+            job = DurableJobStore.get_sync(db, job_id)
+            db.expunge(job)
+            return job
+
+    yield {
+        "factory": factory,
+        "make_job": make_job,
+        "status_of": status_of,
+        "record": record,
+        "tmp_path": tmp_path,
+    }
+    engine.dispose()
+
+
+# ── 正常路径 ────────────────────────────────────────────────────────
+
+
+def test_durable_job_marks_running_then_completed(worker_env):
+    job_id = worker_env["make_job"]()
+
+    with durable_job(job_id, session_factory=worker_env["factory"]) as job:
+        assert worker_env["status_of"](job_id) is JobStatus.running
+        job.progress(50, "计算中", phase="compute")
+
+    status = finish_job(job_id, result={"mean": 0.42}, session_factory=worker_env["factory"])
+    assert status is JobStatus.completed
+
+    rec = worker_env["record"](job_id)
+    assert coerce_status(rec.status) is JobStatus.completed
+    assert rec.progress == 100
+    assert rec.worker_id, "worker_id 必须落库，stale 归因需要它"
+    assert rec.started_at is not None
+
+
+def test_progress_writes_are_throttled(worker_env):
+    """规范 §20：大循环不得每次迭代写一次 DB。"""
+    job_id = worker_env["make_job"]()
+    throttle = ProgressThrottle(min_delta_pct=10.0, min_interval_s=3600.0)
+
+    with durable_job(
+        job_id, session_factory=worker_env["factory"], progress_throttle=throttle
+    ) as job:
+        for i in range(1000):
+            job.progress(i * 100 // 1000, "计算中")
+
+    # 首次 + 每 10% 一次 + 100% ≈ 11 次，绝不是 1000 次
+    assert job.progress_writes <= 12, job.progress_writes
+    assert job.progress_writes >= 2
+
+
+def test_heartbeat_is_refreshed_by_progress(worker_env):
+    job_id = worker_env["make_job"]()
+    with durable_job(job_id, session_factory=worker_env["factory"]) as job:
+        job.progress(10, "start", force=True)
+        rec = worker_env["record"](job_id)
+        assert rec.heartbeat_at is not None
+
+
+# ── 取消 ────────────────────────────────────────────────────────────
+
+
+def test_cooperative_cancel_stops_loop_early(worker_env):
+    """规范 §13 / Scenario 3：取消后不再执行后续 chunk，CPU 真正释放。
+
+    取消事实写进 DB（与 API 走同一条路），然后显式驱动一次看门狗轮询 —— 这样断言
+    完全确定，不依赖后台线程的调度时序。看门狗自己会推送这件事由下一个测试覆盖。
+    """
+    job_id = worker_env["make_job"]()
+    executed: list[int] = []
+    total_chunks = 100
+
+    with pytest.raises(OperationCancelled):
+        with durable_job(
+            job_id, session_factory=worker_env["factory"], cancel_interval=3600.0
+        ) as job:
+            for i in job.chunks(range(total_chunks)):
+                executed.append(i)
+                if i == 4:
+                    with worker_env["factory"]() as db:
+                        DurableJobStore.request_cancel_sync(db, job_id)
+                        db.commit()
+                    job.poll_cancel()  # 看门狗每 tick 做的正是这件事
+
+    assert len(executed) <= 7, f"取消后仍执行了 {len(executed)}/{total_chunks} 个 chunk"
+    assert worker_env["status_of"](job_id) is JobStatus.cancelled
+
+
+def test_watchdog_pushes_cancel_without_body_polling(worker_env):
+    """取消必须被**推**给执行体：任务体不主动查 DB 也要能感知（规范 §11/§12）。
+
+    这是「取消不只是 UI 状态」的核心机制 —— 一段不可中断的 numpy 计算期间没人会去
+    读 DB，只有后台看门狗能点燃 token，让下一个 checkpoint 生效。
+    """
+    job_id = worker_env["make_job"]()
+
+    with pytest.raises(OperationCancelled):
+        with durable_job(
+            job_id, session_factory=worker_env["factory"], cancel_interval=0.02
+        ) as job:
+            with worker_env["factory"]() as db:
+                DurableJobStore.request_cancel_sync(db, job_id)
+                db.commit()
+
+            # 任务体只睡觉，从不 poll_cancel —— token 必须由看门狗线程点燃
+            deadline = time.monotonic() + 10.0
+            while not job.token.cancelled and time.monotonic() < deadline:
+                time.sleep(0.02)
+
+            assert job.token.cancelled, "看门狗未在 10s 内推送取消"
+            assert job.watchdog.db_polls >= 1
+            job.checkpoint()  # 现在应当抛出
+
+    assert worker_env["status_of"](job_id) is JobStatus.cancelled
+
+
+def test_checkpoints_do_not_hit_the_database(worker_env):
+    """checkpoint 只读内存 token —— 密集检查点不得产生 DB 查询。"""
+    job_id = worker_env["make_job"]()
+    with durable_job(
+        job_id, session_factory=worker_env["factory"], cancel_interval=3600.0
+    ) as job:
+        before = job.watchdog.db_polls
+        for _ in job.chunks(range(5000)):
+            pass
+        assert job.checkpoints == 5000
+        assert job.watchdog.db_polls == before, "checkpoint 不应触发 DB 轮询"
+    finish_job(job_id, result={}, session_factory=worker_env["factory"])
+
+
+def test_cancel_before_execution_skips_body(worker_env):
+    """job 在 worker 拿到它之前就被取消 → 任务体一次都不执行。"""
+    job_id = worker_env["make_job"]()
+    with worker_env["factory"]() as db:
+        DurableJobStore.request_cancel_sync(db, job_id)
+        db.commit()
+
+    executed: list[int] = []
+    with pytest.raises(AlreadyFinished):
+        with durable_job(job_id, session_factory=worker_env["factory"]):
+            executed.append(1)
+
+    assert executed == []
+    assert worker_env["status_of"](job_id) is JobStatus.cancelled
+
+
+def test_late_success_after_cancel_converges_to_cancelled(worker_env):
+    """Scenario 4：worker 在 cancelling 期间跑完 → 终态仍是 cancelled。"""
+    job_id = worker_env["make_job"]()
+
+    with durable_job(job_id, session_factory=worker_env["factory"], cancel_interval=3600.0):
+        # 取消到达，但任务体没有 checkpoint（模拟一段不可中断的 numpy 计算）
+        with worker_env["factory"]() as db:
+            DurableJobStore.request_cancel_sync(db, job_id)
+            db.commit()
+
+    status = finish_job(job_id, result={"mean": 0.9}, session_factory=worker_env["factory"])
+    assert status is JobStatus.cancelled
+    rec = worker_env["record"](job_id)
+    assert coerce_status(rec.status) is JobStatus.cancelled
+    assert rec.result_summary is None
+
+
+# ── 重复投递防护 ────────────────────────────────────────────────────
+
+
+def test_duplicate_delivery_of_terminal_job_is_skipped(worker_env):
+    """acks_late 下 broker 可能重投；已终态的 job 绝不能重跑（规范 §16）。"""
+    job_id = worker_env["make_job"]()
+    with durable_job(job_id, session_factory=worker_env["factory"]):
+        pass
+    finish_job(job_id, result={"first": True}, session_factory=worker_env["factory"])
+
+    executed: list[int] = []
+    with pytest.raises(AlreadyFinished):
+        with durable_job(job_id, session_factory=worker_env["factory"]):
+            executed.append(1)
+    assert executed == []
+
+    rec = worker_env["record"](job_id)
+    assert rec.result_summary == {"first": True}, "重投不得改写已完成的结果"
+
+
+def test_unknown_job_raises_already_finished(worker_env):
+    with pytest.raises(AlreadyFinished):
+        with durable_job(999999, session_factory=worker_env["factory"]):
+            pass
+
+
+# ── 失败 ────────────────────────────────────────────────────────────
+
+
+def test_exception_marks_failed_with_redacted_error(worker_env):
+    """错误只落单行摘要，绝不落 traceback（规范 §7 / §10）。"""
+    job_id = worker_env["make_job"]()
+    with pytest.raises(ValueError):
+        with durable_job(job_id, session_factory=worker_env["factory"]):
+            raise ValueError("invalid CRS: EPSG:99999")
+
+    rec = worker_env["record"](job_id)
+    assert coerce_status(rec.status) is JobStatus.failed
+    assert rec.error_trace == "ValueError: invalid CRS: EPSG:99999"
+    assert "Traceback" not in (rec.error_trace or "")
+    assert "\n" not in (rec.error_trace or "")
+
+
+# ── 产物原子性 ──────────────────────────────────────────────────────
+
+
+def test_artifact_is_finalized_atomically(worker_env):
+    """Scenario 14：成功产物 finalize 恰好一次，且中途不可见。"""
+    job_id = worker_env["make_job"]()
+    final = str(worker_env["tmp_path"] / "out" / "ndvi.tif")
+
+    with durable_job(job_id, session_factory=worker_env["factory"]) as job:
+        with job.artifact(final) as tmp:
+            assert not os.path.exists(final), "finalize 之前最终路径不得存在"
+            assert tmp != final
+            with open(tmp, "wb") as fh:
+                fh.write(b"GEOTIFF")
+
+    assert os.path.exists(final)
+    with open(final, "rb") as fh:
+        assert fh.read() == b"GEOTIFF"
+    assert not os.path.exists(tmp)  # 临时文件已被 replace 掉
+
+
+def test_artifact_is_discarded_on_failure(worker_env):
+    """Scenario 13：失败不留 half-ready 产物。"""
+    job_id = worker_env["make_job"]()
+    final = str(worker_env["tmp_path"] / "fail.tif")
+    leaked: list[str] = []
+
+    with pytest.raises(RuntimeError):
+        with durable_job(job_id, session_factory=worker_env["factory"]) as job:
+            with job.artifact(final) as tmp:
+                leaked.append(tmp)
+                with open(tmp, "wb") as fh:
+                    fh.write(b"HALF")
+                raise RuntimeError("compute exploded")
+
+    assert not os.path.exists(final)
+    assert not os.path.exists(leaked[0]), "临时文件必须被清理"
+    assert worker_env["status_of"](job_id) is JobStatus.failed
+
+
+def test_artifact_is_discarded_on_cancel(worker_env):
+    """取消后不得留下半个 GeoTIFF（规范 §24）。"""
+    job_id = worker_env["make_job"]()
+    final = str(worker_env["tmp_path"] / "cancelled.tif")
+    leaked: list[str] = []
+
+    with pytest.raises(OperationCancelled):
+        with durable_job(
+            job_id, session_factory=worker_env["factory"], cancel_interval=3600.0
+        ) as job:
+            with job.artifact(final) as tmp:
+                leaked.append(tmp)
+                with open(tmp, "wb") as fh:
+                    fh.write(b"PARTIAL")
+                with worker_env["factory"]() as db:
+                    DurableJobStore.request_cancel_sync(db, job_id)
+                    db.commit()
+                job.poll_cancel()
+                job.checkpoint()
+
+    assert not os.path.exists(final)
+    assert not os.path.exists(leaked[0])
+    assert worker_env["status_of"](job_id) is JobStatus.cancelled
+
+
+def test_artifact_producer_writing_nothing_is_an_error(worker_env):
+    """声明了产物却什么都没写 → 视为失败，不注册不存在的 artifact。"""
+    job_id = worker_env["make_job"]()
+    final = str(worker_env["tmp_path"] / "empty.tif")
+    with pytest.raises(FileNotFoundError):
+        with durable_job(job_id, session_factory=worker_env["factory"]) as job:
+            with job.artifact(final):
+                pass
+    assert not os.path.exists(final)
+
+
+def test_tracked_temp_files_are_cleaned_on_failure(worker_env):
+    job_id = worker_env["make_job"]()
+    temp = str(worker_env["tmp_path"] / "scratch.dat")
+    with open(temp, "wb") as fh:
+        fh.write(b"scratch")
+
+    with pytest.raises(RuntimeError):
+        with durable_job(job_id, session_factory=worker_env["factory"]) as job:
+            job.track_temp(temp)
+            raise RuntimeError("boom")
+
+    assert not os.path.exists(temp)
+
+
+def test_successful_artifact_is_never_deleted_by_later_cleanup(worker_env):
+    """清理只针对本次的 .part 文件 —— 已 finalize 的成功产物绝不能被删。"""
+    job_id = worker_env["make_job"]()
+    final = str(worker_env["tmp_path"] / "keep.tif")
+
+    with pytest.raises(RuntimeError):
+        with durable_job(job_id, session_factory=worker_env["factory"]) as job:
+            with job.artifact(final) as tmp:
+                with open(tmp, "wb") as fh:
+                    fh.write(b"GOOD")
+            assert os.path.exists(final)
+            raise RuntimeError("later step failed")
+
+    assert os.path.exists(final), "已成功 finalize 的产物不应被后续失败清理掉"
+
+
+# ── atomic_output 独立单测 ──────────────────────────────────────────
+
+
+def test_atomic_output_should_abort_discards(tmp_path):
+    final = str(tmp_path / "aborted.tif")
+    captured: list[str] = []
+    with pytest.raises(RuntimeError):
+        with atomic_output(final, should_abort=lambda: True) as tmp:
+            captured.append(tmp)
+            with open(tmp, "wb") as fh:
+                fh.write(b"x")
+    assert not os.path.exists(final)
+    assert not os.path.exists(captured[0])
+
+
+def test_atomic_output_creates_parent_dirs(tmp_path):
+    final = str(tmp_path / "deep" / "nested" / "out.tif")
+    with atomic_output(final) as tmp:
+        with open(tmp, "wb") as fh:
+            fh.write(b"x")
+    assert os.path.exists(final)
+
+
+def test_atomic_output_overwrites_existing_file(tmp_path):
+    """重跑覆盖旧产物必须是原子替换，不能出现「删了旧的还没写新的」窗口。"""
+    final = str(tmp_path / "out.tif")
+    with open(final, "wb") as fh:
+        fh.write(b"OLD")
+    with atomic_output(final) as tmp:
+        with open(tmp, "wb") as fh:
+            fh.write(b"NEW")
+        with open(final, "rb") as fh:
+            assert fh.read() == b"OLD", "替换前旧产物必须仍然完整可读"
+    with open(final, "rb") as fh:
+        assert fh.read() == b"NEW"

--- a/tests/test_critical_backend_correctness.py
+++ b/tests/test_critical_backend_correctness.py
@@ -470,8 +470,10 @@ async def test_c5_dispatch_task_cancelled_on_disconnect(monkeypatch):
 
     reached_wait = asyncio.Event()
 
-    async def fast_wait(fs, timeout=None):
-        # 标记已进入 dispatch 等待，并立即返回（done 为空，模拟工具仍在跑）
+    async def fast_wait(fs, timeout=None, return_when=None):
+        # 标记已进入 dispatch 等待，并立即返回（done 为空，模拟工具仍在跑）。
+        # ADR-0052：并行 wave 现在用 return_when=FIRST_COMPLETED 并把取消 token 的
+        # 等待任务一起放进 wait 集合（抢占式取消），替身必须接受该参数。
         reached_wait.set()
         return set(), set(fs)
     monkeypatch.setattr(asyncio, "wait", fast_wait)

--- a/tests/test_medium_backend_arch.py
+++ b/tests/test_medium_backend_arch.py
@@ -224,16 +224,33 @@ async def test_m4_chat_marks_task_failed_on_llm_error(monkeypatch):
 
 # ── M7: task_tracker cancel 文档化 ─────────────────────────────────────
 # 注：本测试检查 docstring 内容（API 文档契约），不是源码结构 inspect。
-# cooperative 取消语义是 cancel() 对外的行为约定，文档化它本身就是需求。
+# cancel() 的取消语义是对外行为约定，文档化它本身就是需求。
+#
+# ADR-0052 之后契约变了：cancel 不再「只是协作式、不打断在跑的 tool」，而是
+# 抢占式 + 协作式混合 —— 点燃 CancellationToken 后，asyncio 侧立即打断在飞任务，
+# 同步 GIS 循环在 checkpoint 处退出。因此本测试改为验证新契约被文档化。
 
 
-def test_m7_cancel_docstring_documents_cooperative_limitation():
-    """M7：cancel() docstring 必须说明 cooperative 限制。"""
+def test_m7_cancel_docstring_documents_cancellation_contract():
+    """M7：cancel() docstring 必须说明取消如何贯穿执行路径。"""
     from app.services.task_tracker import TaskTracker
 
     doc = TaskTracker.cancel.__doc__ or ""
-    assert "cooperative" in doc.lower() or "协作" in doc, (
-        "cancel() docstring 应说明 cooperative 语义"
+    lowered = doc.lower()
+
+    # 协作式部分（GIS 循环在检查点退出）仍然是契约的一半
+    assert "协作" in doc or "cooperative" in lowered or "checkpoint" in lowered, (
+        "cancel() docstring 应说明协作式取消（检查点退出）"
     )
-    # 应提到不会打断正在执行的 tool
-    assert "打断" in doc or "interrupt" in doc.lower() or "preemptive" in doc.lower()
+    # 抢占式部分：取消不再等在跑的 tool 自然结束
+    assert "抢占" in doc or "preemptive" in lowered, (
+        "cancel() docstring 应说明抢占式取消（立即打断在飞任务）"
+    )
+    # 传播机制必须写清楚，否则调用方不知道取消能到多深
+    assert "cancellationtoken" in lowered, (
+        "cancel() docstring 应说明通过 CancellationToken 传播"
+    )
+    # 幂等性是调用方最容易踩的点（重复取消）
+    assert "幂等" in doc or "idempotent" in lowered, (
+        "cancel() docstring 应说明重复取消的幂等语义"
+    )

--- a/tests/test_medium_memory_leaks.py
+++ b/tests/test_medium_memory_leaks.py
@@ -232,4 +232,9 @@ def test_s46_lifespan_starts_cleanup_task():
     source = inspect.getsource(main_module.lifespan)
     assert "_periodic_session_cleanup" in source, "lifespan 未启动 cleanup 任务"
     assert "create_task" in source, "lifespan 未用 create_task 启动后台任务"
-    assert "cleanup_task.cancel()" in source, "lifespan 未在退出时 cancel cleanup 任务"
+    # ADR-0052 起 lifespan 管理多个后台任务（session cleanup + stale job sweep），
+    # 退出时在一个循环里统一 cancel。这里断言「cleanup_task 会被 cancel」这个
+    # 不变式，而不是某一行的字面写法 —— 否则每加一个后台任务都要改这个测试。
+    assert "cleanup_task" in source, "lifespan 未持有 cleanup 任务句柄"
+    assert ".cancel()" in source, "lifespan 未在退出时 cancel 后台任务"
+    assert "CancelledError" in source, "lifespan 未在退出时 await 被 cancel 的任务"


### PR DESCRIPTION
## Problem

Three disconnected stores each held part of "what is this task doing":

```
TaskTracker._tasks              in-process dict   agent turn steps, lost on restart
AnalysisTask (analysis_tasks)   PostgreSQL        full state machine + progress — zero callers
TaskQueueService._task_owners   in-process dict   the only source of truth for Celery ownership
```

Concrete consequences, all verified in code rather than inferred:

1. **Cancellation was UI state.** `TaskTracker.cancel()` flipped a boolean polled only *between* rounds and after each completed tool, so an in-flight NDVI or buffer analysis ran 30–60s to completion. Its own docstring admitted this. CPU, worker and memory were never released.
2. **API restart lost ownership.** `_task_owners` is process-local: after a restart a legitimate user got 404 on their own Celery job and could not cancel it; across replicas only the pod that registered the task recognised it.
3. **Agent tasks and background jobs were unrelated.** `task-xxxxxxxx` and `celery_task_id` were separate namespaces, so the UI could only show two unlinked entries.
4. **Worker crash meant permanent `running`.** No heartbeat, lease or sweeper existed.
5. **Progress had no shared contract.** Celery used `update_state` (Redis-only); the agent emitted step events. Neither gave the client a percentage.
6. **Artifacts were not atomic.** NDVI wrote straight to its final path, so cancel or crash left a half-written GeoTIFF indistinguishable from a good one.

## Architecture

```
Agent Turn ──▶ Tool Step ──▶ Durable Job ──▶ Worker ──▶ Artifact
    │              │              │             │           │
 TaskTracker   background_    analysis_tasks  watchdog   temp → os.replace
 + token       job_ids on     (single source   thread     (atomic finalize)
               step_result     of truth)      (cancel+heartbeat)
```

`analysis_tasks` is **evolved**, not replaced — it already had the status CHECK, `progress`, `retry_count`, timestamps and org/creator ownership. Migration `0013` is additive: 17 nullable columns, 5 indexes, a widened `ck_task_status` (adds `cancelling`, `stale`), relaxed `org_id`/`creator_id` nullability. Existing rows stay valid; downgrade normalizes the two new statuses to `failed` instead of deleting data.

Lifecycle, with two invariants enforced by an explicit transition table:

```
pending → queued → running → completed
                     ↓  ↘
              cancelling   failed / stale → (explicit new attempt) → queued
                     ↓
                cancelled
```

* `cancelled` and `completed` have **no successors** — a late success cannot overwrite a cancellation, and a cancelled job is never retried.
* `cancelling` reaches only `cancelled`/`failed` — a worker finishing during cancellation has its result discarded.

## Cancellation

What is genuinely cancellable now, and by what mechanism:

| Path | Mechanism | Behaviour |
|---|---|---|
| In-flight async tool | engine `await`s `token.wait()` inside the parallel wave (`FIRST_COMPLETED`) | **preemptive** — in-flight asyncio tasks cancelled at once |
| Sync GIS loops (hotspot, cluster, LISA, ST-DBSCAN, Moran's I, H3 binning, IDW, Voronoi, isochrone) | token via ContextVar (`asyncio.to_thread` copies context) + `checkpoint()` | exits at next chunk boundary |
| Raster windows (`reclassify`, `raster_calculator`) | per-window `checkpoint()` + `atomic_output` | stops between windows, no partial GeoTIFF |
| Cross-process Celery worker | watchdog thread polls durable `cancel_requested_at` and **pushes** to the token | GIS-library checkpoints become effective |
| Before irreversible effects | `ensure_not_cancelled()` forces a durable read; asset INSERT re-checks in its own transaction | no ready asset for a cancelled job |

The watchdog has to push rather than be polled: a probe read only from `checkpoint()` is useless during an uninterruptible `np.divide` — nobody consults the DB, so the compute finishes anyway.

Not cancellable: a single uninterruptible array operation. The cancel takes effect when it returns. Finer granularity needs band math split into chunked loops (out of scope).

## Persistence

The durable row is the source of truth; `_task_owners` is demoted to a fast-path cache. Ownership accepts three proofs — authenticated `creator_id`, anonymous `owner_token` (mirroring SEC-08), or a verified `session_id` — and with none of them the predicate is **constant-false** rather than an unfiltered scan.

Concurrency safety is atomic conditional updates, `UPDATE ... WHERE status IN (<legal predecessors>)`; `rowcount == 0` tells the caller the state moved. Reads after a bulk UPDATE use column-level SELECTs, because `expire_on_commit=False` plus `synchronize_session='evaluate'` lets a *failed* conditional update rewrite a stale ORM object's attributes in memory — every "re-read after failed update" fallback would otherwise draw the wrong conclusion.

Worker-crash recovery: heartbeats are independent of progress reporting (progress is throttled, so a job whose percentage stalls would otherwise be swept while alive). A 60s sweeper converges lost-heartbeat jobs to `stale` (retryable) — or to `cancelled` when the worker died mid-cancellation, so cancellation cannot be laundered into a re-run — and separately converges `pending`/`queued` rows no worker ever claimed, which never heartbeat and so cannot be caught any other way.

## Frontend

New sidebar Task Center: name, type, status, progress, message, elapsed, cancel, retry, result. Cancel shows `取消中…` and only becomes `已取消` once the backend is terminal; a failed cancel rolls back and surfaces the error. Indeterminate work renders as "进行中", never a fabricated percentage.

Polling is the reload/reconnect fallback only (SSE remains the push path; no new transport). It is bounded on every side: none without a session, none once nothing is active, paused while the tab is hidden, aborted on unmount and session switch, stopped after bounded consecutive errors. A per-request generation plus the session captured at request time discard stale responses; mutations use a separate session **epoch**, because reusing the request generation made a refresh triggered by the mutation itself look stale and silently dropped its error.

## Concurrency

Verified by tests using events/barriers, not sleeps: cancel-vs-complete converges to one terminal state and never hangs in `cancelling`; concurrent completions yield exactly one winner whose result later writes cannot overwrite; concurrent retries increment `attempt` once; 32 contending writers produce exactly 1 winner. Duplicate delivery is blocked by treating `pending|queued → running` as a claim — only one worker wins, and a worker that cannot claim abandons the delivery (chosen over `reject_on_worker_lost`, which would re-run irreversible GIS work).

## Security

All task endpoints are owner-scoped; unknown, non-numeric and cross-tenant ids all return 404 so existence never leaks. Job ids are sequential integers, so enumeration was checked explicitly: an unauthenticated caller gets 404 for every id, and another user's predicate never matches. The unified view never returns `original_request`, parameters, tracebacks or credentials. `dispatch_spec` (needed for faithful retry) is never exposed by any endpoint and is refused outright if it carries a sensitive key at any nesting depth or exceeds its cap.

The literal `"anonymous"` from the auth layer is normalized to NULL: it is not a `users` row, so writing it to `creator_id` violates the FK on PostgreSQL — meaning anonymous users could not create a durable job at all in production, which SQLite hid by not enforcing FKs.

## Performance

Deterministic, behaviour-based (no wall-clock assertions):

| Benchmark | Result |
|---|---|
| `cancelled_chunked_cpu_work` | 51 of 10 000 chunks executed after cancel — **99.49% of the work skipped** |
| `progress_write_rate` | 100 DB writes per 100 000 reports (**0.1%**) |
| terminal-job progress writes | 0 / 200 (stale progress cannot revive a terminal job) |
| `1000_task_summary_query` | 8.9 ms, 50 of 1000 rows (hard-capped) |
| `running_job_poll_payload` | 9 550 B for 20 active jobs (**478 B/job**), no secrets, no coordinates |
| `job_transition_contention` | exactly 1 winner of 32 |
| `checkpoint` overhead (no token) | 0.183 µs/iter |

Before/after for cancellation is the first row: previously all 10 000 chunks ran, because no checkpoint existed inside tools and the flag was only read between them.

## Fixed along the way (pre-existing)

* NDVI assets were **never** registered: the insert used `format="tif"`, rejected by `ck_upload_format` (`geotiff` is allowed), and the `IntegrityError` was swallowed as a warning — so "结果已入库" was never true on a constraint-enforcing DB.
* `e46935cd5dd1` dropped `creator_id NOT NULL` only on the PostgreSQL branch, leaving SQLite diverged from the model.
* `analysis_tasks.status` had both `index=True` and `idx_task_status`, producing two identical indexes.
* `/tasks/status/{id}` raised `AttributeError` against `DisabledBackend` (no Redis) and returned 500; it now degrades to `UNKNOWN`.

## Local tests

```
Backend  (pytest -m "not perf")   2497 passed,  7 failed,  1 skipped   [34:27]
  BASE_SHA baseline               2270 passed,  6 failed,  2 skipped   [34:44]
  → new tests: +227      new regressions: 0

Job suites (tests/jobs/)           240 passed
Job benchmarks (-m perf)             9 passed
ruff check .                      All checks passed
bandit -r app/services/jobs app/api/routes/jobs.py    0 issues (High: 0 overall)

Frontend  vitest                   621 passed, 3 skipped  (+42 new)
          eslint --max-warnings 0  clean
          tsc --noEmit (x2 configs) clean
          next build               succeeded
```

**Pre-existing failures, reproduced on BASE_SHA and unrelated to this branch:**
* `tests/unit/test_templates_api.py` — 6 tests, order-dependent; pass standalone on both BASE_SHA and this branch, fail identically in both full-suite runs.
* `tests/benchmarks/test_perf_harness_v2.py::test_network_event_loop_lag_offload` — timing-sensitive; passes 3/3 standalone on both, flaked under the concurrent load of running two full suites plus a frontend build.
* `test_perf_workload[h3_binning_10k]` (`-m perf`) — warn-band regression that **reproduces on BASE_SHA**.

### Celery integration honesty

The environment has no Redis, so Celery runs in eager mode. `tests/jobs/test_job_celery_e2e.py` states this in its module docstring: real are the task body's code paths, the durable state machine, DB reads/writes, the watchdog thread, cancel propagation and atomic artifact writes; **not** real are cross-process delivery, broker redelivery, revoke/terminate and prefork isolation. These are **worker simulation**, not real-worker integration.

Because no test previously executed the migration (every suite built schema via `create_all`), a Postgres-invalid `DATETIME` column type passed review-round-1 unnoticed; `tests/jobs/test_job_migration.py` now runs real upgrade/downgrade on SQLite and statically validates the Postgres branch.

```
Validation was performed locally only.
GitHub Actions / CI/CD were not used as completion evidence.
```

## Review

Two adversarial review rounds (state machine/races, Celery/worker lifecycle, DB/migration, frontend/stale state, security/ownership, performance/leaks, false-green tests).

Round 1 — 1 P0 + 8 P1 fixed, including: the Postgres migration could not run at all (`DATETIME`); the cancel probe was pull-only so all GIS-library instrumentation was inert for durable jobs; there was no periodic heartbeat, so long quiet jobs were swept as dead and their results discarded; `sweep_stale` selected `cancelling` rows it could never transition (permanent hang); retry flipped state without enqueueing anything; the claim result was ignored so redelivery double-executed; a submit TOCTOU could enqueue one job twice.

Round 2 — verified all 9 fixes correct, found and fixed 1 P1 (idempotency reuse turned cancelled/failed jobs into a permanent dead-end: resubmission returned "reused" and ran nothing, while cancelled jobs can never be retried) plus 3 P2 (asset INSERT still racy against cancel; `pending`/`queued` could hang forever; retry marking an already-delivered job failed) and 2 P3 (recursive credential screening in `dispatch_spec`; `has_active` computed over the truncated page).

Round 3 (final PR-diff review) — found that the pipeline's cooperative-cancel branch was **dead code in production**: `OperationCancelled` subclasses `Exception`, so the generic handlers in `ToolRegistry._dispatch_impl` and `ToolDispatchService.dispatch` converted a cancel into a `TOOL_ERROR` result. Cancellation was being reported to the LLM as a tool malfunction, and `ToolExecutionResult.cancelled` was always `False`. The existing bridge tests missed it because they inject a `dispatch_fn` and bypass the registry — a false green. Fixed by re-raising ahead of both handlers, with new tests that drive the real registry and the real dispatch service. The same round found the cancel cascade was only implemented in the new endpoint, so cancelling through the legacy `DELETE /tasks/{task_id}` (which the frontend actually calls) let a background NDVI run to completion; the cascade is now real in both paths.

**P0 = 0, P1 = 0** at submission. Remaining known P3s are documented in ADR-0052's consequences section.
