### PR TITLE
fix(tests): restore master Backend Tests gate (align 7 tests with post-#338 API shapes)

### DIFF
--- a/tests/test_layer_fetch_abort.py
+++ b/tests/test_layer_fetch_abort.py
@@ -12,11 +12,13 @@ class TestLayerFetchAbort:
         """The geojson_ref fetch must pass an AbortSignal so it can be cancelled."""
         source = _read_source()
 
-        # Find the geojson_ref fetch block
-        fetch_match = re.search(r"fetch\(`\$\{API_BASE\}/api/v1/layers/data/\$\{fetchRef\}", source)
-        assert fetch_match, "Could not find geojson_ref fetch call"
+        # The geojson_ref fetch now goes through apiFetch (transport helper) with
+        # an encodeURIComponent'd ref (H14 + Data Plane). Find the block by the
+        # data endpoint path and verify an AbortSignal is passed to it.
+        fetch_match = re.search(r"api/v1/layers/data/\$\{encodeURIComponent\(fetchRef\)\}", source)
+        assert fetch_match, "Could not find geojson_ref fetch call (apiFetch encodeURIComponent path)"
 
-        # Get surrounding context (200 chars after the fetch URL)
+        # Get surrounding context (300 chars after the fetch URL)
         context_start = fetch_match.start()
         context = source[context_start:context_start + 300]
 

--- a/tests/unit/test_composite_builder.py
+++ b/tests/unit/test_composite_builder.py
@@ -47,7 +47,8 @@ def test_composite_builder_preset_combinations():
     mapspec = builder.assemble({"preset": "cyber_dark"})
 
     assert mapspec["basemap"]["providerId"] == "carto-dark"
-    assert mapspec["layout"]["paperSize"] == "A4"
+    # tmpl_ly_dark_report is defined as A3 landscape (暗色主题 A3 横向版式).
+    assert mapspec["layout"]["paperSize"] == "A3"
 
 
 def test_combine_map_theme_tool_execution():

--- a/tests/unit/test_project_api.py
+++ b/tests/unit/test_project_api.py
@@ -33,7 +33,7 @@ def test_create_and_get_project():
     # List Projects
     list_res = client.get("/api/v1/projects")
     assert list_res.status_code == 200
-    assert any(p["id"] == proj_id for p in list_res.json())
+    assert any(p["id"] == proj_id for p in list_res.json()["items"])
 
 
 def test_attach_and_detach_dataset():
@@ -56,7 +56,7 @@ def test_attach_and_detach_dataset():
     # List Datasets
     ds_list = client.get(f"/api/v1/projects/{proj_id}/datasets")
     assert ds_list.status_code == 200
-    assert len(ds_list.json()) == 1
+    assert len(ds_list.json()["items"]) == 1
 
     # Detach Dataset
     detach_res = client.delete(f"/api/v1/projects/{proj_id}/datasets/{ds_id}")
@@ -64,7 +64,7 @@ def test_attach_and_detach_dataset():
 
     # Verify List Empty
     ds_list_after = client.get(f"/api/v1/projects/{proj_id}/datasets")
-    assert len(ds_list_after.json()) == 0
+    assert len(ds_list_after.json()["items"]) == 0
 
 
 def test_spatial_quality_and_repair_api():

--- a/tests/unit/test_project_listing_n1.py
+++ b/tests/unit/test_project_listing_n1.py
@@ -81,7 +81,7 @@ def test_list_project_artifacts_query_count_is_constant(db_session, project_with
     proj = project_with_artifacts
 
     artifacts, n_queries = _count_queries(
-        db, lambda: ProjectService.list_project_artifacts(db, proj.id)
+        db, lambda: ProjectService.list_project_artifacts(db, proj.id)[0]
     )
     assert len(artifacts) == 20
     # 20 artifacts × ~3 lazy relationship queries each would be ~60+ queries.
@@ -109,7 +109,7 @@ def test_list_project_workflows_and_runs_eager_loaded(db_session, project_with_a
     db.commit()
 
     runs, n_queries = _count_queries(
-        db, lambda: ProjectService.list_workflow_runs(db, proj.id)
+        db, lambda: ProjectService.list_workflow_runs(db, proj.id)[0]
     )
     assert len(runs) == 10
     # Constant query count regardless of N (auth check + join query + 2 selectin

--- a/tests/unit/test_templates_api.py
+++ b/tests/unit/test_templates_api.py
@@ -160,7 +160,7 @@ async def test_user_template_appears_in_list_templates(client):
     get_res = await client.get("/api/v1/templates?kind=basemap")
     assert get_res.status_code == 200
     templates_list = get_res.json()
-    assert any(t["name"] == "我的夜间大屏底图" for t in templates_list)
+    assert any(t["name"] == "我的夜间大屏底图" for t in templates_list["items"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

master 的 **Backend Tests** 门禁自 #338（perf fastpath）起持续为红：7 个测试因 #338 有意的 API 形状变更未同步更新而失败（master 自身 CI run 31551589228 三项全红可证，与 #339/#341 无关）。

## 修复（纯测试文件）

| 测试 | 变更 |
|---|---|
| `test_layer_fetch_abort.py` | geojson_ref fetch 改走 `apiFetch` + `encodeURIComponent(fetchRef)`（AbortSignal 仍经 `layerFetchAbortRef` 传入）——更新源码 grep 测试 |
| `test_composite_builder.py` | cyber_dark preset 的 paperSize 断言 A4 → A3（`tmpl_ly_dark_report` 模板定义为 A3 横向） |
| `test_project_api.py` | /projects 与 /projects/{id}/datasets 列表端点改为分页 `{items, total, ...}`——断言改取 `items` |
| `test_project_listing_n1.py` | `list_project_artifacts`/`list_workflow_runs` 返回 `Tuple[list, total]`——N+1 查询计数测试取 `[0]` |
| `test_templates_api.py` | /templates 列表端点分页化——断言改取 `items` |

## 本地验证（LOCAL TESTS ONLY）

- 原 7 个失败测试全部通过；受影响套件 28 tests 全绿
- ruff 全绿