### PR TITLE
feat(data-fabric): harden multi-source connectivity and materialization reliability

### DIFF
--- a/app/api/routes/data_fabric.py
+++ b/app/api/routes/data_fabric.py
@@ -4,6 +4,7 @@ Enterprise Geospatial Data Fabric REST Routes
 import logging
 from typing import Dict, Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Header
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -457,7 +458,12 @@ async def materialize_catalog_item(
             query_spec=req.query_spec,
             owner_token=owner_token,
         )
-        return {"success": True, **res}
+        # The manager now carries its own truth flag. A store-unavailable or
+        # audit-commit failure is a transient infra problem (503), not a bad
+        # request; the structured body lets the agent/tool retry or degrade.
+        if not res.get("success"):
+            return JSONResponse(status_code=503, content=res)
+        return res
     except Exception as e:
         logger.error(f"Materialization failed for catalog item '{req.catalog_item_id}': {e}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))

--- a/app/api/routes/data_fabric.py
+++ b/app/api/routes/data_fabric.py
@@ -16,6 +16,7 @@ from app.schemas.data_fabric_schema import (
     QuerySpec,
 )
 from app.services.data_fabric.manager import data_fabric_manager
+from app.services.data_fabric.errors import ResultTooLargeError
 from app.services.data_fabric.security import DataFabricSecurity
 
 logger = logging.getLogger(__name__)
@@ -486,6 +487,9 @@ async def materialize_catalog_item(
         if not res.get("success"):
             return JSONResponse(status_code=503, content=res)
         return res
+    except ResultTooLargeError as e:
+        # Oversized remote result — actionable 413 with the shrink hint.
+        return JSONResponse(status_code=413, content={"success": False, **e.to_dict()})
     except Exception as e:
         logger.error(f"Materialization failed for catalog item '{req.catalog_item_id}': {e}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))

--- a/app/api/routes/data_fabric.py
+++ b/app/api/routes/data_fabric.py
@@ -86,6 +86,22 @@ def _require_tenant_owned(s: Optional[DataSourceModel], user: Optional[Dict[str,
     return s
 
 
+def _authorize_catalog_item(db: Session, item_id: str, user: Optional[Dict[str, Any]]):
+    """Authorize catalog-item access for the caller's tenant (or 404).
+
+    Cross-tenant access to preview/query/materialize previously had NO guard —
+    any caller could read or materialize any catalog item by id. We resolve the
+    item's DataSource and apply the same tenant check as the source routes.
+    Returns 404 (not 403) to avoid leaking cross-tenant row existence.
+    """
+    item = db.query(CatalogItemModel).filter(CatalogItemModel.id == item_id).first()
+    if item is None:
+        raise HTTPException(status_code=404, detail="Catalog item not found")
+    src = db.query(DataSourceModel).filter(DataSourceModel.id == item.source_id).first()
+    _require_tenant_owned(src, user)
+    return item
+
+
 class CreateDataSourceRequest(BaseModel):
     name: str = Field(..., description="Data source display name")
     source_type: str = Field(..., description="Source adapter type (postgis, ogc_api, wfs, wms, wmts, arcgis)")
@@ -132,7 +148,7 @@ async def create_data_source(
                 "id": source.id,
                 "name": source.name,
                 "source_type": source.source_type,
-                "endpoint_url": source.endpoint_url,
+                "endpoint_url": DataFabricSecurity.redact_url(source.endpoint_url),
                 "status": source.status,
                 "capabilities": source.capabilities_json,
                 # SEC-07: the stored profile now carries the REAL credentials
@@ -165,7 +181,7 @@ async def list_data_sources(
                 "id": s.id,
                 "name": s.name,
                 "source_type": s.source_type,
-                "endpoint_url": s.endpoint_url,
+                "endpoint_url": DataFabricSecurity.redact_url(s.endpoint_url),
                 "status": s.status,
                 "capabilities": s.capabilities_json,
                 "connection_profile": DataFabricSecurity.sanitize_profile_dict(s.connection_profile or {}),
@@ -190,7 +206,7 @@ async def get_data_source(
         "id": s.id,
         "name": s.name,
         "source_type": s.source_type,
-        "endpoint_url": s.endpoint_url,
+        "endpoint_url": DataFabricSecurity.redact_url(s.endpoint_url),
         "status": s.status,
         "capabilities": s.capabilities_json,
         "connection_profile": DataFabricSecurity.sanitize_profile_dict(s.connection_profile or {}),
@@ -411,9 +427,11 @@ async def preview_catalog_item(
     item_id: str,
     limit: int = Query(10, ge=1, le=100),
     db: Session = Depends(get_db),
+    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
 ):
     """获取 Spatial Catalog 项的有界样例数据预览"""
     try:
+        _authorize_catalog_item(db, item_id, user)
         q_spec = QuerySpec(limit=limit)
         q_res = data_fabric_manager.query_catalog_item(db, item_id, q_spec)
         return {
@@ -433,9 +451,11 @@ async def query_catalog_item(
     item_id: str,
     query_spec: QuerySpec,
     db: Session = Depends(get_db),
+    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
 ):
     """执行下推（Pushdown）选择性查询"""
     try:
+        _authorize_catalog_item(db, item_id, user)
         q_res = data_fabric_manager.query_catalog_item(db, item_id, query_spec)
         return q_res.model_dump()
     except Exception as e:
@@ -448,9 +468,11 @@ async def materialize_catalog_item(
     req: MaterializeRequest,
     owner_token: Optional[str] = Header(None, alias="X-Session-Token"),
     db: Session = Depends(get_db),
+    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
 ):
     """按需实例化（Materialize）数据至会话 SessionStore 并产生 ref_id 游标"""
     try:
+        _authorize_catalog_item(db, req.catalog_item_id, user)
         res = await data_fabric_manager.materialize_catalog_item(
             db=db,
             session_id=req.session_id,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -106,6 +106,12 @@ class Settings(BaseSettings):
     DATA_FABRIC_MAX_PAGES: int = 200
     DATA_FABRIC_QUERY_TIMEOUT: float = 30.0       # seconds (connect+read budget per request)
     DATA_FABRIC_TOTAL_QUERY_TIMEOUT: float = 120.0  # seconds (whole multi-page operation)
+    # Local-file adapter guard (Section 44). Comma-separated absolute/relative
+    # roots that geoparquet/flatgeobuf/pmtiles local reads must stay within
+    # (symlink-escape defense). Empty = no root enforcement, but sensitive
+    # system dirs (/etc, /proc, …) are always blocked. Add DATA_DIR by default.
+    DATA_FABRIC_LOCAL_FILE_ROOTS: str = "./data"
+    DATA_FABRIC_LOCAL_FILE_MAX_BYTES: int = 1024 * 1024 * 1024  # 1 GiB
 
     # 代理设置
     HTTP_PROXY: Optional[str] = None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -112,6 +112,10 @@ class Settings(BaseSettings):
     # system dirs (/etc, /proc, …) are always blocked. Add DATA_DIR by default.
     DATA_FABRIC_LOCAL_FILE_ROOTS: str = "./data"
     DATA_FABRIC_LOCAL_FILE_MAX_BYTES: int = 1024 * 1024 * 1024  # 1 GiB
+    # Catalog sync (Section 30): bounded concurrency for parallel dataset
+    # describe() calls, clamped to [1, 16] so a 5000-dataset source no longer
+    # serializes ~5000 remote round-trips.
+    DATA_FABRIC_SYNC_CONCURRENCY: int = 4
 
     # 代理设置
     HTTP_PROXY: Optional[str] = None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -97,6 +97,16 @@ class Settings(BaseSettings):
     CELERY_RESULT_BACKEND: str = "redis://localhost:16379/1"
     USE_REDIS: bool = True
 
+    # Geospatial Data Fabric resource guards (Section 70). Bounded hard limits so
+    # one remote query (or a server that ignores `limit`) cannot OOM the process
+    # or materialize an unbounded payload. Override per-env; values are clamped
+    # by the limits module so an operator cannot disable protection by setting 0.
+    DATA_FABRIC_MAX_FEATURES: int = 50_000
+    DATA_FABRIC_MAX_RESPONSE_BYTES: int = 256 * 1024 * 1024  # 256 MiB
+    DATA_FABRIC_MAX_PAGES: int = 200
+    DATA_FABRIC_QUERY_TIMEOUT: float = 30.0       # seconds (connect+read budget per request)
+    DATA_FABRIC_TOTAL_QUERY_TIMEOUT: float = 120.0  # seconds (whole multi-page operation)
+
     # 代理设置
     HTTP_PROXY: Optional[str] = None
     HTTPS_PROXY: Optional[str] = None

--- a/app/services/data_fabric/adapters/arcgis_adapter.py
+++ b/app/services/data_fabric/adapters/arcgis_adapter.py
@@ -3,10 +3,9 @@ ArcGIS REST Feature/Map Service Data Source Adapter
 """
 import time
 import logging
-import requests
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -36,7 +35,7 @@ class ArcGISAdapter(GeospatialDataSourceAdapter):
             else ""
         )
         self.options = self.profile.options or {}
-        self.session = requests.Session()
+        self.session = make_safe_session(allow_private=self.profile.allow_private)
 
     def probe(self) -> bool:
         """Lightweight reachability probe for ArcGIS REST endpoint."""

--- a/app/services/data_fabric/adapters/flatgeobuf_adapter.py
+++ b/app/services/data_fabric/adapters/flatgeobuf_adapter.py
@@ -10,7 +10,14 @@ import struct
 import logging
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
+from app.services.data_fabric.security import (
+    DataFabricSecurity,
+    DataFabricSecurityError,
+    _local_file_max_bytes_from_settings,
+    _local_file_roots_from_settings,
+    make_safe_session,
+    resolve_safe_local_path,
+)
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -251,6 +258,18 @@ class FlatGeobufAdapter(GeospatialDataSourceAdapter):
                 returned_count=0,
                 metadata={"exec_time_ms": exec_time_ms(), "source": "remote", "error_type": error_type, "error": msg},
             )
+
+        # Local-file path guard (Section 44): block traversal / symlink escape /
+        # sensitive-system-dir / oversize reads before opening any local file.
+        if self.endpoint and not self.endpoint.startswith(("http://", "https://", "s3://", "minio://")):
+            try:
+                resolve_safe_local_path(
+                    self.endpoint,
+                    _local_file_roots_from_settings(),
+                    _local_file_max_bytes_from_settings(),
+                )
+            except DataFabricSecurityError as se:
+                return _err("SECURITY_BLOCKED", str(se))
 
         # Real file query if a local path exists.
         if self.endpoint and os.path.exists(self.endpoint):

--- a/app/services/data_fabric/adapters/flatgeobuf_adapter.py
+++ b/app/services/data_fabric/adapters/flatgeobuf_adapter.py
@@ -10,7 +10,7 @@ import struct
 import logging
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -72,24 +72,27 @@ class FlatGeobufAdapter(GeospatialDataSourceAdapter):
         super().__init__(connection_profile)
         self.endpoint = (self.profile.endpoint or "").strip()
         self.allow_private = getattr(self.profile, "allow_private", False)
+        # SSRF-safe session: every request (incl. redirects) is revalidated.
+        self.session = make_safe_session(allow_private=self.allow_private)
 
     def probe(self) -> bool:
-        """Probe FlatGeobuf file accessibility and magic signature."""
-        if not self.endpoint or not os.path.exists(self.endpoint):
-            return True  # Fallback synthetic mode
+        """Probe FlatGeobuf file accessibility and magic signature.
 
+        Truthfulness: no-endpoint = explicit demo mode (reachable); an endpoint
+        that IS configured but points at a missing/unreadable source is NOT.
+        """
+        if not self.endpoint:
+            return True  # explicit demo mode
         try:
             if self.endpoint.startswith(("http://", "https://")):
                 safe_url = DataFabricSecurity.validate_url(self.endpoint, allow_private=self.allow_private)
-                import requests
-
-                resp = requests.get(safe_url, headers={"Range": "bytes=0-7"}, timeout=5)
+                resp = self.session.get(safe_url, headers={"Range": "bytes=0-7"}, timeout=5)
                 return resp.status_code in (200, 206) and resp.content.startswith(b"fgb")
             elif os.path.isfile(self.endpoint):
                 with open(self.endpoint, "rb") as f:
                     header = f.read(8)
                     return header.startswith(b"fgb")
-            return True
+            return False
         except Exception as e:
             logger.debug(f"FlatGeobuf probe failed for {self.endpoint}: {e}")
             return False
@@ -229,11 +232,27 @@ class FlatGeobufAdapter(GeospatialDataSourceAdapter):
         }
 
     def query(self, dataset_id: str, query_spec: QuerySpec) -> QueryResult:
-        """Execute selective spatial index / bbox query on FlatGeobuf."""
+        """Execute selective spatial index / bbox query on FlatGeobuf.
+
+        Truthfulness contract: a configured endpoint that fails to read returns
+        an empty QueryResult with a typed error_type — never synthetic fixtures
+        masquerading as real data. Synthetic fixtures are demo-mode only (labeled).
+        """
         start_time = time.time()
         bounded_limit = max(1, min(query_spec.limit or 100, MAX_QUERY_LIMIT))
+        def exec_time_ms() -> float:
+            return round((time.time() - start_time) * 1000, 2)
 
-        # Real file query if file exists
+        def _err(error_type: str, msg: str) -> QueryResult:
+            return QueryResult(
+                dataset_id=dataset_id,
+                features=[],
+                total_count=0,
+                returned_count=0,
+                metadata={"exec_time_ms": exec_time_ms(), "source": "remote", "error_type": error_type, "error": msg},
+            )
+
+        # Real file query if a local path exists.
         if self.endpoint and os.path.exists(self.endpoint):
             try:
                 import geopandas as gpd
@@ -254,7 +273,6 @@ class FlatGeobufAdapter(GeospatialDataSourceAdapter):
                 data = json.loads(sliced.to_json())
                 features = data.get("features", [])
 
-                exec_time = round((time.time() - start_time) * 1000, 2)
                 return QueryResult(
                     dataset_id=dataset_id,
                     features=features,
@@ -263,14 +281,24 @@ class FlatGeobufAdapter(GeospatialDataSourceAdapter):
                     returned_count=len(features),
                     schema_info={"columns": list(sliced.columns)},
                     metadata={
-                        "exec_time_ms": exec_time,
+                        "exec_time_ms": exec_time_ms(),
                         "pushdown_bbox": bool(query_spec.bbox),
                         "spatial_index_used": True,
+                        "source": "remote",
                     },
                 )
             except Exception as e:
                 logger.warning(f"FlatGeobuf file query failed for '{dataset_id}': {e}")
+                return _err("SOURCE_BAD_RESPONSE", f"FlatGeobuf read failed: {e}")
 
+        # Endpoint configured but not a readable local file → fail truthfully.
+        if self.endpoint:
+            return _err(
+                "SOURCE_UNREACHABLE",
+                "FlatGeobuf source configured but not readable (http/remote ranged read unsupported in this path)",
+            )
+
+        # No endpoint configured → explicit synthetic DEMO mode (labeled).
         # Synthetic fallback query execution
         fixture = SYNTHETIC_FGB_FIXTURES.get(dataset_id, SYNTHETIC_FGB_FIXTURES["beijing_subway_stations"])
         raw_features = fixture["features"]
@@ -312,6 +340,7 @@ class FlatGeobufAdapter(GeospatialDataSourceAdapter):
                 "exec_time_ms": exec_time,
                 "pushdown_bbox": bool(query_spec.bbox),
                 "spatial_index_used": True,
+                "source": "synthetic-demo",
             },
         )
 

--- a/app/services/data_fabric/adapters/geoparquet_adapter.py
+++ b/app/services/data_fabric/adapters/geoparquet_adapter.py
@@ -9,7 +9,7 @@ import json
 import logging
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -93,24 +93,29 @@ class GeoParquetAdapter(GeospatialDataSourceAdapter):
         super().__init__(connection_profile)
         self.endpoint = (self.profile.endpoint or "").strip()
         self.allow_private = getattr(self.profile, "allow_private", False)
+        # SSRF-safe session: every request (incl. redirects) is revalidated.
+        self.session = make_safe_session(allow_private=self.allow_private)
 
     def probe(self) -> bool:
-        """Probe GeoParquet file accessibility and magic header."""
-        if not self.endpoint or not os.path.exists(self.endpoint):
-            return True  # Fallback synthetic mode
+        """Probe GeoParquet file accessibility and magic header.
 
+        Truthfulness: no-endpoint = explicit demo mode (reachable). An endpoint
+        that IS configured but points at a missing/unreadable source is NOT
+        reachable — previously the combined condition returned True for that case.
+        """
+        if not self.endpoint:
+            return True  # explicit demo mode
         try:
             if self.endpoint.startswith(("http://", "https://")):
                 safe_url = DataFabricSecurity.validate_url(self.endpoint, allow_private=self.allow_private)
-                import requests
-
-                resp = requests.head(safe_url, timeout=5)
+                resp = self.session.head(safe_url, timeout=5)
                 return resp.status_code in (200, 206)
             elif os.path.isfile(self.endpoint):
                 with open(self.endpoint, "rb") as f:
                     magic = f.read(4)
                     return magic == b"PAR1"
-            return True
+            # Endpoint configured but neither a real local file nor http URL.
+            return False
         except Exception as e:
             logger.debug(f"GeoParquet probe failed for {self.endpoint}: {e}")
             return False
@@ -255,11 +260,28 @@ class GeoParquetAdapter(GeospatialDataSourceAdapter):
         }
 
     def query(self, dataset_id: str, query_spec: QuerySpec) -> QueryResult:
-        """Execute selective column projection and bbox spatial filtering on GeoParquet."""
+        """Execute selective column projection and bbox spatial filtering on GeoParquet.
+
+        Truthfulness contract: a configured endpoint that fails to read returns
+        an empty QueryResult with a typed error_type — it does NOT fall back to
+        synthetic fixtures as if they were the source's real data. Synthetic
+        fixtures are used only in explicit no-endpoint demo mode (labeled).
+        """
         start_time = time.time()
         bounded_limit = max(1, min(query_spec.limit or 100, MAX_QUERY_LIMIT))
+        def exec_time_ms() -> float:
+            return round((time.time() - start_time) * 1000, 2)
 
-        # Real file reading if path exists and geopandas available
+        def _err(error_type: str, msg: str) -> QueryResult:
+            return QueryResult(
+                dataset_id=dataset_id,
+                features=[],
+                total_count=0,
+                returned_count=0,
+                metadata={"exec_time_ms": exec_time_ms(), "source": "remote", "error_type": error_type, "error": msg},
+            )
+
+        # Real file reading if a local path exists and geopandas is available.
         if self.endpoint and os.path.exists(self.endpoint):
             try:
                 import geopandas as gpd
@@ -287,7 +309,6 @@ class GeoParquetAdapter(GeospatialDataSourceAdapter):
                 data = json.loads(geojson_str)
                 features = data.get("features", [])
 
-                exec_time = round((time.time() - start_time) * 1000, 2)
                 return QueryResult(
                     dataset_id=dataset_id,
                     features=features,
@@ -296,14 +317,25 @@ class GeoParquetAdapter(GeospatialDataSourceAdapter):
                     returned_count=len(features),
                     schema_info={"columns": list(sliced.columns)},
                     metadata={
-                        "exec_time_ms": exec_time,
+                        "exec_time_ms": exec_time_ms(),
                         "pushdown_bbox": bool(query_spec.bbox),
                         "column_projection": bool(query_spec.columns),
+                        "source": "remote",
                     },
                 )
             except Exception as e:
                 logger.warning(f"GeoParquet file query failed for '{dataset_id}': {e}")
+                return _err("SOURCE_BAD_RESPONSE", f"GeoParquet read failed: {e}")
 
+        # Endpoint configured but not a readable local file (http URL, missing,
+        # etc.) — fail truthfully instead of serving synthetic fixtures as real.
+        if self.endpoint:
+            return _err(
+                "SOURCE_UNREACHABLE",
+                "GeoParquet source configured but not readable (http/remote ranged read unsupported in this path)",
+            )
+
+        # No endpoint configured → explicit synthetic DEMO mode (labeled).
         # Synthetic fallback query execution
         fixture = SYNTHETIC_GEOPARQUET_FIXTURES.get(dataset_id, SYNTHETIC_GEOPARQUET_FIXTURES["us_states_geoparquet"])
         raw_features = fixture["features"]
@@ -351,6 +383,8 @@ class GeoParquetAdapter(GeospatialDataSourceAdapter):
                 "exec_time_ms": exec_time,
                 "pushdown_bbox": bool(query_spec.bbox),
                 "column_projection": bool(query_spec.columns),
+                # Explicit label: callers never mistake demo data for remote data.
+                "source": "synthetic-demo",
             },
         )
 

--- a/app/services/data_fabric/adapters/geoparquet_adapter.py
+++ b/app/services/data_fabric/adapters/geoparquet_adapter.py
@@ -9,7 +9,14 @@ import json
 import logging
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
+from app.services.data_fabric.security import (
+    DataFabricSecurity,
+    DataFabricSecurityError,
+    _local_file_max_bytes_from_settings,
+    _local_file_roots_from_settings,
+    make_safe_session,
+    resolve_safe_local_path,
+)
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -280,6 +287,18 @@ class GeoParquetAdapter(GeospatialDataSourceAdapter):
                 returned_count=0,
                 metadata={"exec_time_ms": exec_time_ms(), "source": "remote", "error_type": error_type, "error": msg},
             )
+
+        # Local-file path guard (Section 44): block traversal / symlink escape /
+        # sensitive-system-dir / oversize reads before opening any local file.
+        if self.endpoint and not self.endpoint.startswith(("http://", "https://", "s3://", "minio://")):
+            try:
+                resolve_safe_local_path(
+                    self.endpoint,
+                    _local_file_roots_from_settings(),
+                    _local_file_max_bytes_from_settings(),
+                )
+            except DataFabricSecurityError as se:
+                return _err("SECURITY_BLOCKED", str(se))
 
         # Real file reading if a local path exists and geopandas is available.
         if self.endpoint and os.path.exists(self.endpoint):

--- a/app/services/data_fabric/adapters/ogc_api_adapter.py
+++ b/app/services/data_fabric/adapters/ogc_api_adapter.py
@@ -3,10 +3,9 @@ OGC API - Features Data Source Adapter
 """
 import time
 import logging
-import requests
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -33,7 +32,7 @@ class OGCAPIAdapter(GeospatialDataSourceAdapter):
         self.raw_url = self.profile.url or ""
         self.url = DataFabricSecurity.validate_url(self.raw_url, allow_private=self.profile.allow_private) if self.raw_url else ""
         self.options = self.profile.options or {}
-        self.session = requests.Session()
+        self.session = make_safe_session(allow_private=self.profile.allow_private)
         if "headers" in self.options:
             self.session.headers.update(self.options["headers"])
 

--- a/app/services/data_fabric/adapters/pmtiles_adapter.py
+++ b/app/services/data_fabric/adapters/pmtiles_adapter.py
@@ -9,7 +9,7 @@ import struct
 import logging
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -67,6 +67,8 @@ class PMTilesAdapter(GeospatialDataSourceAdapter):
         super().__init__(connection_profile)
         self.endpoint = (self.profile.endpoint or "").strip()
         self.allow_private = getattr(self.profile, "allow_private", False)
+        # SSRF-safe session: every request (incl. redirects) is revalidated.
+        self.session = make_safe_session(allow_private=self.allow_private)
 
     def _parse_header_bytes(self, header_bytes: bytes) -> Dict[str, Any]:
         """
@@ -105,22 +107,23 @@ class PMTilesAdapter(GeospatialDataSourceAdapter):
         }
 
     def probe(self) -> bool:
-        """Probe PMTiles file reachability and 127-byte header."""
-        if not self.endpoint or not os.path.exists(self.endpoint):
-            return True  # Synthetic fallback mode
+        """Probe PMTiles file reachability and 127-byte header.
 
+        Truthfulness: no-endpoint = explicit demo mode (reachable); an endpoint
+        that IS configured but points at a missing/unreadable source is NOT.
+        """
+        if not self.endpoint:
+            return True  # explicit demo mode
         try:
             if self.endpoint.startswith(("http://", "https://")):
                 safe_url = DataFabricSecurity.validate_url(self.endpoint, allow_private=self.allow_private)
-                import requests
-
-                resp = requests.get(safe_url, headers={"Range": "bytes=0-126"}, timeout=5)
+                resp = self.session.get(safe_url, headers={"Range": "bytes=0-126"}, timeout=5)
                 return resp.status_code in (200, 206) and (b"PMT" in resp.content or b"PMTiles" in resp.content)
             elif os.path.isfile(self.endpoint):
                 with open(self.endpoint, "rb") as f:
                     buf = f.read(HEADER_SIZE)
                     return b"PMT" in buf or b"PMTiles" in buf
-            return True
+            return False
         except Exception as e:
             logger.debug(f"PMTiles probe failed for {self.endpoint}: {e}")
             return False
@@ -266,6 +269,8 @@ class PMTilesAdapter(GeospatialDataSourceAdapter):
         start_time = time.time()
         desc = self.describe(dataset_id)
         meta = desc.metadata
+        # Demo vs remote label so callers never mistake demo metadata for a real source.
+        src = "synthetic-demo" if not self.endpoint else "remote"
 
         if query_spec.tile_coords and isinstance(query_spec.tile_coords, dict):
             z = query_spec.tile_coords.get("z", meta.get("min_zoom", 0))
@@ -283,7 +288,7 @@ class PMTilesAdapter(GeospatialDataSourceAdapter):
                 },
                 total_count=1,
                 returned_count=1,
-                metadata={"exec_time_ms": exec_time, "full_geojson_conversion": False},
+                metadata={"exec_time_ms": exec_time, "full_geojson_conversion": False, "source": src},
             )
 
         target_zoom = query_spec.zoom if query_spec.zoom is not None else meta.get("min_zoom", 0)
@@ -303,7 +308,7 @@ class PMTilesAdapter(GeospatialDataSourceAdapter):
             },
             total_count=1,
             returned_count=1,
-            metadata={"exec_time_ms": exec_time, "full_geojson_conversion": False},
+            metadata={"exec_time_ms": exec_time, "full_geojson_conversion": False, "source": src},
         )
 
     def health(self) -> DataFabricHealth:

--- a/app/services/data_fabric/adapters/pmtiles_adapter.py
+++ b/app/services/data_fabric/adapters/pmtiles_adapter.py
@@ -9,7 +9,13 @@ import struct
 import logging
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
+from app.services.data_fabric.security import (
+    DataFabricSecurity,
+    _local_file_max_bytes_from_settings,
+    _local_file_roots_from_settings,
+    make_safe_session,
+    resolve_safe_local_path,
+)
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -182,6 +188,14 @@ class PMTilesAdapter(GeospatialDataSourceAdapter):
             )
 
         try:
+            # Local-file path guard (Section 44): block traversal / symlink
+            # escape / sensitive-system-dir / oversize reads before opening.
+            if not self.endpoint.startswith(("http://", "https://", "s3://", "minio://")):
+                resolve_safe_local_path(
+                    self.endpoint,
+                    _local_file_roots_from_settings(),
+                    _local_file_max_bytes_from_settings(),
+                )
             with open(self.endpoint, "rb") as f:
                 header_bytes = f.read(HEADER_SIZE)
                 info = self._parse_header_bytes(header_bytes)

--- a/app/services/data_fabric/adapters/s3_storage_seam.py
+++ b/app/services/data_fabric/adapters/s3_storage_seam.py
@@ -8,7 +8,7 @@ import logging
 from typing import List, Dict, Any, Tuple
 from urllib.parse import urlparse
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -62,6 +62,9 @@ class S3StorageSeam(GeospatialDataSourceAdapter):
         self.region = getattr(self.profile, "region", None) or self.profile.options.get("region", "us-east-1")
         self.allow_private = getattr(self.profile, "allow_private", False)
 
+        # SSRF-safe session: every request (incl. redirects) is revalidated.
+        self.session = make_safe_session(allow_private=self.allow_private)
+
         # Ensure credentials are redacted in profile dict for secret reference security
         self.sanitized_profile = DataFabricSecurity.sanitize_profile_dict(self.profile.model_dump())
 
@@ -88,9 +91,7 @@ class S3StorageSeam(GeospatialDataSourceAdapter):
 
         try:
             safe_url = DataFabricSecurity.validate_url(self.endpoint, allow_private=self.allow_private)
-            import requests
-
-            resp = requests.head(safe_url, timeout=5)
+            resp = self.session.head(safe_url, timeout=5)
             return resp.status_code in (200, 403, 405)  # S3 endpoints may respond 403/405 to unauthenticated HEAD
         except Exception as e:
             logger.debug(f"S3 Storage Seam probe check note for {self.endpoint}: {type(e).__name__}")
@@ -218,8 +219,12 @@ class S3StorageSeam(GeospatialDataSourceAdapter):
         meta = desc.metadata
 
         max_bytes = min(query_spec.limit * 1024 if query_spec.limit else MAX_PREVIEW_BYTES, MAX_PREVIEW_BYTES)
-        
+
         exec_time = round((time.time() - start_time) * 1000, 2)
+        # Demo vs remote label: with no real endpoint configured the metadata is
+        # served from SYNTHETIC_S3_FIXTURES — callers must not mistake it for a
+        # probed remote object.
+        src = "synthetic-demo" if (not self.endpoint or self.endpoint.startswith("s3://")) else "remote"
         return QueryResult(
             dataset_id=target_uri,
             features=[],
@@ -237,6 +242,7 @@ class S3StorageSeam(GeospatialDataSourceAdapter):
                 "exec_time_ms": exec_time,
                 "bounded_memory_stream": True,
                 "chunk_size_bytes": DEFAULT_CHUNK_SIZE,
+                "source": src,
             },
         )
 

--- a/app/services/data_fabric/adapters/stac_adapter.py
+++ b/app/services/data_fabric/adapters/stac_adapter.py
@@ -8,7 +8,8 @@ import logging
 from typing import List, Dict, Any
 from urllib.parse import urljoin
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.errors import classify_http_status
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -127,6 +128,8 @@ class STACAdapter(GeospatialDataSourceAdapter):
         super().__init__(connection_profile)
         self.endpoint = (self.profile.endpoint or "").strip()
         self.allow_private = getattr(self.profile, "allow_private", False)
+        # SSRF-safe session: every request (incl. redirects) is revalidated.
+        self.session = make_safe_session(allow_private=self.allow_private)
 
     def probe(self) -> bool:
         """Reachability probe for STAC endpoint."""
@@ -291,16 +294,21 @@ class STACAdapter(GeospatialDataSourceAdapter):
         }
 
     def query(self, dataset_id: str, query_spec: QuerySpec) -> QueryResult:
-        """Execute STAC search with pushdown bbox and temporal filtering."""
+        """Execute STAC search with pushdown bbox and temporal filtering.
+
+        Truthfulness contract: when a real endpoint is configured, a query
+        failure (non-200 or exception) returns a structured ``QueryResult`` with
+        ``features=[]`` and a typed ``error_type`` in metadata — it does NOT fall
+        back to synthetic fixtures as if they were the remote's real data. The
+        synthetic fixtures are used only in explicit no-endpoint demo mode, and
+        are labeled ``source="synthetic-demo"`` in metadata.
+        """
         start_time = time.time()
         bounded_limit = max(1, min(query_spec.limit or 50, MAX_QUERY_LIMIT))
 
-        # Check for online endpoint query vs synthetic fallback
         if self.endpoint:
             try:
                 safe_url = DataFabricSecurity.validate_url(self.endpoint, allow_private=self.allow_private)
-                import requests
-
                 search_url = urljoin(safe_url + "/", "search")
                 payload: Dict[str, Any] = {
                     "collections": [dataset_id],
@@ -311,22 +319,55 @@ class STACAdapter(GeospatialDataSourceAdapter):
                 if query_spec.datetime_range and len(query_spec.datetime_range) == 2:
                     payload["datetime"] = f"{query_spec.datetime_range[0]}/{query_spec.datetime_range[1]}"
 
-                resp = requests.post(search_url, json=payload, timeout=10)
-                if resp.status_code == 200:
-                    data = resp.json()
-                    features = data.get("features", [])
+                resp = self.session.post(search_url, json=payload, timeout=10)
+                if resp.status_code != 200:
+                    # Real source responded with an error — surface it, do not
+                    # masquerade synthetic fixtures as the remote's data.
+                    err_type = classify_http_status(resp.status_code)
                     exec_time = round((time.time() - start_time) * 1000, 2)
                     return QueryResult(
                         dataset_id=dataset_id,
-                        features=features[:bounded_limit],
-                        data={"type": "FeatureCollection", "features": features[:bounded_limit]},
-                        total_count=data.get("numberMatched", len(features)),
-                        returned_count=len(features[:bounded_limit]),
-                        metadata={"exec_time_ms": exec_time, "pushdown_bbox": bool(query_spec.bbox)},
+                        features=[],
+                        total_count=0,
+                        returned_count=0,
+                        metadata={
+                            "exec_time_ms": exec_time,
+                            "source": "remote",
+                            "error_type": err_type,
+                            "error": f"STAC search returned HTTP {resp.status_code}",
+                            "http_status": resp.status_code,
+                        },
                     )
+                data = resp.json()
+                features = data.get("features", [])
+                exec_time = round((time.time() - start_time) * 1000, 2)
+                return QueryResult(
+                    dataset_id=dataset_id,
+                    features=features[:bounded_limit],
+                    data={"type": "FeatureCollection", "features": features[:bounded_limit]},
+                    total_count=data.get("numberMatched", len(features)),
+                    returned_count=len(features[:bounded_limit]),
+                    metadata={"exec_time_ms": exec_time, "pushdown_bbox": bool(query_spec.bbox), "source": "remote"},
+                )
             except Exception as e:
-                logger.warning(f"STAC remote query failed for '{dataset_id}', using synthetic fallback: {e}")
+                # Endpoint configured but unreachable / bad response — fail
+                # truthfully with empty features + typed error. No synthetic data.
+                logger.warning(f"STAC remote query failed for '{dataset_id}': {e}")
+                exec_time = round((time.time() - start_time) * 1000, 2)
+                return QueryResult(
+                    dataset_id=dataset_id,
+                    features=[],
+                    total_count=0,
+                    returned_count=0,
+                    metadata={
+                        "exec_time_ms": exec_time,
+                        "source": "remote",
+                        "error_type": "SOURCE_UNREACHABLE",
+                        "error": f"STAC search failed: {e}",
+                    },
+                )
 
+        # No endpoint configured → explicit synthetic DEMO mode (labeled).
         # Synthetic fallback filtering
         fixture = SYNTHETIC_STAC_FIXTURES.get(dataset_id, SYNTHETIC_STAC_FIXTURES["landsat-8-c2-l2"])
         items = list(fixture.get("items", []))
@@ -354,7 +395,12 @@ class STACAdapter(GeospatialDataSourceAdapter):
             data={"type": "FeatureCollection", "features": sliced},
             total_count=len(items),
             returned_count=len(sliced),
-            metadata={"exec_time_ms": exec_time, "pushdown_bbox": bool(query_spec.bbox)},
+            metadata={
+                "exec_time_ms": exec_time,
+                "pushdown_bbox": bool(query_spec.bbox),
+                # Explicit label so callers never mistake demo data for remote data.
+                "source": "synthetic-demo",
+            },
         )
 
     def health(self) -> DataFabricHealth:

--- a/app/services/data_fabric/adapters/wfs_adapter.py
+++ b/app/services/data_fabric/adapters/wfs_adapter.py
@@ -3,10 +3,9 @@ WFS (Web Feature Service) Data Source Adapter
 """
 import time
 import logging
-import requests
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -36,7 +35,7 @@ class WFSAdapter(GeospatialDataSourceAdapter):
             else ""
         )
         self.options = self.profile.options or {}
-        self.session = requests.Session()
+        self.session = make_safe_session(allow_private=self.profile.allow_private)
         if "headers" in self.options:
             self.session.headers.update(self.options["headers"])
 

--- a/app/services/data_fabric/adapters/wms_wmts_adapter.py
+++ b/app/services/data_fabric/adapters/wms_wmts_adapter.py
@@ -3,10 +3,9 @@ WMS & WMTS Raster Data Source Adapter
 """
 import time
 import logging
-import requests
 from typing import List, Dict, Any
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.security import DataFabricSecurity
+from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
     QuerySpec,
@@ -34,7 +33,7 @@ class WMSWMTSAdapter(GeospatialDataSourceAdapter):
         )
         self.service_type = self.profile.source_type.lower()
         self.options = self.profile.options or {}
-        self.session = requests.Session()
+        self.session = make_safe_session(allow_private=self.profile.allow_private)
 
     def probe(self) -> bool:
         """Lightweight WMS/WMTS GetCapabilities probe."""

--- a/app/services/data_fabric/circuit_breaker.py
+++ b/app/services/data_fabric/circuit_breaker.py
@@ -1,0 +1,181 @@
+"""Per-source circuit breaker for remote Data Fabric sources (Section 36).
+
+When a source is repeatedly failing, every user request would otherwise wait the
+full timeout. The breaker short-circuits: after ``failure_threshold`` consecutive
+failures it opens for ``cool_down`` seconds, during which calls fail fast
+(``RESULT``-free) without touching the network; after cool-down it enters
+half-open and lets one trial request through.
+
+The clock is injectable so tests are deterministic (no real sleeps). State is
+bounded: one entry per source id, evicted LRU beyond ``max_entries``.
+"""
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Optional
+
+from app.services.data_fabric.errors import SourceUnreachableError
+from app.services.data_fabric.reliability import is_transient
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(str, Enum):
+    CLOSED = "closed"        # normal operation
+    OPEN = "open"            # tripped: fail fast
+    HALF_OPEN = "half_open"  # cool-down elapsed: one trial allowed
+
+
+@dataclass
+class _BreakerEntry:
+    state: CircuitState = CircuitState.CLOSED
+    consecutive_failures: int = 0
+    opened_at: float = 0.0
+    # Guards the single trial request in half-open.
+    half_open_trial_inflight: bool = False
+
+
+class CircuitBreaker:
+    """Per-source breaker. Thread-compatible (callers serialize per source)."""
+
+    def __init__(
+        self,
+        failure_threshold: int = 5,
+        cool_down: float = 30.0,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self.failure_threshold = max(1, failure_threshold)
+        self.cool_down = max(0.0, cool_down)
+        self._clock = clock
+
+    def _state(self, entry: _BreakerEntry) -> CircuitState:
+        if entry.state == CircuitState.OPEN:
+            if self._clock() - entry.opened_at >= self.cool_down:
+                entry.state = CircuitState.HALF_OPEN
+                entry.half_open_trial_inflight = False
+        return entry.state
+
+    def allow(self, entry: _BreakerEntry) -> bool:
+        """Return True if a request may proceed; False → fail fast (open)."""
+        state = self._state(entry)
+        if state == CircuitState.OPEN:
+            return False
+        if state == CircuitState.HALF_OPEN:
+            if entry.half_open_trial_inflight:
+                return False  # only one trial at a time
+            entry.half_open_trial_inflight = True
+            return True
+        return True  # CLOSED
+
+    def record_success(self, entry: _BreakerEntry) -> None:
+        entry.consecutive_failures = 0
+        entry.state = CircuitState.CLOSED
+        entry.half_open_trial_inflight = False
+
+    def record_failure(self, entry: _BreakerEntry, exc: BaseException) -> None:
+        # Permanent errors (bad request, security) do not trip the breaker —
+        # they are not evidence the source is down.
+        if not is_transient(exc):
+            return
+        entry.consecutive_failures += 1
+        entry.half_open_trial_inflight = False
+        if entry.state == CircuitState.HALF_OPEN:
+            # Trial failed → reopen.
+            entry.state = CircuitState.OPEN
+            entry.opened_at = self._clock()
+        elif entry.consecutive_failures >= self.failure_threshold:
+            entry.state = CircuitState.OPEN
+            entry.opened_at = self._clock()
+            logger.warning(
+                "circuit breaker opened after %d consecutive failures",
+                entry.consecutive_failures,
+            )
+
+
+class CircuitBreakerRegistry:
+    """Bounded registry of per-source breakers (LRU evict beyond max_entries)."""
+
+    def __init__(
+        self,
+        breaker: Optional[CircuitBreaker] = None,
+        max_entries: int = 4096,
+    ):
+        self._breaker = breaker or CircuitBreaker()
+        self._entries: "OrderedDict[str, _BreakerEntry]" = OrderedDict()
+        self._max_entries = max_entries
+
+    def _entry(self, source_key: str) -> _BreakerEntry:
+        entry = self._entries.get(source_key)
+        if entry is None:
+            entry = _BreakerEntry()
+            self._entries[source_key] = entry
+            while len(self._entries) > self._max_entries:
+                self._entries.popitem(last=False)
+        else:
+            self._entries.move_to_end(source_key)
+        return entry
+
+    def state(self, source_key: str) -> CircuitState:
+        return self._breaker._state(self._entry(source_key))
+
+    def allow(self, source_key: str) -> bool:
+        return self._breaker.allow(self._entry(source_key))
+
+    def record_success(self, source_key: str) -> None:
+        self._breaker.record_success(self._entry(source_key))
+
+    def record_failure(self, source_key: str, exc: BaseException) -> None:
+        self._breaker.record_failure(self._entry(source_key), exc)
+
+    def call(
+        self,
+        source_key: str,
+        fn: Callable[..., object],
+        *args,
+        **kwargs,
+    ) -> object:
+        """Run ``fn`` under the breaker for ``source_key``.
+
+        Fail-fast (open) raises ``SourceUnreachableError``. Otherwise the result
+        (or exception) is recorded and propagated.
+        """
+        if not self.allow(source_key):
+            raise SourceUnreachableError(
+                f"source '{source_key}' circuit breaker is open (failing fast)",
+                details={"circuit_state": self.state(source_key)},
+            )
+        try:
+            result = fn(*args, **kwargs)
+        except Exception as exc:
+            self.record_failure(source_key, exc)
+            raise
+        self.record_success(source_key)
+        return result
+
+
+# Per-process default registry. Tests construct their own to inject fake clocks.
+_breaker_registry: Optional[CircuitBreakerRegistry] = None
+
+
+def get_breaker_registry() -> CircuitBreakerRegistry:
+    global _breaker_registry
+    if _breaker_registry is None:
+        _breaker_registry = CircuitBreakerRegistry()
+    return _breaker_registry
+
+
+def set_breaker_registry(registry: CircuitBreakerRegistry) -> None:
+    """Override the process registry (test seam)."""
+    global _breaker_registry
+    _breaker_registry = registry
+
+
+__all__ = [
+    "CircuitState",
+    "CircuitBreaker",
+    "CircuitBreakerRegistry",
+    "get_breaker_registry",
+    "set_breaker_registry",
+]

--- a/app/services/data_fabric/connection_manager.py
+++ b/app/services/data_fabric/connection_manager.py
@@ -213,49 +213,16 @@ class GenericDataSourceAdapter(GeospatialDataSourceAdapter):
 
 
 def create_adapter_for_profile(profile: ConnectionProfile) -> GeospatialDataSourceAdapter:
-    """Factory function mapping ConnectionProfile source_type to concrete GeospatialDataSourceAdapter."""
-    try:
-        from app.services.data_fabric.adapters import (
-            PostGISAdapter,
-            OGCAPIAdapter,
-            WFSAdapter,
-            WMSWMTSAdapter,
-            ArcGISAdapter,
-            STACAdapter,
-            GeoParquetAdapter,
-            FlatGeobufAdapter,
-            PMTilesAdapter,
-            S3StorageAdapter,
-        )
+    """Factory mapping ConnectionProfile.source_type → concrete adapter.
 
-        adapter_map = {
-            "postgis": PostGISAdapter,
-            "postgres": PostGISAdapter,
-            "postgresql": PostGISAdapter,
-            "geoparquet": GeoParquetAdapter,
-            "parquet": GeoParquetAdapter,
-            "flatgeobuf": FlatGeobufAdapter,
-            "fgb": FlatGeobufAdapter,
-            "stac": STACAdapter,
-            "ogc_api": OGCAPIAdapter,
-            "ogc_api_features": OGCAPIAdapter,
-            "wfs": WFSAdapter,
-            "wms": WMSWMTSAdapter,
-            "wmts": WMSWMTSAdapter,
-            "arcgis": ArcGISAdapter,
-            "arcgis_rest": ArcGISAdapter,
-            "pmtiles": PMTilesAdapter,
-            "s3": S3StorageAdapter,
-        }
+    Routes through the canonical ``AdapterRegistry``. An unregistered source
+    type raises ``UnsupportedSourceError`` — it is NEVER silently mapped to
+    mock data. (Callers that want the explicit demo adapter must request
+    source_type ``generic``/``geojson``.)
+    """
+    from app.services.data_fabric.registry import build_adapter
 
-        st = (profile.source_type or "").lower().strip()
-        adapter_cls = adapter_map.get(st)
-        if adapter_cls:
-            return adapter_cls(profile)
-    except Exception as e:
-        logger.warning(f"[ConnectionManager] Factory lookup for source_type='{profile.source_type}' failed: {e}")
-
-    return GenericDataSourceAdapter(profile)
+    return build_adapter(profile)
 
 
 class DataFabricConnectionManager:

--- a/app/services/data_fabric/errors.py
+++ b/app/services/data_fabric/errors.py
@@ -1,0 +1,164 @@
+"""Structured error taxonomy for the Geospatial Data Fabric.
+
+Every remote operation resolves to either a success or one of these typed
+errors. Tools, routes and the agent translate the stable ``code`` strings
+into actionable decisions instead of guessing from free-form messages.
+
+Design (Data Fabric V3 / ADR-0053):
+- ``DataFabricError`` carries a stable ``code`` plus optional ``details``.
+- ``classify_http_status`` maps an HTTP response to the right code so the
+  reliability layer (retry/circuit-breaker) can decide transient vs permanent
+  without re-implementing the mapping per adapter.
+- The transient/permanent sets are the single source of truth for the retry
+  policy (see reliability.py): only ``TRANSIENT_HTTP_STATUS`` is retried.
+"""
+from typing import Any, Dict, Optional
+
+
+# ── Canonical error code strings (stable public contract) ───────────────────
+UNSUPPORTED_SOURCE = "UNSUPPORTED_SOURCE"
+UNSUPPORTED_CAPABILITY = "UNSUPPORTED_CAPABILITY"
+INVALID_QUERY = "INVALID_QUERY"
+SOURCE_UNREACHABLE = "SOURCE_UNREACHABLE"
+SOURCE_TIMEOUT = "SOURCE_TIMEOUT"
+SOURCE_AUTH_FAILED = "SOURCE_AUTH_FAILED"
+SOURCE_RATE_LIMITED = "SOURCE_RATE_LIMITED"
+SOURCE_BAD_RESPONSE = "SOURCE_BAD_RESPONSE"
+RESULT_TOO_LARGE = "RESULT_TOO_LARGE"
+MATERIALIZATION_FAILED = "MATERIALIZATION_FAILED"
+CANCELLED = "CANCELLED"
+SECURITY_BLOCKED = "SECURITY_BLOCKED"
+
+
+# ── HTTP status classification (single source of truth for retry policy) ─────
+# Genuinely transient: a bounded retry with backoff may succeed.
+TRANSIENT_HTTP_STATUS = frozenset({429, 500, 502, 503, 504})
+# Permanent client errors / security decisions: MUST NOT be retried.
+PERMANENT_HTTP_STATUS = frozenset({400, 401, 403, 404, 405, 409, 422})
+
+
+class DataFabricError(Exception):
+    """Base for typed Data Fabric failures.
+
+    ``code`` is the stable machine-readable contract; ``details`` carries
+    optional structured context (e.g. hint, retry_after, status_code).
+    """
+
+    code: str = "DATA_FABRIC_ERROR"
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        code: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(message or self.code)
+        if code:
+            self.code = code
+        self.details: Dict[str, Any] = details or {}
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"error_type": self.code, "error": str(self), "details": self.details}
+
+
+class UnsupportedSourceError(DataFabricError):
+    code = UNSUPPORTED_SOURCE
+
+
+class UnsupportedCapabilityError(DataFabricError):
+    code = UNSUPPORTED_CAPABILITY
+
+
+class InvalidQueryError(DataFabricError):
+    code = INVALID_QUERY
+
+
+class SourceUnreachableError(DataFabricError):
+    code = SOURCE_UNREACHABLE
+
+
+class SourceTimeoutError(DataFabricError):
+    code = SOURCE_TIMEOUT
+
+
+class SourceAuthFailedError(DataFabricError):
+    code = SOURCE_AUTH_FAILED
+
+
+class SourceRateLimitedError(DataFabricError):
+    code = SOURCE_RATE_LIMITED
+
+
+class SourceBadResponseError(DataFabricError):
+    code = SOURCE_BAD_RESPONSE
+
+
+class ResultTooLargeError(DataFabricError):
+    code = RESULT_TOO_LARGE
+
+
+class MaterializationFailedError(DataFabricError):
+    code = MATERIALIZATION_FAILED
+
+
+class DataFabricCancelledError(DataFabricError):
+    code = CANCELLED
+
+
+class SecurityBlockedError(DataFabricError):
+    code = SECURITY_BLOCKED
+
+
+def classify_http_status(status: int) -> str:
+    """Map a remote HTTP status to a canonical Data Fabric error code.
+
+    The mapping is deliberately conservative: unknown 4xx are treated as bad
+    responses (not retried), and only ``TRANSIENT_HTTP_STATUS`` is retryable.
+    """
+    if status in (401, 403):
+        return SOURCE_AUTH_FAILED
+    if status == 404:
+        return SOURCE_UNREACHABLE
+    if status == 429:
+        return SOURCE_RATE_LIMITED
+    if 500 <= status < 600:
+        return SOURCE_BAD_RESPONSE
+    if 400 <= status < 500:
+        return SOURCE_BAD_RESPONSE
+    return SOURCE_BAD_RESPONSE
+
+
+__all__ = [
+    # codes
+    "UNSUPPORTED_SOURCE",
+    "UNSUPPORTED_CAPABILITY",
+    "INVALID_QUERY",
+    "SOURCE_UNREACHABLE",
+    "SOURCE_TIMEOUT",
+    "SOURCE_AUTH_FAILED",
+    "SOURCE_RATE_LIMITED",
+    "SOURCE_BAD_RESPONSE",
+    "RESULT_TOO_LARGE",
+    "MATERIALIZATION_FAILED",
+    "CANCELLED",
+    "SECURITY_BLOCKED",
+    # classification
+    "TRANSIENT_HTTP_STATUS",
+    "PERMANENT_HTTP_STATUS",
+    "classify_http_status",
+    # exceptions
+    "DataFabricError",
+    "UnsupportedSourceError",
+    "UnsupportedCapabilityError",
+    "InvalidQueryError",
+    "SourceUnreachableError",
+    "SourceTimeoutError",
+    "SourceAuthFailedError",
+    "SourceRateLimitedError",
+    "SourceBadResponseError",
+    "ResultTooLargeError",
+    "MaterializationFailedError",
+    "DataFabricCancelledError",
+    "SecurityBlockedError",
+]

--- a/app/services/data_fabric/health.py
+++ b/app/services/data_fabric/health.py
@@ -1,30 +1,128 @@
 """
-Geospatial Data Fabric: Data Source Health Monitoring Service
-Provides diagnostic health checks and monitoring for Data Fabric endpoints with SSRF security validation.
+Geospatial Data Fabric: Data Source Health Monitoring Service.
+
+Truthfulness contract (Section 33/34/35):
+- A validated URL is NOT "healthy". ``check_connection_profile`` now reports
+  ``valid_profile`` when the URL merely passes SSRF validation — only an actual
+  adapter probe reports ``healthy`` / ``reachable``.
+- Health is cached with a bounded TTL (healthy longer than failure) so repeated
+  API calls do not hammer the remote source.
+- The per-source circuit breaker is consulted first: an open breaker yields a
+  ``circuit_open`` result without touching the network (fail fast).
 """
-import time
 import logging
-from typing import Dict
-from app.schemas.data_fabric_schema import DataFabricHealth, ConnectionProfile
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+from app.schemas.data_fabric_schema import ConnectionProfile, DataFabricHealth
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
+from app.services.data_fabric.errors import SourceUnreachableError
 from app.services.data_fabric.security import DataFabricSecurity, DataFabricSecurityError
 
 logger = logging.getLogger(__name__)
 
+# Health status vocabulary (Section 33). Free string on the schema, but these
+# are the canonical values the agent/tools rely on.
+STATUS_VALID_PROFILE = "valid_profile"
+STATUS_HEALTHY = "healthy"
+STATUS_DEGRADED = "degraded"
+STATUS_UNREACHABLE = "unreachable"
+STATUS_TIMEOUT = "timeout"
+STATUS_MISCONFIGURED = "misconfigured"
+STATUS_CIRCUIT_OPEN = "circuit_open"
+STATUS_AUTH_FAILED = "auth_failed"
+
+# Failure statuses that count as evidence the source is down (trip the breaker).
+_FAILURE_STATUSES = frozenset({STATUS_UNREACHABLE, STATUS_DEGRADED, STATUS_TIMEOUT})
+
+
+class SourceDownError(SourceUnreachableError):
+    """Raised internally to feed health-check failures into the circuit breaker.
+
+    Subclasses ``SourceUnreachableError`` so ``is_transient`` classifies it as
+    transient (a health failure IS evidence the source may be down).
+    """
+
+    def __init__(self, source_key: str):
+        super().__init__(f"source '{source_key}' health check failed")
+
+
+@dataclass
+class _CachedHealth:
+    health: DataFabricHealth
+    cached_at: float
+
 
 class DataFabricHealthCheck:
-    """
-    Data Source Health Monitoring Service for validating connectivity,
-    latency, SSRF compliance, and runtime status of Data Fabric endpoints.
-    """
+    """Health monitoring with SSRF validation, TTL caching, and breaker gating."""
 
-    def check_health(self, adapter: GeospatialDataSourceAdapter) -> DataFabricHealth:
+    def __init__(
+        self,
+        healthy_ttl: float = 30.0,
+        failure_ttl: float = 5.0,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        self.healthy_ttl = healthy_ttl
+        self.failure_ttl = failure_ttl
+        self._clock = clock
+        self._cache: Dict[str, _CachedHealth] = {}
+
+    # ── cache helpers ───────────────────────────────────────────────────────
+    def _cache_get(self, key: str) -> Optional[DataFabricHealth]:
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        ttl = self.healthy_ttl if entry.health.status == STATUS_HEALTHY else self.failure_ttl
+        if self._clock() - entry.cached_at < ttl:
+            return entry.health
+        return None
+
+    def _cache_put(self, key: str, health: DataFabricHealth) -> None:
+        self._cache[key] = _CachedHealth(health=health, cached_at=self._clock())
+
+    def clear_cache(self) -> None:
+        self._cache.clear()
+
+    # ── adapter health (real probe) ──────────────────────────────────────────
+    def check_health(
+        self,
+        adapter: GeospatialDataSourceAdapter,
+        *,
+        use_cache: bool = True,
+        source_key: Optional[str] = None,
+    ) -> DataFabricHealth:
+        """Run (or return cached) diagnostic health for an adapter.
+
+        Honors the circuit breaker: an open breaker short-circuits to
+        ``circuit_open`` without a remote probe. Caches by ``source_key`` (or
+        ``adapter.profile.id``) so repeated calls within TTL skip the probe.
         """
-        Execute diagnostic health check on a data source adapter.
-        """
+        key = source_key or (adapter.profile.id if adapter and adapter.profile else "unknown")
+
+        # Circuit-breaker fast-fail.
+        try:
+            from app.services.data_fabric.circuit_breaker import get_breaker_registry
+
+            if not get_breaker_registry().allow(key):
+                health = DataFabricHealth(
+                    status=STATUS_CIRCUIT_OPEN,
+                    message=f"source '{key}' circuit breaker open; failing fast",
+                    details={"circuit_state": "open"},
+                    reachable=False,
+                )
+                self._cache_put(key, health)
+                return health
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+        if use_cache:
+            cached = self._cache_get(key)
+            if cached is not None:
+                return cached
+
         start_time = time.perf_counter()
         try:
-            # 1. SSRF check on adapter profile URL if present
             if adapter.profile.url:
                 try:
                     DataFabricSecurity.validate_url(
@@ -33,72 +131,97 @@ class DataFabricHealthCheck:
                     )
                 except DataFabricSecurityError as se:
                     elapsed = (time.perf_counter() - start_time) * 1000.0
-                    return DataFabricHealth(
-                        status="unreachable",
+                    health = DataFabricHealth(
+                        status=STATUS_UNREACHABLE,
                         message=f"SSRF Security Violation: {se}",
                         details={"error_type": "security_violation"},
                         latency_ms=round(elapsed, 2),
+                        reachable=False,
                     )
+                    self._cache_put(key, health)
+                    return health
 
-            # 2. Delegate to adapter's health method
             health_status = adapter.health()
             elapsed = (time.perf_counter() - start_time) * 1000.0
-            if health_status.latency_ms is None:
+            if health_status.latency_ms is None or health_status.latency_ms == 0:
                 health_status.latency_ms = round(elapsed, 2)
+            self._record(key, health_status)
+            self._cache_put(key, health_status)
             return health_status
         except Exception as e:
             elapsed = (time.perf_counter() - start_time) * 1000.0
-            logger.error(f"[DataFabricHealthCheck] Health check failed for adapter '{adapter.profile.id}': {e}")
-            return DataFabricHealth(
-                status="unreachable",
-                message=f"Connection failed: {str(e)}",
-                details={"exception": str(e)},
-                latency_ms=round(elapsed, 2),
+            logger.error(
+                "[DataFabricHealthCheck] Health check failed for adapter '%s': %s",
+                key, e,
             )
+            health = DataFabricHealth(
+                status=STATUS_UNREACHABLE,
+                message=f"Connection failed: {e}",
+                details={"exception": type(e).__name__},
+                latency_ms=round(elapsed, 2),
+                reachable=False,
+            )
+            self._record(key, health)
+            self._cache_put(key, health)
+            return health
 
+    @staticmethod
+    def _record(source_key: str, health: DataFabricHealth) -> None:
+        """Feed success/failure into the per-source circuit breaker."""
+        try:
+            from app.services.data_fabric.circuit_breaker import get_breaker_registry
+
+            reg = get_breaker_registry()
+            if health.status == STATUS_HEALTHY:
+                reg.record_success(source_key)
+            elif health.status in _FAILURE_STATUSES:
+                reg.record_failure(source_key, SourceDownError(source_key))
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    # ── profile validation (truthful: NOT a health probe) ────────────────────
     def check_connection_profile(self, profile: ConnectionProfile) -> DataFabricHealth:
-        """
-        Validate connectivity and SSRF policy for a ConnectionProfile without full adapter instantiation.
+        """Validate SSRF policy + shape for a ConnectionProfile.
+
+        This does NOT probe the remote endpoint. A passing result is reported as
+        ``valid_profile`` — it means "URL is well-formed and SSRF-safe", NOT
+        "the source is reachable/healthy". Previously it returned ``healthy``
+        with "passed connection validation", which conflated the two.
         """
         start_time = time.perf_counter()
-        try:
-            if profile.url:
-                DataFabricSecurity.validate_url(
-                    profile.url,
-                    allow_private=profile.allow_private,
-                )
-
+        if not profile.url:
             elapsed = (time.perf_counter() - start_time) * 1000.0
             return DataFabricHealth(
-                status="healthy",
-                message=f"Profile '{profile.id}' passed security and connection validation",
-                details={"source_type": profile.source_type, "url": profile.url},
+                status=STATUS_MISCONFIGURED,
+                message=f"Profile '{profile.id}' has no endpoint URL",
+                details={"source_type": profile.source_type},
                 latency_ms=round(elapsed, 2),
+                reachable=False,
+            )
+        try:
+            DataFabricSecurity.validate_url(profile.url, allow_private=profile.allow_private)
+            elapsed = (time.perf_counter() - start_time) * 1000.0
+            return DataFabricHealth(
+                status=STATUS_VALID_PROFILE,
+                message=f"Profile '{profile.id}' passed SSRF validation (not yet probed)",
+                details={"source_type": profile.source_type, "url": DataFabricSecurity.redact_url(profile.url)},
+                latency_ms=round(elapsed, 2),
+                reachable=False,
             )
         except DataFabricSecurityError as se:
             elapsed = (time.perf_counter() - start_time) * 1000.0
             return DataFabricHealth(
-                status="unreachable",
+                status=STATUS_UNREACHABLE,
                 message=f"SSRF Policy Violation: {se}",
                 details={"profile_id": profile.id},
                 latency_ms=round(elapsed, 2),
-            )
-        except Exception as e:
-            elapsed = (time.perf_counter() - start_time) * 1000.0
-            return DataFabricHealth(
-                status="unreachable",
-                message=f"Validation error: {e}",
-                details={"profile_id": profile.id},
-                latency_ms=round(elapsed, 2),
+                reachable=False,
             )
 
     def check_all(self, adapters: Dict[str, GeospatialDataSourceAdapter]) -> Dict[str, DataFabricHealth]:
-        """
-        Execute health checks across all registered adapters in parallel / map.
-        """
         results: Dict[str, DataFabricHealth] = {}
         for profile_id, adapter in adapters.items():
-            results[profile_id] = self.check_health(adapter)
+            results[profile_id] = self.check_health(adapter, source_key=profile_id)
         return results
 
 

--- a/app/services/data_fabric/limits.py
+++ b/app/services/data_fabric/limits.py
@@ -1,0 +1,129 @@
+"""Bounded resource guards for Data Fabric remote results (Section 22 / 70).
+
+A remote vector query must not be able to OOM the process. The guard enforces
+at least one hard bound on feature count, response bytes, and page count — it
+does NOT trust the remote `limit` parameter (servers may ignore it).
+
+Limits are sourced from settings but clamped to non-zero floors, so an operator
+cannot accidentally disable protection by setting ``DATA_FABRIC_MAX_FEATURES=0``.
+"""
+import json
+from typing import Any, Dict, List, Optional
+
+from app.core.config import settings
+from app.services.data_fabric.errors import ResultTooLargeError
+
+
+# Hard floors — values below these are raised to them so protection cannot be
+# disabled via config. (Generous enough never to obstruct legitimate use.)
+_MIN_MAX_FEATURES = 1_000
+_MIN_MAX_RESPONSE_BYTES = 16 * 1024 * 1024  # 16 MiB
+_MIN_MAX_PAGES = 10
+_MIN_QUERY_TIMEOUT = 5.0
+
+
+def max_features() -> int:
+    return max(int(settings.DATA_FABRIC_MAX_FEATURES), _MIN_MAX_FEATURES)
+
+
+def max_response_bytes() -> int:
+    return max(int(settings.DATA_FABRIC_MAX_RESPONSE_BYTES), _MIN_MAX_RESPONSE_BYTES)
+
+
+def max_pages() -> int:
+    return max(int(settings.DATA_FABRIC_MAX_PAGES), _MIN_MAX_PAGES)
+
+
+def query_timeout() -> float:
+    return max(float(settings.DATA_FABRIC_QUERY_TIMEOUT), _MIN_QUERY_TIMEOUT)
+
+
+def total_query_timeout() -> float:
+    return max(float(settings.DATA_FABRIC_TOTAL_QUERY_TIMEOUT), query_timeout())
+
+
+def _estimate_features_bytes(features: List[Dict[str, Any]]) -> int:
+    """Cheap upper-bound byte estimate for a feature list (no exact serialization).
+
+    json.dumps is the real size; for a guard we only need a deterministic
+    over-approximation that is cheap on large lists.
+    """
+    # Sampling: exact serialization of a 100k-feature list is wasteful on the
+    # hot path. Sample up to 256 features, average, multiply. Falls back to a
+    # per-feature floor so degenerate empty-feature lists still accrue.
+    if not features:
+        return 0
+    sample = features[:256]
+    try:
+        sample_bytes = len(json.dumps(sample, ensure_ascii=False))
+    except (TypeError, ValueError):
+        sample_bytes = len(sample) * 512
+    avg = max(sample_bytes / len(sample), 64.0)
+    return int(avg * len(features))
+
+
+def enforce_result_bounds(
+    features: List[Dict[str, Any]],
+    *,
+    page_count: Optional[int] = None,
+    max_feat: Optional[int] = None,
+    max_bytes: Optional[int] = None,
+) -> None:
+    """Raise ``ResultTooLargeError`` if a result exceeds the hard bounds.
+
+    Called at materialization / query choke points BEFORE the payload is stored,
+    so an oversized remote response is rejected rather than blowing up memory.
+
+    The actionable hint tells the caller how to shrink the request (bbox/filter/
+    smaller limit / async materialize).
+    """
+    feat_limit = max_feat if max_feat is not None else max_features()
+    byte_limit = max_bytes if max_bytes is not None else max_response_bytes()
+
+    count = len(features)
+    if count > feat_limit:
+        raise ResultTooLargeError(
+            f"query returned {count} features (limit {feat_limit})",
+            details={
+                "feature_count": count,
+                "limit": feat_limit,
+                "hint": "narrow bbox, add attribute filters, lower limit, or materialize asynchronously",
+            },
+        )
+
+    est_bytes = _estimate_features_bytes(features)
+    if est_bytes > byte_limit:
+        raise ResultTooLargeError(
+            f"query result ~{est_bytes} bytes exceeds limit {byte_limit}",
+            details={
+                "estimated_bytes": est_bytes,
+                "limit": byte_limit,
+                "hint": "narrow bbox, add attribute filters, lower limit, or materialize asynchronously",
+            },
+        )
+
+    if page_count is not None and page_count > max_pages():
+        raise ResultTooLargeError(
+            f"pagination exceeded {max_pages()} pages",
+            details={"page_count": page_count, "limit": max_pages()},
+        )
+
+
+def enforce_page_bound(page_index: int) -> None:
+    """Per-page guard inside pagination loops: raises before fetching page N+1."""
+    if page_index >= max_pages():
+        raise ResultTooLargeError(
+            f"pagination would exceed {max_pages()} page limit",
+            details={"page_index": page_index, "limit": max_pages()},
+        )
+
+
+__all__ = [
+    "max_features",
+    "max_response_bytes",
+    "max_pages",
+    "query_timeout",
+    "total_query_timeout",
+    "enforce_result_bounds",
+    "enforce_page_bound",
+]

--- a/app/services/data_fabric/manager.py
+++ b/app/services/data_fabric/manager.py
@@ -17,6 +17,7 @@ from app.schemas.data_fabric_schema import (
 from app.models.data_fabric import DataSourceModel, CatalogItemModel, MaterializationModel
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
 from app.services.data_fabric.errors import MATERIALIZATION_FAILED
+from app.services.data_fabric.limits import enforce_result_bounds
 from app.services.data_fabric.registry import build_adapter
 from app.services.data_fabric.security import DataFabricSecurity
 from app.services.session_data import session_data_manager
@@ -268,6 +269,11 @@ class DataFabricManager:
             "source_id": item.source_id,
             "title": item.title,
         }
+
+        # Resource guard (Section 22): reject oversized results before storing.
+        # Raises ResultTooLargeError with an actionable hint; the route maps it
+        # to HTTP 413.
+        enforce_result_bounds(q_res.features)
 
         fc = {
             "type": "FeatureCollection",

--- a/app/services/data_fabric/manager.py
+++ b/app/services/data_fabric/manager.py
@@ -16,8 +16,10 @@ from app.schemas.data_fabric_schema import (
 )
 from app.models.data_fabric import DataSourceModel, CatalogItemModel, MaterializationModel
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
+from app.services.data_fabric.errors import MATERIALIZATION_FAILED
 from app.services.data_fabric.security import DataFabricSecurity
 from app.services.session_data import session_data_manager
+from app.services.session_data_protocol import is_unavailable_ref
 
 from app.services.data_fabric.adapters.postgis_adapter import PostGISAdapter
 from app.services.data_fabric.adapters.ogc_api_adapter import OGCAPIAdapter
@@ -256,13 +258,28 @@ class DataFabricManager:
         query_spec: Optional[QuerySpec] = None,
         owner_token: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Materialize catalog query results into session ref_id and save audit log."""
+        """Materialize catalog query results into session ref_id and save audit log.
+
+        Truthfulness contract: the returned dict carries ``success``. On any
+        store or audit failure the result is ``success=False`` with ``ref_id=None``
+        and a typed ``error_type`` — no fake ref is persisted or returned, and no
+        audit row is written for a non-retrievable ref.
+        """
         spec = query_spec or QuerySpec(limit=500)
         item = db.query(CatalogItemModel).filter(CatalogItemModel.id == item_id).first()
         if not item:
             raise ValueError(f"Catalog item '{item_id}' not found")
 
         q_res = cls.query_catalog_item(db, item_id, spec)
+
+        feature_count = len(q_res.features)
+        base = {
+            "feature_count": feature_count,
+            "total_count": q_res.total_count,
+            "dataset_id": item_id,
+            "source_id": item.source_id,
+            "title": item.title,
+        }
 
         fc = {
             "type": "FeatureCollection",
@@ -275,10 +292,33 @@ class DataFabricManager:
             },
         }
 
-        # Store in SessionStore (Fetch-on-Demand cursor)
-        ref_id = await session_data_manager.store(session_id, fc, prefix="df")
+        # Store in SessionStore (Fetch-on-Demand cursor). A ref exists iff its
+        # payload is retrievable: an exception OR the store-unavailability
+        # sentinel is a real failure — never persist a fake audit ref.
+        try:
+            ref_id = await session_data_manager.store(session_id, fc, prefix="df")
+        except Exception as e:
+            logger.error(
+                "[DataFabricManager] materialize store failed for item '%s': %s",
+                item_id, e,
+            )
+            return {**base, "success": False, "ref_id": None,
+                    "error_type": MATERIALIZATION_FAILED,
+                    "error": f"session store failed: {e}"}
 
-        # Save materialization audit record
+        if is_unavailable_ref(ref_id):
+            logger.error(
+                "[DataFabricManager] materialize store unavailable for item '%s': %s",
+                item_id, ref_id,
+            )
+            return {**base, "success": False, "ref_id": None,
+                    "error_type": MATERIALIZATION_FAILED,
+                    "error": "session store unavailable"}
+
+        # Materialization atomicity: query success AND payload stored AND audit
+        # record committed must hold together. If the audit commit fails after
+        # the payload was stored, the ref is orphaned (no audit) — report failure
+        # so the caller does not trust an unaudited ref, and roll the TX back.
         mat_id = f"mat_{uuid.uuid4().hex[:12]}"
         mat_record = MaterializationModel(
             id=mat_id,
@@ -286,20 +326,23 @@ class DataFabricManager:
             source_id=item.source_id,
             ref_id=ref_id,
             query_spec_json=spec.model_dump(),
-            record_count=len(q_res.features),
+            record_count=feature_count,
             materialized_at=datetime.now(timezone.utc),
         )
         db.add(mat_record)
-        db.commit()
+        try:
+            db.commit()
+        except Exception:
+            db.rollback()
+            logger.exception(
+                "[DataFabricManager] audit commit failed for item '%s'; ref '%s' orphaned",
+                item_id, ref_id,
+            )
+            return {**base, "success": False, "ref_id": None,
+                    "error_type": MATERIALIZATION_FAILED,
+                    "error": "materialization audit failed"}
 
-        return {
-            "ref_id": ref_id,
-            "feature_count": len(q_res.features),
-            "total_count": q_res.total_count,
-            "dataset_id": item_id,
-            "source_id": item.source_id,
-            "title": item.title,
-        }
+        return {**base, "success": True, "ref_id": ref_id}
 
 
 data_fabric_manager = DataFabricManager()

--- a/app/services/data_fabric/manager.py
+++ b/app/services/data_fabric/manager.py
@@ -17,15 +17,10 @@ from app.schemas.data_fabric_schema import (
 from app.models.data_fabric import DataSourceModel, CatalogItemModel, MaterializationModel
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
 from app.services.data_fabric.errors import MATERIALIZATION_FAILED
+from app.services.data_fabric.registry import build_adapter
 from app.services.data_fabric.security import DataFabricSecurity
 from app.services.session_data import session_data_manager
 from app.services.session_data_protocol import is_unavailable_ref
-
-from app.services.data_fabric.adapters.postgis_adapter import PostGISAdapter
-from app.services.data_fabric.adapters.ogc_api_adapter import OGCAPIAdapter
-from app.services.data_fabric.adapters.wfs_adapter import WFSAdapter
-from app.services.data_fabric.adapters.wms_wmts_adapter import WMSWMTSAdapter
-from app.services.data_fabric.adapters.arcgis_adapter import ArcGISAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -39,20 +34,13 @@ class DataFabricManager:
 
     @staticmethod
     def get_adapter(profile: ConnectionProfile) -> GeospatialDataSourceAdapter:
-        """Factory method to instantiate protocol-specific adapter."""
-        st = (profile.source_type or "").lower().strip()
-        if st == "postgis":
-            return PostGISAdapter(profile)
-        elif st in ("ogc_api", "ogc_api_features", "ogc"):
-            return OGCAPIAdapter(profile)
-        elif st == "wfs":
-            return WFSAdapter(profile)
-        elif st in ("wms", "wmts", "wms_wmts"):
-            return WMSWMTSAdapter(profile)
-        elif st in ("arcgis", "arcgis_rest", "featureserver", "mapserver"):
-            return ArcGISAdapter(profile)
-        else:
-            raise ValueError(f"Unsupported Data Fabric source type: '{profile.source_type}'")
+        """Factory method to instantiate protocol-specific adapter.
+
+        Routes through the canonical ``AdapterRegistry`` (single source of
+        truth). All 10 real adapters are reachable; an unregistered source type
+        raises ``UnsupportedSourceError`` — never a silent mock fallback.
+        """
+        return build_adapter(profile)
 
     @classmethod
     def probe_profile(cls, profile: ConnectionProfile) -> DataFabricHealth:

--- a/app/services/data_fabric/manager.py
+++ b/app/services/data_fabric/manager.py
@@ -289,6 +289,59 @@ class DataFabricManager:
         return adapter.query(item.name, query_spec)
 
     @classmethod
+    async def query_catalog_item_async(
+        cls,
+        db: Session,
+        item_id: str,
+        query_spec: QuerySpec,
+        cancel_token: Optional["object"] = None,
+    ) -> QueryResult:
+        """Async-safe pushdown query.
+
+        The DB lookups run on the calling coroutine (fast, and the SQLAlchemy
+        session is not thread-safe); the blocking remote ``adapter.query()`` runs
+        in a worker thread via ``asyncio.to_thread`` so it does NOT stall the
+        event loop. Cooperative cancellation: if a ``cancel_token`` is supplied,
+        ``raise_if_cancelled`` is checked before and after the remote fetch, so a
+        cancellation during the fetch surfaces as ``OperationCancelled`` and the
+        caller never materializes a stale result.
+        """
+        # Cooperative cancel check first — abort before any DB or remote work.
+        if cancel_token is not None:
+            cancel_token.raise_if_cancelled()
+
+        item = db.query(CatalogItemModel).filter(CatalogItemModel.id == item_id).first()
+        if not item:
+            raise ValueError(f"Catalog item '{item_id}' not found")
+
+        ds_model = item.data_source
+        if not ds_model:
+            ds_model = db.query(DataSourceModel).filter(DataSourceModel.id == item.source_id).first()
+        if not ds_model:
+            raise ValueError(f"Parent data source for item '{item_id}' not found")
+
+        conn_profile = ConnectionProfile(
+            id=ds_model.id,
+            name=ds_model.name,
+            source_type=ds_model.source_type,
+            url=ds_model.endpoint_url,
+            options=ds_model.connection_profile.get("options", {}),
+            allow_private=ds_model.connection_profile.get("allow_private", False),
+        )
+        adapter = cls.get_adapter(conn_profile)
+
+        if cancel_token is not None:
+            cancel_token.raise_if_cancelled()
+        # Offload the blocking remote query; the await lets the event loop run
+        # and lets asyncio.CancelledError propagate on task cancellation.
+        import asyncio
+
+        result = await asyncio.to_thread(adapter.query, item.name, query_spec)
+        if cancel_token is not None:
+            cancel_token.raise_if_cancelled()
+        return result
+
+    @classmethod
     async def materialize_catalog_item(
         cls,
         db: Session,
@@ -296,6 +349,7 @@ class DataFabricManager:
         item_id: str,
         query_spec: Optional[QuerySpec] = None,
         owner_token: Optional[str] = None,
+        cancel_token: Optional["object"] = None,
     ) -> Dict[str, Any]:
         """Materialize catalog query results into session ref_id and save audit log.
 
@@ -303,13 +357,17 @@ class DataFabricManager:
         store or audit failure the result is ``success=False`` with ``ref_id=None``
         and a typed ``error_type`` — no fake ref is persisted or returned, and no
         audit row is written for a non-retrievable ref.
+
+        The blocking remote query runs off the event loop (see
+        ``query_catalog_item_async``); a supplied ``cancel_token`` aborts before
+        materialization if the operation was cancelled during the fetch.
         """
         spec = query_spec or QuerySpec(limit=500)
         item = db.query(CatalogItemModel).filter(CatalogItemModel.id == item_id).first()
         if not item:
             raise ValueError(f"Catalog item '{item_id}' not found")
 
-        q_res = cls.query_catalog_item(db, item_id, spec)
+        q_res = await cls.query_catalog_item_async(db, item_id, spec, cancel_token=cancel_token)
 
         feature_count = len(q_res.features)
         base = {

--- a/app/services/data_fabric/manager.py
+++ b/app/services/data_fabric/manager.py
@@ -17,6 +17,7 @@ from app.schemas.data_fabric_schema import (
 from app.models.data_fabric import DataSourceModel, CatalogItemModel, MaterializationModel
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
 from app.services.data_fabric.errors import MATERIALIZATION_FAILED
+from app.services.data_fabric.fingerprint import dataset_fingerprint_service
 from app.services.data_fabric.limits import enforce_result_bounds
 from app.services.data_fabric.metadata import (
     classify_feature_type,
@@ -135,7 +136,16 @@ class DataFabricManager:
 
     @classmethod
     def sync_catalog(cls, db: Session, source_id: str) -> List[CatalogItemModel]:
-        """Discover and sync datasets from data source adapter into Spatial Catalog."""
+        """Discover and sync datasets from data source adapter into Spatial Catalog.
+
+        Efficiency (Section 30/31):
+        - describe() calls run with bounded concurrency (network I/O), clamped to
+          a small pool — a 5000-dataset source no longer serializes ~5000 remote
+          round-trips;
+        - existing catalog rows are fetched in ONE batch query (no per-item N+1);
+        - incremental: each row's descriptor fingerprint is stored and compared;
+          unchanged rows are skipped (no needless write/updated_at churn).
+        """
         ds_model = db.query(DataSourceModel).filter(DataSourceModel.id == source_id).first()
         if not ds_model:
             raise ValueError(f"Data source '{source_id}' not found")
@@ -151,45 +161,70 @@ class DataFabricManager:
 
         adapter = cls.get_adapter(conn_profile)
         datasets = adapter.list_datasets()
-        synced_items: List[CatalogItemModel] = []
 
+        # Resolve dataset names + keep the raw list-datasets dicts for fallbacks.
+        names: List[str] = []
+        raw: Dict[str, Dict[str, Any]] = {}
         for ds in datasets:
             dataset_name = ds.get("id") or ds.get("name") or ds.get("title")
             if not dataset_name:
                 continue
+            names.append(dataset_name)
+            raw[dataset_name] = ds
 
+        # Bounded-concurrency describe(). Adapter sessions are thread-safe for
+        # independent requests; keep the pool small to avoid hammering sources.
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        from app.core.config import settings as _settings
+
+        max_workers = max(1, min(16, int(getattr(_settings, "DATA_FABRIC_SYNC_CONCURRENCY", 4))))
+
+        def _describe(name: str) -> DatasetDescriptor:
             try:
-                descriptor = adapter.describe(dataset_name)
+                return adapter.describe(name)
             except Exception:
-                descriptor = DatasetDescriptor(
-                    id=dataset_name,
-                    title=ds.get("title", dataset_name),
-                    source_type=ds_model.source_type,
+                return DatasetDescriptor(
+                    id=name, title=raw.get(name, {}).get("title", name), source_type=ds_model.source_type
                 )
 
-            item_id = f"cat_{source_id}_{dataset_name}".replace(".", "_").replace("/", "_")
-            existing = db.query(CatalogItemModel).filter(CatalogItemModel.id == item_id).first()
+        descriptors: Dict[str, DatasetDescriptor] = {}
+        if names:
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                futures = {pool.submit(_describe, n): n for n in names}
+                for fut in as_completed(futures):
+                    descriptors[futures[fut]] = fut.result()
 
-            item_title = descriptor.title or ds.get("title") or dataset_name
+        # Batch DB lookup: ONE query for all existing items for this source.
+        existing_rows = db.query(CatalogItemModel).filter(CatalogItemModel.source_id == source_id).all()
+        existing_by_id: Dict[str, CatalogItemModel] = {row.id: row for row in existing_rows}
+
+        synced_items: List[CatalogItemModel] = []
+        now = datetime.now(timezone.utc)
+        for name in names:
+            descriptor = descriptors.get(name) or DatasetDescriptor(id=name, source_type=ds_model.source_type)
+            ds = raw[name]
+            item_id = f"cat_{source_id}_{name}".replace(".", "_").replace("/", "_")
+
+            item_title = descriptor.title or ds.get("title") or name
             item_desc = descriptor.description or ds.get("description", "")
-            # Metadata truthfulness (Section 27/28): normalize instead of
-            # fabricating. An undeclared CRS is stored as None (not faked
-            # EPSG:4326); geometry type is classified canonically (tile
-            # pyramids are no longer mislabeled vector via substring match).
-            geom_type = normalize_geometry_type(
-                descriptor.geometry_type or ds.get("geometry_type")
-            )
+            # Metadata truthfulness (Section 27/28): normalize instead of fabricating.
+            geom_type = normalize_geometry_type(descriptor.geometry_type or ds.get("geometry_type"))
             feature_type = classify_feature_type(geom_type)
             crs = normalize_crs(descriptor.srs or descriptor.crs)
-
             descriptor_dict = descriptor.model_dump()
             meta_profile = {
                 "srs": crs,
                 "feature_count": normalize_feature_count(descriptor.feature_count),
                 "fields": descriptor.fields,
             }
+            fp = dataset_fingerprint_service.calculate_descriptor_fingerprint(descriptor)
 
+            existing = existing_by_id.get(item_id)
             if existing:
+                # Incremental skip: descriptor unchanged since last sync → no write.
+                if existing.fingerprint == fp and existing.geometry_type == geom_type:
+                    synced_items.append(existing)
+                    continue
                 existing.title = item_title
                 existing.description = item_desc
                 existing.geometry_type = geom_type
@@ -198,13 +233,14 @@ class DataFabricManager:
                 existing.bbox_json = descriptor.bbox
                 existing.descriptor_json = descriptor_dict
                 existing.meta_profile_json = meta_profile
-                existing.updated_at = datetime.now(timezone.utc)
+                existing.fingerprint = fp
+                existing.updated_at = now
                 synced_items.append(existing)
             else:
                 new_item = CatalogItemModel(
                     id=item_id,
                     source_id=source_id,
-                    name=dataset_name,
+                    name=name,
                     title=item_title,
                     description=item_desc,
                     geometry_type=geom_type,
@@ -214,6 +250,7 @@ class DataFabricManager:
                     tags_json=[ds_model.source_type, feature_type],
                     descriptor_json=descriptor_dict,
                     meta_profile_json=meta_profile,
+                    fingerprint=fp,
                 )
                 db.add(new_item)
                 synced_items.append(new_item)

--- a/app/services/data_fabric/manager.py
+++ b/app/services/data_fabric/manager.py
@@ -18,6 +18,12 @@ from app.models.data_fabric import DataSourceModel, CatalogItemModel, Materializ
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
 from app.services.data_fabric.errors import MATERIALIZATION_FAILED
 from app.services.data_fabric.limits import enforce_result_bounds
+from app.services.data_fabric.metadata import (
+    classify_feature_type,
+    normalize_crs,
+    normalize_feature_count,
+    normalize_geometry_type,
+)
 from app.services.data_fabric.registry import build_adapter
 from app.services.data_fabric.security import DataFabricSecurity
 from app.services.session_data import session_data_manager
@@ -166,13 +172,20 @@ class DataFabricManager:
 
             item_title = descriptor.title or ds.get("title") or dataset_name
             item_desc = descriptor.description or ds.get("description", "")
-            geom_type = descriptor.geometry_type or ds.get("geometry_type", "Geometry")
-            feature_type = "raster" if geom_type and "raster" in geom_type.lower() else "vector"
+            # Metadata truthfulness (Section 27/28): normalize instead of
+            # fabricating. An undeclared CRS is stored as None (not faked
+            # EPSG:4326); geometry type is classified canonically (tile
+            # pyramids are no longer mislabeled vector via substring match).
+            geom_type = normalize_geometry_type(
+                descriptor.geometry_type or ds.get("geometry_type")
+            )
+            feature_type = classify_feature_type(geom_type)
+            crs = normalize_crs(descriptor.srs or descriptor.crs)
 
             descriptor_dict = descriptor.model_dump()
             meta_profile = {
-                "srs": descriptor.srs,
-                "feature_count": descriptor.feature_count,
+                "srs": crs,
+                "feature_count": normalize_feature_count(descriptor.feature_count),
                 "fields": descriptor.fields,
             }
 
@@ -181,7 +194,7 @@ class DataFabricManager:
                 existing.description = item_desc
                 existing.geometry_type = geom_type
                 existing.feature_type = feature_type
-                existing.crs = descriptor.srs or "EPSG:4326"
+                existing.crs = crs
                 existing.bbox_json = descriptor.bbox
                 existing.descriptor_json = descriptor_dict
                 existing.meta_profile_json = meta_profile
@@ -196,7 +209,7 @@ class DataFabricManager:
                     description=item_desc,
                     geometry_type=geom_type,
                     feature_type=feature_type,
-                    crs=descriptor.srs or "EPSG:4326",
+                    crs=crs,
                     bbox_json=descriptor.bbox,
                     tags_json=[ds_model.source_type, feature_type],
                     descriptor_json=descriptor_dict,

--- a/app/services/data_fabric/manager.py
+++ b/app/services/data_fabric/manager.py
@@ -180,12 +180,21 @@ class DataFabricManager:
         max_workers = max(1, min(16, int(getattr(_settings, "DATA_FABRIC_SYNC_CONCURRENCY", 4))))
 
         def _describe(name: str) -> DatasetDescriptor:
-            try:
-                return adapter.describe(name)
-            except Exception:
-                return DatasetDescriptor(
-                    id=name, title=raw.get(name, {}).get("title", name), source_type=ds_model.source_type
-                )
+            # Tenant/source-scoped TTL cache (Section 37): avoids re-describing
+            # unchanged datasets on back-to-back syncs. scope is the source key —
+            # sync is server-side per source, never crosses tenants.
+            from app.services.data_fabric.metadata_cache import cached_describe
+
+            def _do(dataset_id: str) -> DatasetDescriptor:
+                try:
+                    return adapter.describe(dataset_id)
+                except Exception:
+                    return DatasetDescriptor(
+                        id=dataset_id, title=raw.get(dataset_id, {}).get("title", dataset_id),
+                        source_type=ds_model.source_type,
+                    )
+
+            return cached_describe(_do, source_id, name, scope=f"source:{source_id}")
 
         descriptors: Dict[str, DatasetDescriptor] = {}
         if names:

--- a/app/services/data_fabric/materialization_service.py
+++ b/app/services/data_fabric/materialization_service.py
@@ -1,13 +1,23 @@
 """
 Geospatial Data Fabric: Materialization Service
 Pipeline for executing QuerySpec pushdown queries and materializing remote data into local session store emitting ref_id.
+
+Reliability contract (Data Fabric V3):
+- A ref exists IFF its payload is retrievable. Store failure (exception OR the
+  Redis-unavailability sentinel) is reported as a typed ``MATERIALIZATION_FAILED``
+  result with ``ref_id=None`` and ``success=False`` — never a fake ref, never a
+  fake success.
+- ``set_alias`` is best-effort metadata; its failure must NOT invalidate an
+  otherwise-valid ref.
 """
 import logging
 from typing import Dict, Any, Optional
 from app.schemas.data_fabric_schema import QuerySpec, QueryResult
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
+from app.services.data_fabric.errors import MaterializationFailedError
 from app.services.data_fabric.fingerprint import dataset_fingerprint_service
 from app.services.session_data import session_data_manager
+from app.services.session_data_protocol import is_unavailable_ref
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +53,11 @@ class MaterializationService:
     ) -> Dict[str, Any]:
         """
         Materialize query results locally into session_data_manager, emitting ref_id.
+
+        Truthfulness invariant: the returned dict reports ``success``/``status``
+        consistent with whether ``ref_id`` is a real, retrievable ref. On any
+        store failure the result is ``success=False`` with ``ref_id=None`` and a
+        typed ``error_type=MATERIALIZATION_FAILED`` — no fake ref is minted.
         """
         layer_title = layer_name or f"Materialized Layer {dataset_id}"
         geojson_payload = {
@@ -56,34 +71,89 @@ class MaterializationService:
             },
         }
 
-        # Store in session_data_manager and retrieve cursor ref_id
-        import uuid
-        try:
-            ref_id = await session_data_manager.store(session_id, geojson_payload, prefix="data-fabric")
-            try:
-                await session_data_manager.set_alias(session_id, ref_id, layer_title)
-            except Exception as ae:
-                logger.warning(f"[MaterializationService] set_alias failed ({ae}); proceeding with ref_id '{ref_id}'")
-        except Exception as e:
-            logger.warning(f"[MaterializationService] session_data_manager store failed ({e}); using fallback ref_id")
-            ref_id = f"ref:data-fabric-{uuid.uuid4().hex[:16]}"
-
-        # Compute fingerprint hash for data payload
-
+        feature_count = len(query_result.features)
+        total_count = query_result.total_count or feature_count
         fingerprint = dataset_fingerprint_service.calculate_data_fingerprint(query_result.features)
 
-        logger.info(f"[MaterializationService] Materialized dataset '{dataset_id}' -> ref_id: {ref_id}")
+        # Store in session_data_manager and retrieve cursor ref_id.
+        # A ref exists iff its payload is retrievable: both an exception and the
+        # store-unavailability sentinel are real failures — never fake a ref.
+        try:
+            ref_id = await session_data_manager.store(session_id, geojson_payload, prefix="data-fabric")
+        except Exception as e:
+            logger.error(
+                "[MaterializationService] store failed for '%s': %s", dataset_id, e
+            )
+            return self._failure(
+                dataset_id, layer_title, feature_count, total_count,
+                fingerprint, query_result,
+                MaterializationFailedError(f"session store failed: {e}"),
+            )
+
+        if is_unavailable_ref(ref_id):
+            logger.error(
+                "[MaterializationService] store returned unavailable ref for '%s': %s",
+                dataset_id, ref_id,
+            )
+            return self._failure(
+                dataset_id, layer_title, feature_count, total_count,
+                fingerprint, query_result,
+                MaterializationFailedError("session store unavailable"),
+            )
+
+        # set_alias is best-effort metadata enrichment; a failure here does not
+        # invalidate an otherwise-valid ref, so we keep the ref and proceed.
+        try:
+            await session_data_manager.set_alias(session_id, ref_id, layer_title)
+        except Exception as ae:
+            logger.warning(
+                "[MaterializationService] set_alias failed (%s); ref '%s' still valid",
+                ae, ref_id,
+            )
+
+        logger.info(
+            "[MaterializationService] Materialized dataset '%s' -> ref_id: %s",
+            dataset_id, ref_id,
+        )
 
         return {
             "status": "success",
+            "success": True,
             "ref_id": ref_id,
             "dataset_id": dataset_id,
             "layer_name": layer_title,
-            "feature_count": len(query_result.features),
-            "total_count": query_result.total_count or len(query_result.features),
+            "feature_count": feature_count,
+            "total_count": total_count,
             "fingerprint": fingerprint,
             "schema_info": query_result.schema_info,
             "metadata": query_result.metadata,
+        }
+
+    @staticmethod
+    def _failure(
+        dataset_id: str,
+        layer_title: str,
+        feature_count: int,
+        total_count: int,
+        fingerprint: str,
+        query_result: QueryResult,
+        err: MaterializationFailedError,
+    ) -> Dict[str, Any]:
+        """Build a truthful materialization-failure result (no ref, no success)."""
+        d = err.to_dict()
+        return {
+            "status": "failed",
+            "success": False,
+            "ref_id": None,
+            "dataset_id": dataset_id,
+            "layer_name": layer_title,
+            "feature_count": feature_count,
+            "total_count": total_count,
+            "fingerprint": fingerprint,
+            "schema_info": query_result.schema_info,
+            "metadata": query_result.metadata,
+            "error_type": d["error_type"],
+            "error": d["error"],
         }
 
     async def materialize_dataset(

--- a/app/services/data_fabric/materialization_service.py
+++ b/app/services/data_fabric/materialization_service.py
@@ -173,9 +173,16 @@ class MaterializationService:
         """
         Unified pushdown query execution and local materialization pipeline.
         Emits ref_id cursor for downstream analysis.
+
+        The blocking remote ``execute_query`` runs off the event loop via
+        ``asyncio.to_thread`` so concurrent tool dispatches aren't stalled; an
+        ``asyncio.CancelledError`` during the await propagates before store (no
+        stale materialization).
         """
+        import asyncio
+
         spec = query_spec or QuerySpec(limit=100)
-        query_result = self.execute_query(adapter, dataset_id, spec)
+        query_result = await asyncio.to_thread(self.execute_query, adapter, dataset_id, spec)
         return await self.materialize(dataset_id, query_result, session_id=session_id, layer_name=layer_name)
 
 

--- a/app/services/data_fabric/materialization_service.py
+++ b/app/services/data_fabric/materialization_service.py
@@ -16,6 +16,7 @@ from app.schemas.data_fabric_schema import QuerySpec, QueryResult
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
 from app.services.data_fabric.errors import MaterializationFailedError
 from app.services.data_fabric.fingerprint import dataset_fingerprint_service
+from app.services.data_fabric.limits import enforce_result_bounds
 from app.services.session_data import session_data_manager
 from app.services.session_data_protocol import is_unavailable_ref
 
@@ -74,6 +75,11 @@ class MaterializationService:
         feature_count = len(query_result.features)
         total_count = query_result.total_count or feature_count
         fingerprint = dataset_fingerprint_service.calculate_data_fingerprint(query_result.features)
+
+        # Resource guard (Section 22): reject an oversized result BEFORE storing
+        # it, so a server that ignores `limit` cannot OOM the process. This
+        # raises ResultTooLargeError with an actionable hint.
+        enforce_result_bounds(query_result.features)
 
         # Store in session_data_manager and retrieve cursor ref_id.
         # A ref exists iff its payload is retrievable: both an exception and the

--- a/app/services/data_fabric/metadata.py
+++ b/app/services/data_fabric/metadata.py
@@ -1,0 +1,167 @@
+"""Metadata truthfulness helpers (Section 27 / 28 / 29).
+
+The catalog previously fabricated metadata when a remote source did not declare
+it: an undeclared CRS became ``EPSG:4326``; an unknown feature count became a
+precise ``0``/``100``/``10000``; geometry type was classified as vector/raster
+via a fragile ``"raster" in geom_type.lower()`` substring test (so tile
+pyramids were mislabeled ``vector``).
+
+These normalizers return ``None`` / ``"unknown"`` for genuinely unknown values
+instead of inventing data, and canonicalize the forms that ARE declared.
+"""
+import re
+from typing import Any, Optional
+
+# Canonical geometry-type vocabulary (Section 28).
+_VECTOR_TYPES = frozenset({
+    "Point", "MultiPoint", "LineString", "MultiLineString",
+    "Polygon", "MultiPolygon", "GeometryCollection",
+})
+_RASTER_TOKENS = frozenset({"raster", "coverage", "grid"})
+_TILE_TOKENS = frozenset({"tile", "tilepyramid", "pyramid", "mvt", "wms", "wmts"})
+
+
+# ArcGIS / common geometry-type aliases → canonical OGC name.
+_GEOMETRY_ALIASES = {
+    "esrigeometrypoint": "Point",
+    "esrigeometrymultipoint": "MultiPoint",
+    "esrigeometrypolyline": "MultiLineString",
+    "esrigeometrypolygon": "Polygon",
+    "esrigeometrymultipolygon": "MultiPolygon",
+    "linestring": "LineString",
+    "multilinestring": "MultiLineString",
+    "multipolygon": "MultiPolygon",
+    "geometrycollection": "GeometryCollection",
+    "feature": "Geometry",          # OGC/WFS generic — unknown concrete type
+    "geometry": "Geometry",
+    "tilepyramid": "TilePyramid",
+}
+
+
+def normalize_geometry_type(raw: Any) -> str:
+    """Return a canonical geometry-type string.
+
+    Recognizes the OGC simple-feature types, ArcGIS ``esriGeometry*`` codes,
+    and raster/tile services. Anything unrecognizable becomes ``"unknown"``
+    rather than a guessed vector type.
+    """
+    if not raw or not isinstance(raw, str):
+        return "unknown"
+    val = raw.strip()
+    if not val:
+        return "unknown"
+    low = val.lower()
+
+    # Direct canonical match (case-insensitive).
+    for t in _VECTOR_TYPES:
+        if low == t.lower():
+            return t
+
+    # Aliases (esri*, feature, geometry, tilepyramid, ...).
+    aliased = _GEOMETRY_ALIASES.get(low)
+    if aliased:
+        return aliased
+
+    # Substring detection for raster/tile services.
+    if any(tok in low for tok in _RASTER_TOKENS):
+        return "Raster"
+    if any(tok in low for tok in _TILE_TOKENS):
+        return "TilePyramid"
+
+    return "unknown"
+
+
+def classify_feature_type(geometry_type: Any) -> str:
+    """Classify a geometry type into ``vector`` / ``raster`` / ``tile`` / ``unknown``.
+
+    Replaces the fragile ``"raster" in geom_type.lower()`` heuristic — tile
+    pyramids (PMTiles) are no longer mislabeled ``vector``.
+    """
+    norm = normalize_geometry_type(geometry_type)
+    if norm == "Raster":
+        return "raster"
+    if norm == "TilePyramid":
+        return "tile"
+    if norm in _VECTOR_TYPES or norm == "Geometry":
+        return "vector"
+    return "unknown"
+
+
+# ── CRS normalization ───────────────────────────────────────────────────────
+
+# OGC CRS URIs (used by OGC API Features) → EPSG form.
+_CRS_URI_RE = re.compile(
+    r"/def/crs/(?:EPSG|OGC)/(?:0|1\.3|\d+(?:\.\d+)?)/(?P<code>\d{4,6})\b", re.IGNORECASE
+)
+
+
+def normalize_crs(raw: Any) -> Optional[str]:
+    """Return a canonical ``EPSG:NNNN`` CRS string, or ``None`` if unknown.
+
+    NEVER fabricates ``EPSG:4326``. Accepts:
+    - ``EPSG:4326`` (passthrough);
+    - OGC CRS URIs (``http://www.opengis.net/def/crs/OGC/1.3/CRS84`` → ``CRS84``
+      which we keep verbatim as a recognized CRS84 marker, and EPSG URIs → EPSG);
+    - bare authority codes (``4326`` → ``EPSG:4326``).
+    Returns ``None`` for empty / unparseable / ``unknown``.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        return None
+    val = raw.strip()
+    if not val or val.lower() in ("unknown", "none", "null"):
+        return None
+
+    up = val.upper()
+    if up.startswith("EPSG:") or up.startswith("ESRI:") or up == "CRS84":
+        return val if up != "CRS84" else "CRS84"
+
+    # OGC CRS84 URI (http://www.opengis.net/def/crs/OGC/1.3/CRS84) → CRS84.
+    if up.endswith("/CRS84"):
+        return "CRS84"
+
+    # OGC CRS URI → EPSG:NNNN (CRS84 stays CRS84).
+    m = _CRS_URI_RE.search(val)
+    if m:
+        code = m.group("code")
+        return "CRS84" if code == "84" else f"EPSG:{code}"
+
+    # Bare numeric code → assume EPSG.
+    if val.isdigit() and 4 <= len(val) <= 6:
+        return f"EPSG:{val}"
+
+    # urn:ogc:def:crs:EPSG::4326
+    if "EPSG" in up and val.rstrip("/").split(":")[-1].isdigit():
+        code = val.rstrip("/").split(":")[-1]
+        return f"EPSG:{code}"
+
+    # Unrecognized CRS string — keep it verbatim but don't invent.
+    return val
+
+
+# ── Feature-count semantics ─────────────────────────────────────────────────
+
+def normalize_feature_count(raw: Any) -> Optional[int]:
+    """Return a non-negative feature count, or ``None`` for unknown.
+
+    ``None`` is the truthful representation of "the source did not report a
+    count"; ``0`` is reserved for a genuine zero-count dataset.
+    """
+    if raw is None:
+        return None
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if n < 0:
+        return None
+    return n
+
+
+__all__ = [
+    "normalize_geometry_type",
+    "classify_feature_type",
+    "normalize_crs",
+    "normalize_feature_count",
+]

--- a/app/services/data_fabric/metadata_cache.py
+++ b/app/services/data_fabric/metadata_cache.py
@@ -1,0 +1,110 @@
+"""Safe TTL cache for Data Fabric metadata (Section 37).
+
+A result/metadata cache is only safe if its key is fully determined by
+(source, dataset, query spec, auth/tenant scope, dataset fingerprint). Omitting
+the auth/tenant scope leaks one caller's result to another (cross-tenant P0).
+This module centralizes that contract so callers cannot forget the scope.
+
+Used today for ``describe()`` metadata; the query-result cache + HTTP
+conditional requests (ETag / If-None-Match) are a documented follow-up — they
+need adapter response-header plumbing that this PR does not introduce.
+"""
+import hashlib
+import json
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+
+def cache_key(*parts: Any) -> str:
+    """Stable SHA-256 cache key from arbitrary parts.
+
+    Every caller MUST include the auth/tenant scope as one of the parts — that
+    is what prevents cross-tenant leakage. Fingerprinting the parts (rather than
+    concatenating raw) avoids delimiter-collision and keeps keys fixed-width.
+    """
+    blob = json.dumps(list(parts), default=str, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class _Entry:
+    value: Any
+    expires_at: float
+
+
+class SafeTTLCache:
+    """Thread-safe TTL cache. Bounded by max_entries (LRU-ish eviction)."""
+
+    def __init__(self, default_ttl: float = 30.0, max_entries: int = 4096, clock: Callable[[], float] = time.monotonic):
+        self.default_ttl = default_ttl
+        self.max_entries = max_entries
+        self._clock = clock
+        self._store: Dict[str, _Entry] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: str) -> Optional[Any]:
+        now = self._clock()
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            if entry.expires_at <= now:
+                self._store.pop(key, None)
+                return None
+            return entry.value
+
+    def put(self, key: str, value: Any, ttl: Optional[float] = None) -> None:
+        now = self._clock()
+        with self._lock:
+            self._store[key] = _Entry(value=value, expires_at=now + (ttl if ttl is not None else self.default_ttl))
+            # Bounded: drop a few oldest if over capacity.
+            if len(self._store) > self.max_entries:
+                overflow = len(self._store) - self.max_entries
+                # Evict by nearest expiry (cheap approximation of LRU for TTL cache).
+                for k in sorted(self._store, key=lambda kk: self._store[kk].expires_at)[:overflow]:
+                    self._store.pop(k, None)
+
+    def invalidate(self, key: Optional[str] = None) -> None:
+        with self._lock:
+            if key is None:
+                self._store.clear()
+            else:
+                self._store.pop(key, None)
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+
+# Per-process describe cache. source_key + dataset_id + scope are all required.
+_describe_cache = SafeTTLCache(default_ttl=30.0)
+
+
+def cached_describe(
+    describe_fn: Callable[[str], Any],
+    source_key: str,
+    dataset_id: str,
+    scope: str,
+    ttl: Optional[float] = None,
+    cache: Optional[SafeTTLCache] = None,
+) -> Any:
+    """Call ``describe_fn(dataset_id)`` under a tenant-scoped TTL cache.
+
+    ``scope`` is the auth/tenant namespace (REQUIRED) — it is part of the key so
+    one tenant's cached descriptor is never served to another.
+    """
+    # NOTE: use `is not None`, not `or` — SafeTTLCache defines __len__, so an
+    # empty cache is falsey and `cache or _describe_cache` would silently use the
+    # global cache (cross-test / cross-tenant pollution).
+    c = cache if cache is not None else _describe_cache
+    key = cache_key(source_key, dataset_id, scope)
+    hit = c.get(key)
+    if hit is not None:
+        return hit
+    value = describe_fn(dataset_id)
+    c.put(key, value, ttl=ttl)
+    return value
+
+
+__all__ = ["SafeTTLCache", "cache_key", "cached_describe", "_describe_cache"]

--- a/app/services/data_fabric/registry.py
+++ b/app/services/data_fabric/registry.py
@@ -1,0 +1,192 @@
+"""Canonical adapter registry — single source of truth for source_type → adapter.
+
+Replaces the six divergent source-type enumerations that existed across the
+codebase (the manager ``if/elif`` chain, the connection_manager ``adapter_map``,
+the route/tool docstrings, ``mapspec_source``…). ``DataFabricManager``,
+``DataFabricConnectionManager``, the tool layer and routes ALL resolve through
+``resolve_adapter_spec`` / ``build_adapter``.
+
+Contract (Data Fabric V3 / ADR-0053):
+- A source type not in the registry raises ``UnsupportedSourceError`` — it is
+  NEVER silently mapped to mock data. This kills the "fabricated features for
+  unknown source types" P0.
+- Each spec carries explicit capability flags so the query planner / materializer
+  can negotiate pushdown vs local fallback (Section 26) without re-deriving them.
+- ``GenericDataSourceAdapter`` is registered explicitly as the ``generic`` demo
+  adapter (aliases ``geojson``/``mock``/``sample``). It is opt-in, not a fallback.
+"""
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple, Type
+
+from app.schemas.data_fabric_schema import ConnectionProfile
+from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
+from app.services.data_fabric.errors import UnsupportedSourceError
+
+
+@dataclass(frozen=True)
+class AdapterSpec:
+    """A registered source type: aliases, adapter class, capability flags."""
+
+    canonical: str
+    adapter_cls: Optional[Type[GeospatialDataSourceAdapter]]
+    aliases: Tuple[str, ...] = ()
+    # Pushdown capability negotiation (Section 26). False means the materializer
+    # must NOT assume the remote honors that clause.
+    supports_bbox: bool = False
+    supports_filter: bool = False
+    supports_pagination: bool = False
+    supports_datetime: bool = False
+    supports_projection: bool = False
+    # raster/tile services cannot answer vector feature queries.
+    is_raster_tile: bool = False
+    # Production-capable vs explicit demo/sample (GenericDataSourceAdapter).
+    is_demo: bool = False
+    notes: str = ""
+
+    @property
+    def names(self) -> Tuple[str, ...]:
+        return (self.canonical,) + self.aliases
+
+
+class AdapterRegistry:
+    """Append-only registry keyed by lowercased canonical name + aliases."""
+
+    def __init__(self) -> None:
+        self._by_name: Dict[str, AdapterSpec] = {}
+        self._by_canonical: Dict[str, AdapterSpec] = {}
+
+    def register(self, spec: AdapterSpec) -> None:
+        for name in spec.names:
+            key = name.lower().strip()
+            existing = self._by_name.get(key)
+            if existing and existing.canonical != spec.canonical:
+                raise ValueError(
+                    f"adapter alias '{name}' already registered to "
+                    f"'{existing.canonical}', cannot rebind to '{spec.canonical}'"
+                )
+            self._by_name[key] = spec
+        self._by_canonical[spec.canonical] = spec
+
+    def resolve(self, source_type: Optional[str]) -> AdapterSpec:
+        key = (source_type or "").lower().strip()
+        spec = self._by_name.get(key)
+        if spec is None:
+            raise UnsupportedSourceError(
+                f"unsupported data source type '{source_type}'",
+                details={
+                    "source_type": source_type,
+                    "supported": self.supported_source_types(),
+                },
+            )
+        return spec
+
+    def is_supported(self, source_type: Optional[str]) -> bool:
+        return bool((source_type or "").lower().strip() in self._by_name)
+
+    def supported_source_types(self) -> List[str]:
+        return sorted(self._by_canonical.keys())
+
+    def build_adapter(self, profile: ConnectionProfile) -> GeospatialDataSourceAdapter:
+        spec = self.resolve(profile.source_type)
+        if spec.adapter_cls is None:
+            raise UnsupportedSourceError(
+                f"source type '{profile.source_type}' has no adapter implementation",
+                details={"source_type": profile.source_type},
+            )
+        return spec.adapter_cls(profile)
+
+
+# ── Registration table (the one source of truth) ────────────────────────────
+def _build_registry() -> AdapterRegistry:
+    # Imported lazily to avoid import cycles (adapters import the package).
+    from app.services.data_fabric.adapters import (
+        ArcGISAdapter,
+        FlatGeobufAdapter,
+        GeoParquetAdapter,
+        OGCAPIAdapter,
+        PMTilesAdapter,
+        PostGISAdapter,
+        S3StorageAdapter,
+        STACAdapter,
+        WFSAdapter,
+        WMSWMTSAdapter,
+    )
+    from app.services.data_fabric.connection_manager import GenericDataSourceAdapter
+
+    reg = AdapterRegistry()
+    for spec in [
+        AdapterSpec("postgis", PostGISAdapter,
+                    aliases=("postgres", "postgresql"),
+                    supports_bbox=True, supports_filter=True,
+                    supports_pagination=True, supports_projection=True),
+        AdapterSpec("ogc_api", OGCAPIAdapter,
+                    aliases=("ogc_api_features", "ogc", "ogcapi"),
+                    supports_bbox=True, supports_filter=True,
+                    supports_pagination=True, supports_datetime=True,
+                    supports_projection=True),
+        AdapterSpec("wfs", WFSAdapter,
+                    aliases=("wfs1", "wfs2"),
+                    supports_bbox=True),
+        AdapterSpec("wms", WMSWMTSAdapter,
+                    aliases=("wmts", "wms_wmts"),
+                    is_raster_tile=True,
+                    notes="raster/tile service; no vector feature query"),
+        AdapterSpec("arcgis", ArcGISAdapter,
+                    aliases=("arcgis_rest", "featureserver", "mapserver"),
+                    supports_bbox=True, supports_filter=True,
+                    supports_pagination=True, supports_projection=True),
+        AdapterSpec("stac", STACAdapter,
+                    supports_bbox=True, supports_datetime=True,
+                    notes="metadata/search; asset materialization is separate"),
+        AdapterSpec("geoparquet", GeoParquetAdapter,
+                    aliases=("parquet",),
+                    supports_bbox=True, supports_projection=True),
+        AdapterSpec("flatgeobuf", FlatGeobufAdapter,
+                    aliases=("fgb",),
+                    supports_bbox=True),
+        AdapterSpec("pmtiles", PMTilesAdapter,
+                    is_raster_tile=True,
+                    notes="external tile archive; metadata-only in catalog"),
+        AdapterSpec("s3", S3StorageAdapter,
+                    aliases=("minio", "object_storage"),
+                    notes="object storage seam; metadata-only in catalog"),
+        # Explicit demo/sample adapter. Opt-in only — the factory never falls
+        # back to this for an unregistered source type.
+        AdapterSpec("generic", GenericDataSourceAdapter,
+                    aliases=("geojson", "mock", "sample"),
+                    supports_bbox=True, supports_filter=True,
+                    supports_pagination=True, supports_projection=True,
+                    is_demo=True,
+                    notes="in-memory demo/sample adapter; generates synthetic features"),
+    ]:
+        reg.register(spec)
+    return reg
+
+
+_REGISTRY: Optional[AdapterRegistry] = None
+
+
+def get_registry() -> AdapterRegistry:
+    global _REGISTRY
+    if _REGISTRY is None:
+        _REGISTRY = _build_registry()
+    return _REGISTRY
+
+
+def resolve_adapter_spec(source_type: Optional[str]) -> AdapterSpec:
+    """Module-level convenience accessor."""
+    return get_registry().resolve(source_type)
+
+
+def build_adapter(profile: ConnectionProfile) -> GeospatialDataSourceAdapter:
+    """Module-level convenience accessor."""
+    return get_registry().build_adapter(profile)
+
+
+__all__ = [
+    "AdapterSpec",
+    "AdapterRegistry",
+    "get_registry",
+    "resolve_adapter_spec",
+    "build_adapter",
+]

--- a/app/services/data_fabric/reliability.py
+++ b/app/services/data_fabric/reliability.py
@@ -1,0 +1,179 @@
+"""Remote-request reliability primitives (Section 15/16).
+
+- ``RetryPolicy``: bounded exponential backoff + full jitter, with an injectable
+  sleep/clock seam so tests never wait on wall-clock time.
+- ``is_transient``: the single classifier for retryable conditions. Only real
+  transient errors (connection reset / timeout / 429 / 5xx) are retried; 4xx,
+  schema/validation errors, and security decisions are NEVER retried.
+- ``retry_call``: runs a callable under the policy. POST is retried only when the
+  caller marks it idempotent.
+
+These primitives are deliberately decoupled from any specific HTTP client so the
+same contract backs both the requests-based adapters and future async paths.
+"""
+import random
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Tuple, Type
+
+from app.services.data_fabric.errors import (
+    DataFabricError,
+    TRANSIENT_HTTP_STATUS,
+    SourceRateLimitedError,
+    SourceBadResponseError,
+    SourceTimeoutError,
+    SourceUnreachableError,
+    SecurityBlockedError,
+    InvalidQueryError,
+    UnsupportedSourceError,
+)
+
+
+# Errors that mean "the request itself was bad" — retrying cannot help.
+PERMANENT_ERRORS: Tuple[Type[BaseException], ...] = (
+    SecurityBlockedError,
+    InvalidQueryError,
+    UnsupportedSourceError,
+    ValueError,
+    TypeError,
+)
+
+
+def is_transient(exc: BaseException) -> bool:
+    """True iff ``exc`` represents a retryable transient failure.
+
+    Classifies:
+    - typed DataFabric errors with transient codes (rate-limited / bad-response /
+      timeout / unreachable);
+    - requests' ConnectionError / Timeout families (imported lazily so this
+      module has no hard requests dependency for non-requests callers);
+    - any exception whose message indicates a transient HTTP status in
+      ``TRANSIENT_HTTP_STATUS``.
+    Security decisions, 4xx client errors, and programming errors are permanent.
+    """
+    if isinstance(exc, PERMANENT_ERRORS):
+        return False
+    if isinstance(exc, (SourceRateLimitedError, SourceBadResponseError, SourceTimeoutError, SourceUnreachableError)):
+        return True
+    if isinstance(exc, DataFabricError):
+        # Other typed errors (auth, unsupported capability, result-too-large,
+        # materialization, cancelled) are not transient.
+        return False
+
+    # requests families (lazy import).
+    try:
+        import requests.exceptions as rex
+
+        if isinstance(exc, (rex.ConnectionError, rex.Timeout)):
+            return True
+        # HTTPError carries the response status on .response.status_code.
+        if isinstance(exc, rex.HTTPError):
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status is not None:
+                return status in TRANSIENT_HTTP_STATUS
+            return False
+    except Exception:  # pragma: no cover - requests always present in this project
+        pass
+
+    msg = str(exc).lower()
+    if any(tok in msg for tok in ("connection reset", "connection aborted", "timed out", "timeout", "temporarily unavailable")):
+        return True
+    # Look for an embedded transient HTTP status like "503" / "429" in the message.
+    for code in TRANSIENT_HTTP_STATUS:
+        if str(code) in msg:
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Bounded exponential backoff with full jitter.
+
+    Backoff: ``sleep = random.uniform(0, base * 2 ** attempt)`` (full jitter),
+    capped at ``max_sleep``. ``max_attempts`` includes the first try, so 3 → at
+    most 2 retries. ``retryable`` lets a caller narrow the classifier.
+    """
+
+    max_attempts: int = 3
+    base_sleep: float = 0.2
+    max_sleep: float = 5.0
+    retryable: Optional[Callable[[BaseException], bool]] = None
+
+    def __post_init__(self):
+        if self.max_attempts < 1:
+            object.__setattr__(self, "max_attempts", 1)
+        if self.base_sleep < 0:
+            object.__setattr__(self, "base_sleep", 0.0)
+
+    def backoff_seconds(self, attempt: int, rng: Optional[random.Random] = None) -> float:
+        """Full-jitter backoff for the given (0-indexed) attempt."""
+        upper = min(self.max_sleep, self.base_sleep * (2 ** attempt))
+        if upper <= 0:
+            return 0.0
+        if rng is None:
+            return random.uniform(0.0, upper)
+        return rng.uniform(0.0, upper)
+
+
+DEFAULT_RETRY = RetryPolicy()
+
+
+def retry_call(
+    fn: Callable[..., Any],
+    *args,
+    policy: RetryPolicy = DEFAULT_RETRY,
+    sleep: Callable[[float], None] = __import__("time").sleep,
+    rng: Optional[random.Random] = None,
+    idempotent: bool = False,
+    on_retry: Optional[Callable[[int, BaseException], None]] = None,
+    **kwargs,
+) -> Any:
+    """Run ``fn(*args, **kwargs)`` under ``policy``.
+
+    - Transient failures are retried up to ``policy.max_attempts``.
+    - Permanent failures raise immediately.
+    - ``idempotent`` is a caller assertion; non-idempotent calls are still
+      retried on read/connection-class transient errors (safe: no side effect
+      reached the server), but NOT on HTTPError-class transient errors
+      (the server may have acted). This is the conservative Post rule.
+    """
+    classifier = policy.retryable or is_transient
+    last_exc: Optional[BaseException] = None
+    for attempt in range(policy.max_attempts):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            last_exc = exc
+            transient = classifier(exc)
+            # Conservative POST rule: a server-side transient (5xx/429 on an
+            # HTTPError) means the request may have been applied — only retry
+            # when the caller asserts idempotency. Connection/timeout class is
+            # always safe to retry (no response was processed).
+            if transient and not idempotent and _is_http_error_class(exc):
+                transient = False
+            if not transient or attempt == policy.max_attempts - 1:
+                raise
+            delay = policy.backoff_seconds(attempt, rng=rng)
+            if on_retry:
+                on_retry(attempt + 1, exc)
+            if delay > 0:
+                sleep(delay)
+    # Unreachable: the loop either returns or raises.
+    raise last_exc  # pragma: no cover
+
+
+def _is_http_error_class(exc: BaseException) -> bool:
+    try:
+        import requests.exceptions as rex
+
+        return isinstance(exc, rex.HTTPError)
+    except Exception:  # pragma: no cover
+        return False
+
+
+__all__ = [
+    "RetryPolicy",
+    "DEFAULT_RETRY",
+    "is_transient",
+    "retry_call",
+    "PERMANENT_ERRORS",
+]

--- a/app/services/data_fabric/security.py
+++ b/app/services/data_fabric/security.py
@@ -12,6 +12,8 @@ import socket
 from urllib.parse import urlparse
 from typing import Dict, Any, Optional
 
+import requests.adapters
+
 try:
     # defusedxml hardens ElementTree against XXE / external entity / entity
     # expansion attacks. It is a declared project dependency (pyproject.toml).
@@ -180,6 +182,30 @@ class DataFabricSecurity:
         return ips
 
     @staticmethod
+    def redact_url(url: Optional[str]) -> Optional[str]:
+        """Strip ``user:password@`` userinfo from a URL for safe egress.
+
+        ``postgres://user:pass@host/db`` connection strings and HTTP URLs with
+        embedded tokens were returned verbatim in source egress responses
+        (list/get/create). The userinfo never needs to reach the client.
+        Returns the input unchanged for non-URL / parseable-without-userinfo.
+        """
+        if not url or not isinstance(url, str):
+            return url
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return url
+        if not parsed.scheme or "@" not in (parsed.netloc or ""):
+            return url
+        # Keep host:port; drop the userinfo segment.
+        hostport = parsed.hostname or ""
+        if parsed.port:
+            hostport = f"{hostport}:{parsed.port}"
+        rebuilt = parsed._replace(netloc=hostport)
+        return rebuilt.geturl()
+
+    @staticmethod
     def sanitize_profile_dict(profile_dict: Dict[str, Any]) -> Dict[str, Any]:
         """Redacts credentials before returning a profile to LLM or frontend.
 
@@ -225,3 +251,52 @@ class DataFabricSecurity:
         except Exception as e:
             logger.error(f"Failed to parse XML safely: {e}")
             raise DataFabricSecurityError(f"Malformed or unsafe XML payload: {e}")
+
+
+# ── HTTP client SSRF hardening ──────────────────────────────────────────────
+#
+# validate_url() is a *pre-flight* gate: it runs once on the URL the user
+# registered. The original adapters then handed the URL to a plain
+# ``requests.Session`` with the default ``allow_redirects=True``. ``requests``
+# follows redirects internally and never re-validated the ``Location`` target,
+# so a registered public host that answered ``302 → http://169.254.169.254/``
+# was followed straight into the cloud metadata service (redirect-SSRF P0).
+#
+# Mitigation: ``SSRFSafeHTTPAdapter`` re-runs ``validate_url`` inside ``send()``
+# on *every* request. Because ``requests`` re-invokes the mounted adapter for
+# each redirect hop, every redirect target is re-validated against the same
+# SSRF policy (private IPs, loopback, metadata, ULA/link-local, IPv4-mapped
+# IPv6). Re-resolving inside ``send()`` also shrinks the DNS-rebinding TOCTOU
+# window: the hostname is resolved immediately before the underlying urllib3
+# connect, not seconds earlier at registration time. (A residual micro-window
+# between resolve and connect remains; full connect-time IP pinning would need
+# a socket-level transport and is documented as ADR-0053 follow-up.)
+
+
+class SSRFSafeHTTPAdapter(requests.adapters.HTTPAdapter):
+    """``requests`` HTTPAdapter that enforces SSRF policy on every send.
+
+    Mount on both ``http://`` and ``https://`` (see ``make_safe_session``) so
+    initial requests AND every redirect hop are validated.
+    """
+
+    def __init__(self, *args, allow_private: bool = False, **kwargs):
+        self._allow_private = allow_private
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):  # type: ignore[override]
+        url = getattr(request, "url", None)
+        if url:
+            DataFabricSecurity.validate_url(url, allow_private=self._allow_private)
+        return super().send(request, **kwargs)
+
+
+def make_safe_session(allow_private: bool = False):
+    """Return a ``requests.Session`` whose every request (incl. redirects) is
+    SSRF-validated. Adapters MUST use this instead of a bare ``requests.Session``.
+    """
+    session = requests.Session()
+    adapter = SSRFSafeHTTPAdapter(allow_private=allow_private)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session

--- a/app/services/data_fabric/security.py
+++ b/app/services/data_fabric/security.py
@@ -42,6 +42,15 @@ BLOCKED_IPS_EXPLICIT = {
     ipaddress.ip_address("fd00:ec2::254"),     # AWS IMDSv6 metadata
 }
 
+# System directories a geospatial local-file adapter must never read from, even
+# when an internal caller supplies such a path (defense in depth — the public
+# REST API already blocks bare/file: paths at validate_url, but adapters can be
+# constructed programmatically with arbitrary local paths).
+SENSITIVE_SYSTEM_DIRS = (
+    "/etc", "/proc", "/sys", "/dev", "/run", "/boot",
+    "/root", "/var/log", "/usr/lib", "/usr/sbin", "/sbin", "/bin",
+)
+
 # Networks that are private/loopback/link-local and must be blocked.
 BLOCKED_NETWORKS = [
     ipaddress.ip_network("0.0.0.0/8"),          # "this network"
@@ -300,3 +309,68 @@ def make_safe_session(allow_private: bool = False):
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     return session
+
+
+def resolve_safe_local_path(path, allowed_roots=None, max_bytes=None):
+    """Validate a local file path for adapter reads (Section 44).
+
+    Defenses (defense-in-depth — the public REST API already blocks bare/file:
+    paths at ``validate_url``):
+    - rejects empty / non-string paths;
+    - canonicalizes via realpath (collapses ``..`` and resolves symlinks);
+    - blocks reads under sensitive system dirs (``/etc``, ``/proc``, ``~/.ssh``…);
+    - when ``allowed_roots`` is provided, the real path must be under one of
+      them (blocks symlink escape beyond the intended directory);
+    - optional file-size cap.
+
+    Raises ``DataFabricSecurityError`` on violation; returns the resolved
+    ``pathlib.Path`` otherwise.
+    """
+    from pathlib import Path
+
+    if not path or not isinstance(path, str):
+        raise DataFabricSecurityError("empty or invalid local file path")
+    raw = Path(path)
+    real = raw.resolve() if raw.is_absolute() else (Path.cwd() / raw).resolve()
+    real_str = str(real)
+
+    # Always block sensitive system locations + the user's SSH dir.
+    home_ssh = str(Path.home() / ".ssh")
+    blocked = list(SENSITIVE_SYSTEM_DIRS) + [home_ssh]
+    for sens in blocked:
+        if real_str == sens or real_str.startswith(sens + "/"):
+            raise DataFabricSecurityError(
+                f"local file path '{path}' is in a blocked system directory"
+            )
+
+    if allowed_roots:
+        roots = []
+        for r in allowed_roots:
+            rp = Path(r).expanduser()
+            roots.append(str(rp.resolve()))
+        if not any(real_str == rr or real_str.startswith(rr + "/") for rr in roots if rr):
+            raise DataFabricSecurityError(
+                f"local file path '{path}' escapes the allowed roots"
+            )
+
+    if max_bytes is not None and real.exists() and real.is_file():
+        size = real.stat().st_size
+        if size > max_bytes:
+            raise DataFabricSecurityError(
+                f"local file '{path}' size {size} exceeds limit {max_bytes}"
+            )
+    return real
+
+
+def _local_file_roots_from_settings():
+    """Resolve the configured local-file roots list from settings (helper for adapters)."""
+    from app.core.config import settings
+
+    raw = getattr(settings, "DATA_FABRIC_LOCAL_FILE_ROOTS", "") or ""
+    return [r.strip() for r in raw.split(",") if r.strip()]
+
+
+def _local_file_max_bytes_from_settings():
+    from app.core.config import settings
+
+    return int(getattr(settings, "DATA_FABRIC_LOCAL_FILE_MAX_BYTES", 1024 * 1024 * 1024))

--- a/app/services/session_data_protocol.py
+++ b/app/services/session_data_protocol.py
@@ -8,6 +8,25 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Protocol, Union, runtime_checkable
 
 
+# Sentinel prefix minted by the Redis backend when the store is unavailable,
+# so a transient Redis timeout does NOT crash the chat dispatch loop (the store
+# returns this marker instead of raising — see audit C3). Consumers that require
+# a *retrievable* ref (e.g. Data Fabric materialization) MUST detect it via
+# ``is_unavailable_ref`` and report failure rather than treating it as a real ref.
+# Invariant: a ref exists iff its payload is retrievable.
+UNAVAILABLE_REF_PREFIX = "ref:redis-unavailable-"
+
+
+def is_unavailable_ref(ref_id: Optional[str]) -> bool:
+    """True iff ``ref_id`` is a non-retrievable store-unavailability sentinel.
+
+    A ref minted under this prefix has NO payload stored anywhere; ``get`` will
+    always miss. Any caller that persists or returns a ref to a downstream
+    consumer must treat this as failure, not success.
+    """
+    return bool(ref_id) and ref_id.startswith(UNAVAILABLE_REF_PREFIX)
+
+
 @dataclass(frozen=True)
 class SessionRefDataResult:
     """Immutable value object returned by SessionStore.get_ref_data()."""

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 import redis.asyncio as aioredis
-from app.services.session_data_protocol import BaseSessionStore
+from app.services.session_data_protocol import BaseSessionStore, UNAVAILABLE_REF_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -248,7 +248,7 @@ class RedisSessionStore(BaseSessionStore):
                 "Redis store failed for session %s (prefix=%s): %s — returning unavailable ref",
                 session_id, prefix, e,
             )
-            return f"ref:redis-unavailable-{uuid.uuid4().hex[:16]}"
+            return f"{UNAVAILABLE_REF_PREFIX}{uuid.uuid4().hex[:16]}"
         # RUN-06: a new ref must be visible to the next get_session_metadata /
         # list_refs round within the same chat turn. The metadata L1 bundle
         # caches list_refs + event_log (2s TTL); drop it so we don't serve the

--- a/app/tools/data_fabric_tools.py
+++ b/app/tools/data_fabric_tools.py
@@ -17,10 +17,9 @@ from app.services.data_fabric.spatial_catalog import spatial_catalog_service
 from app.services.data_fabric.fingerprint import dataset_fingerprint_service
 from app.services.data_fabric.materialization_service import materialization_service
 from app.services.data_fabric.health import data_fabric_health_check
-from app.services.data_fabric.connection_manager import (
-    connection_manager,
-    GenericDataSourceAdapter,
-)
+from app.services.data_fabric.connection_manager import connection_manager
+from app.services.data_fabric.registry import build_adapter
+from app.services.data_fabric.errors import UNSUPPORTED_SOURCE
 
 logger = logging.getLogger(__name__)
 
@@ -120,10 +119,12 @@ def register_data_fabric_tools(registry: ToolRegistry):
             adapter = connection_manager.get_adapter(profile_id)
             if not adapter:
                 profile = connection_manager.get_profile(profile_id)
-                if profile:
-                    adapter = GenericDataSourceAdapter(profile)
-                else:
+                if not profile:
                     raise RuntimeError(f"Data source connection profile '{profile_id}' not found. Please connect first.")
+                # Build the profile's real adapter via the canonical registry.
+                # An unregistered source type raises UnsupportedSourceError rather
+                # than silently producing mock data.
+                adapter = build_adapter(profile)
 
             health = data_fabric_health_check.check_health(adapter)
             caps = adapter.capabilities()
@@ -276,8 +277,19 @@ def register_data_fabric_tools(registry: ToolRegistry):
             adapter = connection_manager.get_adapter(pid) if pid else None
 
             if not adapter:
-                profile = ConnectionProfile(id=pid or "default-profile", source_type="geojson")
-                adapter = GenericDataSourceAdapter(profile)
+                # Do NOT fabricate a geojson mock adapter — that would serve
+                # synthetic features as if they were real remote data. Return a
+                # typed, actionable error so the agent connects a source first.
+                return {
+                    "status": "error",
+                    "error_type": UNSUPPORTED_SOURCE,
+                    "error": (
+                        f"No connected data source adapter for dataset '{dataset_id}' "
+                        f"(profile_id={pid}). Connect a data source first."
+                    ),
+                    "dataset_id": dataset_id,
+                    "features": [],
+                }
 
             spec = QuerySpec(
                 limit=limit,
@@ -341,8 +353,19 @@ def register_data_fabric_tools(registry: ToolRegistry):
         adapter = connection_manager.get_adapter(pid) if pid else None
 
         if not adapter:
-            profile = ConnectionProfile(id=pid or "default-profile", source_type="geojson")
-            adapter = GenericDataSourceAdapter(profile)
+            # Do NOT fabricate a geojson mock adapter and materialize synthetic
+            # features as real data. Return a typed error so the agent connects
+            # a source first.
+            return {
+                "status": "error",
+                "error_type": UNSUPPORTED_SOURCE,
+                "error": (
+                    f"No connected data source adapter for dataset '{dataset_id}' "
+                    f"(profile_id={pid}). Connect a data source first."
+                ),
+                "dataset_id": dataset_id,
+                "ref_id": None,
+            }
 
         spec = QuerySpec(
             limit=limit,

--- a/docs/adr/0053-data-fabric-v3-reliability.md
+++ b/docs/adr/0053-data-fabric-v3-reliability.md
@@ -1,0 +1,123 @@
+# Data Fabric V3 — Reliability, Truthfulness & Offline Resilience
+
+Hardens the V1/V2 Data Fabric (ADR-0050) into a connectivity layer whose results
+are **truthful, bounded, tenant-isolated, and verifiable offline**. This ADR is
+the single consolidated record for the V3 reliability contracts; it supersedes
+the ad-hoc notes that preceded it and consolidates the changes landed in the
+Data Fabric V3 PR.
+
+## Context & Problem
+
+The V1 architecture was correct in shape but several contracts were unsound in
+practice (see `.scratch/data-fabric-v3/findings.md`, swarm audit round 1):
+
+- **Fake materialization success.** A session-store failure was masked: a random
+  `ref:…` was minted and `status:"success"` returned for a ref that resolved to
+  no payload.
+- **Synthetic data as real.** Five adapters (STAC, GeoParquet, FlatGeobuf,
+  PMTiles, S3) and the `GenericDataSourceAdapter` fallback served fabricated
+  features as if they were remote results on any error.
+- **SSRF redirect bypass.** `validate_url` ran once; `requests` then followed
+  redirects to `169.254.169.254` with no re-validation. Cross-tenant catalog
+  reads had no guard.
+- **Fabricated metadata.** Undeclared CRS became `EPSG:4326`; unknown counts
+  became exact `0/100/10000`; tile pyramids were mislabeled `vector`.
+- **Unbounded results / OOM.** The `limit` param capped the request, not the
+  accepted payload.
+- **Six divergent source-type registries**; no retries; blocking sync I/O inside
+  async materialization; no health cache; no circuit breaker.
+
+## Decisions
+
+### 1. Truthful materialization (P0)
+A ref exists **iff** its payload is retrievable. Store failure (exception OR the
+Redis-unavailability sentinel — a deliberate cross-cutting resilience seam kept
+for chat-dispatch stability) is reported as a typed `MATERIALIZATION_FAILED`
+result with `ref_id=None`, `success=False`. Audit-row writes are atomic with the
+store: a commit failure rolls back and reports failure (no orphan success). The
+REST route honors the flag (503 store-down vs 200 success vs 413 oversized).
+
+### 2. Canonical adapter registry (P1)
+`AdapterRegistry` (`registry.py`) is the single source of truth for
+`source_type → adapter`. All 10 adapters are reachable from both the REST
+manager and the tool connection-manager. Unknown types raise
+`UnsupportedSourceError` — the factory **never** falls back to mock data.
+`GenericDataSourceAdapter` is an explicit opt-in demo adapter
+(canonical `generic`, aliases `geojson/mock/sample`). Each spec declares
+capability flags for pushdown negotiation.
+
+### 3. SSRF re-validation per hop (P0)
+`SSRFSafeHTTPAdapter` re-runs `validate_url` inside `send()`. Because `requests`
+re-invokes the mounted adapter for every redirect hop, each redirect target is
+re-validated (closing the 302→metadata bypass) and the DNS-rebinding TOCTOU
+window is shrunk (re-resolve immediately before connect). All HTTP adapters use
+`make_safe_session()`. Residual: full connect-time IP pinning is a documented
+follow-up.
+
+### 4. Tenant isolation on the catalog (P0)
+`preview`/`query`/`materialize` routes now resolve the item's `DataSource` and
+apply `_require_tenant_owned` (404, not 403, to avoid existence leaks). Anonymous
+callers reach only truly global sources. `endpoint_url` is redacted of userinfo
+on egress.
+
+### 5. Bounded resource guards (P0)
+`limits.py` centralizes hard bounds (`DATA_FABRIC_MAX_FEATURES / MAX_RESPONSE_BYTES
+/ MAX_PAGES / QUERY_TIMEOUT`), clamped to non-zero floors so protection cannot be
+disabled via config. `enforce_result_bounds` runs at both materialization choke
+points before store; oversized results raise `RESULT_TOO_LARGE` (HTTP 413) with an
+actionable shrink hint. Does not trust the remote `limit`.
+
+### 6. Reliability controls (P1)
+- `reliability.py`: transient-only retry (`is_transient`) with bounded exp
+  backoff + full jitter and an injectable sleep/clock seam (tests never wait).
+  4xx / validation / security errors are never retried; the conservative POST
+  rule retries HTTPError-class transients only when idempotent.
+- `circuit_breaker.py`: per-source closed/open/half-open breaker with injectable
+  clock and bounded LRU registry; open ⇒ fail-fast `SourceUnreachableError`.
+- `health.py`: truthful semantics — a validated URL reports `valid_profile`, not
+  `healthy`; only an adapter probe reports `healthy`. TTL health cache (healthy
+  longer than failure) and breaker-gated fast-fail.
+
+### 7. Metadata truthfulness (P0)
+`metadata.py` normalizes at the persistence boundary: undeclared CRS → `None`
+(never fakes `EPSG:4326`); OGC CRS URIs canonicalized; geometry types recognized
+across `esri*` codes and raster/tile (tile pyramids no longer `vector`);
+feature count `None` for unknown (`0` reserved for genuine zero).
+
+### 8. Structured errors (P1)
+`errors.py` defines the canonical taxonomy
+(`UNSUPPORTED_SOURCE`, `SOURCE_UNREACHABLE`, `SOURCE_TIMEOUT`, `SOURCE_AUTH_FAILED`,
+`SOURCE_RATE_LIMITED`, `SOURCE_BAD_RESPONSE`, `RESULT_TOO_LARGE`,
+`MATERIALIZATION_FAILED`, `CANCELLED`, `SECURITY_BLOCKED`, …) and
+`classify_http_status`, the single retry/circuit-breaker classifier.
+
+### 9. Offline fault-injection (testability)
+`FakeFabricAdapter` (subclass of `SSRFSafeHTTPAdapter`) returns canned responses
+per route with no sockets, while still enforcing per-hop SSRF validation — so
+the real `requests` redirect machinery exercises redirect-SSRF, retry,
+pagination, auth and oversized paths fully offline and deterministically.
+
+## Deferred / follow-up
+
+- **File-format adapters** (GeoParquet/FlatGeobuf/PMTiles/S3) still fall back to
+  synthetic fixtures on real-endpoint error. Containment is in place (canonical
+  registry, result guard, truthful materialization); the STAC fix (b3a98c4) is
+  the reference pattern to apply per adapter.
+- **Connect-time IP pinning** for full DNS-rebinding defense (socket-level transport).
+- **Async / cancellation**: blocking sync I/O still runs inside async
+  materialization; `OperationCancelled`/`to_thread` propagation is a follow-up.
+- **HTTP conditional requests** (ETag / If-None-Match) and a safe TTL result cache.
+- **Catalog sync efficiency**: bounded concurrency, batch DB lookup, incremental
+  sync via descriptor fingerprint, removed-dataset marking.
+
+## Consequences
+
+- Error semantics changed from fake-success to typed failure for store/health
+  failures. This is an allowed correctness fix (ADR-0050 §egress); clients that
+  treated `success:true` on every 200 must now read the `success`/`error_type`
+  fields. The REST route preserves a structured body on the failure status codes.
+- The `GenericDataSourceAdapter` is no longer an implicit fallback; integrations
+  that relied on `source_type="geojson"` continue to work (it is a registered
+  demo adapter), but arbitrary unknown types now raise.
+- No DB migration required (the `crs` column is nullable; `None` is stored for
+  unknown CRS).

--- a/docs/adr/0053-data-fabric-v3-reliability.md
+++ b/docs/adr/0053-data-fabric-v3-reliability.md
@@ -99,16 +99,35 @@ pagination, auth and oversized paths fully offline and deterministically.
 
 ## Deferred / follow-up
 
-- **File-format adapters** (GeoParquet/FlatGeobuf/PMTiles/S3) still fall back to
-  synthetic fixtures on real-endpoint error. Containment is in place (canonical
-  registry, result guard, truthful materialization); the STAC fix (b3a98c4) is
-  the reference pattern to apply per adapter.
-- **Connect-time IP pinning** for full DNS-rebinding defense (socket-level transport).
-- **Async / cancellation**: blocking sync I/O still runs inside async
-  materialization; `OperationCancelled`/`to_thread` propagation is a follow-up.
-- **HTTP conditional requests** (ETag / If-None-Match) and a safe TTL result cache.
-- **Catalog sync efficiency**: bounded concurrency, batch DB lookup, incremental
-  sync via descriptor fingerprint, removed-dataset marking.
+The V3 follow-up slices landed in this PR (P2 set):
+
+- **File-format adapters** (GeoParquet/FlatGeobuf/PMTiles/S3) no longer serve
+  synthetic fixtures as real data — a configured endpoint that fails returns a
+  typed error; synthetic is demo-mode only and labeled `source="synthetic-demo"`.
+  STAC (b3a98c4) was the reference pattern, now applied to all four (c3211b0).
+- **Local-file path guards** (Section 44): `resolve_safe_local_path` blocks
+  traversal / symlink escape / sensitive-system-dir / oversize reads (355f99a).
+- **Catalog sync efficiency** (Section 30/31): bounded-concurrency describe,
+  batch DB lookup (no N+1), incremental fingerprint skip (5f360b0).
+- **Async / cancellation** (Section 13/17): blocking adapter I/O offloaded via
+  `asyncio.to_thread`; cooperative `CancellationToken` aborts before store
+  (0f33b2c).
+- **Safe TTL metadata cache** (Section 37): tenant-scoped `SafeTTLCache` /
+  `cached_describe`; the scope is a mandatory key part (no cross-tenant leak) (aa53cbc).
+
+Still deferred (P3):
+
+- **Connect-time IP pinning** for full DNS-rebinding defense (socket-level
+  transport pin). The per-send revalidation in `SSRFSafeHTTPAdapter` already
+  shrinks the practical TOCTOU window to the resolve→connect gap inside one
+  `send()`; pinning the connection to a pre-validated IP would close the
+  residual gap but risks breaking legitimate dual-stack / CDN connections, so
+  it is deferred unless a deployment requires it.
+- **HTTP conditional requests** (ETag / If-None-Match) and a **query-result**
+  cache: needs adapter response-header plumbing this PR does not introduce;
+  metadata caching is already in place.
+- **Removed-dataset marking**: cohesive write+read change (status convention +
+  catalog-list filtering), no migration-free win; tracked separately.
 
 ## Consequences
 

--- a/tests/benchmarks/test_perf_harness_v2.py
+++ b/tests/benchmarks/test_perf_harness_v2.py
@@ -28,6 +28,7 @@ from app.services.data_fabric.adapters import (
     STACAdapter,
     WFSAdapter,
 )
+from app.services.data_fabric.errors import UnsupportedSourceError
 from app.schemas.data_fabric_schema import ConnectionProfile
 from app.services.raster_tile_service import render_raster_tile
 
@@ -145,7 +146,6 @@ def test_data_fabric_factory_adapter_routing():
         ConnectionProfile(id="p_fgb", source_type="flatgeobuf", url="https://example.com/test.fgb"),
         ConnectionProfile(id="p_stac", source_type="stac", url="https://earth-search.aws.element84.com/v1"),
         ConnectionProfile(id="p_wfs", source_type="wfs", url="https://example.com/wfs"),
-        ConnectionProfile(id="p_gen", source_type="unknown_custom", url="https://example.com/custom"),
     ]
 
     for p in profiles:
@@ -160,8 +160,18 @@ def test_data_fabric_factory_adapter_routing():
             assert isinstance(adapter, STACAdapter)
         elif p.source_type == "wfs":
             assert isinstance(adapter, WFSAdapter)
-        elif p.source_type == "unknown_custom":
-            assert isinstance(adapter, GenericDataSourceAdapter)
+
+    # Unregistered source types MUST raise UnsupportedSourceError — never fall
+    # back to a mock adapter that fabricates synthetic features as real data.
+    bad = ConnectionProfile(id="p_gen", source_type="unknown_custom", url="https://example.com/custom")
+    with pytest.raises(UnsupportedSourceError):
+        cm.connect(bad)
+
+    # The demo/sample adapter is still reachable via its explicit canonical name.
+    demo_prof, demo_adapter = cm.connect(
+        ConnectionProfile(id="p_demo", source_type="generic")
+    )
+    assert isinstance(demo_adapter, GenericDataSourceAdapter)
 
 
 @pytest.mark.asyncio

--- a/tests/fixtures/data_fabric/fake_server.py
+++ b/tests/fixtures/data_fabric/fake_server.py
@@ -1,0 +1,128 @@
+"""Offline fault-injection transport for Data Fabric adapter tests (Section 59).
+
+``FakeFabricAdapter`` is a ``requests`` HTTPAdapter that returns canned responses
+keyed by URL path — no network, no sockets, fully deterministic. Crucially it
+subclasses ``SSRFSafeHTTPAdapter`` and runs the same per-hop SSRF validation, so
+``requests``' redirect machinery exercises the real redirect→revalidate path:
+a route answering ``302 → http://169.254.169.254/`` makes the next ``send()``
+call ``validate_url`` on the metadata IP and raise ``DataFabricSecurityError``.
+
+Mount via ``session_with_fake(routes)``. Routes match by path prefix; the first
+matching handler wins. Handlers receive the ``PreparedRequest`` and return a
+``requests.Response`` (use ``make_response``).
+"""
+from __future__ import annotations
+
+import json as _json
+from typing import Callable, Dict, Iterable, Optional, Tuple
+
+import requests
+
+from app.services.data_fabric.security import SSRFSafeHTTPAdapter
+
+# A route handler: given the prepared request, return a response.
+RouteHandler = Callable[[requests.PreparedRequest], requests.Response]
+# Route table: ordered (path-prefix, handler) pairs — first match wins.
+RouteTable = Tuple[Tuple[str, RouteHandler], ...]
+
+
+def make_response(
+    url: str,
+    *,
+    status: int = 200,
+    json_body: Optional[object] = None,
+    text: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> requests.Response:
+    resp = requests.Response()
+    resp.url = url
+    resp.status_code = status
+    resp.headers.update(headers or {})
+    if json_body is not None:
+        resp._content = _json.dumps(json_body).encode()
+        resp.headers["Content-Type"] = "application/json"
+    elif text is not None:
+        resp._content = text.encode()
+        resp.headers["Content-Type"] = "text/plain"
+    else:
+        resp._content = b""
+    return resp
+
+
+def redirect_to(url: str, target: str) -> requests.Response:
+    """Build a 302 response from ``url`` redirecting to ``target``."""
+    return make_response(url, status=302, headers={"Location": target})
+
+
+def _normalize_routes(routes) -> list[tuple[str, RouteHandler]]:
+    """Accept either [(prefix, handler), ...] or a single (prefix, handler) pair."""
+    if not routes:
+        return []
+    # Single (prefix, handler) pair vs list of pairs: disambiguate by the first
+    # element being a string (prefix) vs a tuple (a route).
+    if isinstance(routes[0], str):
+        return [(routes[0], routes[1])]
+    return [(r[0], r[1]) for r in routes]
+
+
+class FakeFabricAdapter(SSRFSafeHTTPAdapter):
+    """Canned-response adapter that still enforces per-hop SSRF validation."""
+
+    def __init__(self, routes, allow_private: bool = False):
+        super().__init__(allow_private=allow_private)
+        self.routes = _normalize_routes(routes)
+        self.requests: list[str] = []  # record of URLs seen (for assertions)
+
+    def send(self, request, **kwargs):  # type: ignore[override]
+        # Inherited contract: validate every hop (incl. redirect targets).
+        from urllib.parse import urlparse
+
+        from app.services.data_fabric.security import DataFabricSecurity
+
+        DataFabricSecurity.validate_url(request.url, allow_private=self._allow_private)
+        self.requests.append(request.url)
+        path = urlparse(request.url).path
+        for prefix, handler in self.routes:
+            if path.startswith(prefix):
+                resp = handler(request)
+                # requests' redirect resolver reads .request and .connection to
+                # rebuild/re-send the redirected request through this adapter.
+                resp.request = request
+                resp.connection = self
+                return resp
+        resp = make_response(request.url, status=404, text=f"no fake route for {path}")
+        resp.request = request
+        resp.connection = self
+        return resp
+
+
+def session_with_fake(routes: RouteTable, allow_private: bool = False) -> requests.Session:
+    """A requests.Session whose every request is served by the fake routes,
+    with SSRF validation enforced per hop (redirect-safe)."""
+    s = requests.Session()
+    adapter = FakeFabricAdapter(routes, allow_private=allow_private)
+    s.mount("http://", adapter)
+    s.mount("https://", adapter)
+    return s
+
+
+# ── Stateful helpers for pagination / counters ──────────────────────────────
+
+
+class PageCounter:
+    """Helper to build multi-page OGC-style responses with a deterministic
+    ``next`` link chain and request counting."""
+
+    def __init__(self, base_url: str, pages: Iterable[list]):
+        self.base_url = base_url.rstrip("/")
+        self.pages = list(pages)
+        self.calls = 0
+
+    def handler(self, request):
+        self.calls += 1
+        idx = min(self.calls - 1, len(self.pages) - 1)
+        page = self.pages[idx]
+        body: dict = {"type": "FeatureCollection", "features": page}
+        if self.calls < len(self.pages):
+            body["links"] = {"next": f"{self.base_url}/items?page={self.calls + 1}"}
+        return make_response(request.url, json_body=body)

--- a/tests/unit/test_data_fabric_adapters.py
+++ b/tests/unit/test_data_fabric_adapters.py
@@ -80,9 +80,12 @@ def test_stac_adapter_interface():
 
 
 def test_geoparquet_adapter_interface():
+    # Demo mode (no endpoint): probe is reachable; describe returns the
+    # synthetic fixture metadata. Configured-but-unreachable is covered in the
+    # fault-injection suite (truthful probe()==False), not here (offline).
     profile = ConnectionProfile(
         source_type="geoparquet",
-        endpoint_url="s3://mybucket/data.parquet",
+        endpoint_url="",
         name="test_parquet",
     )
     adapter = GeoParquetAdapter(profile)
@@ -92,9 +95,11 @@ def test_geoparquet_adapter_interface():
 
 
 def test_flatgeobuf_adapter_interface():
+    # Demo mode (no endpoint): probe is reachable. Real-http probe behavior is
+    # exercised offline via FakeFabricAdapter in the fault-injection suite.
     profile = ConnectionProfile(
         source_type="flatgeobuf",
-        endpoint_url="https://flatgeobuf.org/test.fgb",
+        endpoint_url="",
         name="test_fgb",
     )
     adapter = FlatGeobufAdapter(profile)
@@ -102,9 +107,10 @@ def test_flatgeobuf_adapter_interface():
 
 
 def test_pmtiles_adapter_interface():
+    # Demo mode (no endpoint): probe is reachable; describe returns tile type.
     profile = ConnectionProfile(
         source_type="pmtiles",
-        endpoint_url="https://pmtiles.io/test.pmtiles",
+        endpoint_url="",
         name="test_pmtiles",
     )
     adapter = PMTilesAdapter(profile)

--- a/tests/unit/test_data_fabric_catalog_sync.py
+++ b/tests/unit/test_data_fabric_catalog_sync.py
@@ -1,0 +1,106 @@
+"""Catalog sync efficiency tests (Section 30/31): batch DB lookup (no N+1),
+bounded concurrency, and incremental fingerprint skip."""
+from unittest.mock import MagicMock
+
+from app.schemas.data_fabric_schema import DatasetDescriptor
+from app.services.data_fabric.manager import DataFabricManager
+
+
+class _FakeAdapter:
+    """Minimal adapter: returns a fixed dataset list + descriptors."""
+
+    def __init__(self, datasets):
+        self._datasets = datasets
+
+    def list_datasets(self):
+        return [{"id": d.id, "title": d.title} for d in self._datasets]
+
+    def describe(self, name):
+        for d in self._datasets:
+            if d.id == name:
+                return d
+        return DatasetDescriptor(id=name)
+
+
+def _mock_db(ds_model, existing_items=None):
+    existing_items = existing_items or []
+    db = MagicMock()
+
+    ds_q = MagicMock()
+    ds_q.filter.return_value.first.return_value = ds_model
+    cat_q = MagicMock()
+    cat_q.filter.return_value.all.return_value = list(existing_items)
+    # DataSourceModel lookup first, then the batch CatalogItemModel lookup.
+    db.query.side_effect = [ds_q, cat_q]
+    return db
+
+
+def _ds_model():
+    ds = MagicMock()
+    ds.id = "src1"
+    ds.name = "src"
+    ds.source_type = "ogc_api"
+    ds.endpoint_url = "https://example.org"
+    ds.connection_profile = {"options": {}, "allow_private": False}
+    return ds
+
+
+def test_sync_uses_one_batched_catalog_query_not_n_plus_one(monkeypatch):
+    """The batch lookup must issue a SINGLE CatalogItemModel query regardless of
+    how many datasets the source exposes (no per-item N+1)."""
+    datasets = [DatasetDescriptor(id=f"ds_{i}", title=f"D{i}") for i in range(50)]
+    db = _mock_db(_ds_model())
+
+    monkeypatch.setattr(DataFabricManager, "get_adapter", staticmethod(lambda profile: _FakeAdapter(datasets)))
+
+    DataFabricManager.sync_catalog(db, "src1")
+
+    # Exactly two db.query calls: DataSourceModel, then the ONE batch
+    # CatalogItemModel query. No per-item SELECTs.
+    assert db.query.call_count == 2
+    db.commit.assert_called_once()
+
+
+def test_sync_writes_descriptor_fingerprint_on_new_items(monkeypatch):
+    datasets = [DatasetDescriptor(id="ds_a", title="A")]
+    db = _mock_db(_ds_model())
+
+    monkeypatch.setattr(DataFabricManager, "get_adapter", staticmethod(lambda profile: _FakeAdapter(datasets)))
+
+    DataFabricManager.sync_catalog(db, "src1")
+
+    added = [c for c in db.add.call_args_list][0]
+    new_item = added.args[0]
+    assert new_item.fingerprint  # non-empty descriptor fingerprint stored
+
+
+def test_incremental_sync_skips_unchanged_rows(monkeypatch):
+    """A second sync whose descriptors produce the same fingerprint must NOT
+    rewrite the row (updated_at untouched) — the incremental skip."""
+    from app.services.data_fabric.fingerprint import dataset_fingerprint_service
+
+    class _Row:
+        def __init__(self, **kw):
+            self.__dict__.update(kw)
+
+    desc = DatasetDescriptor(id="ds_a", title="A", geometry_type=None)  # -> "unknown"
+    fp = dataset_fingerprint_service.calculate_descriptor_fingerprint(desc)
+    existing = _Row(
+        id="cat_src1_ds_a",
+        source_id="src1",
+        name="ds_a",
+        fingerprint=fp,
+        geometry_type="unknown",
+        title="OLD TITLE",
+        updated_at="old_ts",
+    )
+
+    db = _mock_db(_ds_model(), existing_items=[existing])
+    monkeypatch.setattr(DataFabricManager, "get_adapter", staticmethod(lambda profile: _FakeAdapter([desc])))
+
+    DataFabricManager.sync_catalog(db, "src1")
+
+    # Skipped: row untouched (title/updated_at unchanged), nothing added.
+    assert existing.title == "OLD TITLE"
+    assert existing.updated_at == "old_ts"
+    db.add.assert_not_called()

--- a/tests/unit/test_data_fabric_catalog_sync.py
+++ b/tests/unit/test_data_fabric_catalog_sync.py
@@ -2,8 +2,20 @@
 bounded concurrency, and incremental fingerprint skip."""
 from unittest.mock import MagicMock
 
+import pytest
+
 from app.schemas.data_fabric_schema import DatasetDescriptor
 from app.services.data_fabric.manager import DataFabricManager
+from app.services.data_fabric.metadata_cache import _describe_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_describe_cache():
+    """sync_catalog uses the process-global describe TTL cache; clear it between
+    tests so descriptors don't leak across cases."""
+    _describe_cache.invalidate()
+    yield
+    _describe_cache.invalidate()
 
 
 class _FakeAdapter:

--- a/tests/unit/test_data_fabric_fault_injection.py
+++ b/tests/unit/test_data_fabric_fault_injection.py
@@ -1,0 +1,149 @@
+"""End-to-end Data Fabric fault-injection tests — fully offline (Section 59/63).
+
+Uses FakeFabricAdapter (canned responses + per-hop SSRF validation) so the real
+requests redirect machinery exercises redirect-SSRF, retry, pagination, auth and
+oversized-response paths without any network.
+"""
+import pytest
+
+from app.services.data_fabric.errors import (
+    ResultTooLargeError,
+    SourceAuthFailedError,
+    SourceBadResponseError,
+)
+from app.services.data_fabric import limits
+from app.services.data_fabric.reliability import RetryPolicy, retry_call
+from app.services.data_fabric.security import DataFabricSecurityError
+
+from tests.fixtures.data_fabric.fake_server import (
+    PageCounter,
+    make_response,
+    redirect_to,
+    session_with_fake,
+)
+
+# A public-looking, unresolvable host passes validate_url's pre-flight gate
+# (unresolvable hostnames are not hard-blocked), so we can reach the redirect
+# logic entirely offline.
+BASE = "http://fabric-fault-injection.example"
+
+
+# ── SSRF: redirect to cloud metadata is blocked on the next hop ──────────────
+
+
+def test_redirect_to_metadata_ip_is_blocked():
+    """The P0 redirect-SSRF bypass: a 302 to 169.254.169.254 must be rejected
+    when the safe session follows it (validate runs per hop)."""
+    routes = (("/redirect", lambda req: redirect_to(req.url, "http://169.254.169.254/latest/meta-data/")),)
+    s = session_with_fake(routes, allow_private=False)
+    with pytest.raises(DataFabricSecurityError):
+        s.get(f"{BASE}/redirect", timeout=2)
+
+
+def test_redirect_to_loopback_is_blocked():
+    routes = (("/r", lambda req: redirect_to(req.url, "http://127.0.0.1:8080/internal")),)
+    s = session_with_fake(routes, allow_private=False)
+    with pytest.raises(DataFabricSecurityError):
+        s.get(f"{BASE}/r", timeout=2)
+
+
+def test_legitimate_same_host_redirect_followed():
+    """Non-SSRF redirects still work — the guard is not over-broad."""
+    routes = (("/ok", lambda req: redirect_to(req.url, f"{BASE}/final")),
+              ("/final", lambda req: make_response(req.url, json_body={"ok": True})))
+    s = session_with_fake(routes, allow_private=False)
+    resp = s.get(f"{BASE}/ok", timeout=2)
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+# ── Retry: transient retried, auth not ───────────────────────────────────────
+
+
+def test_retry_then_success_on_transient_503():
+    """retry_call recovers when the 3rd attempt succeeds."""
+    state = {"n": 0}
+
+    def handler(req):
+        state["n"] += 1
+        if state["n"] < 3:
+            return make_response(req.url, status=503, text="down")
+        return make_response(req.url, json_body={"features": []})
+
+    s = session_with_fake(("/q", handler))
+
+    def do_get():
+        r = s.get(f"{BASE}/q", timeout=2)
+        if r.status_code != 200:
+            raise SourceBadResponseError(f"status {r.status_code}")
+        return r
+
+    out = retry_call(do_get, policy=RetryPolicy(max_attempts=5, base_sleep=0), sleep=lambda _s: None)
+    assert out.status_code == 200
+    assert state["n"] == 3
+
+
+def test_auth_failure_not_retried():
+    """401 is permanent — no retry."""
+    state = {"n": 0}
+
+    def handler(req):
+        state["n"] += 1
+        return make_response(req.url, status=401, text="unauthorized")
+
+    s = session_with_fake(("/auth", handler))
+
+    def do_get():
+        r = s.get(f"{BASE}/auth", timeout=2)
+        if r.status_code == 401:
+            raise SourceAuthFailedError("401")
+        return r
+
+    with pytest.raises(SourceAuthFailedError):
+        retry_call(do_get, policy=RetryPolicy(max_attempts=4, base_sleep=0), sleep=lambda _s: None)
+    assert state["n"] == 1  # not retried
+
+
+# ── Pagination: bounded pages, empty final ──────────────────────────────────
+
+
+def test_pagination_collects_all_pages_then_stops():
+    pc = PageCounter(BASE + "/items", [[{"id": 1}], [{"id": 2}], []])
+    s = session_with_fake(("/items", pc.handler))
+
+    collected = []
+    url = f"{BASE}/items"
+    for _ in range(10):  # bounded by the test, not the client
+        r = s.get(url, timeout=2)
+        body = r.json()
+        collected.extend(body.get("features", []))
+        nxt = (body.get("links") or {}).get("next")
+        if not nxt:
+            break
+        url = nxt
+    assert collected == [{"id": 1}, {"id": 2}]
+    assert pc.calls == 3  # collected 2 pages + saw the empty terminator
+
+
+# ── Oversized result guard ──────────────────────────────────────────────────
+
+
+def test_oversized_response_trips_guard():
+    """A server that ignores `limit` and returns a huge payload is rejected by
+    enforce_result_bounds before materialization."""
+    big = [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]}, "properties": {"id": i}} for i in range(10)]
+    with pytest.raises(ResultTooLargeError):
+        limits.enforce_result_bounds(big, max_feat=3, max_bytes=10 * 1024 * 1024)
+
+
+# ── Error taxonomy on HTTP status ───────────────────────────────────────────
+
+
+def test_classify_http_status_mapping():
+    from app.services.data_fabric.errors import classify_http_status
+
+    assert classify_http_status(401) == "SOURCE_AUTH_FAILED"
+    assert classify_http_status(404) == "SOURCE_UNREACHABLE"
+    assert classify_http_status(429) == "SOURCE_RATE_LIMITED"
+    assert classify_http_status(503) == "SOURCE_BAD_RESPONSE"
+    assert classify_http_status(400) == "SOURCE_BAD_RESPONSE"

--- a/tests/unit/test_data_fabric_fault_injection.py
+++ b/tests/unit/test_data_fabric_fault_injection.py
@@ -147,3 +147,38 @@ def test_classify_http_status_mapping():
     assert classify_http_status(429) == "SOURCE_RATE_LIMITED"
     assert classify_http_status(503) == "SOURCE_BAD_RESPONSE"
     assert classify_http_status(400) == "SOURCE_BAD_RESPONSE"
+
+
+# ── Adapter truthfulness: real-endpoint failure never returns synthetic data ──
+
+
+def test_stac_real_endpoint_failure_returns_typed_error_not_synthetic():
+    """When a real STAC endpoint is configured and returns 503, the adapter must
+    return empty features + a typed error_type — NOT synthetic fixtures
+    masquerading as remote results (the 'silent wrong data' P0)."""
+    from app.schemas.data_fabric_schema import ConnectionProfile, QuerySpec
+    from app.services.data_fabric.adapters.stac_adapter import STACAdapter
+
+    stac_base = "http://stac-fake.example"
+    routes = (("/search", lambda req: make_response(req.url, status=503, text="down")),)
+    fake_session = session_with_fake(routes, allow_private=False)
+
+    adapter = STACAdapter(ConnectionProfile(provider_type="stac", endpoint=stac_base))
+    adapter.session = fake_session  # inject the offline transport
+
+    res = adapter.query("landsat-8-c2-l2", QuerySpec(limit=10))
+    assert res.features == []           # no fabricated features
+    assert res.metadata["source"] == "remote"
+    assert res.metadata["error_type"] == "SOURCE_BAD_RESPONSE"
+
+
+def test_stac_no_endpoint_demo_mode_is_labeled_synthetic():
+    """No-endpoint demo mode still returns fixtures, but explicitly labeled."""
+    from app.schemas.data_fabric_schema import ConnectionProfile, QuerySpec
+    from app.services.data_fabric.adapters.stac_adapter import STACAdapter
+
+    adapter = STACAdapter(ConnectionProfile(provider_type="stac", endpoint=""))
+    res = adapter.query("landsat-8-c2-l2", QuerySpec(limit=5))
+    assert len(res.features) > 0
+    assert res.metadata["source"] == "synthetic-demo"
+

--- a/tests/unit/test_data_fabric_fault_injection.py
+++ b/tests/unit/test_data_fabric_fault_injection.py
@@ -182,3 +182,52 @@ def test_stac_no_endpoint_demo_mode_is_labeled_synthetic():
     assert len(res.features) > 0
     assert res.metadata["source"] == "synthetic-demo"
 
+
+def test_geoparquet_configured_but_unreadable_returns_typed_error():
+    """A configured GeoParquet source that isn't a readable local file must NOT
+    serve synthetic fixtures as real data — it returns empty + SOURCE_UNREACHABLE."""
+    from app.schemas.data_fabric_schema import ConnectionProfile, QuerySpec
+    from app.services.data_fabric.adapters.geoparquet_adapter import GeoParquetAdapter
+
+    adapter = GeoParquetAdapter(ConnectionProfile(source_type="geoparquet", endpoint="s3://bucket/data.parquet"))
+    assert adapter.probe() is False  # configured but not a readable local file
+    res = adapter.query("data.parquet", QuerySpec(limit=5))
+    assert res.features == []
+    assert res.metadata["source"] == "remote"
+    assert res.metadata["error_type"] == "SOURCE_UNREACHABLE"
+
+
+def test_geoparquet_demo_mode_is_labeled_synthetic():
+    from app.schemas.data_fabric_schema import ConnectionProfile, QuerySpec
+    from app.services.data_fabric.adapters.geoparquet_adapter import GeoParquetAdapter
+
+    adapter = GeoParquetAdapter(ConnectionProfile(source_type="geoparquet", endpoint=""))
+    res = adapter.query("us_states_geoparquet", QuerySpec(limit=5))
+    assert len(res.features) > 0
+    assert res.metadata["source"] == "synthetic-demo"
+
+
+def test_flatgeobuf_configured_but_unreadable_returns_typed_error():
+    from app.schemas.data_fabric_schema import ConnectionProfile, QuerySpec
+    from app.services.data_fabric.adapters.flatgeobuf_adapter import FlatGeobufAdapter
+
+    adapter = FlatGeobufAdapter(ConnectionProfile(source_type="flatgeobuf", endpoint="s3://bucket/data.fgb"))
+    assert adapter.probe() is False
+    res = adapter.query("data.fgb", QuerySpec(limit=5))
+    assert res.features == []
+    assert res.metadata["error_type"] == "SOURCE_UNREACHABLE"
+
+
+def test_pmtiles_and_s3_query_carry_source_label():
+    """PMTiles/S3 queries are metadata-only but must label demo vs remote."""
+    from app.schemas.data_fabric_schema import ConnectionProfile, QuerySpec
+    from app.services.data_fabric.adapters.pmtiles_adapter import PMTilesAdapter
+    from app.services.data_fabric.adapters.s3_storage_seam import S3StorageAdapter
+
+    pm_demo = PMTilesAdapter(ConnectionProfile(source_type="pmtiles", endpoint=""))
+    assert pm_demo.query("world_basemap_vector", QuerySpec(limit=1)).metadata["source"] == "synthetic-demo"
+
+    s3_demo = S3StorageAdapter(ConnectionProfile(source_type="s3", endpoint="s3://bucket/x.fgb"))
+    assert s3_demo.query("x.fgb", QuerySpec(limit=1)).metadata["source"] == "synthetic-demo"
+
+

--- a/tests/unit/test_data_fabric_local_path_guard.py
+++ b/tests/unit/test_data_fabric_local_path_guard.py
@@ -1,0 +1,70 @@
+"""Local-file path guard tests (Section 44): traversal, symlink escape,
+sensitive-system-dir blocking, allowed-root enforcement, size cap."""
+import os
+
+import pytest
+
+from app.services.data_fabric.security import (
+    DataFabricSecurityError,
+    resolve_safe_local_path,
+)
+
+
+def test_blocks_sensitive_system_dir():
+    with pytest.raises(DataFabricSecurityError):
+        resolve_safe_local_path("/etc/passwd")
+    with pytest.raises(DataFabricSecurityError):
+        resolve_safe_local_path("/proc/self/environ")
+
+
+def test_blocks_empty_and_nonstring():
+    with pytest.raises(DataFabricSecurityError):
+        resolve_safe_local_path("")
+    with pytest.raises(DataFabricSecurityError):
+        resolve_safe_local_path(None)  # type: ignore[arg-type]
+
+
+def test_allows_path_under_allowed_root(tmp_path):
+    f = tmp_path / "data.parquet"
+    f.write_bytes(b"PAR1")
+    resolved = resolve_safe_local_path(str(f), allowed_roots=[str(tmp_path)])
+    assert str(resolved).endswith("data.parquet")
+
+
+def test_blocks_path_outside_allowed_root(tmp_path):
+    f = tmp_path / "data.parquet"
+    f.write_bytes(b"PAR1")
+    # allowed root is a different dir -> the file escapes it
+    other = tmp_path.parent / "other_root_x"
+    with pytest.raises(DataFabricSecurityError):
+        resolve_safe_local_path(str(f), allowed_roots=[str(other)])
+
+
+def test_blocks_symlink_escape(tmp_path):
+    """A symlink that resolves outside the allowed root is rejected."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret")
+    link = allowed / "link.parquet"
+    os.symlink(outside, link)
+    with pytest.raises(DataFabricSecurityError):
+        resolve_safe_local_path(str(link), allowed_roots=[str(allowed)])
+
+
+def test_blocks_oversize_file(tmp_path):
+    f = tmp_path / "big.parquet"
+    f.write_bytes(b"x" * 2048)
+    with pytest.raises(DataFabricSecurityError):
+        resolve_safe_local_path(str(f), allowed_roots=[str(tmp_path)], max_bytes=1024)
+
+
+def test_guard_blocks_geoparquet_sensitive_path():
+    """The wired guard returns SECURITY_BLOCKED, never reads the file."""
+    from app.schemas.data_fabric_schema import ConnectionProfile, QuerySpec
+    from app.services.data_fabric.adapters.geoparquet_adapter import GeoParquetAdapter
+
+    adapter = GeoParquetAdapter(ConnectionProfile(source_type="geoparquet", endpoint="/etc/passwd"))
+    res = adapter.query("/etc/passwd", QuerySpec(limit=5))
+    assert res.features == []
+    assert res.metadata["error_type"] == "SECURITY_BLOCKED"

--- a/tests/unit/test_data_fabric_materialization_integrity.py
+++ b/tests/unit/test_data_fabric_materialization_integrity.py
@@ -125,14 +125,19 @@ def _mock_db_with_item():
     return db, item
 
 
+async def _async_query(cls, db, item_id, spec, cancel_token=None):
+    """Async stand-in for query_catalog_item_async (bypasses real adapter build)."""
+    return _qr()
+
+
 @pytest.mark.asyncio
 async def test_manager_materialize_store_unavailable_writes_no_audit(monkeypatch):
     """Store-unavailable → success=False AND no audit row added/committed."""
     db, _item = _mock_db_with_item()
     monkeypatch.setattr(
         DataFabricManager,
-        "query_catalog_item",
-        classmethod(lambda cls, d, i, s: _qr()),
+        "query_catalog_item_async",
+        classmethod(_async_query),
     )
 
     async def fake_store(session_id, data, prefix="data"):
@@ -156,8 +161,8 @@ async def test_manager_materialize_audit_commit_failure_rolls_back(monkeypatch):
     db.commit.side_effect = RuntimeError("db gone")
     monkeypatch.setattr(
         DataFabricManager,
-        "query_catalog_item",
-        classmethod(lambda cls, d, i, s: _qr()),
+        "query_catalog_item_async",
+        classmethod(_async_query),
     )
 
     async def fake_store(session_id, data, prefix="data"):
@@ -179,8 +184,8 @@ async def test_manager_materialize_success_commits_audit(monkeypatch):
     db, _item = _mock_db_with_item()
     monkeypatch.setattr(
         DataFabricManager,
-        "query_catalog_item",
-        classmethod(lambda cls, d, i, s: _qr()),
+        "query_catalog_item_async",
+        classmethod(_async_query),
     )
 
     async def fake_store(session_id, data, prefix="data"):
@@ -194,3 +199,26 @@ async def test_manager_materialize_success_commits_audit(monkeypatch):
     assert res["ref_id"] == "ref:df-real789"
     db.add.assert_called_once()
     db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_materialize_respects_cancel_token_before_store(monkeypatch):
+    """A pre-cancelled token must abort BEFORE the remote query/store — no stale
+    materialization (Section 17)."""
+    from app.services.jobs.cancellation import CancellationToken, OperationCancelled
+
+    db, _item = _mock_db_with_item()
+    token = CancellationToken(job_id="job1")
+    token.cancel("user requested")
+
+    async def no_store(*a, **k):  # pragma: no cover - must not be reached
+        raise AssertionError("store must not run for a cancelled materialize")
+
+    monkeypatch.setattr(df_manager.session_data_manager, "store", no_store)
+
+    with pytest.raises(OperationCancelled):
+        await DataFabricManager.materialize_catalog_item(
+            db=db, session_id="s1", item_id="cat1", cancel_token=token
+        )
+    db.add.assert_not_called()
+    db.commit.assert_not_called()

--- a/tests/unit/test_data_fabric_materialization_integrity.py
+++ b/tests/unit/test_data_fabric_materialization_integrity.py
@@ -1,0 +1,196 @@
+"""Data Fabric materialization integrity tests (P0: truthful refs).
+
+Invariant under test: *a ref exists IFF its payload is retrievable*.
+Materialization must NEVER mint a fake ref or report success when the session
+store failed (raised or returned the store-unavailability sentinel), and must
+NOT persist an audit row for a non-retrievable ref.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.schemas.data_fabric_schema import QueryResult
+from app.services.data_fabric import manager as df_manager
+from app.services.data_fabric import materialization_service as mat_svc
+from app.services.data_fabric.manager import DataFabricManager
+from app.services.session_data_protocol import UNAVAILABLE_REF_PREFIX
+
+
+def _qr(features=None) -> QueryResult:
+    return QueryResult(
+        dataset_id="ds1",
+        features=features
+        or [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [0.0, 0.0]},
+                "properties": {"id": 1},
+            }
+        ],
+        total_count=1,
+    )
+
+
+# ── Service layer ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_materialize_success_ref_is_retrievable(monkeypatch):
+    """Case A: store success → success=True AND ref points at stored payload."""
+    stored = {}
+
+    async def fake_store(session_id, data, prefix="data"):
+        ref = f"ref:{prefix}-real123"
+        stored[ref] = data
+        return ref
+
+    async def fake_set_alias(session_id, ref_id, alias):
+        return None
+
+    monkeypatch.setattr(mat_svc.session_data_manager, "store", fake_store)
+    monkeypatch.setattr(mat_svc.session_data_manager, "set_alias", fake_set_alias)
+
+    res = await mat_svc.materialization_service.materialize("ds1", _qr(), session_id="s1")
+
+    assert res["success"] is True
+    assert res["status"] == "success"
+    assert res["ref_id"] == "ref:data-fabric-real123"
+    # invariant: the ref we returned resolves to a stored payload
+    assert res["ref_id"] in stored
+
+
+@pytest.mark.asyncio
+async def test_materialize_store_exception_returns_no_fake_ref(monkeypatch):
+    """Case B: store raises → success=False, ref_id=None, typed error."""
+
+    async def boom(session_id, data, prefix="data"):
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(mat_svc.session_data_manager, "store", boom)
+
+    res = await mat_svc.materialization_service.materialize("ds1", _qr(), session_id="s1")
+
+    assert res["success"] is False
+    assert res["status"] == "failed"
+    assert res["ref_id"] is None
+    assert res["error_type"] == "MATERIALIZATION_FAILED"
+    assert "redis down" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_materialize_store_unavailable_sentinel_returns_no_fake_ref(monkeypatch):
+    """Case B': store returns the redis-unavailable sentinel → still a failure."""
+
+    async def fake_store(session_id, data, prefix="data"):
+        return f"{UNAVAILABLE_REF_PREFIX}abc"
+
+    monkeypatch.setattr(mat_svc.session_data_manager, "store", fake_store)
+
+    res = await mat_svc.materialization_service.materialize("ds1", _qr(), session_id="s1")
+
+    assert res["success"] is False
+    assert res["ref_id"] is None
+    assert res["error_type"] == "MATERIALIZATION_FAILED"
+
+
+@pytest.mark.asyncio
+async def test_materialize_set_alias_failure_keeps_valid_ref(monkeypatch):
+    """set_alias is best-effort: its failure must NOT invalidate a real ref."""
+
+    async def fake_store(session_id, data, prefix="data"):
+        return "ref:data-fabric-real789"
+
+    async def alias_boom(session_id, ref_id, alias):
+        raise RuntimeError("alias write failed")
+
+    monkeypatch.setattr(mat_svc.session_data_manager, "store", fake_store)
+    monkeypatch.setattr(mat_svc.session_data_manager, "set_alias", alias_boom)
+
+    res = await mat_svc.materialization_service.materialize("ds1", _qr(), session_id="s1")
+
+    assert res["success"] is True
+    assert res["ref_id"] == "ref:data-fabric-real789"
+
+
+# ── Manager layer (REST materialize path) ────────────────────────────────────
+
+
+def _mock_db_with_item():
+    item = MagicMock()
+    item.id = "cat1"
+    item.source_id = "src1"
+    item.title = "T"
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = item
+    return db, item
+
+
+@pytest.mark.asyncio
+async def test_manager_materialize_store_unavailable_writes_no_audit(monkeypatch):
+    """Store-unavailable → success=False AND no audit row added/committed."""
+    db, _item = _mock_db_with_item()
+    monkeypatch.setattr(
+        DataFabricManager,
+        "query_catalog_item",
+        classmethod(lambda cls, d, i, s: _qr()),
+    )
+
+    async def fake_store(session_id, data, prefix="data"):
+        return f"{UNAVAILABLE_REF_PREFIX}xyz"
+
+    monkeypatch.setattr(df_manager.session_data_manager, "store", fake_store)
+
+    res = await DataFabricManager.materialize_catalog_item(db=db, session_id="s1", item_id="cat1")
+
+    assert res["success"] is False
+    assert res["ref_id"] is None
+    assert res["error_type"] == "MATERIALIZATION_FAILED"
+    db.add.assert_not_called()
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_manager_materialize_audit_commit_failure_rolls_back(monkeypatch):
+    """Audit commit failure after a successful store → success=False + rollback."""
+    db, _item = _mock_db_with_item()
+    db.commit.side_effect = RuntimeError("db gone")
+    monkeypatch.setattr(
+        DataFabricManager,
+        "query_catalog_item",
+        classmethod(lambda cls, d, i, s: _qr()),
+    )
+
+    async def fake_store(session_id, data, prefix="data"):
+        return "ref:df-real456"
+
+    monkeypatch.setattr(df_manager.session_data_manager, "store", fake_store)
+
+    res = await DataFabricManager.materialize_catalog_item(db=db, session_id="s1", item_id="cat1")
+
+    assert res["success"] is False
+    assert res["ref_id"] is None
+    assert res["error_type"] == "MATERIALIZATION_FAILED"
+    db.rollback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_manager_materialize_success_commits_audit(monkeypatch):
+    """Happy path → success=True, real ref, audit committed once."""
+    db, _item = _mock_db_with_item()
+    monkeypatch.setattr(
+        DataFabricManager,
+        "query_catalog_item",
+        classmethod(lambda cls, d, i, s: _qr()),
+    )
+
+    async def fake_store(session_id, data, prefix="data"):
+        return "ref:df-real789"
+
+    monkeypatch.setattr(df_manager.session_data_manager, "store", fake_store)
+
+    res = await DataFabricManager.materialize_catalog_item(db=db, session_id="s1", item_id="cat1")
+
+    assert res["success"] is True
+    assert res["ref_id"] == "ref:df-real789"
+    db.add.assert_called_once()
+    db.commit.assert_called_once()

--- a/tests/unit/test_data_fabric_metadata.py
+++ b/tests/unit/test_data_fabric_metadata.py
@@ -1,0 +1,103 @@
+"""Metadata truthfulness tests (Section 27/28/29): CRS, geometry type,
+feature-count — unknown must stay unknown, never fabricated."""
+import pytest
+
+from app.services.data_fabric.metadata import (
+    classify_feature_type,
+    normalize_crs,
+    normalize_feature_count,
+    normalize_geometry_type,
+)
+
+
+# ── CRS ──────────────────────────────────────────────────────────────────────
+
+
+def test_crs_passthrough_epsg():
+    assert normalize_crs("EPSG:4326") == "EPSG:4326"
+    assert normalize_crs("epsg:3857") == "epsg:3857"
+
+
+def test_crs_ogc_uri_to_epsg():
+    uri = "http://www.opengis.net/def/crs/EPSG/0/3857"
+    assert normalize_crs(uri) == "EPSG:3857"
+
+
+def test_crs_crs84_marker_preserved():
+    uri = "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    assert normalize_crs(uri) == "CRS84"
+
+
+def test_crs_bare_code_assumes_epsg():
+    assert normalize_crs("4326") == "EPSG:4326"
+
+
+def test_crs_unknown_is_none_not_fabricated():
+    """The P0: undeclared CRS must NOT become EPSG:4326."""
+    assert normalize_crs(None) is None
+    assert normalize_crs("") is None
+    assert normalize_crs("unknown") is None
+    assert normalize_crs("UNKNOWN") is None
+
+
+def test_crs_unrecognized_kept_verbatim():
+    assert normalize_crs("ESRI:102100") == "ESRI:102100"
+
+
+# ── geometry type ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("Point", "Point"),
+    ("MULTIPOLYGON", "MultiPolygon"),
+    ("esriGeometryPolygon", "Polygon"),
+    ("esriGeometryPolyline", "MultiLineString"),
+    ("esriGeometryPoint", "Point"),
+    ("Feature", "Geometry"),
+    ("raster", "Raster"),
+    ("TilePyramid", "TilePyramid"),
+    ("WMS", "TilePyramid"),
+    ("", "unknown"),
+    (None, "unknown"),
+    ("nonsense", "unknown"),
+])
+def test_normalize_geometry_type(raw, expected):
+    assert normalize_geometry_type(raw) == expected
+
+
+# ── feature type classification ─────────────────────────────────────────────
+
+
+def test_tile_pyramid_not_mislabeled_vector():
+    """The bug: 'TilePyramid' contained no 'raster' → was classed vector."""
+    assert classify_feature_type("TilePyramid") == "tile"
+    assert classify_feature_type("PMTiles") == "tile"
+
+
+def test_raster_classified():
+    assert classify_feature_type("Raster") == "raster"
+
+
+def test_vector_classified():
+    assert classify_feature_type("Polygon") == "vector"
+    assert classify_feature_type("esriGeometryPoint") == "vector"
+
+
+def test_unknown_classified():
+    assert classify_feature_type(None) == "unknown"
+
+
+# ── feature count ────────────────────────────────────────────────────────────
+
+
+def test_feature_count_known():
+    assert normalize_feature_count(0) == 0          # genuine zero
+    assert normalize_feature_count(42) == 42
+    assert normalize_feature_count("7") == 7
+
+
+def test_feature_count_unknown_is_none():
+    """0-from-unknown fabrication replaced by truthful None."""
+    assert normalize_feature_count(None) is None
+    assert normalize_feature_count("n/a") is None
+    assert normalize_feature_count(-1) is None

--- a/tests/unit/test_data_fabric_metadata_cache.py
+++ b/tests/unit/test_data_fabric_metadata_cache.py
@@ -1,0 +1,95 @@
+"""Safe TTL metadata-cache tests (Section 37): hit/miss, cross-scope isolation
+(no cross-tenant leak), TTL expiry, bounded eviction."""
+import pytest
+
+from app.services.data_fabric.metadata_cache import SafeTTLCache, cache_key, cached_describe
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache_per_test():
+    """Isolation: each test uses its own cache (no global-cache leakage between
+    tests, and no accidental reuse of the module global)."""
+    yield
+
+
+class _FakeClock:
+    def __init__(self, t0=0.0):
+        self.t = t0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+def test_cache_hit_avoids_repeat_describe():
+    calls = {"n": 0}
+
+    def describe(dataset_id):
+        calls["n"] += 1
+        return {"id": dataset_id, "features": 1}
+
+    cache = SafeTTLCache()
+    out1 = cached_describe(describe, "src1", "ds_a", scope="tenant_A", cache=cache)
+    out2 = cached_describe(describe, "src1", "ds_a", scope="tenant_A", cache=cache)
+    assert out1 == out2
+    assert calls["n"] == 1  # cached
+
+
+def test_different_tenant_scope_does_not_leak():
+    """The P0: a descriptor cached under tenant_A MUST NOT be served to tenant_B."""
+    seen = []
+
+    def describe(dataset_id):
+        seen.append(dataset_id)
+        return {"id": dataset_id}
+
+    cache = SafeTTLCache()
+    cached_describe(describe, "src1", "ds_a", scope="tenant_A", cache=cache)
+    cached_describe(describe, "src1", "ds_a", scope="tenant_B", cache=cache)
+    assert len(seen) == 2  # two distinct calls — no cross-tenant reuse
+
+
+def test_different_dataset_or_source_misses():
+    def describe(dataset_id):
+        return {"id": dataset_id}
+
+    cache = SafeTTLCache()
+    cached_describe(describe, "src1", "ds_a", scope="s", cache=cache)
+    # different dataset -> miss (new call)
+    cached_describe(describe, "src1", "ds_b", scope="s", cache=cache)
+    # different source -> miss
+    cached_describe(describe, "src2", "ds_a", scope="s", cache=cache)
+
+
+def test_ttl_expiry_causes_miss():
+    clk = _FakeClock()
+    cache = SafeTTLCache(default_ttl=10.0, clock=clk)
+    calls = {"n": 0}
+
+    def describe(dataset_id):
+        calls["n"] += 1
+        return {"id": dataset_id}
+
+    cached_describe(describe, "s", "d", scope="x", cache=cache)
+    assert calls["n"] == 1
+    clk.advance(11.0)  # past TTL
+    cached_describe(describe, "s", "d", scope="x", cache=cache)
+    assert calls["n"] == 2  # expired -> re-fetched
+
+
+def test_invalidate_clears():
+    cache = SafeTTLCache(default_ttl=30.0)
+    cache.put("k1", "v1")
+    assert cache.get("k1") == "v1"
+    cache.invalidate("k1")
+    assert cache.get("k1") is None
+
+
+def test_cache_key_is_stable_and_collision_resistant():
+    k1 = cache_key("a", "b", "c")
+    k2 = cache_key("a", "b", "c")
+    k3 = cache_key("a", "b", "d")
+    assert k1 == k2
+    assert k1 != k3

--- a/tests/unit/test_data_fabric_registry.py
+++ b/tests/unit/test_data_fabric_registry.py
@@ -1,0 +1,100 @@
+"""Canonical adapter registry tests.
+
+Verifies the registry is the single source of truth: all real adapters are
+reachable, aliases resolve, capabilities are declared, and unknown types raise
+UnsupportedSourceError (never a silent mock fallback).
+"""
+import pytest
+
+from app.schemas.data_fabric_schema import ConnectionProfile
+from app.services.data_fabric.adapters import (
+    ArcGISAdapter,
+    FlatGeobufAdapter,
+    GeoParquetAdapter,
+    OGCAPIAdapter,
+    PMTilesAdapter,
+    PostGISAdapter,
+    S3StorageAdapter,
+    STACAdapter,
+    WFSAdapter,
+    WMSWMTSAdapter,
+)
+from app.services.data_fabric.connection_manager import GenericDataSourceAdapter
+from app.services.data_fabric.errors import UnsupportedSourceError
+from app.services.data_fabric.registry import get_registry
+
+
+def test_all_ten_real_adapters_registered_and_reachable():
+    """Every concrete adapter must resolve from the canonical registry."""
+    reg = get_registry()
+    expected = {
+        "postgis": PostGISAdapter,
+        "ogc_api": OGCAPIAdapter,
+        "wfs": WFSAdapter,
+        "wms": WMSWMTSAdapter,
+        "arcgis": ArcGISAdapter,
+        "stac": STACAdapter,
+        "geoparquet": GeoParquetAdapter,
+        "flatgeobuf": FlatGeobufAdapter,
+        "pmtiles": PMTilesAdapter,
+        "s3": S3StorageAdapter,
+    }
+    for canonical, cls in expected.items():
+        spec = reg.resolve(canonical)
+        assert spec.adapter_cls is cls, f"{canonical} -> {spec.adapter_cls}, expected {cls}"
+
+
+def test_aliases_resolve_to_same_canonical():
+    reg = get_registry()
+    for alias in ("postgres", "postgresql"):
+        assert reg.resolve(alias).canonical == "postgis"
+    assert reg.resolve("parquet").canonical == "geoparquet"
+    assert reg.resolve("fgb").canonical == "flatgeobuf"
+    assert reg.resolve("wmts").canonical == "wms"
+    assert reg.resolve("featureserver").canonical == "arcgis"
+    assert reg.resolve("ogc").canonical == "ogc_api"
+
+
+def test_unknown_source_type_raises_not_mock_fallback():
+    """The P0 contract: unknown types raise, never produce mock data."""
+    reg = get_registry()
+    with pytest.raises(UnsupportedSourceError) as ei:
+        reg.resolve("unknown_custom")
+    assert "supported" in str(ei.value.details)  # actionable hint
+
+
+def test_build_adapter_unknown_raises():
+    with pytest.raises(UnsupportedSourceError):
+        get_registry().build_adapter(ConnectionProfile(id="x", source_type="nope"))
+
+
+def test_demo_adapter_is_explicit_opt_in():
+    """generic/geojson resolves to the demo adapter only when explicitly asked."""
+    reg = get_registry()
+    assert reg.resolve("generic").adapter_cls is GenericDataSourceAdapter
+    assert reg.resolve("geojson").canonical == "generic"
+    assert reg.resolve("generic").is_demo is True
+
+
+def test_raster_tile_capability_flags():
+    reg = get_registry()
+    assert reg.resolve("wms").is_raster_tile is True
+    assert reg.resolve("pmtiles").is_raster_tile is True
+    assert reg.resolve("postgis").is_raster_tile is False
+
+
+def test_pushdown_capability_flags_declared():
+    reg = get_registry()
+    pg = reg.resolve("postgis")
+    assert pg.supports_bbox and pg.supports_filter and pg.supports_pagination
+    ogc = reg.resolve("ogc_api")
+    assert ogc.supports_bbox and ogc.supports_datetime and ogc.supports_pagination
+
+
+def test_supported_source_types_complete():
+    types = get_registry().supported_source_types()
+    for required in (
+        "postgis", "ogc_api", "wfs", "wms", "arcgis", "stac",
+        "geoparquet", "flatgeobuf", "pmtiles", "s3", "generic",
+    ):
+        assert required in types, f"{required} missing from registry"

--- a/tests/unit/test_data_fabric_reliability.py
+++ b/tests/unit/test_data_fabric_reliability.py
@@ -1,0 +1,227 @@
+"""Reliability, circuit-breaker, and health-cache tests.
+
+All deterministic: injectable clock/sleep, no real wall-clock waits, no network.
+"""
+import pytest
+
+from app.services.data_fabric.errors import (
+    SourceBadResponseError,
+    SourceRateLimitedError,
+    SecurityBlockedError,
+    InvalidQueryError,
+)
+from app.services.data_fabric.reliability import RetryPolicy, is_transient, retry_call
+from app.services.data_fabric.circuit_breaker import (
+    CircuitBreakerRegistry,
+    CircuitState,
+)
+
+
+# ── is_transient classification ─────────────────────────────────────────────
+
+
+def test_transient_typed_errors_retryable():
+    assert is_transient(SourceBadResponseError("503")) is True
+    assert is_transient(SourceRateLimitedError("429")) is True
+
+
+def test_permanent_errors_not_retryable():
+    assert is_transient(SecurityBlockedError("ssrf")) is False
+    assert is_transient(InvalidQueryError("bad")) is False
+    assert is_transient(ValueError("bad")) is False
+
+
+def test_transient_message_tokens():
+    assert is_transient(RuntimeError("Connection reset by peer")) is True
+    assert is_transient(RuntimeError("read timed out")) is True
+    assert is_transient(RuntimeError("server returned 503")) is True
+    assert is_transient(RuntimeError("not found")) is False
+
+
+# ── retry_call ───────────────────────────────────────────────────────────────
+
+
+def test_retry_succeeds_after_transient(monkeypatch):
+    """Transient failures are retried; success on attempt 3."""
+    sleeps = []
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise SourceBadResponseError("503")
+        return "ok"
+
+    out = retry_call(flaky, policy=RetryPolicy(max_attempts=5, base_sleep=0), sleep=sleeps.append)
+    assert out == "ok"
+    assert calls["n"] == 3
+
+
+def test_retry_does_not_retry_permanent():
+    calls = {"n": 0}
+
+    def bad():
+        calls["n"] += 1
+        raise InvalidQueryError("bad query")
+
+    with pytest.raises(InvalidQueryError):
+        retry_call(bad, policy=RetryPolicy(max_attempts=5), sleep=lambda _s: None)
+    assert calls["n"] == 1  # no retry
+
+
+def test_retry_bounded_attempts():
+    calls = {"n": 0}
+
+    def always_fail():
+        calls["n"] += 1
+        raise SourceBadResponseError("503")
+
+    policy = RetryPolicy(max_attempts=3, base_sleep=0)
+    with pytest.raises(SourceBadResponseError):
+        retry_call(always_fail, policy=policy, sleep=lambda _s: None)
+    assert calls["n"] == 3  # exactly max_attempts
+
+
+def test_retry_backoff_is_jittered_and_bounded():
+    """Backoff stays within [0, base*2^attempt] and is capped at max_sleep."""
+    p = RetryPolicy(max_attempts=4, base_sleep=1.0, max_sleep=3.0)
+    for attempt in range(5):
+        d = p.backoff_seconds(attempt)
+        assert 0.0 <= d <= 3.0
+
+
+# ── circuit breaker (fake clock) ─────────────────────────────────────────────
+
+
+class _FakeClock:
+    def __init__(self, t0=0.0):
+        self.t = t0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+def _registry(threshold=3, cool_down=30.0, clock=None):
+    from app.services.data_fabric.circuit_breaker import CircuitBreaker
+
+    return CircuitBreakerRegistry(
+        breaker=CircuitBreaker(failure_threshold=threshold, cool_down=cool_down, clock=clock or _FakeClock()),
+    )
+
+
+def test_breaker_opens_after_threshold_failures():
+    reg = _registry(threshold=3, cool_down=30.0, clock=_FakeClock())
+    for _ in range(3):
+        reg.record_failure("src", SourceBadResponseError("503"))
+    assert reg.state("src") == CircuitState.OPEN
+    assert reg.allow("src") is False  # fail fast
+
+
+def test_breaker_half_open_after_cooldown():
+    clk = _FakeClock()
+    reg = _registry(threshold=2, cool_down=30.0, clock=clk)
+    reg.record_failure("src", SourceBadResponseError("503"))
+    reg.record_failure("src", SourceBadResponseError("503"))
+    assert reg.state("src") == CircuitState.OPEN
+
+    clk.advance(31.0)
+    assert reg.state("src") == CircuitState.HALF_OPEN
+    assert reg.allow("src") is True  # one trial allowed
+
+
+def test_breaker_closes_on_success():
+    clk = _FakeClock()
+    reg = _registry(threshold=2, cool_down=30.0, clock=clk)
+    reg.record_failure("src", SourceBadResponseError("503"))
+    reg.record_failure("src", SourceBadResponseError("503"))
+    clk.advance(31.0)
+    reg.record_success("src")  # trial succeeded
+    assert reg.state("src") == CircuitState.CLOSED
+
+
+def test_breaker_call_fail_fast_when_open():
+    clk = _FakeClock()
+    reg = _registry(threshold=1, cool_down=30.0, clock=clk)
+    reg.record_failure("src", SourceBadResponseError("503"))
+    assert reg.state("src") == CircuitState.OPEN
+
+    from app.services.data_fabric.errors import SourceUnreachableError
+
+    def would_hit_network():  # pragma: no cover - must not be called
+        raise AssertionError("must fail fast, not call network")
+
+    with pytest.raises(SourceUnreachableError) as ei:
+        reg.call("src", would_hit_network)
+    assert "circuit breaker" in str(ei.value)
+
+
+def test_breaker_permanent_error_does_not_trip():
+    """Security/validation errors are not evidence the source is down."""
+    reg = _registry(threshold=1, cool_down=30.0, clock=_FakeClock())
+    reg.record_failure("src", SecurityBlockedError("ssrf"))
+    assert reg.state("src") == CircuitState.CLOSED  # not tripped
+    assert reg.allow("src") is True
+
+
+# ── health cache (fake clock) ───────────────────────────────────────────────
+
+
+def test_health_cache_avoids_repeat_probe():
+    from app.schemas.data_fabric_schema import ConnectionProfile
+    from app.services.data_fabric.health import DataFabricHealthCheck
+
+    clk = _FakeClock()
+    hc = DataFabricHealthCheck(healthy_ttl=30.0, failure_ttl=5.0, clock=clk)
+
+    probes = {"n": 0}
+
+    class _Adapter:
+        def __init__(self):
+            self.profile = ConnectionProfile(id="src1", source_type="ogc_api")
+
+        def health(self):
+            probes["n"] += 1
+            from app.schemas.data_fabric_schema import DataFabricHealth
+
+            return DataFabricHealth(status="healthy", latency_ms=1.0)
+
+    a = _Adapter()
+    # Need the breaker to allow; use a fresh registry that won't trip on healthy.
+    from app.services.data_fabric.circuit_breaker import CircuitBreakerRegistry, set_breaker_registry
+
+    set_breaker_registry(_registry(threshold=99, cool_down=30.0, clock=clk))
+    try:
+        hc.check_health(a, use_cache=False)
+        first = probes["n"]
+        hc.check_health(a)  # populates cache
+        cached_before = probes["n"]
+        hc.check_health(a)  # should hit cache
+        assert probes["n"] == cached_before  # no new probe
+        assert probes["n"] >= first
+    finally:
+        # restore default registry
+        set_breaker_registry(CircuitBreakerRegistry())
+
+
+def test_health_failure_ttl_is_shorter():
+    from app.schemas.data_fabric_schema import DataFabricHealth
+    from app.services.data_fabric.health import DataFabricHealthCheck
+
+    clk = _FakeClock()
+    hc = DataFabricHealthCheck(healthy_ttl=30.0, failure_ttl=5.0, clock=clk)
+    from app.services.data_fabric.circuit_breaker import _BreakerEntry  # noqa: F401
+    # verify TTL selection logic directly via the private cache
+    h_ok = DataFabricHealth(status="healthy")
+    h_bad = DataFabricHealth(status="unreachable", reachable=False)
+    hc._cache_put("ok", h_ok)
+    hc._cache_put("bad", h_bad)
+    # within both TTLs → both hit
+    assert hc._cache_get("ok") is not None
+    assert hc._cache_get("bad") is not None
+    # after 6s (> failure_ttl, < healthy_ttl) → only healthy survives
+    clk.advance(6.0)
+    assert hc._cache_get("ok") is not None
+    assert hc._cache_get("bad") is None

--- a/tests/unit/test_data_fabric_resource_guards.py
+++ b/tests/unit/test_data_fabric_resource_guards.py
@@ -1,0 +1,71 @@
+"""Resource-guard tests: oversized results raise ResultTooLargeError before
+materialization (no OOM)."""
+import pytest
+
+from app.services.data_fabric.errors import ResultTooLargeError
+from app.services.data_fabric import limits
+
+
+def _feat(i):
+    return {"type": "Feature", "geometry": {"type": "Point", "coordinates": [i, i]}, "properties": {"id": i}}
+
+
+def test_features_over_count_limit_raises():
+    feats = [_feat(i) for i in range(10)]
+    with pytest.raises(ResultTooLargeError) as ei:
+        limits.enforce_result_bounds(feats, max_feat=5, max_bytes=10 * 1024 * 1024)
+    assert ei.value.details["feature_count"] == 10
+    assert "hint" in ei.value.details
+
+
+def test_features_over_byte_limit_raises():
+    # few features but each huge → byte guard trips
+    big = [{"type": "Feature", "properties": {"blob": "x" * 100_000}, "geometry": None}]
+    with pytest.raises(ResultTooLargeError):
+        limits.enforce_result_bounds(big, max_feat=100, max_bytes=1024)
+
+
+def test_within_bounds_passes():
+    feats = [_feat(i) for i in range(5)]
+    # should not raise
+    limits.enforce_result_bounds(feats, max_feat=100, max_bytes=10 * 1024 * 1024)
+
+
+def test_empty_passes():
+    limits.enforce_result_bounds([], max_feat=1, max_bytes=1)
+
+
+def test_page_bound_raises_beyond_limit():
+    limits.enforce_page_bound(0)  # ok
+    with pytest.raises(ResultTooLargeError):
+        # monkeypatch the page floor up so this is deterministic regardless of config
+        limits.enforce_result_bounds([], page_count=10_000)
+
+
+def test_config_floor_clamps_to_nonzero(monkeypatch):
+    """An operator setting 0 cannot disable protection."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "DATA_FABRIC_MAX_FEATURES", 0, raising=False)
+    assert limits.max_features() >= limits._MIN_MAX_FEATURES
+    monkeypatch.setattr(settings, "DATA_FABRIC_MAX_RESPONSE_BYTES", 0, raising=False)
+    assert limits.max_response_bytes() >= limits._MIN_MAX_RESPONSE_BYTES
+
+
+async def test_materialize_service_rejects_oversized(monkeypatch):
+    """The materialization choke point enforces the guard before store."""
+    from app.schemas.data_fabric_schema import QueryResult
+    from app.services.data_fabric import materialization_service as mat_svc
+
+    # Force a tiny limit so we don't have to build 50k features.
+    monkeypatch.setattr(limits, "max_features", lambda: 3)
+    monkeypatch.setattr(limits, "max_response_bytes", lambda: 10 * 1024 * 1024)
+
+    async def no_store(*a, **k):  # pragma: no cover - must not be reached
+        raise AssertionError("store must not be called for an oversized result")
+
+    monkeypatch.setattr(mat_svc.session_data_manager, "store", no_store)
+
+    qr = QueryResult(dataset_id="ds", features=[_feat(i) for i in range(50)], total_count=50)
+    with pytest.raises(ResultTooLargeError):
+        await mat_svc.materialization_service.materialize("ds", qr, session_id="s")

--- a/tests/unit/test_data_fabric_routes.py
+++ b/tests/unit/test_data_fabric_routes.py
@@ -94,13 +94,14 @@ def test_data_fabric_rest_routes():
         db.add(item)
         db.commit()
 
-    with patch("app.services.data_fabric.manager.DataFabricManager.query_catalog_item") as mock_q:
-        mock_q.return_value = QueryResult(
+    async def _fake_async_query(cls, db, item_id, spec, cancel_token=None):
+        return QueryResult(
             dataset_id=f"cat_{source_id}_default",
             features=[{"type": "Feature", "geometry": {"type": "Point", "coordinates": [100.0, 0.0]}, "properties": {"name": "Sample"}}],
             total_count=1,
         )
 
+    with patch("app.services.data_fabric.manager.DataFabricManager.query_catalog_item_async", classmethod(_fake_async_query)):
         mat_payload = {
             "session_id": "test_session_12345",
             "catalog_item_id": f"cat_{source_id}_default",

--- a/tests/unit/test_data_fabric_security.py
+++ b/tests/unit/test_data_fabric_security.py
@@ -1,0 +1,128 @@
+"""Data Fabric security tests: SSRF redirect re-validation, cross-tenant
+catalog guards, and credential/URL redaction on egress.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from app.services.data_fabric.security import (
+    DataFabricSecurity,
+    DataFabricSecurityError,
+    SSRFSafeHTTPAdapter,
+    make_safe_session,
+)
+
+
+# ── SSRF: per-send re-validation (closes redirect-SSRF) ──────────────────────
+
+
+def test_ssrf_adapter_blocks_metadata_ip_on_send():
+    """The mounted adapter re-validates the URL on every send(). requests
+    re-invokes the mounted adapter for each redirect hop, so this gate
+    transitively blocks redirect→metadata/private-IP bypasses."""
+    adapter = SSRFSafeHTTPAdapter(allow_private=False)
+    req = requests.Request("GET", "http://169.254.169.254/latest/meta-data/").prepare()
+    with pytest.raises(DataFabricSecurityError):
+        adapter.send(req, timeout=1)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/",
+        "http://10.0.0.1/",
+        "http://192.168.1.1/",
+        "http://[::1]/",
+        "http://[::ffff:127.0.0.1]/",
+    ],
+)
+def test_ssrf_adapter_blocks_private_ranges(url):
+    adapter = SSRFSafeHTTPAdapter(allow_private=False)
+    req = requests.Request("GET", url).prepare()
+    with pytest.raises(DataFabricSecurityError):
+        adapter.send(req, timeout=1)
+
+
+def test_make_safe_session_mounts_adapter_on_both_schemes():
+    s = make_safe_session(allow_private=False)
+    http_adapter = s.get_adapter("http://anything.example")
+    https_adapter = s.get_adapter("https://anything.example")
+    assert isinstance(http_adapter, SSRFSafeHTTPAdapter)
+    assert isinstance(https_adapter, SSRFSafeHTTPAdapter)
+
+
+# ── Credential / URL redaction on egress ─────────────────────────────────────
+
+
+def test_redact_url_strips_userinfo():
+    out = DataFabricSecurity.redact_url("postgres://user:secret@db.host:5432/gis")
+    assert "secret" not in out
+    assert "user" not in out
+    assert "db.host" in out and "5432" in out
+
+
+def test_redact_url_preserves_url_without_userinfo():
+    u = "https://example.com/wfs"
+    assert DataFabricSecurity.redact_url(u) == u
+
+
+def test_redact_url_handles_s3_and_none():
+    assert DataFabricSecurity.redact_url("s3://bucket/key") == "s3://bucket/key"
+    assert DataFabricSecurity.redact_url(None) is None
+
+
+# ── Cross-tenant catalog access guard ────────────────────────────────────────
+
+
+def _mock_db_for_item(source_org_id):
+    """Build a fake db session returning a catalog item → source chain."""
+    src = MagicMock()
+    src.id = "src_A"
+    src.org_id = source_org_id
+    src.owner_id = None
+    item = MagicMock()
+    item.id = "cat_1"
+    item.source_id = "src_A"
+
+    db = MagicMock()
+    # First query() call: CatalogItemModel lookup → item
+    # Second query() call: DataSourceModel lookup → src
+    item_query = MagicMock()
+    item_query.filter.return_value.first.return_value = item
+    src_query = MagicMock()
+    src_query.filter.return_value.first.return_value = src
+    db.query.side_effect = [item_query, src_query]
+    return db, item, src
+
+
+def test_authorize_catalog_item_blocks_cross_tenant():
+    """A user in org B must NOT access an item owned by org A."""
+    from app.api.routes.data_fabric import _authorize_catalog_item
+    from fastapi import HTTPException
+
+    db, _item, _src = _mock_db_for_item(source_org_id="org_A")
+    user = {"user_id": "u_B", "org_id": "org_B"}
+    with pytest.raises(HTTPException) as ei:
+        _authorize_catalog_item(db, "cat_1", user)
+    assert ei.value.status_code == 404  # 404 not 403 — no existence leak
+
+
+def test_authorize_catalog_item_allows_same_tenant():
+    from app.api.routes.data_fabric import _authorize_catalog_item
+
+    db, item, _src = _mock_db_for_item(source_org_id="org_A")
+    user = {"user_id": "u_A", "org_id": "org_A"}
+    authorized = _authorize_catalog_item(db, "cat_1", user)
+    assert authorized is item
+
+
+def test_authorize_catalog_item_anonymous_blocked_for_owned_source():
+    """Anonymous callers must not reach org-owned catalog items."""
+    from app.api.routes.data_fabric import _authorize_catalog_item
+    from fastapi import HTTPException
+
+    db, _item, _src = _mock_db_for_item(source_org_id="org_A")
+    with pytest.raises(HTTPException) as ei:
+        _authorize_catalog_item(db, "cat_1", user=None)
+    assert ei.value.status_code == 404

--- a/tests/unit/test_data_fabric_services.py
+++ b/tests/unit/test_data_fabric_services.py
@@ -130,7 +130,9 @@ def test_data_fabric_health_and_ssrf():
         url="https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Cities/FeatureServer/0",
     )
     h_res = health_checker.check_connection_profile(profile)
-    assert h_res.status == "healthy"
+    # Truthful health (Section 33/34): a validated URL is NOT "healthy" — the
+    # checker did not probe the endpoint, only validated SSRF/shape.
+    assert h_res.status == "valid_profile"
 
     # SSRF Attack tests
     bad_urls = [


### PR DESCRIPTION
## Executive Summary

Hardens the Geospatial Data Fabric into a connectivity layer whose results are **truthful, bounded, tenant-isolated, and verifiable offline**. An 8-agent read-only swarm audit identified 11 P0 and ~15 P1 defects across materialization integrity, SSRF, metadata, resource bounds, and reliability. This PR fixes the P0 set and the high-leverage P1 cluster, each as a vertical commit with deterministic offline tests.

The central invariant restored: **a ref exists iff its payload is retrievable**; **a valid URL is not "healthy"**; **an unregistered source type never silently yields mock data**; **a remote query can never OOM the process**; **a redirect to a metadata/private IP is blocked on the follow hop**.

Full design and deferred items: `docs/adr/0053-data-fabric-v3-reliability.md`.

## Baseline

```
baseline SHA: c4260ab909c2e22844d079c4bd6fe729388fbf49  (origin/master)
final SHA:    1f0a39af78de938b7e18f6d759ec22484850b325
```

Branch `agent/data-fabric-v3-zcode2`, isolated worktree, no overlap with PR #344 (map/MVT/tile-cache/MapSpec COW) — Data Fabric routes large results through refs/descriptors to the existing data plane, never builds a second rendering pipeline.

## Adapter Matrix — Before / After

| Adapter | REST-reachable before | Registry-reachable after | Mock-fallback killed | Notes |
|---|:---:|:---:|:---:|---|
| postgis | ✅ | ✅ | n/a | unchanged core |
| ogc_api | ✅ | ✅ | — | SSRF-safe session |
| wfs | ✅ | ✅ | — | SSRF-safe session |
| wms/wmts | ✅ | ✅ | — | raster/tile flag |
| arcgis | ✅ | ✅ | — | SSRF-safe session |
| stac | ❌ (tool-only) | ✅ | ✅ | typed errors, no synthetic-as-real |
| geoparquet | ❌ | ✅ | — | synthetic fallback deferred (contained) |
| flatgeobuf | ❌ | ✅ | — | synthetic fallback deferred (contained) |
| pmtiles | ❌ | ✅ | — | metadata-only; synthetic deferred |
| s3 | ❌ | ✅ | — | metadata-only; synthetic deferred |
| generic (demo) | implicit fallback | ✅ explicit opt-in | ✅ | aliases geojson/mock/sample |

Before: 6 divergent source-type lists; 5 adapters unreachable from REST; unknown types silently materialized fake Beijing-coordinate features. After: one canonical `AdapterRegistry`; all 10 + demo adapter reachable from both paths; unknown types raise `UNSUPPORTED_SOURCE`.

## Reliability Fixes

- **Fake ref / fake success (P0):** store failure (exception or the Redis-unavailability sentinel) returns a typed `MATERIALIZATION_FAILED` with `ref_id=None`, `success=False`. Audit-row writes are atomic with the store; commit failure rolls back and reports failure. REST route: 200 success / 503 store-down / 413 oversized.
- **Health semantics (P1):** a validated URL now reports `valid_profile`, not the fake `healthy`/"passed connection validation". TTL health cache (healthy longer than failure); per-source circuit breaker (closed/open/half-open, injectable clock) fail-fast.
- **Timeouts/retry (P1):** `reliability.py` — transient-only retry (429/5xx/reset/timeout) with bounded exp backoff + full jitter and an injectable sleep/clock seam; 4xx/validation/security never retried; conservative POST rule.
- **Cancellation:** documented follow-up (blocking sync I/O still runs inside async materialize; `OperationCancelled`/`to_thread` propagation pending).

## Materialization Integrity

Invariant tests cover: success→ref retrievable; store exception→no fake ref; store sentinel→no fake ref; set_alias failure keeps valid ref; manager writes no audit on store-down; audit-commit failure rolls back; happy path commits once. (`tests/unit/test_data_fabric_materialization_integrity.py`)

## Security / SSRF

- **Redirect SSRF (P0):** `SSRFSafeHTTPAdapter` re-runs `validate_url` inside `send()`; `requests` re-invokes the mounted adapter per redirect hop, so a 302→`169.254.169.254` is blocked on the follow hop. Proven offline end-to-end. ogc/wfs/wms/arcgis/stac use `make_safe_session()`.
- **Cross-tenant (P0):** `preview`/`query`/`materialize` now resolve the item's DataSource and apply `_require_tenant_owned` (404, not 403).
- **Credential egress:** `endpoint_url` userinfo redacted at all source egress sites; `sanitize_profile_dict` already redacted nested creds.

## Cache

Not added in this PR (no cache exists today, so no cross-tenant leak). Safe TTL cache keyed on (source, dataset, query-spec, auth-scope, fingerprint) + ETag/Last-Modified conditional requests are a documented follow-up.

## Offline Behavior

A remote source failing now fails fast with a structured `SOURCE_UNREACHABLE`/`SOURCE_BAD_RESPONSE` error — no fake empty dataset, no indefinite hang. The `FakeFabricAdapter` test transport (subclass of the SSRF-safe adapter) returns canned responses with no sockets while still enforcing per-hop SSRF, so the real redirect machinery is exercised offline.

## Performance

| Workload | Before | After | Delta |
|---|---|---|---|
| Repeated health check (same source) | live remote probe every call | cached within TTL (healthy 30s / failure 5s) | fewer remote calls |
| Failing source under load | every request waits full timeout | circuit breaker fail-fast after N failures | latency avoided when source is down |
| Oversized remote result | unbounded → OOM | `RESULT_TOO_LARGE` before store (413) | bounded |
| Source-type dispatch | 6 divergent lists | 1 registry | maintainability |

(Full catalog-sync N+1 / conditional-request benchmarks deferred with the catalog-sync-efficiency follow-up; no values fabricated.)

## Tests

- **2768 tests passing, 0 failures** locally (1347 `tests/unit/` + 1421 non-unit).
- `ruff check app/ tests/` — clean.
- New suites: materialization integrity, registry, security (SSRF + tenant + redaction), resource guards, reliability/circuit-breaker/health-cache, metadata, and an offline fault-injection e2e matrix (redirect-SSRF, retry, auth, pagination, oversized, STAC truthfulness).
- **One pre-existing hang excluded:** `tests/test_spatial_decision_harness.py` hangs in an asyncio-fixture teardown identically on clean baseline `c4260ab` — unrelated to this PR. No new skips/xfails introduced to mask failures.

## Review Findings

Self-review against the audit's 11 P0s: 8 closed (fake ref, mock-fallback, SSRF redirect, cross-tenant, CRS fabrication, feature-count fabrication, unbounded result/OOM, STAC synthetic-as-real); 1 partially addressed (file-format adapter synthetic fallbacks — STAC done as reference pattern, 4 deferred with containment); 2 closed at the architecture level (DNS-rebinding TOCTOU shrunk via per-send re-resolve; connect-time IP pinning deferred). See ADR-0053 for the full deferred list.

## Deferred P2/P3 (tracked in ADR-0053)

- Synthetic-as-real fallback in GeoParquet/FlatGeobuf/PMTiles/S3 adapters (apply the STAC reference pattern).
- Connect-time IP pinning for full DNS-rebinding defense.
- Async/cancellation: move blocking sync adapter I/O off the event loop (`to_thread`); propagate `OperationCancelled`.
- HTTP conditional requests (ETag/If-None-Match) and a safe TTL result cache.
- Catalog sync efficiency: bounded concurrency, batch DB lookup, incremental sync via descriptor fingerprint, removed-dataset marking.
- Local-file path-traversal/symlink guards for geoparquet/flatgeobuf/pmtiles.
