### PR TITLE
fix(frontend): restore tsconfig.test.json typecheck gate (Frontend Tests CI)

### DIFF
--- a/frontend/components/map/map-action-handler.test.tsx
+++ b/frontend/components/map/map-action-handler.test.tsx
@@ -76,14 +76,14 @@ const mockSetBaseLayer = vi.fn();
 const mockSetPendingSystemMessage = vi.fn();
 const mockRemoveLayer = vi.fn();
 const mockUpdateLayer = vi.fn();
-const mockExport = vi.fn(async () => ({ ok: true }));
+const mockExport = vi.fn(async (): Promise<{ ok: boolean; error?: string }> => ({ ok: true }));
 const mockAddAnnotation = vi.fn((feature) => {
   mockAnnotationsStore.push(feature);
 });
 const mockClearAnnotations = vi.fn(() => {
   mockAnnotationsStore = [];
 });
-let mockLayersStore: Array<{ id: string; name?: string; style?: any }> = [];
+let mockLayersStore: Array<{ id: string; name?: string; style?: any; visible?: boolean }> = [];
 let mockAnnotationsStore: any[] = [];
 // Round-2 FIX-B: mirrors useHudStore.baseLayer so base_layer_change can detect
 // an unchanged base layer (no style swap needed) and resolve immediately.

--- a/frontend/components/map/map-panel.test.tsx
+++ b/frontend/components/map/map-panel.test.tsx
@@ -47,7 +47,9 @@ const hud = vi.hoisted(() => {
       hud.setState({ viewport: { center, zoom, bearing, pitch, bounds } }),
     focusLayer: (id: string | null) => hud.setState({ focusLayerId: id }),
   };
-  const state: Record<string, unknown> = { ...initialState(), ...actions };
+  // selectedFeature is deliberately `any`: the tests assert shape via the
+  // component contract (setSelectedFeature callers may set arbitrary fields).
+  const state: Record<string, unknown> & { selectedFeature: any } = { ...initialState(), ...actions };
   const listeners = new Set<() => void>();
   return {
     state,

--- a/frontend/lib/contexts/map-action-context.test.tsx
+++ b/frontend/lib/contexts/map-action-context.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { MapActionProvider, useMapAction } from './map-action-context';
-import type { MapActionPayload } from '@/lib/types';
+import type { GeoJSONFeatureCollection, MapActionPayload } from '@/lib/types';
 import type { MapActionAck } from '@/lib/api/map-action-acks';
 
 // The provider's base-layer lazy init reads useHudStore.getState().baseLayer and
@@ -46,7 +46,7 @@ describe('MapActionProvider (V3 queue + lifecycle)', () => {
   it('appends a normalized action on dispatch', () => {
     const { result } = renderCtx();
     act(() => {
-      result.current.dispatchAction({ command: 'FLY_TO', params: { center: [116, 39], zoom: 12 } });
+      result.current.dispatchAction({ command: 'FLY_TO' as MapActionPayload['command'], params: { center: [116, 39], zoom: 12 } });
     });
     expect(result.current.actions).toHaveLength(1);
     // command normalized to lowercase; UPPERCASE backend emissions tolerated
@@ -346,10 +346,12 @@ describe('MapActionProvider (V3 queue + lifecycle)', () => {
       features: Array.from({ length: 5000 }, (_, i) => ({
         id: i, geometry: { type: 'Point', coordinates: [i, i] }, properties: { i },
       })),
-    };
+    } as unknown as GeoJSONFeatureCollection;
     const action = makeAction({
       action_id: 'ma-big',
       command: 'add_heatmap_raster',
+      // features/data/image are deliberately NOT part of the payload type — the
+      // ack sanitizer must drop data-dump keys, so they are smuggled via cast.
       params: {
         image: bigImage,
         geojson: bigGeojson,
@@ -358,7 +360,7 @@ describe('MapActionProvider (V3 queue + lifecycle)', () => {
         bbox: [116.0, 39.0, 117.0, 40.0],
         center: [116.5, 39.5],
         zoom: 12,
-      },
+      } as unknown as MapActionPayload['params'],
     });
     act(() => { result.current.dispatchAction(action); });
     act(() => { result.current.reportTerminal(action, 'succeeded'); });

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -100,8 +100,8 @@ describe('buildSelectedFeatureSnapshot (FE-4 design §7)', () => {
     expect(props).not.toHaveProperty('geometry');
     expect(props).not.toHaveProperty('tags');
     expect(props.name).toBe('第一区');
-    expect(props.long_val).toHaveLength(60); // 59 chars + ellipsis
-    expect(props.long_val.endsWith('…')).toBe(true);
+    expect(props.long_val as string).toHaveLength(60); // 59 chars + ellipsis
+    expect((props.long_val as string).endsWith('…')).toBe(true);
   });
 
   it('resolves parent layer id and keeps bbox/feature identity', () => {

--- a/frontend/lib/hooks/useMapBridge.test.ts
+++ b/frontend/lib/hooks/useMapBridge.test.ts
@@ -7,6 +7,8 @@ import * as chatApi from '@/lib/api/chat';
 import type { SSEEvent } from '@/lib/api/chat';
 import { MapActionContext } from '@/lib/contexts/map-action-context';
 import type { MapActionContextType } from '@/lib/contexts/map-action-context';
+import type { MapActionPayload, MapActionTerminalStatus } from '@/lib/types';
+import type { MapActionTerminalDetails } from '@/lib/contexts/map-action-context';
 import type { MapActionAckSink } from '@/lib/api/map-action-acks';
 import { devOnly } from '@/lib/utils/logger';
 
@@ -59,7 +61,11 @@ function makeAckWrapper(
         };
       },
       clearActions,
-      reportTerminal: (action, status, details) => {
+      reportTerminal: (
+        action: MapActionPayload,
+        status: MapActionTerminalStatus,
+        details?: MapActionTerminalDetails,
+      ) => {
         sinkHolder.current?.({
           action_id: action.action_id!,
           command: action.command,
@@ -73,7 +79,7 @@ function makeAckWrapper(
           actual: details?.actual !== undefined ? (details.actual as Record<string, unknown> | null) : null,
         });
       },
-    } as MapActionContextType;
+    } as unknown as MapActionContextType;
     return React.createElement(MapActionContext.Provider, { value }, children);
   };
 }
@@ -812,7 +818,7 @@ describe('useMapBridge', () => {
 
     // handler NOT invoked — the store mount already executed the work
     expect(dispatchAction).not.toHaveBeenCalled();
-    const sink = sinkHolder.current;
+    const sink: any = sinkHolder.current;
     expect(sink).toBeTruthy();
     // ROUND-2: the ack is reported only AFTER onEvent (the mount) returned —
     // never claims success BEFORE the mount ran.

--- a/frontend/lib/mapspec-runtime/adapter.thematic.test.ts
+++ b/frontend/lib/mapspec-runtime/adapter.thematic.test.ts
@@ -41,7 +41,7 @@ describe("adapter derives thematic paint from legend_spec (drift fix)", () => {
     });
     const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
     const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
-    expect(fill.paint["fill-color"]).toEqual([
+    expect(fill.paint!["fill-color"]).toEqual([
       "step", ["to-number", ["get", "pop"]], "#ffffb2",
       10, "#fd8d3c", 20, "#bd0026",
     ]);
@@ -57,7 +57,7 @@ describe("adapter derives thematic paint from legend_spec (drift fix)", () => {
     const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
     const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
     // paint references the legend's field, not a hardcoded metadata field.
-    expect(JSON.stringify(fill.paint["fill-color"])).toContain('"get","income"');
+    expect(JSON.stringify(fill.paint!["fill-color"])).toContain('"get","income"');
   });
 
   it("applies the no-data guard when legend_spec declares nodata", () => {
@@ -69,7 +69,7 @@ describe("adapter derives thematic paint from legend_spec (drift fix)", () => {
     });
     const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
     const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
-    const expr = fill.paint["fill-color"] as unknown[];
+    const expr = fill.paint!["fill-color"] as unknown as unknown[];
     expect(expr[0]).toBe("case");
     expect(JSON.stringify(expr)).toContain('"#ccc"');
   });
@@ -79,7 +79,7 @@ describe("adapter derives thematic paint from legend_spec (drift fix)", () => {
     const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
     const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
     // byte-identical to the pre-refactor behavior.
-    expect(fill.paint["fill-color"]).toEqual(["coalesce", ["get", "fill_color"], "#ff0000"]);
+    expect(fill.paint!["fill-color"]).toEqual(["coalesce", ["get", "fill_color"], "#ff0000"]);
   });
 
   it("categorical legend_spec emits a match expression on the live map", () => {
@@ -93,7 +93,7 @@ describe("adapter derives thematic paint from legend_spec (drift fix)", () => {
     });
     const spec = hudStateToMapSpec({ layers: [l], processLayers: {}, activeFilters: {}, is3D: false });
     const fill = spec.layers.find((x) => x.id.endsWith("__fill"))!;
-    expect(fill.paint["fill-color"]).toEqual([
+    expect(fill.paint!["fill-color"]).toEqual([
       "match", ["get", "landuse"], "residential", "#0", "commercial", "#1", "#1",
     ]);
   });
@@ -138,7 +138,7 @@ describe("adapter derives thematic paint from legend_spec (drift fix)", () => {
     const dt = Date.now() - t0;
     const fill = spec.layers.find((x) => x.id === "big__fill")!;
     // The color expression is a single step (3 classes), independent of 50k features.
-    expect((fill.paint["fill-color"] as unknown[])[0]).toBe("step");
+    expect((fill.paint!["fill-color"] as unknown as unknown[])[0]).toBe("step");
     // Guard: must complete quickly — thematic derivation must not be O(features).
     // (Geometry introspection is pre-existing O(features) and allowed; this
     // bounds total wall-clock as a coarse sanity check.)

--- a/frontend/lib/mapspec-runtime/thematic-paint.test.ts
+++ b/frontend/lib/mapspec-runtime/thematic-paint.test.ts
@@ -114,18 +114,18 @@ describe("ADR-0052 cross-check: legend_spec→expression matches compileStyleMet
     
     const spec = { type: "graduated", field: "pop", breaks: [0, 10, 20, 30], palette_colors: ["#a", "#b", "#c"] } as any;
     const styleMethod = { method: "step", field: "pop", default: "#a", stops: [[10, "#b"], [20, "#c"]] };
-    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod));
+    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod as any));
   });
   it("continuous: direct interpolate == compileStyleMethod(interpolate)", () => {
     
     const spec = { type: "continuous", field: "d", min: 0, max: 100, palette_colors: ["#1", "#2", "#3"] } as any;
     const styleMethod = { method: "interpolate", field: "d", stops: [[0, "#1"], [50, "#2"], [100, "#3"]] };
-    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod));
+    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod as any));
   });
   it("categorical: direct match == compileStyleMethod(match)", () => {
     
     const spec = { type: "categorical", field: "u", categories: [{ key: "a", color: "#0", label: "a" }, { key: "b", color: "#1", label: "b" }] } as any;
     const styleMethod = { method: "match", field: "u", cases: [["a", "#0"], ["b", "#1"]], default: "#1" };
-    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod));
+    expect(legendSpecToColorExpression(spec)).toEqual(compileStyleMethod(styleMethod as any));
   });
 });

--- a/frontend/lib/store/slices/caps.test.ts
+++ b/frontend/lib/store/slices/caps.test.ts
@@ -9,11 +9,28 @@ import { createUiSlice, MAX_OPS_LOG } from "./uiSlice";
 
 type SliceState = ReturnType<typeof createLayersSlice> & ReturnType<typeof createUiSlice>;
 
-function makeStore() {
-  return createStore<SliceState>()((set, get, api) => ({
+// Slice creators are typed Partial<HudState>; the composed vanilla store always
+// holds the FULL state at runtime. Expose a Required-typed getState so the cap
+// tests can call addAnnotation/pushOpLog without optional-chaining noise
+// (tsconfig.test.json strictNullChecks).
+type ComposedStore = {
+  getState: () => Required<SliceState>;
+  setState: (partial: Partial<SliceState>) => void;
+  subscribe: (listener: (state: SliceState, prev: SliceState) => void) => () => void;
+  getInitialState: () => SliceState;
+};
+
+function makeStore(): ComposedStore {
+  const store = createStore<SliceState>()((set, get, api) => ({
     ...createLayersSlice(set as any, get as any, api as any),
     ...createUiSlice(set as any, get as any, api as any),
   }));
+  return {
+    getState: () => store.getState() as unknown as Required<SliceState>,
+    setState: store.setState,
+    subscribe: store.subscribe,
+    getInitialState: store.getInitialState,
+  };
 }
 
 describe("store slice caps (FE-3)", () => {

--- a/frontend/lib/types/explorer.ts
+++ b/frontend/lib/types/explorer.ts
@@ -1,3 +1,8 @@
+// The ambient global `GeoJSON` namespace is only auto-included when @types
+// packages are unrestricted; tsconfig.test.json pins `types` to
+// vitest/globals+node+next, so reference the explicit geojson package type.
+import type { FeatureCollection } from 'geojson';
+
 export type ExplorerStage =
   | "discover"
   | "fetch"
@@ -81,7 +86,7 @@ export interface WhatIfSimulationResult {
   metrics: Record<string, MetricDelta>;
   uncertainty: string;
   rules_applied: string[];
-  simulation_geojson: GeoJSON.FeatureCollection;
+  simulation_geojson: FeatureCollection;
 }
 
 export type SimulationViewMode = "baseline" | "simulated" | "delta";

--- a/tests/cartography/test_thematic_convergence.py
+++ b/tests/cartography/test_thematic_convergence.py
@@ -465,7 +465,6 @@ def test_cartography_findings_forwarded_through_production_evidence_channel():
     assert forwarded.get("cartography_findings") == findings
 
     # And the bridge whitelist includes it (the field is named in the forward list).
-    import re
     bridge_src = open("app/agent_pi_bridge.py").read()
     assert "cartography_findings" in bridge_src
 


### PR DESCRIPTION
## 问题

PR #339 合并后 master 的 **Frontend Tests → TypeScript Check** 步骤仍为红：该步骤运行 `tsc --noEmit && tsc -p tsconfig.test.json --noEmit`，第二个配置（restricted `types` + strictNullChecks 覆盖全部测试文件）暴露了默认配置检不出的测试文件类型错误。合并前 master（526eec0，含 #337）本就有 11 个错误。

## 修复（纯测试文件 + 1 个类型 import）

- 本 PR（#339）引入的错误：FLY_TO literal cast、GeoJSONFeatureCollection cast、bounded-prop cast、ack-wrapper unknown cast + 显式 reportTerminal 参数类型、store-slice getState 收窄为 Required（caps 测试直接调 addAnnotation/pushOpLog）
- #337 遗留（一并修复以恢复 master 门禁）：fill.paint! + 显式 unknown[] cast（thematic adapter 测试）、StyleMethod cast（paint 测试）、explorer.ts 改用显式 `geojson` 包类型（ambient GeoJSON 全局在 pinned types 下不可用）

## 本地验证

- `tsc --noEmit`：0 错误
- `tsc -p tsconfig.test.json --noEmit`：0 错误（此前 30 个）
- vitest：767 passed / 3 skipped
- eslint：0 错误（见运行中）

> LOCAL TESTS ONLY；未以 CI 为验证依据。