### PR TITLE
feat(agent): converge planning, tool selection and execution recovery

### DIFF
--- a/app/services/chat/context_assembler.py
+++ b/app/services/chat/context_assembler.py
@@ -126,6 +126,7 @@ class ChatContextAssembler:
         session_id: str,
         messages: List[dict],
         project_id: Optional[str] = None,
+        tools_payload_chars: int = 0,
     ) -> ContextAssemblyResult:
         """
         Assemble the complete LLM request message list from session state,
@@ -139,6 +140,9 @@ class ChatContextAssembler:
         about the active project — see also the
         ``get_session_metadata`` path which is still a no-op for
         ``project_id``).
+
+        ``tools_payload_chars``（design-v3 §4）：调用方把已选出的工具 schema
+        序列化字节数传入，软计入 estimated_tokens（仅影响估算，不改变任何截断）。
         """
         if not messages:
             return ContextAssemblyResult(
@@ -148,7 +152,6 @@ class ChatContextAssembler:
         from app.services.chat.context_builder import (
             build_last_analysis_context,
             build_map_state_summary,
-            build_plan_block,
             truncate_history_by_budget,
             _build_truncation_notice,
         )
@@ -221,7 +224,9 @@ class ChatContextAssembler:
 
         plan = get_plan(session_id)
         if plan is not None:
-            head.append({"role": "system", "content": build_plan_block(plan)})
+            # design-v3 §4：计划块单一渲染来源（plan_orchestrator.render_plan_block）。
+            from app.services.chat.plan_orchestrator import render_plan_block
+            head.append({"role": "system", "content": render_plan_block(plan)})
 
         last_ctx = build_last_analysis_context(messages)
         if last_ctx:
@@ -240,6 +245,10 @@ class ChatContextAssembler:
         total_tokens = sum(
             _estimate_tokens(str(m.get("content", ""))) for m in head
         )
+        if tools_payload_chars and tools_payload_chars > 0:
+            # design-v3 §4：工具 schema 是 ASCII-heavy JSON，按 4 字符 ≈ 1 token
+            # 软计入。只影响估算与可观测性，不改变任何截断行为。
+            total_tokens += int(tools_payload_chars / 4) + 1
 
         return ContextAssemblyResult(
             messages=head,

--- a/app/services/chat/context_assembler.py
+++ b/app/services/chat/context_assembler.py
@@ -127,6 +127,7 @@ class ChatContextAssembler:
         messages: List[dict],
         project_id: Optional[str] = None,
         tools_payload_chars: int = 0,
+        tools_payload: Optional[str] = None,
     ) -> ContextAssemblyResult:
         """
         Assemble the complete LLM request message list from session state,
@@ -141,8 +142,14 @@ class ChatContextAssembler:
         ``get_session_metadata`` path which is still a no-op for
         ``project_id``).
 
-        ``tools_payload_chars``（design-v3 §4）：调用方把已选出的工具 schema
-        序列化字节数传入，软计入 estimated_tokens（仅影响估算，不改变任何截断）。
+        ``tools_payload``（P3 #3，优先）：调用方把已选出的工具 schema 序列化
+        JSON（``json.dumps(..., ensure_ascii=False)``）传入，按与历史压缩相同的
+        ``_estimate_tokens`` 权重软计入 estimated_tokens（CJK 1 char ≈ 1.5
+        tokens、ASCII 4 char ≈ 1 token——不再用 ASCII-heavy 近似）。只影响估算，
+        不改变任何截断行为。
+
+        ``tools_payload_chars``（兼容旧调用——测试/benchmark 传字符数）：仅在
+        ``tools_payload`` 未提供时使用 chars/4 近似，语义不变。
         """
         if not messages:
             return ContextAssemblyResult(
@@ -245,9 +252,14 @@ class ChatContextAssembler:
         total_tokens = sum(
             _estimate_tokens(str(m.get("content", ""))) for m in head
         )
-        if tools_payload_chars and tools_payload_chars > 0:
-            # design-v3 §4：工具 schema 是 ASCII-heavy JSON，按 4 字符 ≈ 1 token
-            # 软计入。只影响估算与可观测性，不改变任何截断行为。
+        if tools_payload:
+            # P3 #3：CJK-aware —— 与历史压缩同一权重（CJK 1 char ≈ 1.5 tokens、
+            # ASCII 4 char ≈ 1 token）。软计入，只影响估算与可观测性，不改变
+            # 任何截断行为。工具 schema 里中文描述（描述/参数说明）越多，估算
+            # 越接近真实 token 数。
+            total_tokens += _estimate_tokens(tools_payload)
+        elif tools_payload_chars and tools_payload_chars > 0:
+            # 兼容旧调用（测试/benchmark 只传字符数）：ASCII-heavy 近似。
             total_tokens += int(tools_payload_chars / 4) + 1
 
         return ContextAssemblyResult(

--- a/app/services/chat/context_builder.py
+++ b/app/services/chat/context_builder.py
@@ -278,9 +278,11 @@ def build_last_analysis_context(messages: list[dict]) -> str:
 
     ctx = "[最近对话上下文]\n"
     if last_user_msg:
-        ctx += f"- 用户上一次请求：{last_user_msg}\n"
+        # P2-8（context/token P2）：去重后本块只覆盖历史窗口**之前**的轮次，
+        # "上一次请求/回复"标签有误导性 —— 改成"较早对话摘要"。
+        ctx += f"- 较早对话摘要（用户）：{last_user_msg}\n"
     if last_assistant_msg:
-        ctx += f"- 你上一次回复摘要：{last_assistant_msg}...\n"
+        ctx += f"- 较早对话摘要（助手）：{last_assistant_msg}...\n"
     if data_refs:
         unique_refs = list(dict.fromkeys(data_refs))[-5:]
         ctx += f"- 可复用的数据引用：{', '.join(unique_refs)}\n"

--- a/app/services/chat/context_builder.py
+++ b/app/services/chat/context_builder.py
@@ -242,12 +242,26 @@ _REF_RE = re.compile(r"(ref:[\w-]+)")
 
 
 def build_last_analysis_context(messages: list[dict]) -> str:
-    """从最近的历史消息中提取分析上下文摘要，帮 LLM 维持追问连贯性。"""
+    """从最近的历史消息中提取分析上下文摘要，帮 LLM 维持追问连贯性。
+
+    design-v3 §4 去重：历史窗口（truncate_history_by_budget 至少保留
+    HISTORY_MIN_TURNS=2 轮）已逐字包含最近若干轮对话，[最近对话上下文]
+    块只覆盖**窗口之前**的轮次——避免同一轮 user/assistant 交换被
+    同时注入两次（块 + 历史）。
+    """
+    # system 消息不参与轮次划分（messages[0] 通常是 system prompt）
+    nonsystem = [m for m in messages if m.get("role") != "system"]
+    turns = _group_into_turns(nonsystem)
+    if len(turns) <= HISTORY_MIN_TURNS:
+        # 全部对话都在历史窗口内，无“窗口之前”的内容可提炼。
+        return ""
+    scan = [m for turn in turns[: len(turns) - HISTORY_MIN_TURNS] for m in turn]
+
     last_user_msg = ""
     last_assistant_msg = ""
     data_refs: list[str] = []
 
-    for msg in reversed(messages):
+    for msg in reversed(scan):
         role = msg.get("role", "")
         content = msg.get("content", "") or ""
         if role == "assistant" and content and not last_assistant_msg:
@@ -278,22 +292,13 @@ def build_last_analysis_context(messages: list[dict]) -> str:
 
 
 def build_plan_block(plan) -> str:
-    """把 Plan 渲染成 [执行计划] 系统块，步骤带 ✅/⬜ 完成标记。"""
-    lines = [
-        "[执行计划] — 你为本任务制定的步骤，按此推进，完成一步即视为打勾",
-        f"- 意图: {plan.intent}",
-    ]
-    if plan.steps:
-        lines.append("- 步骤:")
-        for step in plan.steps:
-            mark = "✅" if step.done else "⬜"
-            lines.append(f"  {mark} {step.n}. {step.goal}")
-        if any(not s.done for s in plan.steps):
-            lines.append(
-                "⚠️ 仍有未完成步骤。若要给出最终回复，请先确认这些步骤是否"
-                "已无必要，或在回复中向用户说明未完成的原因。"
-            )
-    return "\n".join(lines)
+    """把 Plan 渲染成 [执行计划] 系统块（design-v3 §4 单一渲染来源）。
+
+    兼容壳：渲染逻辑收敛到 plan_orchestrator.render_plan_block，避免
+    重复的 plan 状态格式化。
+    """
+    from app.services.chat.plan_orchestrator import render_plan_block
+    return render_plan_block(plan)
 
 
 _default_assembler = None

--- a/app/services/chat/decision_log.py
+++ b/app/services/chat/decision_log.py
@@ -32,6 +32,12 @@ class ToolDecisionRecord:
     tool_args: dict[str, Any]
     result_quality: str            # "ok" | "empty" | "error"
     plan_step_matched: Optional[int]  # 命中的计划步骤号；无计划时为 None
+    # design-v3 §6 observability（additive）：
+    plan_id: Optional[str] = None
+    plan_revision: Optional[int] = None
+    step_id: Optional[str] = None        # 命中的 canonical 步骤 id（如 s1）
+    failure_class: Optional[str] = None  # 仅 status=="error" 时有值
+    recovery_action: Optional[str] = None
 
     def to_dict(self) -> dict:
         d = dataclasses.asdict(self)

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -47,6 +47,27 @@ from app.services.chat.tool_pipeline import ToolExecutionPipeline, ToolExecution
 
 logger = logging.getLogger(__name__)
 
+# 计划自身 ref 的判定（P2-6 / recovery P2）：plan-mode 计划以 ref:plan-* 存，
+# canonical 计划经别名 plan-current / plan-id:* 寻址。它们只代表"计划存在"，
+# 不代表会话有可复用的数据 —— session_has_refs 必须把它们排除，否则
+# "仅存了计划"的会话会被 ref_reuse 分类误判。
+_PLAN_REF_PREFIX = "ref:plan-"
+_PLAN_ALIAS_PREFIX = "plan-id:"
+_PLAN_CURRENT_ALIAS = "plan-current"
+
+
+def _has_non_plan_refs(refs: dict) -> bool:
+    """list_refs() 结果里是否存在非计划数据引用（ref:plan-* / plan 别名除外）。"""
+    for rid, alias in (refs or {}).items():
+        rid_s = str(rid)
+        alias_s = str(alias or "")
+        if rid_s.startswith(_PLAN_REF_PREFIX):
+            continue
+        if alias_s == _PLAN_CURRENT_ALIAS or alias_s.startswith(_PLAN_ALIAS_PREFIX):
+            continue
+        return True
+    return False
+
 
 class ChatExecutionEngine:
     """Agent 对话与流式响应执行引擎"""
@@ -55,9 +76,16 @@ class ChatExecutionEngine:
         self,
         tool_registry: ToolRegistry,
         tool_catalog: Optional["ToolCatalog"] = None,
+        *,
+        is_subagent_engine: bool = False,
     ):
         self.registry = tool_registry
         self.catalog = tool_catalog
+        # P2-7（Pi#1/#2）：子代理引擎轮次绝不推进父会话的计划。SubagentDispatcher
+        # 构造子引擎时传 is_subagent_engine=True；_maybe_plan / mark_step_done /
+        # _flush_plan 据此跳过一切计划推进，避免子代理的工具调用把父会话的
+        # 活跃计划打勾/改写。
+        self.is_subagent_engine = is_subagent_engine
         self.base_url = settings.LLM_BASE_URL.rstrip("/")
         self.model = settings.LLM_MODEL
         self.api_key = settings.LLM_API_KEY
@@ -401,6 +429,11 @@ class ChatExecutionEngine:
         from app.services.planning.followup import classify_followup
         from app.services.planning import FollowUpKind
         from app.services.tool_catalog import DOMAIN_KEYWORDS
+        # P2-7（Pi#1/#2）：子代理引擎的轮次不参与父会话的规划（独立微会话，
+        # 计划推进只属于主代理）。getattr 兜底：测试用 __new__ 构造的引擎没有
+        # 该属性时按 False（主代理）处理。
+        if getattr(self, "is_subagent_engine", False):
+            return None
         env = await self._get_map_state_summary(session_id)
         try:
             # R5/R10：进程重启续接——把 store 里的 canonical 计划恢复到本进程 LRU。
@@ -415,12 +448,16 @@ class ChatExecutionEngine:
                 refs = await session_data_manager.list_refs(session_id)
             except Exception:  # noqa: BLE001
                 refs = {}
+            # P2-6（recovery P2 / Pi#3）：session_has_refs 必须排除计划自身的
+            # ref（ref:plan-* 与 plan-current / plan-id:* 别名）——否则"仅存了
+            # 一个计划、没有任何数据"的会话会被 ref_reuse 误判。
+            has_data_refs = _has_non_plan_refs(refs)
             # design-v3 §followup：确定性分类喂给 should_plan。
             kind = classify_followup(
                 message,
                 has_active_plan=has_plan,
                 active_domains=active_domains,
-                session_has_refs=bool(refs),
+                session_has_refs=has_data_refs,
                 domain_keywords=DOMAIN_KEYWORDS,
             )
             if kind == FollowUpKind.new_goal and self.catalog is not None:
@@ -563,6 +600,9 @@ class ChatExecutionEngine:
 
     async def _flush_plan(self, session_id: str) -> None:
         """把活跃 canonical 计划持久化（advance_step 的 done 标志写回 store）。"""
+        # P2-7：子代理引擎不 flush 父会话的计划（独立微会话，计划属于主代理）。
+        if getattr(self, "is_subagent_engine", False):
+            return
         try:
             from app.services.chat import planner as _planner
             if _planner.get_plan(session_id) is None:
@@ -659,7 +699,8 @@ class ChatExecutionEngine:
                             # R6-nonstreaming / R2：非流式路径同样只在“非可疑成功”
                             # 时推进计划（失败/空结果绝不打勾）。
                             if (
-                                exec_res.outcome is not None
+                                not getattr(self, "is_subagent_engine", False)  # P2-7：子代理不打勾父计划
+                                and exec_res.outcome is not None
                                 and exec_res.outcome.status == "ok"
                                 and not _is_suspicious_result_fn(exec_res.outcome.raw_result)
                             ):
@@ -770,9 +811,11 @@ class ChatExecutionEngine:
                             "intent": plan.intent,
                             "domains": plan.domains,
                             "steps": [
+                                # P3-2/P2-6：done 取投影的真实打勾状态（恢复出的
+                                # 计划带已完成步骤），不再硬编码 False。
                                 {"n": s.n, "goal": s.goal,
                                  "tool_family": s.tool_family if s.tool_family is not None else "core",
-                                 "done": False}
+                                 "done": s.done}
                                 for s in plan.steps
                             ],
                         })
@@ -1004,6 +1047,7 @@ class ChatExecutionEngine:
                                     if (
                                         outcome.status == "ok"
                                         and not _is_suspicious_result_fn(outcome.raw_result)
+                                        and not getattr(self, "is_subagent_engine", False)  # P2-7
                                     ):
                                         step_n_matched = _planner.mark_step_done(
                                             session_id, tool_name, self.registry

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -259,17 +259,20 @@ class ChatExecutionEngine:
         project_id: Optional[str] = None,
         tools: Optional[list] = None,
     ) -> list[dict]:
-        tools_payload_chars = 0
+        tools_payload = None
         if tools:
             try:
-                tools_payload_chars = len(json.dumps(tools, ensure_ascii=False))
+                # P3 #3：把序列化后的工具 schema JSON 交给 assembler 做 CJK-aware
+                # token 估算（_estimate_tokens，与历史压缩同权重）——只传一次字符串，
+                # 不重复序列化。
+                tools_payload = json.dumps(tools, ensure_ascii=False)
             except (TypeError, ValueError):
-                tools_payload_chars = 0
+                tools_payload = None
         res = await self.context_assembler.assemble(
             session_id,
             messages,
             project_id=project_id,
-            tools_payload_chars=tools_payload_chars,
+            tools_payload=tools_payload,
         )
         return res.to_messages()
 
@@ -599,7 +602,12 @@ class ChatExecutionEngine:
                 self._trim_session_tail(messages)
 
     async def _flush_plan(self, session_id: str) -> None:
-        """把活跃 canonical 计划持久化（advance_step 的 done 标志写回 store）。"""
+        """把活跃 canonical 计划持久化（advance_step 的 done 标志写回 store）。
+
+        既作回合末 flush（chat / chat_stream 的 finally），也作 P3 #4 的
+        mid-turn tick flush（mark_step_done 打勾后立即调用）——二者幂等（同一
+        载荷原地 overwrite）。best-effort：任何失败只记 warning，绝不破坏回合。
+        """
         # P2-7：子代理引擎不 flush 父会话的计划（独立微会话，计划属于主代理）。
         if getattr(self, "is_subagent_engine", False):
             return
@@ -705,9 +713,13 @@ class ChatExecutionEngine:
                                 and not _is_suspicious_result_fn(exec_res.outcome.raw_result)
                             ):
                                 from app.services.chat import planner as _planner
-                                _planner.mark_step_done(
+                                step_n_matched = _planner.mark_step_done(
                                     session_id, exec_res.tool_name, self.registry
                                 )
+                                if step_n_matched is not None:
+                                    # P3 #4：打勾后立即 best-effort 落盘（回合末
+                                    # flush 仍保留，幂等）。崩溃/断连不丢 tick。
+                                    await self._flush_plan(session_id)
 
                         if standard_calls:
                             messages.append({
@@ -1052,6 +1064,10 @@ class ChatExecutionEngine:
                                         step_n_matched = _planner.mark_step_done(
                                             session_id, tool_name, self.registry
                                         )
+                                        if step_n_matched is not None:
+                                            # P3 #4：打勾后立即 best-effort 落盘
+                                            # （回合末 flush 仍保留，幂等）。
+                                            await self._flush_plan(session_id)
                                     elif outcome.status == "error":
                                         failure_class, recovery_action = self._classify_failure(outcome)
                                     self._log_tool_decision(

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -229,9 +229,19 @@ class ChatExecutionEngine:
         session_id: str,
         messages: list[dict],
         project_id: Optional[str] = None,
+        tools: Optional[list] = None,
     ) -> list[dict]:
+        tools_payload_chars = 0
+        if tools:
+            try:
+                tools_payload_chars = len(json.dumps(tools, ensure_ascii=False))
+            except (TypeError, ValueError):
+                tools_payload_chars = 0
         res = await self.context_assembler.assemble(
-            session_id, messages, project_id=project_id,
+            session_id,
+            messages,
+            project_id=project_id,
+            tools_payload_chars=tools_payload_chars,
         )
         return res.to_messages()
 
@@ -388,10 +398,37 @@ class ChatExecutionEngine:
 
     async def _maybe_plan(self, session_id: str, message: str, messages: list[dict]):
         from app.services.chat.plan_orchestrator import plan_orchestrator
+        from app.services.planning.followup import classify_followup
+        from app.services.planning import FollowUpKind
+        from app.services.tool_catalog import DOMAIN_KEYWORDS
         env = await self._get_map_state_summary(session_id)
         try:
+            # R5/R10：进程重启续接——把 store 里的 canonical 计划恢复到本进程 LRU。
+            await plan_orchestrator.restore_plan(session_id)
+        except Exception as e:
+            logger.warning(f"[chat_execution_engine] plan restore 失败: {e}")
+        try:
+            plan = plan_orchestrator.get_plan(session_id)
+            has_plan = plan is not None
+            active_domains = list(plan.domains) if plan else []
+            try:
+                refs = await session_data_manager.list_refs(session_id)
+            except Exception:  # noqa: BLE001
+                refs = {}
+            # design-v3 §followup：确定性分类喂给 should_plan。
+            kind = classify_followup(
+                message,
+                has_active_plan=has_plan,
+                active_domains=active_domains,
+                session_has_refs=bool(refs),
+                domain_keywords=DOMAIN_KEYWORDS,
+            )
+            if kind == FollowUpKind.new_goal and self.catalog is not None:
+                # design-v3 §5：明确换目标 → 旧领域 sticky 停止污染本轮工具选择。
+                self.catalog.reset_sticky(session_id)
             return await plan_orchestrator.orchestrate_plan(
-                self._planner_llm_config(), session_id, message, messages, env
+                self._planner_llm_config(), session_id, message, messages, env,
+                followup_kind=kind,
             )
         except Exception as e:
             logger.warning(f"[chat_execution_engine] 规划阶段异常，降级无计划: {e}")
@@ -407,9 +444,12 @@ class ChatExecutionEngine:
         outcome: ToolDispatchResult,
         subset_size: int,
         step_n: int | None = None,
+        failure_class: Optional[str] = None,
+        recovery_action: Optional[str] = None,
     ) -> None:
         from app.services.chat import planner
         from app.services.chat.decision_log import ToolDecisionRecord, log_tool_decision
+        from app.services.planning.store import plan_store
 
         if outcome.status == "error":
             quality = "error"
@@ -419,6 +459,21 @@ class ChatExecutionEngine:
             quality = "ok"
         plan = planner.get_plan(session_id)
         active = self.catalog.active_domains(session_id) if self.catalog else set()
+        # Observability (design-v3 §6)：有活跃计划时附带 plan_id / plan_revision /
+        # step_id（只做 plan_store 进程缓存查，绝不读 session store）。
+        plan_id: Optional[str] = None
+        plan_revision: Optional[int] = None
+        step_id: Optional[str] = None
+        if plan is not None:
+            canon = plan_store.peek(session_id)
+            if canon is not None:
+                plan_id = canon.plan_id
+                plan_revision = canon.revision
+                if step_n is not None:
+                    for cs in canon.steps:
+                        if cs.n == step_n:
+                            step_id = cs.id
+                            break
         try:
             log_tool_decision(ToolDecisionRecord(
                 session_id=session_id,
@@ -432,6 +487,11 @@ class ChatExecutionEngine:
                 tool_args=tool_args if isinstance(tool_args, dict) else {},
                 result_quality=quality,
                 plan_step_matched=step_n,
+                plan_id=plan_id,
+                plan_revision=plan_revision,
+                step_id=step_id,
+                failure_class=failure_class,
+                recovery_action=recovery_action,
             ))
         except Exception as e:
             logger.warning(f"[chat_execution_engine] 决策日志记录失败: {e}")
@@ -495,9 +555,22 @@ class ChatExecutionEngine:
                     message, session_id, messages, skill_name, user_id, project_id,
                 )
             finally:
+                # design-v3：把本进程 canonical 计划（含打勾进度）持久化到 store。
+                await self._flush_plan(session_id)
                 # C-F12: bound the in-memory tail once the turn's appends are
                 # complete (every exit path — return, exception, cancel).
                 self._trim_session_tail(messages)
+
+    async def _flush_plan(self, session_id: str) -> None:
+        """把活跃 canonical 计划持久化（advance_step 的 done 标志写回 store）。"""
+        try:
+            from app.services.chat import planner as _planner
+            if _planner.get_plan(session_id) is None:
+                return
+            from app.services.chat.plan_orchestrator import plan_orchestrator
+            await plan_orchestrator.flush(session_id)
+        except Exception as e:
+            logger.warning(f"[chat_execution_engine] plan flush 失败: {e}")
 
     async def _chat_locked(
         self,
@@ -525,9 +598,12 @@ class ChatExecutionEngine:
                 if self.tracker.is_cancelled(task.id):
                     return {"session_id": session_id, "content": "任务已取消", **({"owner_token": owner_token} if owner_token else {})}
 
-                messages_with_context = await self._compose_request_messages(session_id, messages)
-
+                # tools 先选（含 tools payload 软计入估算），再组装上下文
                 tools = self._select_tools(session_id, messages)
+                messages_with_context = await self._compose_request_messages(
+                    session_id, messages, tools=tools,
+                )
+
                 response = await self._call_llm(messages_with_context, tools)
                 choice = response.get("choices", [{}])[0]
                 assistant_msg = choice.get("message", {})
@@ -580,6 +656,17 @@ class ChatExecutionEngine:
                             llm_payload = f"Tool execution failed: {exec_res}"
                         else:
                             llm_payload = exec_res.llm_payload
+                            # R6-nonstreaming / R2：非流式路径同样只在“非可疑成功”
+                            # 时推进计划（失败/空结果绝不打勾）。
+                            if (
+                                exec_res.outcome is not None
+                                and exec_res.outcome.status == "ok"
+                                and not _is_suspicious_result_fn(exec_res.outcome.raw_result)
+                            ):
+                                from app.services.chat import planner as _planner
+                                _planner.mark_step_done(
+                                    session_id, exec_res.tool_name, self.registry
+                                )
 
                         if standard_calls:
                             messages.append({
@@ -671,6 +758,10 @@ class ChatExecutionEngine:
                 yield sse_event("task_start", task_start_data)
 
                 plan = await self._maybe_plan(session_id, message, messages)
+                plan_existed_this_turn = plan is not None
+                if not plan_existed_this_turn:
+                    from app.services.chat import planner as _planner_ctx
+                    plan_existed_this_turn = _planner_ctx.get_plan(session_id) is not None
                 try:
                     if plan is not None:
                         yield sse_event("plan_ready", {
@@ -679,7 +770,9 @@ class ChatExecutionEngine:
                             "intent": plan.intent,
                             "domains": plan.domains,
                             "steps": [
-                                {"n": s.n, "goal": s.goal, "tool_family": s.tool_family, "done": False}
+                                {"n": s.n, "goal": s.goal,
+                                 "tool_family": s.tool_family if s.tool_family is not None else "core",
+                                 "done": False}
                                 for s in plan.steps
                             ],
                         })
@@ -687,6 +780,10 @@ class ChatExecutionEngine:
                     logger.warning(f"[chat_execution_engine] plan_ready 发送失败: {e}")
 
                 def _maybe_plan_finalized_event():
+                    # design-v3：只有本轮确实存在/产生过非终态计划才发 plan_finalized，
+                    # 避免无计划轮次或已恢复出终态计划时发出 spurious finalize。
+                    if not plan_existed_this_turn:
+                        return None
                     try:
                         from app.services.chat import planner as _planner
                         plan_obj = _planner.get_plan(session_id)
@@ -705,8 +802,10 @@ class ChatExecutionEngine:
                 executed_tools = set()
 
                 for round_index in range(self.max_rounds):
+                    # tools 先选（含 tools payload 软计入估算），再组装上下文
+                    tools = self._select_tools(session_id, messages)
                     messages_with_context = await self._compose_request_messages(
-                        session_id, messages, project_id=project_id,
+                        session_id, messages, project_id=project_id, tools=tools,
                     )
 
                     if self.tracker.is_cancelled(task.id):
@@ -715,8 +814,6 @@ class ChatExecutionEngine:
                             yield pf
                         yield sse_event("task_cancelled", {"task_id": task.id})
                         return
-
-                    tools = self._select_tools(session_id, messages)
 
                     streamed_content_parts: list[str] = []
                     assistant_msg: dict = {}
@@ -881,22 +978,44 @@ class ChatExecutionEngine:
                                     except Exception as e:  # noqa: BLE001 防御（execute_tool_call 内部已兜底）
                                         logger.error(f"[chat_execution_engine] tool task raised for {tool_name}: {e}")
                                         self.tracker.fail_step(task.id, step.id, str(e))
-                                        yield sse_event("step_error", {
+                                        fc, ra = self._classify_failure(
+                                            outcome=None, exception=e
+                                        )
+                                        step_error_payload = {
                                             "task_id": task.id,
                                             "step_id": step.id,
                                             "tool": tool_name,
                                             "error": str(e),
-                                        })
+                                        }
+                                        if fc:
+                                            step_error_payload["failure_class"] = fc
+                                            step_error_payload["recovery_action"] = ra
+                                        yield sse_event("step_error", step_error_payload)
                                         continue
 
                                     outcome = exec_res.outcome
 
+                                    # R2 (design-v3 §2)：只有“非可疑成功”才推进计划步骤；
+                                    # 失败 / 重复 / 校验错误 / 空结果绝不打勾。
                                     from app.services.chat import planner as _planner
-                                    step_n_matched = _planner.mark_step_done(session_id, tool_name, self.registry)
+                                    step_n_matched = None
+                                    failure_class: Optional[str] = None
+                                    recovery_action: Optional[str] = None
+                                    if (
+                                        outcome.status == "ok"
+                                        and not _is_suspicious_result_fn(outcome.raw_result)
+                                    ):
+                                        step_n_matched = _planner.mark_step_done(
+                                            session_id, tool_name, self.registry
+                                        )
+                                    elif outcome.status == "error":
+                                        failure_class, recovery_action = self._classify_failure(outcome)
                                     self._log_tool_decision(
                                         session_id, round_index, message, tool_name,
                                         tool_args_dict, outcome, len(tools or []),
                                         step_n=step_n_matched,
+                                        failure_class=failure_class,
+                                        recovery_action=recovery_action,
                                     )
                                     try:
                                         if step_n_matched is not None:
@@ -928,12 +1047,16 @@ class ChatExecutionEngine:
                                         })
                                     elif outcome.status == "error":
                                         self.tracker.fail_step(task.id, step.id, outcome.error_msg or "")
-                                        yield sse_event("step_error", {
+                                        step_error_payload = {
                                             "task_id": task.id,
                                             "step_id": step.id,
                                             "tool": tool_name,
                                             "error": outcome.error_msg,
-                                        })
+                                        }
+                                        if failure_class:
+                                            step_error_payload["failure_class"] = failure_class
+                                            step_error_payload["recovery_action"] = recovery_action
+                                        yield sse_event("step_error", step_error_payload)
                                         yield sse_event("tool_result", {"name": tool_name, "result": msg_result_str, "session_id": session_id})
                                     else:
                                         self.tracker.complete_step(task.id, step.id, outcome.raw_result)
@@ -1058,6 +1181,8 @@ class ChatExecutionEngine:
                     self.tracker.fail_task(task.id, "chat_stream exception")
                 raise
             finally:
+                # design-v3：把本进程 canonical 计划（含打勾进度）持久化到 store。
+                await self._flush_plan(session_id)
                 # C-F12: bound the in-memory tail once the turn's appends
                 # are complete (every exit path — done, cancelled, max rounds,
                 # disconnect/exception via generator close).
@@ -1115,6 +1240,11 @@ class ChatExecutionEngine:
             from app.services.chat import planner
             planner.clear_plan(session_id)
             try:
+                from app.services.planning.store import plan_store
+                await plan_store.clear(session_id)
+            except Exception as e:
+                logger.warning(f"[chat_execution_engine] plan_store.clear 失败: {e}")
+            try:
                 from app.services.chat.context.layer_schema import clear_layer_schema_cache
                 clear_layer_schema_cache(session_id)
             except ImportError:
@@ -1125,3 +1255,38 @@ class ChatExecutionEngine:
 
     def _detect_suspicious_result(self, result: Any) -> bool:
         return _is_suspicious_result_fn(result)
+
+    @staticmethod
+    def _classify_failure(
+        outcome: Optional[ToolDispatchResult],
+        exception: Optional[Exception] = None,
+    ) -> tuple[Optional[str], Optional[str]]:
+        """design-v3 §recovery：把一次工具失败分类成 failure_class + recovery_action。
+
+        供 step_error SSE / decision_log 附加字段使用（additive，不改变任何
+        现有行为与自愈路径）。
+        """
+        from app.services.planning.models import FailureClass as _FailureClass
+        from app.services.planning.recovery import (
+            classify_error as _classify_error,
+            recovery_action_for as _recovery_action_for,
+        )
+        try:
+            if exception is not None:
+                fc = _classify_error(exception=exception)
+            else:
+                raw = outcome.raw_result if isinstance(outcome.raw_result, dict) else {}
+                if raw.get("cancelled"):
+                    fc = _FailureClass.cancelled
+                else:
+                    fc = _classify_error(
+                        status=outcome.status,
+                        code=raw.get("code"),
+                        error_type=raw.get("error_type"),
+                        message=outcome.error_msg,
+                    )
+            ra = _recovery_action_for(fc)
+            return fc.value, ra.value
+        except Exception as e:  # noqa: BLE001 分类失败不拖垮主流程
+            logger.warning(f"[chat_execution_engine] failure 分类失败: {e}")
+            return None, None

--- a/app/services/chat/plan_orchestrator.py
+++ b/app/services/chat/plan_orchestrator.py
@@ -2,15 +2,42 @@
 
 深入封装启发式门控、结构化 LLM 规划、LRU 计划内存缓存、
 工具步骤匹配与 ToolCatalog 领域衰减。
+
+design-v3 收敛（本切片）：
+- CanonicalPlan（app/services/planning/）成为计划的持久化 source of truth；
+  本模块的 ``Plan``/``PlanStep`` dataclass 退化为它的**投影**（compatibility
+  projection），``get_plan``/``set_plan``/``clear_plan``/``make_plan``/
+  ``advance_step``/``should_plan`` 保持原签名与返回类型。
+- ``advance_step`` 移除 ``"core"`` 通配（R1）：只有真实 domain 重叠才打勾；
+  使用与 tool_dispatch_service 一致的规范化工具名做 domain 查找（R6/R7）。
+- ``parse_plan`` 逐字段防御（R4）：``n`` 强转、``tool_family`` 校验（非法 →
+  None，步骤保留）、步骤数上限 MAX_PLAN_STEPS。
+- ``should_plan`` 接受可选的 ``followup_kind``（followup.py 分类结果）：
+  new_goal → 规划；style_change/ref_reuse/continuation + 活跃计划 → 跳过。
+  不传时行为与旧版一致。
+- 双衰减路径移除（R8）：``advance_step`` 不再调用
+  ``tool_catalog.decay_sticky_domain``（该分支在生产路径从不触发——引擎
+  从未传过 tool_catalog；TTL 衰减由 select_schemas 每轮自然进行）。
 """
 import dataclasses
 import json
 import logging
 import re
+import uuid
 from typing import Optional, List, Set
 
 from app.services.chat.llm_client import LLMConfig, LRUCache
 from app.services.tool_catalog import DOMAIN_KEYWORDS
+from app.services.tool_dispatch_service import normalize_tool_name
+
+from app.services.planning.models import (
+    TERMINAL_STATUSES,
+    CanonicalPlan,
+    CanonicalStep,
+    StepStatus,
+)
+from app.services.planning.store import plan_store
+from app.services.planning.followup import FollowUpKind
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +50,9 @@ _SHORT_THRESHOLD = 20  # 字符数
 
 # 合法 domain 取值 = ToolCatalog 的主题键集合 + "core"（基础工具）
 VALID_DOMAINS: Set[str] = set(DOMAIN_KEYWORDS) | {"core"}
+
+# R4: 单计划步骤数硬上限（prompt 里的 5 步只是软约束，代码层强制 8）
+MAX_PLAN_STEPS = 8
 
 PLANNER_PROMPT = """你是 WebGIS 空间分析任务的规划器。给定用户请求与当前地图状态，
 输出一个简洁的执行计划。只输出 JSON，不要任何解释文字、不要 Markdown 代码围栏。
@@ -64,7 +94,7 @@ def _planning_messages(user_message: str, env_summary: str) -> List[dict]:
 class PlanStep:
     n: int
     goal: str
-    tool_family: str
+    tool_family: Optional[str]
     done: bool = False
 
 
@@ -75,8 +105,56 @@ class Plan:
     steps: List[PlanStep]
 
 
-def parse_plan(raw: str) -> Optional[Plan]:
-    """防御式解析规划 LLM 的 JSON 输出"""
+def _coerce_step_n(raw: object, fallback: int) -> int:
+    """R4: 把 LLM 输出的 ``n`` 稳健转成 int。None / "1.0" / "2" → int；
+    无法解析 → fallback（该步骤在 steps 里的序号）。"""
+    if isinstance(raw, bool):
+        return fallback
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, float):
+        return int(raw) if raw.is_integer() else fallback
+    if isinstance(raw, str):
+        try:
+            return int(float(raw.strip()))
+        except (TypeError, ValueError):
+            return fallback
+    return fallback
+
+
+def _validate_tool_family(raw: object, valid_families: Set[str]) -> Optional[str]:
+    """R4: tool_family 必须在 (registry 声明的 domains ∪ VALID_DOMAINS) 内；
+    非法 → None（步骤保留，仅失去打勾能力）。"""
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    fam = raw.strip()
+    return fam if fam in valid_families else None
+
+
+def _registry_domains(registry: object) -> Set[str]:
+    """收集 registry 里所有工具声明的 domains（用于 parse_plan 校验）。"""
+    if registry is None:
+        return set()
+    domains: Set[str] = set()
+    try:
+        for meta in registry.all_metadata().values():
+            domains.update(meta.get("domains", []))
+    except Exception as e:  # noqa: BLE001 防御式：registry 异常不阻断规划
+        logger.warning(f"[plan_orchestrator] 读取 registry domains 失败: {e}")
+    return domains
+
+
+def _get_registry() -> object:
+    """按仓库既有模式拿全局 ToolRegistry（agent_pi_bridge 注入）；未初始化 → None。"""
+    try:
+        from app.agent_pi_bridge import get_tool_registry
+        return get_tool_registry()
+    except Exception:  # noqa: BLE001 — 测试/独立环境未注入 registry 时降级
+        return None
+
+
+def parse_plan(raw: str, registry: object = None) -> Optional[Plan]:
+    """防御式解析规划 LLM 的 JSON 输出（R4：逐字段容错，绝不 raise）。"""
     if not raw or not raw.strip():
         return None
     text = raw.strip()
@@ -97,22 +175,46 @@ def parse_plan(raw: str) -> Optional[Plan]:
         return None
     if not isinstance(domains, list) or not isinstance(steps_raw, list):
         return None
-    domains = [d for d in domains if d in VALID_DOMAINS]
+    valid_domains = set(VALID_DOMAINS) | _registry_domains(registry)
+    domains = [d for d in domains if isinstance(d, str) and d in valid_domains]
+    valid_families = valid_domains
     steps: List[PlanStep] = []
-    for i, s in enumerate(steps_raw, start=1):
+    for i, s in enumerate(steps_raw[:MAX_PLAN_STEPS], start=1):
         if not isinstance(s, dict):
-            continue
+            continue  # 坏步骤跳过，不报废整个计划
         steps.append(PlanStep(
-            n=int(s.get("n", i)),
+            n=_coerce_step_n(s.get("n"), i),
             goal=str(s.get("goal", "")),
-            tool_family=str(s.get("tool_family", "core")),
+            tool_family=_validate_tool_family(s.get("tool_family", "core"), valid_families),
         ))
     return Plan(intent=intent.strip(), domains=domains, steps=steps)
 
 
-def should_plan(message: str, messages: List[dict], has_active_plan: bool) -> bool:
-    """启发式门控判断"""
+def should_plan(
+    message: str,
+    messages: List[dict],
+    has_active_plan: bool,
+    followup_kind: Optional[FollowUpKind] = None,
+) -> bool:
+    """启发式门控判断。
+
+    ``followup_kind``（design-v3 §followup）显式传入时优先：
+    - new_goal               → 必须规划（含"换成查路线"这类短消息换目标）
+    - style_change / ref_reuse / continuation + 有活跃计划 → 跳过
+    - 其余（unclear / 无活跃计划）→ 回落到旧的长度 + 关键词启发式。
+    ``followup_kind`` 为 None 时行为与旧版完全一致（向后兼容）。
+    """
     text = (message or "").strip()
+    if followup_kind is not None:
+        if followup_kind == FollowUpKind.new_goal:
+            return True
+        if has_active_plan and followup_kind in (
+            FollowUpKind.style_change,
+            FollowUpKind.ref_reuse,
+            FollowUpKind.continuation,
+        ):
+            return False
+        # unclear，或 kind 有值但无活跃计划 → 走旧启发式
     is_short = len(text) <= _SHORT_THRESHOLD
     is_followup = bool(_FOLLOWUP_PATTERN.search(text))
     if is_short and is_followup and has_active_plan:
@@ -120,21 +222,136 @@ def should_plan(message: str, messages: List[dict], has_active_plan: bool) -> bo
     return True
 
 
+def render_plan_block(plan) -> str:
+    """把 Plan 投影渲染成 [执行计划] 系统块（单一渲染来源，design-v3 §4）。
+
+    context_assembler / context_builder 都走这里，避免重复的 plan 状态格式化。
+    """
+    lines = [
+        "[执行计划] — 你为本任务制定的步骤，按此推进，完成一步即视为打勾",
+        f"- 意图: {plan.intent}",
+    ]
+    if getattr(plan, "steps", None):
+        lines.append("- 步骤:")
+        for step in plan.steps:
+            mark = "✅" if step.done else "⬜"
+            lines.append(f"  {mark} {step.n}. {step.goal}")
+        if any(not s.done for s in plan.steps):
+            lines.append(
+                "⚠️ 仍有未完成步骤。若要给出最终回复，请先确认这些步骤是否"
+                "已无必要，或在回复中向用户说明未完成的原因。"
+            )
+    return "\n".join(lines)
+
+
 class AgentPlanOrchestrator:
-    """Agent 计划编排与状态引擎"""
+    """Agent 计划编排与状态引擎（canonical 持久化 + 投影缓存）。"""
 
     def __init__(self, capacity: int = 200):
+        # 投影缓存：get/set 返回的就是这里存的对象（身份语义不变）。
         self._plans: LRUCache = LRUCache(capacity=capacity)
+        # canonical 副本：与 plan_store 的写穿缓存共享同一对象（原地修改即可见）。
+        self._canonical: LRUCache = LRUCache(capacity=capacity)
+
+    # ── 投影 <-> canonical 转换 ──────────────────────────────────────────
+
+    def _to_projection(self, canon: CanonicalPlan) -> Plan:
+        """CanonicalPlan → Plan 投影（done = canonical step 已 completed）。"""
+        return Plan(
+            intent=canon.intent,
+            domains=list(canon.domains),
+            steps=[
+                PlanStep(
+                    n=s.n,
+                    goal=s.goal,
+                    tool_family=s.tool_family,
+                    done=s.status == StepStatus.completed,
+                )
+                for s in canon.steps
+            ],
+        )
+
+    def _canonical_from_projection(self, plan: Plan, session_id: str) -> CanonicalPlan:
+        """Plan 投影 → 新 CanonicalPlan（新计划：新 plan_id、status=proposed）。"""
+        plan_id = f"plan-orch-{uuid.uuid4().hex[:12]}"
+        steps = [
+            CanonicalStep(
+                id=f"s{i}",
+                n=s.n,
+                goal=s.goal,
+                tool_family=s.tool_family,
+                status=StepStatus.completed if s.done else StepStatus.pending,
+            )
+            for i, s in enumerate(plan.steps, start=1)
+        ]
+        return CanonicalPlan(
+            plan_id=plan_id,
+            session_id=session_id,
+            intent=plan.intent,
+            domains=list(plan.domains),
+            steps=steps,
+        )
+
+    # ── 公共 API（签名不变） ─────────────────────────────────────────────
 
     def get_plan(self, session_id: str) -> Optional[Plan]:
-        return self._plans.get(session_id)
+        """返回投影；LRU 未命中时尝试从 plan_store 缓存同步恢复（R5/R10）。
+
+        恢复出的计划若已是终态（completed/failed/cancelled/superseded），
+        视为无活跃计划。真正的跨进程/重启恢复走 ``restore_plan``（异步读 store）。
+        """
+        plan = self._plans.get(session_id)
+        if plan is not None:
+            return plan
+        canon = plan_store.peek(session_id)
+        if canon is None:
+            return None
+        if canon.status in TERMINAL_STATUSES:
+            return None
+        proj = self._to_projection(canon)
+        self._plans[session_id] = proj
+        self._canonical[session_id] = canon
+        return proj
+
+    async def restore_plan(self, session_id: str) -> Optional[Plan]:
+        """从 plan_store 恢复当前计划（进程重启续接，R5/R10）。
+
+        已在本进程 LRU 中则直接返回（不重建投影，保持身份）。恢复出的
+        终态计划视为无活跃计划。
+        """
+        cached = self._plans.get(session_id)
+        if cached is not None:
+            return cached
+        canon = await plan_store.load_current(session_id)
+        if canon is None:
+            return None
+        self._canonical[session_id] = canon
+        if canon.status in TERMINAL_STATUSES:
+            return None
+        proj = self._to_projection(canon)
+        self._plans[session_id] = proj
+        return proj
+
+    async def flush(self, session_id: str) -> None:
+        """把本进程 canonical 计划（含步骤 done 状态）持久化到 plan_store。"""
+        canon = self._canonical.get(session_id)
+        if canon is None:
+            return
+        canon.status = canon.recompute_status()
+        await plan_store.save(canon)
 
     def set_plan(self, session_id: str, plan: Plan) -> None:
         self._plans[session_id] = plan
+        canon = self._canonical_from_projection(plan, session_id)
+        self._canonical[session_id] = canon
+        plan_store.cache_put(canon)
 
     def clear_plan(self, session_id: str) -> None:
         if session_id in self._plans:
             del self._plans[session_id]
+        if session_id in self._canonical:
+            del self._canonical[session_id]
+        plan_store.forget(session_id)
 
     async def make_plan(
         self,
@@ -143,7 +360,12 @@ class AgentPlanOrchestrator:
         user_message: str,
         env_summary: str,
     ) -> Optional[Plan]:
-        """跑一次规划 LLM 调用，解析并存储计划"""
+        """跑一次规划 LLM 调用，解析、能力校验并存储计划。
+
+        新计划替换旧的非终态计划时，旧 canonical 会被 ``plan_store.supersede``
+        标记 superseded（design-v3：换目标绝不静默覆盖）。
+        """
+        registry = _get_registry()
         try:
             from app.services.chat import planner
             resp = await planner.call_llm(cfg, _planning_messages(user_message, env_summary))
@@ -153,16 +375,73 @@ class AgentPlanOrchestrator:
         except Exception as e:
             logger.warning(f"[plan_orchestrator] make_plan LLM 调用失败: {e}")
             return None
-        plan = parse_plan(raw)
+        plan = parse_plan(raw, registry=registry)
         if plan is None:
             logger.info(f"[plan_orchestrator] session={session_id} 计划解析失败，降级无计划")
             return None
+        self._apply_capability_validation(plan, registry)
+
+        prev = self._canonical.get(session_id)
+        canon = self._canonical_from_projection(plan, session_id)
+        if (
+            prev is not None
+            and prev.status not in TERMINAL_STATUSES
+            and prev.plan_id != canon.plan_id
+        ):
+            # design-v3：换目标 → 旧计划 superseded，绝不静默覆盖。
+            await plan_store.supersede(session_id, canon)
+        else:
+            await plan_store.save(canon)
         self.set_plan(session_id, plan)
         logger.info(
             f"[plan_orchestrator] session={session_id} 计划已生成: "
             f"intent={plan.intent!r} domains={plan.domains} steps={len(plan.steps)}"
         )
         return plan
+
+    def _apply_capability_validation(self, plan: Plan, registry: object) -> None:
+        """design-v3 §capability：能力校验只记日志，不阻断规划（warning 不阻塞）。
+
+        tool_family 无任何已注册工具支撑的步骤 → tool_family=None（步骤保留，
+        失去打勾能力），避免该步骤永远无法完成的死步骤。
+        """
+        if registry is None:
+            return
+        try:
+            from app.services.planning.capability import validate_plan_capabilities
+            from app.services.planning.models import (
+                CanonicalPlan as _CP,
+                CanonicalStep as _CS,
+            )
+            temp = _CP(
+                plan_id="tmp",
+                session_id="",
+                intent=plan.intent,
+                domains=list(plan.domains),
+                steps=[
+                    _CS(id=f"s{i}", n=s.n, goal=s.goal, tool_family=s.tool_family)
+                    for i, s in enumerate(plan.steps, start=1)
+                ],
+            )
+            issues = validate_plan_capabilities(temp, registry)
+            for issue in issues:
+                logger.warning(f"[plan_orchestrator] 能力校验: {issue}")
+            family_domains: Set[str] = set()
+            for meta in registry.all_metadata().values():
+                family_domains.update(meta.get("domains", []))
+            for step in plan.steps:
+                if (
+                    step.tool_family
+                    and step.tool_family != "core"
+                    and step.tool_family not in family_domains
+                ):
+                    logger.warning(
+                        f"[plan_orchestrator] step n={step.n} tool_family "
+                        f"{step.tool_family!r} 无已注册工具，置 None"
+                    )
+                    step.tool_family = None
+        except Exception as e:  # noqa: BLE001 能力校验失败不阻断规划
+            logger.warning(f"[plan_orchestrator] 能力校验失败: {e}")
 
     async def orchestrate_plan(
         self,
@@ -171,30 +450,40 @@ class AgentPlanOrchestrator:
         user_message: str,
         messages: List[dict],
         env_summary: str,
+        followup_kind: Optional[FollowUpKind] = None,
     ) -> Optional[Plan]:
-        """门控 + 规划编排入口"""
+        """门控 + 规划编排入口（followup_kind 透传给 should_plan，design-v3 §followup）。"""
         has_plan = self.get_plan(session_id) is not None
-        if not should_plan(user_message, messages, has_plan):
+        if not should_plan(user_message, messages, has_plan, followup_kind=followup_kind):
             return None
         from app.services.chat import planner
         return await planner.make_plan(cfg, session_id, user_message, env_summary)
 
     def advance_step(self, session_id: str, tool_name: str, registry, tool_catalog=None) -> Optional[int]:
-        """把工具调用匹配到第一个未完成的计划步骤并打勾，并同步触发 ToolCatalog 领域衰减"""
+        """把工具调用匹配到第一个未完成的计划步骤并打勾（R1/R6/R7）。
+
+        - 移除 ``"core"`` 通配：只有调用工具声明 domain 与步骤 tool_family
+          真实重叠才打勾（R1，G-report 实测未知工具/样式工具误打勾）。
+        - 使用规范化工具名做 domain 查找（R7：遗留名如 set_layer_style 也能匹配）。
+        - 不再调用 ``tool_catalog.decay_sticky_domain``（R8 死代码分支；TTL 衰减
+          由 select_schemas 每轮自然进行）。``tool_catalog`` 参数保留仅为签名兼容。
+        """
         plan = self.get_plan(session_id)
         if plan is None:
             return None
-        tool_domains = set(registry.metadata(tool_name).get("domains", []))
-        for step in plan.steps:
+        canon = self._canonical.get(session_id)
+        norm = normalize_tool_name(tool_name)
+        try:
+            tool_domains = set(registry.metadata(norm).get("domains", []))
+        except Exception:  # noqa: BLE001 未知工具/registry 异常 → 无 domain → 不打勾
+            tool_domains = set()
+        for idx, step in enumerate(plan.steps):
             if step.done:
                 continue
-            if step.tool_family in tool_domains or step.tool_family == "core":
+            if step.tool_family in tool_domains:
                 step.done = True
-                if tool_catalog is not None and hasattr(tool_catalog, "decay_sticky_domain"):
-                    try:
-                        tool_catalog.decay_sticky_domain(session_id)
-                    except Exception as e:
-                        logger.warning(f"[plan_orchestrator] domain decay failed: {e}")
+                if canon is not None and idx < len(canon.steps):
+                    canon.steps[idx].status = StepStatus.completed
                 return step.n
         return None
 

--- a/app/services/chat/plan_orchestrator.py
+++ b/app/services/chat/plan_orchestrator.py
@@ -8,8 +8,10 @@ design-v3 收敛（本切片）：
   本模块的 ``Plan``/``PlanStep`` dataclass 退化为它的**投影**（compatibility
   projection），``get_plan``/``set_plan``/``clear_plan``/``make_plan``/
   ``advance_step``/``should_plan`` 保持原签名与返回类型。
-- ``advance_step`` 移除 ``"core"`` 通配（R1）：只有真实 domain 重叠才打勾；
-  使用与 tool_dispatch_service 一致的规范化工具名做 domain 查找（R6/R7）。
+- ``advance_step`` 的 ``"core"`` 通配改为**限定通配**（P1-A）：core 步骤只在
+  调用工具已注册且非展示类（PRESENTATION_TOOLS：样式/视图/交互工具）时打勾，
+  或工具的声明 domains 与 plan.domains 有交集；使用与 tool_dispatch_service
+  一致的规范化工具名做 domain 查找（R6/R7）。幻觉/未注册工具与样式工具绝不打勾。
 - ``parse_plan`` 逐字段防御（R4）：``n`` 强转、``tool_family`` 校验（非法 →
   None，步骤保留）、步骤数上限 MAX_PLAN_STEPS。
 - ``should_plan`` 接受可选的 ``followup_kind``（followup.py 分类结果）：
@@ -53,6 +55,31 @@ VALID_DOMAINS: Set[str] = set(DOMAIN_KEYWORDS) | {"core"}
 
 # R4: 单计划步骤数硬上限（prompt 里的 5 步只是软约束，代码层强制 8）
 MAX_PLAN_STEPS = 8
+
+# P1-A（R1-qualified）：core 通配的**展示类工具排除集**。
+# 生产注册表里 0/149 个工具声明 domain "core"（149 个里有 86 个 tier-1 分析
+# 工具干脆不声明任何 domain），而规划 prompt 让 LLM 对最常见的步骤发
+# tool_family:"core"——所以 core 步骤必须用「已注册 ∧ 非展示类」的限定通配
+# 打勾，否则样式/视图/交互类工具（webgis_layer_upsert、缩放/飞行/视角工具、
+# 样式设置器…）会把用户"换个颜色"这类纯展示操作误打成分析步骤。
+# 本集合从实际展示工具清单手工整理（app/tools/map_view.py、layer_manager.py、
+# cartography.py、cartography_tools.py），保持显式、小、可审计。
+PRESENTATION_TOOLS: frozenset[str] = frozenset({
+    # 视图 / 相机控制（map_view.py + webgis_view_set）
+    "fly_to_location", "zoom_to_bbox", "zoom_to_layer", "reset_map_view", "set_map_view",
+    "webgis_view_set",
+    # 图层展示 / 样式 / 交互（layer_manager.py）
+    "alias_layer", "inventory_layers", "switch_base_layer", "set_layer_status",
+    "update_layer_appearance", "reorder_layer", "remove_layer",
+    "apply_layer_filter", "display_layer",
+    # MapSpec 制图生命周期 / 版面 / 编译（cartography_tools.py + templates.py）
+    "webgis_layer_upsert", "webgis_layer_remove", "webgis_layout_set",
+    "webgis_project_init", "webgis_state_get", "webgis_source_profile",
+    "webgis_validate", "webgis_compile_maplibre", "webgis_checkpoint",
+    "webgis_rollback", "webgis_runtime_validate", "webgis_map_combine",
+    # 成果导出（cartography.py）
+    "export_thematic_map", "export_batch_maps",
+})
 
 PLANNER_PROMPT = """你是 WebGIS 空间分析任务的规划器。给定用户请求与当前地图状态，
 输出一个简洁的执行计划。只输出 JSON，不要任何解释文字、不要 Markdown 代码围栏。
@@ -187,6 +214,12 @@ def parse_plan(raw: str, registry: object = None) -> Optional[Plan]:
             goal=str(s.get("goal", "")),
             tool_family=_validate_tool_family(s.get("tool_family", "core"), valid_families),
         ))
+    if not steps:
+        # P2-4（adversarial P2-7 zombie plan）：解析出的步骤列表为空
+        # （steps:[] 或全部步骤非法被跳过）→ 视为无计划，绝不返回
+        # 一个"活着的空计划"卡住 should_plan/get_plan 状态机。
+        logger.info(f"[plan_orchestrator] 计划 JSON 步骤列表为空，降级无计划: {text[:200]}")
+        return None
     return Plan(intent=intent.strip(), domains=domains, steps=steps)
 
 
@@ -299,9 +332,17 @@ class AgentPlanOrchestrator:
 
         恢复出的计划若已是终态（completed/failed/cancelled/superseded），
         视为无活跃计划。真正的跨进程/重启恢复走 ``restore_plan``（异步读 store）。
+
+        P2-5：**热缓存路径同样做终态过滤**——本轮 flush 把 canonical 算成
+        completed 后，下轮 get_plan 不得再把它当活跃计划返回（进程内保持
+        "已完成即失效"，与 restore 的冷路径一致）。
         """
         plan = self._plans.get(session_id)
         if plan is not None:
+            canon = self._canonical.get(session_id)
+            if canon is not None and canon.status in TERMINAL_STATUSES:
+                self.clear_plan(session_id)
+                return None
             return plan
         canon = plan_store.peek(session_id)
         if canon is None:
@@ -317,10 +358,15 @@ class AgentPlanOrchestrator:
         """从 plan_store 恢复当前计划（进程重启续接，R5/R10）。
 
         已在本进程 LRU 中则直接返回（不重建投影，保持身份）。恢复出的
-        终态计划视为无活跃计划。
+        终态计划视为无活跃计划（热缓存路径与 get_plan 一样做终态过滤，
+        见 P2-5）。
         """
         cached = self._plans.get(session_id)
         if cached is not None:
+            canon = self._canonical.get(session_id)
+            if canon is not None and canon.status in TERMINAL_STATUSES:
+                self.clear_plan(session_id)
+                return None
             return cached
         canon = await plan_store.load_current(session_id)
         if canon is None:
@@ -333,11 +379,17 @@ class AgentPlanOrchestrator:
         return proj
 
     async def flush(self, session_id: str) -> None:
-        """把本进程 canonical 计划（含步骤 done 状态）持久化到 plan_store。"""
+        """把本进程 canonical 计划（含步骤 done 状态）持久化到 plan_store。
+
+        P1-B(4)：flush 前 bump revision —— canonical 被 advance_step 打勾 /
+        recompute_status 改状态，revision 必须真实递增，否则 tool_metrics 里
+        plan_revision 恒为 1，跨 worker revision guard 也失去意义。
+        """
         canon = self._canonical.get(session_id)
         if canon is None:
             return
         canon.status = canon.recompute_status()
+        canon.bump_revision()
         await plan_store.save(canon)
 
     def set_plan(self, session_id: str, plan: Plan) -> None:
@@ -382,6 +434,16 @@ class AgentPlanOrchestrator:
         self._apply_capability_validation(plan, registry)
 
         prev = self._canonical.get(session_id)
+        if prev is None:
+            # P1-B(3)：进程 _canonical 缓存未命中（evicted / 重启后的新 worker）
+            # 时，supersede 判定必须回落到 store 的当前计划——否则一个刚
+            # 恢复出旧计划/无缓存的 worker 会静默 overwrite 掉更新计划，
+            # 而不是把它 supersede。
+            try:
+                prev = await plan_store.load_current(session_id)
+            except Exception as e:  # noqa: BLE001 store 读失败不阻断规划
+                logger.warning(f"[plan_orchestrator] make_plan 读取 store 当前计划失败: {e}")
+                prev = None
         canon = self._canonical_from_projection(plan, session_id)
         if (
             prev is not None
@@ -460,10 +522,17 @@ class AgentPlanOrchestrator:
         return await planner.make_plan(cfg, session_id, user_message, env_summary)
 
     def advance_step(self, session_id: str, tool_name: str, registry, tool_catalog=None) -> Optional[int]:
-        """把工具调用匹配到第一个未完成的计划步骤并打勾（R1/R6/R7）。
+        """把工具调用匹配到第一个未完成的计划步骤并打勾（R1/R6/R7 + P1-A）。
 
-        - 移除 ``"core"`` 通配：只有调用工具声明 domain 与步骤 tool_family
-          真实重叠才打勾（R1，G-report 实测未知工具/样式工具误打勾）。
+        - 非 core 步骤：只有调用工具声明 domain 与步骤 tool_family 真实重叠
+          才打勾（R1，G-report 实测未知工具/样式工具误打勾）。
+        - **core 步骤（限定通配，P1-A）**：生产注册表没有任何工具声明
+          domain "core"，而 planner prompt 对最常见步骤发 tool_family:"core"，
+          纯 domain 重叠会让 core 步骤永远无法打勾。因此 core 步骤按
+          「工具已注册（先规范化名称）∧ 不在 PRESENTATION_TOOLS 展示类排除集」
+          打勾——成功调用的分析工具（buffer_analysis / clip_layer…）打勾，
+          样式/视图/交互工具与幻觉工具名不打勾；另加一层安全网：工具的
+          声明 domains 与 plan.domains 有交集时也打勾。
         - 使用规范化工具名做 domain 查找（R7：遗留名如 set_layer_style 也能匹配）。
         - 不再调用 ``tool_catalog.decay_sticky_domain``（R8 死代码分支；TTL 衰减
           由 select_schemas 每轮自然进行）。``tool_catalog`` 参数保留仅为签名兼容。
@@ -477,10 +546,27 @@ class AgentPlanOrchestrator:
             tool_domains = set(registry.metadata(norm).get("domains", []))
         except Exception:  # noqa: BLE001 未知工具/registry 异常 → 无 domain → 不打勾
             tool_domains = set()
+        try:
+            registered = norm in set(registry.list_tools())
+        except Exception:  # noqa: BLE001 registry 异常 → 视为未注册
+            registered = False
+        plan_domains = set(plan.domains)
         for idx, step in enumerate(plan.steps):
             if step.done:
                 continue
-            if step.tool_family in tool_domains:
+            if step.tool_family == "core":
+                # P1-A 限定通配：core 步骤只按「已注册 ∧ 非展示类」打勾，或
+                # 工具的声明 domains 与 plan.domains 有交集（额外安全网）。
+                # core 步骤**永远不走**裸 domain 重叠分支——否则一个谎称
+                # core domain 的展示工具仍能误打勾。
+                if (registered and norm not in PRESENTATION_TOOLS) or (
+                    tool_domains & plan_domains
+                ):
+                    step.done = True
+                    if canon is not None and idx < len(canon.steps):
+                        canon.steps[idx].status = StepStatus.completed
+                    return step.n
+            elif step.tool_family in tool_domains:
                 step.done = True
                 if canon is not None and idx < len(canon.steps):
                     canon.steps[idx].status = StepStatus.completed

--- a/app/services/chat/plan_orchestrator.py
+++ b/app/services/chat/plan_orchestrator.py
@@ -384,6 +384,13 @@ class AgentPlanOrchestrator:
         P1-B(4)：flush 前 bump revision —— canonical 被 advance_step 打勾 /
         recompute_status 改状态，revision 必须真实递增，否则 tool_metrics 里
         plan_revision 恒为 1，跨 worker revision guard 也失去意义。
+
+        P3 #5（partially_completed 语义）：save 前先 ``recompute_status()``——
+        步骤打勾后 canonical 状态永远由步骤状态推导，不靠调用方手动设置。
+        部分成功（部分步骤完成、其余 failed/skipped 且无 pending/running）推导
+        为 ``partially_completed``：它是**非终态**（TERMINAL_STATUSES 不含它），
+        ``get_plan`` / ``restore_plan`` 不过滤它，重启后仍作为活跃计划恢复
+        （可继续推进剩余步骤）——与 plan_mode 的可恢复部分完成语义一致。
         """
         canon = self._canonical.get(session_id)
         if canon is None:

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -27,18 +27,21 @@ from pydantic import BaseModel, Field
 from app.services.session_data import session_data_manager
 from app.services.planning.deps import MissingRefError, resolve_arg_refs
 from app.services.jobs.cancellation import OperationCancelled
+from app.services.distributed_lock import session_lock_registry
 from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
 
-# ─────────────────── 进程内 per-plan 执行锁（P1-C） ───────────────────
+# ─────────────────── per-plan 执行锁（P1-C + 跨进程 claim） ───────────────────
 # 把 execute_plan 的「status 检查 → running 写入 → 执行」整段按 plan 串行化，
 # 堵住 check-then-act TOCTOU 双派发（两个并发 execute_plan 同时通过 running
-# 检查后各自 dispatch 一遍）。注意：这是**单 worker 作用域**的 asyncio.Lock
-# （跨进程的原子 plan claim 是 design-v3 明确延后项，见 .planning 文档）。
-# Redis 版 distributed_lock 是 per-session 的，且跨进程 claim 已延后，故此处
-# 使用进程内锁 + 注释声明作用域。
+# 检查后各自 dispatch 一遍）。两层锁：
+#   1. 进程内 per-plan asyncio.Lock（本模块，有界、按 (session, plan) 键控）；
+#   2. 分布式锁 session_lock_registry.lock(f"plan:{plan_id}")（P3 延后项 #2）——
+#      Redis 在时跨进程/跨 pod 原子 claim，Redis 不可用时透明降级为进程内锁
+#      （distributed_lock 契约：永不抛未处理异常）。plan_id 全局唯一，无需
+#      session 前缀。
 _PLAN_EXEC_LOCKS: dict[str, asyncio.Lock] = {}
 _PLAN_LOCKS_MAX = 1024
 
@@ -329,6 +332,85 @@ async def update_plan_status(session_id: str, plan_id: str, **updates: Any) -> N
         await set_alias(session_id, new_ref, plan_id)
 
 
+# ─────────────────── __step_results__ slim 持久化（P3 延后项 #1） ───────────────────
+# plan payload 里不再内嵌完整工具结果（大 GeoJSON / 栅格摘要可达 MB 级，Redis
+# payload 有界性问题）。每个已完成步骤的完整结果存入独立的 session ref
+# （ref:planresult-*，deterministic 别名 + 原地 overwrite——不随执行次数 mint
+# 新 ref），plan payload 只保留 slim 摘要 {__slim__, ref, keys}。resume 时按
+# ref 水合回完整结果供 ${stepId[.path]} 解析——payload 有界、语义不变。
+_PLANRESULT_ALIAS_PREFIX = "planresult:"
+
+
+def _step_result_alias(plan_id: str, step_id: str) -> str:
+    """一个 (plan, step) 一个 deterministic 结果 ref 别名（供原地 overwrite）。"""
+    return f"{_PLANRESULT_ALIAS_PREFIX}{plan_id}:{step_id}"
+
+
+def _is_slim_result(value: Any) -> bool:
+    """True 当 value 是 slim 摘要（ref 指向别处存储的完整结果）。"""
+    return isinstance(value, dict) and value.get("__slim__") is True
+
+
+def _build_slim_result(ref_id: str, result: Any) -> dict:
+    """slim 摘要：ref + 顶层 keys（有界，与完整结果大小无关）。"""
+    keys = sorted(result) if isinstance(result, dict) else []
+    return {"__slim__": True, "ref": ref_id, "keys": keys}
+
+
+async def _persist_step_results(
+    session_id: str, plan_id: str, step_results: dict[str, Any]
+) -> dict[str, Any]:
+    """把（内存中的）完整步骤结果落库到 ref:planresult-*，返回 slim 摘要 dict。
+
+    每个 (plan, step) 对应一个 deterministic 别名：首次 store() + set_alias，
+    之后 overwrite() 原地更新（镜像 PlanStore.save 的 resilience——overwrite
+    失败即重新 mint + 别名，绝不静默丢数据）。返回的摘要 dict 写入 plan payload。
+    """
+    slim: dict[str, Any] = {}
+    for sid, result in step_results.items():
+        if _is_slim_result(result):
+            slim[sid] = result  # 已是摘要（防御：水合前理论上不应出现）
+            continue
+        alias = _step_result_alias(plan_id, sid)
+        ref_id = await session_data_manager.resolve_alias(session_id, alias)
+        if ref_id != alias and await session_data_manager.overwrite(session_id, ref_id, result):
+            slim[sid] = _build_slim_result(ref_id, result)
+            continue
+        new_ref = await session_data_manager.store(session_id, result, prefix="planresult")
+        await session_data_manager.set_alias(session_id, new_ref, alias)
+        slim[sid] = _build_slim_result(new_ref, result)
+    return slim
+
+
+async def _hydrate_step_results(
+    session_id: str, step_results: dict[str, Any]
+) -> dict[str, Any]:
+    """resume 时把 slim 摘要还原为完整结果（按 ref 从 session store 读取）。
+
+    ref 已被逐出/过期 → 保留摘要原值（后续 ${} 解析会以 missing_ref 响亮失败，
+    绝不静默得到 None/""，与 deps.py 的失败哲学一致）。
+    """
+    hydrated: dict[str, Any] = {}
+    for sid, value in step_results.items():
+        if _is_slim_result(value):
+            ref = value.get("ref")
+            try:
+                full = await session_data_manager.get(session_id, ref)
+            except Exception as e:  # noqa: BLE001 读失败按失效处理
+                logger.warning(f"[PlanMode] 水合步骤结果失败 sid={sid} ref={ref}: {e}")
+                full = None
+            if full is not None:
+                hydrated[sid] = full
+            else:
+                logger.warning(
+                    f"[PlanMode] 步骤 {sid} 的结果 ref {ref} 已失效，resume 引用将失败"
+                )
+                hydrated[sid] = value
+        else:
+            hydrated[sid] = value
+    return hydrated
+
+
 # ─────────────────────────────── 执行引擎 ───────────────────────────────
 
 
@@ -360,9 +442,11 @@ async def execute_plan_async(
     - **失败持久化**：失败时同样写回 ``__step_results__``，供后续 resume 复用。
 
     P1-C（并发与崩溃恢复）：
-    - 整段执行持有**进程内 per-plan 锁**（status 检查 → running 写入 → 执行
-      串行化），堵住 check-then-act TOCTOU 双派发。作用域为单 worker
-      （跨进程原子 claim 是 design-v3 延后项）。
+    - 整段执行持有**两层 per-plan 锁**：进程内 asyncio.Lock（status 检查 →
+      running 写入 → 执行串行化）之上再套一层分布式锁
+      ``session_lock_registry.lock(f"plan:{plan_id}")``——Redis 在时跨 worker/
+      跨 pod 原子 claim（P3 延后项 #2 落地），Redis 不可用时降级为进程内锁
+      （单 worker / 测试语义不变）。绝无双派发。
     - ``running`` 但 ``__updated_at__`` 陈旧（>300s）→ 视为 crashed，允许 resume。
     - 终态写入（completed/failed/partially_completed）前重读：绝不覆盖已被
       superseded / cancelled 的计划。
@@ -375,10 +459,16 @@ async def execute_plan_async(
       transient_network）→ 直接返回存储的失败（livelock guard），不重跑。
     - superseded / legacy 计划且**无已存结果** → success=False + 明确消息。
 
+    P3 延后项 #1（payload 有界）：
+    - ``__step_results__`` 持久化采用 slim 形状（完整结果存入独立的
+      ref:planresult-* 引用，payload 只留 {__slim__, ref, keys} 摘要）；
+      resume 时按 ref 水合回完整结果供 ``${stepId[.path]}`` 解析，语义不变。
+
     返回汇总 {plan_id, status, executed, results, failed_step, error}。
     """
-    async with _get_plan_lock(session_id, plan_id):
-        return await _execute_plan_locked(session_id, plan_id, registry)
+    async with session_lock_registry.lock(f"plan:{plan_id}"):
+        async with _get_plan_lock(session_id, plan_id):
+            return await _execute_plan_locked(session_id, plan_id, registry)
 
 
 async def _execute_plan_locked(
@@ -420,8 +510,12 @@ async def _execute_plan_locked(
     plan = PlanProposal.model_validate({k: v for k, v in plan_data.items() if not k.startswith("__")})
 
     # design-v3 §4：用已存结果播种 step_results（resume 起点）。
+    # P3 #1：已存结果是 slim 摘要 → 先按 ref 水合回完整结果，保证 ${} 解析
+    # 拿到真实值（ref 失效时保留摘要，解析会响亮失败而非静默 None）。
     stored_results = plan_data.get("__step_results__")
     step_results: dict[str, Any] = dict(stored_results) if isinstance(stored_results, dict) else {}
+    if step_results:
+        step_results = await _hydrate_step_results(session_id, step_results)
 
     # 先定义辅助闭包（终态写入等），供下方环检查复用。
     async def _write_terminal(**updates: Any) -> None:
@@ -582,7 +676,7 @@ async def _execute_plan_locked(
                     __failed_step__=sid,
                     __error__=hint,
                     __failure_class__="missing_ref",
-                    __step_results__=step_results,
+                    __step_results__=await _persist_step_results(session_id, plan_id, step_results),
                 )
                 return _fail(
                     sid,
@@ -596,7 +690,7 @@ async def _execute_plan_locked(
                     __status__=_failure_status(),
                     __failed_step__=sid,
                     __error__=f"args 解析异常: {e}",
-                    __step_results__=step_results,
+                    __step_results__=await _persist_step_results(session_id, plan_id, step_results),
                 )
                 return _fail(
                     sid,
@@ -609,7 +703,7 @@ async def _execute_plan_locked(
                     __status__=_failure_status(),
                     __failed_step__=sid,
                     __error__=f"args 解析后不是 dict: {type(r).__name__}",
-                    __step_results__=step_results,
+                    __step_results__=await _persist_step_results(session_id, plan_id, step_results),
                 )
                 return _fail(
                     sid,
@@ -655,7 +749,7 @@ async def _execute_plan_locked(
                     await _write_terminal(
                         __status__="cancelled",
                         __error__=str(e) or "用户取消",
-                        __step_results__=step_results,
+                        __step_results__=await _persist_step_results(session_id, plan_id, step_results),
                     )
                     return {
                         "success": False,
@@ -710,7 +804,8 @@ async def _execute_plan_locked(
                 "__failed_step__": sid,
                 "__error__": err,
                 # design-v3 §4：失败也保留已完成结果，供下次 execute_plan resume。
-                "__step_results__": step_results,
+                # P3 #1：持久化 slim 摘要（完整结果在 ref:planresult-*）。
+                "__step_results__": await _persist_step_results(session_id, plan_id, step_results),
             }
             if fc is not None:
                 updates["__failure_class__"] = fc
@@ -726,7 +821,7 @@ async def _execute_plan_locked(
 
     await _write_terminal(
         __status__="completed",
-        __step_results__=step_results,
+        __step_results__=await _persist_step_results(session_id, plan_id, step_results),
     )
     return {
         "success": True,

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 from pydantic import BaseModel, Field
 
 from app.services.session_data import session_data_manager
+from app.services.planning.deps import MissingRefError, resolve_arg_refs
 from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
@@ -200,8 +201,57 @@ async def store_plan(session_id: str, plan: PlanProposal) -> str:
     """把计划落进 session_data_manager，返回 plan_id (即 ref:plan-xxxxxx)。"""
     payload = plan.model_dump()
     payload["__kind__"] = "plan_proposal"
-    payload["__status__"] = "pending"  # pending | running | completed | failed | cancelled
+    # 状态词表：pending | running | partially_completed | completed | failed
+    #           | cancelled | superseded
+    # 说明：fail-fast 路径失败时仍写 ``failed``（向后兼容 get_plan_status /
+    # execute_plan 的既有调用方）；``partially_completed`` 作为可读/可恢复状态
+    # 被 execute_plan 接受（与 failed 同样触发 resume 语义）。
+    payload["__status__"] = "pending"
     return await session_data_manager.store(session_id, payload, prefix="plan")
+
+
+async def supersede_active_plans(session_id: str) -> None:
+    """design-v3 §4：新计划提出时，把该 session 其他 pending/running 的
+    plan-mode 计划标记为 superseded（绝不静默覆盖/并发双活）。
+
+    只扫描 ref:plan-* 条目；scan + get 都是 session_data 的轻量读。
+    """
+    try:
+        refs = await session_data_manager.list_refs(session_id)
+    except Exception:  # noqa: BLE001
+        return
+    for ref in refs:
+        if not str(ref).startswith("ref:plan-"):
+            continue
+        data = await session_data_manager.get(session_id, ref)
+        if not isinstance(data, dict):
+            continue
+        if data.get("__status__") in ("pending", "running"):
+            await update_plan_status(session_id, ref, __status__="superseded")
+
+
+def validate_static_refs(plan: PlanProposal) -> list[str]:
+    """Propose-time 静态引用校验（design-v3 §deps）。
+
+    委托 app/services/planning/deps.validate_static_refs（CanonicalStep 形态）。
+    与 validate_plan 的重叠检查（未知 id / 前向引用 / 自引用 / 环）在 validate_plan
+    中已全部拦截，此调用是补充性第二道闸——返回完整 issue 列表，空列表即通过。
+    """
+    from app.services.planning.deps import validate_static_refs as _v
+    from app.services.planning.models import CanonicalStep
+    steps = [
+        CanonicalStep(
+            id=s.id,
+            n=i + 1,
+            goal=s.purpose or s.tool,
+            tool_family=None,
+            tool=s.tool,
+            args=s.args,
+            depends_on=list(s.depends_on),
+        )
+        for i, s in enumerate(plan.steps)
+    ]
+    return _v(steps)
 
 
 async def load_plan(session_id: str, plan_id: str) -> Optional[dict]:
@@ -250,14 +300,26 @@ async def execute_plan_async(
 
     语义差异（与纯串行相比）：同一波次中与失败步骤无依赖关系的兄弟
     步骤可能已完成（结果计入 executed）——"立即中止" 指不再启动新的
-    波次，已派发的任务允许收尾。
+    波次，已派发的任务允许收尾（siblings-finish 契约，见下方失败处理）。
+
+    design-v3 §4 收敛：
+    - **Resume**：对 ``__status__`` ∈ {failed, partially_completed} 的计划，
+      ``__step_results__`` 里已记录成功结果的步骤**不重新 dispatch**，其
+      结果直接用于 ``${stepId}`` 解析；只有 pending/failed 步骤执行。
+      completed / superseded 的计划直接返回已存结果，不重放（运行中 guard
+      "已在执行中" 保持）。无新参数，resume 语义自动生效。
+    - **Typed refs**：``${stepId[.path]}`` 解析失败（坏路径 / 无结果）→ 该
+      步骤立即失败，``failure_class=missing_ref`` + 修正提示（列出坏路径与
+      可用 keys），不再静默得到 None/""。
+    - **失败持久化**：失败时同样写回 ``__step_results__``，供后续 resume 复用。
 
     返回汇总 {plan_id, status, executed, results, failed_step, error}。
     """
     plan_data = await load_plan(session_id, plan_id)
     if plan_data is None:
         return {"success": False, "error": f"找不到 plan_id={plan_id}"}
-    if plan_data.get("__status__") == "running":
+    status = plan_data.get("__status__", "pending")
+    if status == "running":
         return {"success": False, "error": f"plan {plan_id} 已在执行中"}
 
     # 还原 Pydantic 模型用于拓扑排序
@@ -268,27 +330,37 @@ async def execute_plan_async(
         await update_plan_status(session_id, plan_id, __status__="failed", __error__="cycle")
         return {"success": False, "error": "依赖图含环"}
 
-    # 构建邻接表 / 入度，用于波次调度（与 _topological_order 同一依赖口径）
     topo_idx = {sid: i for i, sid in enumerate(order)}
-    in_degree: dict[str, int] = {s.id: 0 for s in plan.steps}
-    edges: dict[str, list[str]] = {s.id: [] for s in plan.steps}
-    for step in plan.steps:
-        deps = set(step.depends_on) | _extract_refs(step.args)
-        deps.discard(step.id)
-        for dep in deps:
-            if dep in in_degree:
-                edges[dep].append(step.id)
-                in_degree[step.id] += 1
-
     step_by_id = {s.id: s for s in plan.steps}
-    step_results: dict[str, Any] = {}
-    await update_plan_status(session_id, plan_id, __status__="running")
+
+    # design-v3 §4：用已存结果播种 step_results（resume 起点）。
+    stored_results = plan_data.get("__step_results__")
+    step_results: dict[str, Any] = dict(stored_results) if isinstance(stored_results, dict) else {}
 
     def _ordered_executed() -> list[str]:
         """已执行步骤按拓扑序输出（确定性，不依赖并发完成顺序）。"""
         return sorted(step_results.keys(), key=topo_idx.__getitem__)
 
-    def _fail(sid: str, error: str, last_result: Optional[Any] = None) -> dict:
+    # design-v3 §4：completed / superseded 计划直接返回已存结果，不重放。
+    if status in ("completed", "superseded") or all(
+        s.id in step_results for s in plan.steps
+    ):
+        return {
+            "success": True,
+            "plan_id": plan_id,
+            "status": status if status in ("completed", "superseded") else "completed",
+            "executed": _ordered_executed(),
+            "results": step_results,
+        }
+
+    def _fail(
+        sid: str,
+        error: str,
+        last_result: Optional[Any] = None,
+        failure_class: Optional[str] = None,
+        recovery_action: Optional[str] = None,
+        correction_hint: Optional[str] = None,
+    ) -> dict:
         # 失败中止：不再启动新波次；已完成的兄弟步骤保留在 executed 中。
         ret: dict = {
             "success": False,
@@ -299,9 +371,31 @@ async def execute_plan_async(
             "executed": _ordered_executed(),
             "results": step_results,
         }
+        if failure_class is not None:
+            ret["failure_class"] = failure_class
+        if recovery_action is not None:
+            ret["recovery_action"] = recovery_action
+        if correction_hint is not None:
+            ret["correction_hint"] = correction_hint
         if last_result is not None:
             ret["last_result"] = last_result
         return ret
+
+    await update_plan_status(session_id, plan_id, __status__="running")
+
+    # RESUME：已有结果的步骤跳过（上次运行存下的结果继续供 ${} 引用），
+    # 只对剩余步骤构建波次 DAG；已完成依赖不阻塞剩余步骤。
+    unfinished = [s for s in plan.steps if s.id not in step_results]
+    in_degree: dict[str, int] = {s.id: 0 for s in unfinished}
+    edges: dict[str, list[str]] = {s.id: [] for s in unfinished}
+    for step in unfinished:
+        deps = (set(step.depends_on) | _extract_refs(step.args)) - {step.id}
+        for dep in deps:
+            if dep in step_results:
+                continue  # 依赖已有结果（本次或上次运行）→ 不阻塞
+            if dep in in_degree:
+                edges[dep].append(step.id)
+                in_degree[step.id] += 1
 
     ready: list[str] = [sid for sid, d in in_degree.items() if d == 0]
 
@@ -315,23 +409,52 @@ async def execute_plan_async(
         for sid in wave:
             step = step_by_id[sid]
             try:
-                r = resolve_refs(step.args, step_results)
+                r = resolve_arg_refs(step.args, step_results)
+            except MissingRefError as e:
+                hint = str(e)
+                await update_plan_status(
+                    session_id, plan_id,
+                    __status__="failed",
+                    __failed_step__=sid,
+                    __error__=hint,
+                    __failure_class__="missing_ref",
+                    __step_results__=step_results,
+                )
+                return _fail(
+                    sid,
+                    f"步骤 {sid!r} 引用解析失败: {hint}",
+                    failure_class="missing_ref",
+                    recovery_action="reuse_ref",
+                    correction_hint=hint,
+                )
             except Exception as e:  # noqa: BLE001
                 await update_plan_status(
                     session_id, plan_id,
                     __status__="failed",
                     __failed_step__=sid,
                     __error__=f"args 解析异常: {e}",
+                    __step_results__=step_results,
                 )
-                return _fail(sid, f"步骤 {sid!r} args 解析异常: {e}")
+                return _fail(
+                    sid,
+                    f"步骤 {sid!r} args 解析异常: {e}",
+                    failure_class="internal",
+                    recovery_action="replan_remaining",
+                )
             if not isinstance(r, dict):
                 await update_plan_status(
                     session_id, plan_id,
                     __status__="failed",
                     __failed_step__=sid,
                     __error__=f"args 解析后不是 dict: {type(r).__name__}",
+                    __step_results__=step_results,
                 )
-                return _fail(sid, f"步骤 {sid!r} args 解析后不是 dict")
+                return _fail(
+                    sid,
+                    f"步骤 {sid!r} args 解析后不是 dict",
+                    failure_class="validation",
+                    recovery_action="correct_args",
+                )
 
             resolved_args[sid] = r
 
@@ -349,7 +472,8 @@ async def execute_plan_async(
         task_to_sid = {t: sid for sid, t in tasks.items()}
 
         wave_successes: dict[str, Any] = {}
-        failure: Optional[tuple[str, str, Optional[Any]]] = None  # (sid, error, last_result)
+        # (sid, error, last_result, failure_class, recovery_action)
+        failure: Optional[tuple[str, str, Optional[Any], Optional[str], Optional[str]]] = None
         pending: set[asyncio.Task] = set(tasks.values())
         while pending:
             done, pending = await asyncio.wait(
@@ -363,11 +487,14 @@ async def execute_plan_async(
                     continue  # 外部取消（如引擎关闭），忽略该任务
                 except Exception as e:
                     logger.exception(f"[PlanMode] step {sid} raised")
-                    failure = (sid, str(e), None)
+                    fc, ra = _classify_failure(exception=e)
+                    failure = (sid, str(e), None, fc, ra)
                     break
                 # 工具返回 success=False（V3.x Exception As Thought 包装）也视为失败
                 if isinstance(result, dict) and result.get("success") is False:
-                    failure = (sid, result.get("message") or result.get("error", "tool failed"), result)
+                    err = result.get("message") or result.get("error", "tool failed")
+                    fc, ra = _classify_failure(result=result)
+                    failure = (sid, err, result, fc, ra)
                     break
                 wave_successes[sid] = result
             if failure is not None:
@@ -396,14 +523,18 @@ async def execute_plan_async(
                 step_results[sid] = wave_successes[sid]
 
         if failure is not None:
-            sid, err, last_result = failure
-            await update_plan_status(
-                session_id, plan_id,
-                __status__="failed",
-                __failed_step__=sid,
-                __error__=err,
-            )
-            return _fail(sid, err, last_result)
+            sid, err, last_result, fc, ra = failure
+            updates: dict[str, Any] = {
+                "__status__": "failed",
+                "__failed_step__": sid,
+                "__error__": err,
+                # design-v3 §4：失败也保留已完成结果，供下次 execute_plan resume。
+                "__step_results__": step_results,
+            }
+            if fc is not None:
+                updates["__failure_class__"] = fc
+            await update_plan_status(session_id, plan_id, **updates)
+            return _fail(sid, err, last_result, failure_class=fc, recovery_action=ra)
 
         # 波次完成 → 推进依赖图，解锁下一波次
         for sid in wave:
@@ -424,3 +555,25 @@ async def execute_plan_async(
         "executed": _ordered_executed(),
         "results": step_results,
     }
+
+
+def _classify_failure(
+    *,
+    result: Optional[dict] = None,
+    exception: Optional[Exception] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """design-v3 §recovery：把 plan-mode 工具失败分类成 failure_class +
+    recovery_action（additive 返回字段，不改变任何重试行为）。"""
+    from app.services.planning.recovery import classify_error, recovery_action_for
+    try:
+        if exception is not None:
+            fc = classify_error(exception=exception)
+        else:
+            fc = classify_error(
+                code=(result or {}).get("code"),
+                error_type=(result or {}).get("error_type"),
+                message=(result or {}).get("message") or (result or {}).get("error"),
+            )
+        return fc.value, recovery_action_for(fc).value
+    except Exception:  # noqa: BLE001 分类失败不拖垮执行
+        return None, None

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from collections import deque
 from typing import Any, Optional
 
@@ -25,9 +26,39 @@ from pydantic import BaseModel, Field
 
 from app.services.session_data import session_data_manager
 from app.services.planning.deps import MissingRefError, resolve_arg_refs
+from app.services.jobs.cancellation import OperationCancelled
 from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
+
+
+# ─────────────────── 进程内 per-plan 执行锁（P1-C） ───────────────────
+# 把 execute_plan 的「status 检查 → running 写入 → 执行」整段按 plan 串行化，
+# 堵住 check-then-act TOCTOU 双派发（两个并发 execute_plan 同时通过 running
+# 检查后各自 dispatch 一遍）。注意：这是**单 worker 作用域**的 asyncio.Lock
+# （跨进程的原子 plan claim 是 design-v3 明确延后项，见 .planning 文档）。
+# Redis 版 distributed_lock 是 per-session 的，且跨进程 claim 已延后，故此处
+# 使用进程内锁 + 注释声明作用域。
+_PLAN_EXEC_LOCKS: dict[str, asyncio.Lock] = {}
+_PLAN_LOCKS_MAX = 1024
+
+# running 状态超过该秒数视为 crashed（worker 崩溃/被杀），允许 resume。
+_RUNNING_STALE_SECONDS = 300
+
+
+def _get_plan_lock(session_id: str, plan_id: str) -> asyncio.Lock:
+    """取该 (session, plan) 的执行锁（进程内、有界）。"""
+    key = f"{session_id}\0{plan_id}"
+    lock = _PLAN_EXEC_LOCKS.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _PLAN_EXEC_LOCKS[key] = lock
+        if len(_PLAN_EXEC_LOCKS) > _PLAN_LOCKS_MAX:
+            # 淘汰空闲锁（无持有者无等待者），防止长跑进程无限增长。
+            idle = [k for k, lock in _PLAN_EXEC_LOCKS.items() if not lock.locked()][: _PLAN_LOCKS_MAX // 4]
+            for k in idle:
+                _PLAN_EXEC_LOCKS.pop(k, None)
+    return lock
 
 
 # ────────────────────────────── 数据模型 ──────────────────────────────
@@ -207,6 +238,7 @@ async def store_plan(session_id: str, plan: PlanProposal) -> str:
     # execute_plan 的既有调用方）；``partially_completed`` 作为可读/可恢复状态
     # 被 execute_plan 接受（与 failed 同样触发 resume 语义）。
     payload["__status__"] = "pending"
+    payload["__updated_at__"] = time.time()  # P1-C：stale-running 判定依赖它
     return await session_data_manager.store(session_id, payload, prefix="plan")
 
 
@@ -269,18 +301,32 @@ async def update_plan_status(session_id: str, plan_id: str, **updates: Any) -> N
     生成新的 ref_id 而非原地覆盖。所以这里用 overwrite() 把更新后的 dict 写回
     原始 key。内存后端虽然返回的是同一个对象（mutation 会“偶然”可见），但同样
     走 overwrite 以保持两个后端行为一致。
+
+    P0-1（数据丢失防御）：overwrite() 返回 False 说明原始 ref 已被逐出（LRU
+    容量淘汰 / Redis DATA_TTL 过期）或后端降级——此时**重新 mint** 一个新 ref
+    并把旧 plan_id 注册为别名，持有 plan_id 的调用方（load_plan /
+    get_plan_status）仍能经别名寻址到最新 payload（镜像 PlanStore.save 的
+    resilience，见 app/services/planning/store.py:123-141）。绝不静默丢写。
+
+    每次写回都会自动刷新 ``__updated_at__``（stale-running 判定用），除非
+    调用方显式传了该字段。
     """
     plan_data = await load_plan(session_id, plan_id)
     if plan_data is None:
         logger.warning(f"update_plan_status: plan {plan_id} 不存在")
         return
+    updates.setdefault("__updated_at__", time.time())
     plan_data.update(updates)
     overwrite = getattr(session_data_manager, "overwrite", None)
-    if overwrite is not None:
-        await overwrite(session_id, plan_id, plan_data)
-    else:
-        # Backends without overwrite(): fall back to store (in-memory only path).
-        await session_data_manager.store(session_id, plan_data, prefix="plan")
+    if overwrite is not None and await overwrite(session_id, plan_id, plan_data):
+        return
+    # overwrite 失败（ref 被逐出 / 后端降级）→ 重新 mint + 把旧 plan_id 注册为
+    # 别名，保证既有调用方仍读到更新后的 payload。set_alias 缺失的后端（测试
+    # stub）退化为仅 re-mint（尽力而为）。
+    new_ref = await session_data_manager.store(session_id, plan_data, prefix="plan")
+    set_alias = getattr(session_data_manager, "set_alias", None)
+    if set_alias is not None:
+        await set_alias(session_id, new_ref, plan_id)
 
 
 # ─────────────────────────────── 执行引擎 ───────────────────────────────
@@ -313,45 +359,164 @@ async def execute_plan_async(
       可用 keys），不再静默得到 None/""。
     - **失败持久化**：失败时同样写回 ``__step_results__``，供后续 resume 复用。
 
+    P1-C（并发与崩溃恢复）：
+    - 整段执行持有**进程内 per-plan 锁**（status 检查 → running 写入 → 执行
+      串行化），堵住 check-then-act TOCTOU 双派发。作用域为单 worker
+      （跨进程原子 claim 是 design-v3 延后项）。
+    - ``running`` 但 ``__updated_at__`` 陈旧（>300s）→ 视为 crashed，允许 resume。
+    - 终态写入（completed/failed/partially_completed）前重读：绝不覆盖已被
+      superseded / cancelled 的计划。
+    - 工具抛 ``OperationCancelled`` → 写终态 ``cancelled``（terminal），
+      resume 拒绝 cancelled 计划。
+
+    P2-1（失败语义）：
+    - 失败路径有已存结果时写 ``partially_completed``，否则 ``failed``。
+    - 确定性失败（首个未完成步骤 == 上次失败步骤，failure_class 非
+      transient_network）→ 直接返回存储的失败（livelock guard），不重跑。
+    - superseded / legacy 计划且**无已存结果** → success=False + 明确消息。
+
     返回汇总 {plan_id, status, executed, results, failed_step, error}。
     """
+    async with _get_plan_lock(session_id, plan_id):
+        return await _execute_plan_locked(session_id, plan_id, registry)
+
+
+async def _execute_plan_locked(
+    session_id: str,
+    plan_id: str,
+    registry: ToolRegistry,
+) -> dict:
+    """execute_plan_async 的锁内实现（P1-C / P2-1 语义见 execute_plan_async）。"""
     plan_data = await load_plan(session_id, plan_id)
     if plan_data is None:
         return {"success": False, "error": f"找不到 plan_id={plan_id}"}
     status = plan_data.get("__status__", "pending")
     if status == "running":
-        return {"success": False, "error": f"plan {plan_id} 已在执行中"}
+        # P1-C：running 但 updated_at 陈旧（>300s，或字段缺失）→ 视为 crashed，
+        # 允许 resume。旧 payload 无 __updated_at__ → 一律视为 crashed 孤儿。
+        updated_at = plan_data.get("__updated_at__")
+        try:
+            stale = updated_at is None or (time.time() - float(updated_at)) > _RUNNING_STALE_SECONDS
+        except (TypeError, ValueError):
+            stale = True
+        if stale:
+            logger.info(
+                f"[PlanMode] plan {plan_id} 上次运行状态已陈旧（crashed 判定），按可恢复计划继续"
+            )
+        else:
+            return {"success": False, "error": f"plan {plan_id} 已在执行中"}
+    elif status == "cancelled":
+        # P1-C：resume 必须拒绝已取消的计划。
+        return {
+            "success": False,
+            "plan_id": plan_id,
+            "status": "cancelled",
+            "error": f"plan {plan_id} 已取消，拒绝执行",
+            "executed": [],
+            "results": {},
+        }
 
     # 还原 Pydantic 模型用于拓扑排序
     plan = PlanProposal.model_validate({k: v for k, v in plan_data.items() if not k.startswith("__")})
-
-    order = _topological_order(plan)
-    if order is None:
-        await update_plan_status(session_id, plan_id, __status__="failed", __error__="cycle")
-        return {"success": False, "error": "依赖图含环"}
-
-    topo_idx = {sid: i for i, sid in enumerate(order)}
-    step_by_id = {s.id: s for s in plan.steps}
 
     # design-v3 §4：用已存结果播种 step_results（resume 起点）。
     stored_results = plan_data.get("__step_results__")
     step_results: dict[str, Any] = dict(stored_results) if isinstance(stored_results, dict) else {}
 
+    # 先定义辅助闭包（终态写入等），供下方环检查复用。
+    async def _write_terminal(**updates: Any) -> None:
+        """终态写入（P1-C）：写入前重读，绝不覆盖 superseded / cancelled。
+
+        执行中途被 supersede_active_plans 取代 / 被用户取消的计划，其终态是
+        真相；本执行体的 completed / failed 不得把它覆盖回活跃语义。
+        """
+        fresh = await load_plan(session_id, plan_id)
+        cur = (fresh or {}).get("__status__")
+        if cur in ("superseded", "cancelled"):
+            logger.info(
+                f"[PlanMode] plan {plan_id} 已处于 {cur}，跳过终态覆盖 {updates.get('__status__')}"
+            )
+            return
+        await update_plan_status(session_id, plan_id, **updates)
+
+    order = _topological_order(plan)
+    if order is None:
+        await _write_terminal(__status__="failed", __error__="cycle")
+        return {"success": False, "error": "依赖图含环"}
+
+    topo_idx = {sid: i for i, sid in enumerate(order)}
+    step_by_id = {s.id: s for s in plan.steps}
+
     def _ordered_executed() -> list[str]:
         """已执行步骤按拓扑序输出（确定性，不依赖并发完成顺序）。"""
         return sorted(step_results.keys(), key=topo_idx.__getitem__)
 
-    # design-v3 §4：completed / superseded 计划直接返回已存结果，不重放。
-    if status in ("completed", "superseded") or all(
-        s.id in step_results for s in plan.steps
-    ):
+    # design-v3 §4：superseded 计划优先于 completed 判定（存储状态即真相）——
+    # 有已存结果则返回（不重放），无结果则明确失败（P2-3）。
+    if status == "superseded":
+        if not step_results:
+            return {
+                "success": False,
+                "plan_id": plan_id,
+                "status": "superseded",
+                "error": f"plan {plan_id} 已被新计划取代且未执行任何步骤",
+                "executed": [],
+                "results": {},
+            }
         return {
             "success": True,
             "plan_id": plan_id,
-            "status": status if status in ("completed", "superseded") else "completed",
+            "status": "superseded",
             "executed": _ordered_executed(),
             "results": step_results,
         }
+    # completed 或全部步骤已有结果 → 直接返回已存结果，不重放。
+    if status == "completed" or all(s.id in step_results for s in plan.steps):
+        return {
+            "success": True,
+            "plan_id": plan_id,
+            "status": "completed",
+            "executed": _ordered_executed(),
+            "results": step_results,
+        }
+
+    # P2-2 livelock guard：确定性失败（首个未完成步骤 == 上次失败步骤，
+    # 且 failure_class 非 transient_network）→ 直接返回存储的失败，不重跑。
+    if status in ("failed", "partially_completed"):
+        failed_step = plan_data.get("__failed_step__")
+        fc = plan_data.get("__failure_class__")
+        unfinished = [sid for sid in order if sid not in step_results]
+        if (
+            failed_step
+            and fc
+            and fc != "transient_network"
+            and unfinished
+            and unfinished[0] == failed_step
+        ):
+            err = plan_data.get("__error__") or f"步骤 {failed_step!r} 确定性失败"
+            ra = _recovery_action_for_class(fc)
+            logger.info(
+                f"[PlanMode] plan {plan_id} 步骤 {failed_step} 为确定性失败（{fc}），"
+                f"拒绝盲目重跑（livelock guard）"
+            )
+            ret: dict = {
+                "success": False,
+                "plan_id": plan_id,
+                "status": status,
+                "failed_step": failed_step,
+                "tool": step_by_id[failed_step].tool,
+                "error": err,
+                "failure_class": fc,
+                "executed": _ordered_executed(),
+                "results": step_results,
+            }
+            if ra is not None:
+                ret["recovery_action"] = ra
+            return ret
+
+    def _failure_status() -> str:
+        """P2-1：有已存结果 → partially_completed（可读/可恢复）；否则 failed。"""
+        return "partially_completed" if step_results else "failed"
 
     def _fail(
         sid: str,
@@ -412,9 +577,8 @@ async def execute_plan_async(
                 r = resolve_arg_refs(step.args, step_results)
             except MissingRefError as e:
                 hint = str(e)
-                await update_plan_status(
-                    session_id, plan_id,
-                    __status__="failed",
+                await _write_terminal(
+                    __status__=_failure_status(),
                     __failed_step__=sid,
                     __error__=hint,
                     __failure_class__="missing_ref",
@@ -428,9 +592,8 @@ async def execute_plan_async(
                     correction_hint=hint,
                 )
             except Exception as e:  # noqa: BLE001
-                await update_plan_status(
-                    session_id, plan_id,
-                    __status__="failed",
+                await _write_terminal(
+                    __status__=_failure_status(),
                     __failed_step__=sid,
                     __error__=f"args 解析异常: {e}",
                     __step_results__=step_results,
@@ -442,9 +605,8 @@ async def execute_plan_async(
                     recovery_action="replan_remaining",
                 )
             if not isinstance(r, dict):
-                await update_plan_status(
-                    session_id, plan_id,
-                    __status__="failed",
+                await _write_terminal(
+                    __status__=_failure_status(),
                     __failed_step__=sid,
                     __error__=f"args 解析后不是 dict: {type(r).__name__}",
                     __step_results__=step_results,
@@ -485,6 +647,25 @@ async def execute_plan_async(
                     result = t.result()
                 except asyncio.CancelledError:
                     continue  # 外部取消（如引擎关闭），忽略该任务
+                except OperationCancelled as e:
+                    # P1-C：用户取消不是工具故障 —— 写终态 cancelled（terminal），
+                    # 用 logger.info 记录（不是 exception）。走 _write_terminal：
+                    # 若计划已在途中被 superseded，保留 superseded 不被覆盖。
+                    logger.info(f"[PlanMode] plan {plan_id} 执行被取消: {e}")
+                    await _write_terminal(
+                        __status__="cancelled",
+                        __error__=str(e) or "用户取消",
+                        __step_results__=step_results,
+                    )
+                    return {
+                        "success": False,
+                        "plan_id": plan_id,
+                        "status": "cancelled",
+                        "error": f"plan {plan_id} 已取消",
+                        "executed": _ordered_executed(),
+                        "results": step_results,
+                        "failure_class": "cancelled",
+                    }
                 except Exception as e:
                     logger.exception(f"[PlanMode] step {sid} raised")
                     fc, ra = _classify_failure(exception=e)
@@ -525,7 +706,7 @@ async def execute_plan_async(
         if failure is not None:
             sid, err, last_result, fc, ra = failure
             updates: dict[str, Any] = {
-                "__status__": "failed",
+                "__status__": _failure_status(),
                 "__failed_step__": sid,
                 "__error__": err,
                 # design-v3 §4：失败也保留已完成结果，供下次 execute_plan resume。
@@ -533,7 +714,7 @@ async def execute_plan_async(
             }
             if fc is not None:
                 updates["__failure_class__"] = fc
-            await update_plan_status(session_id, plan_id, **updates)
+            await _write_terminal(**updates)
             return _fail(sid, err, last_result, failure_class=fc, recovery_action=ra)
 
         # 波次完成 → 推进依赖图，解锁下一波次
@@ -543,8 +724,7 @@ async def execute_plan_async(
                 if in_degree[nxt] == 0:
                     ready.append(nxt)
 
-    await update_plan_status(
-        session_id, plan_id,
+    await _write_terminal(
         __status__="completed",
         __step_results__=step_results,
     )
@@ -555,6 +735,16 @@ async def execute_plan_async(
         "executed": _ordered_executed(),
         "results": step_results,
     }
+
+
+def _recovery_action_for_class(failure_class: str) -> Optional[str]:
+    """从 failure_class 反查 recovery_action；分类失败返回 None。"""
+    try:
+        from app.services.planning.models import FailureClass as _FC
+        from app.services.planning.recovery import recovery_action_for
+        return recovery_action_for(_FC(failure_class)).value
+    except Exception:  # noqa: BLE001 分类失败不拖垮执行
+        return None
 
 
 def _classify_failure(

--- a/app/services/planning/__init__.py
+++ b/app/services/planning/__init__.py
@@ -1,0 +1,74 @@
+"""Planning foundation package (design-v3 §"New package app/services/planning/").
+
+The canonical planning model (``CanonicalPlan``) is the source of truth for
+plan state, persisted per session via ``PlanStore`` over the existing
+``session_data_manager``. This slice ships the foundation only — integration
+with the orchestrator / plan_mode / execution engine lands in a later slice.
+"""
+from .capability import (
+    PRODUCES_REF_DOMAINS,
+    ToolCapability,
+    capability_of,
+    validate_plan_capabilities,
+)
+from .deps import (
+    REF_PATTERN,
+    MissingRefError,
+    resolve_arg_refs,
+    validate_static_refs,
+)
+from .followup import (
+    CONTINUATION_KEYWORDS,
+    REF_REUSE_KEYWORDS,
+    STYLE_KEYWORDS,
+    FollowUpKind,
+    classify_followup,
+)
+from .models import (
+    TERMINAL_STATUSES,
+    CanonicalPlan,
+    CanonicalStep,
+    FailureClass,
+    PlanStatus,
+    RecoveryAction,
+    StepError,
+    StepStatus,
+)
+from .recovery import RECOVERY_POLICY, classify_error, recovery_action_for
+from .store import CURRENT_PLAN_ALIAS, PlanStore, plan_store
+
+__all__ = [
+    # models
+    "PlanStatus",
+    "TERMINAL_STATUSES",
+    "StepStatus",
+    "FailureClass",
+    "RecoveryAction",
+    "StepError",
+    "CanonicalStep",
+    "CanonicalPlan",
+    # store
+    "PlanStore",
+    "plan_store",
+    "CURRENT_PLAN_ALIAS",
+    # capability
+    "ToolCapability",
+    "capability_of",
+    "validate_plan_capabilities",
+    "PRODUCES_REF_DOMAINS",
+    # deps
+    "REF_PATTERN",
+    "MissingRefError",
+    "validate_static_refs",
+    "resolve_arg_refs",
+    # recovery
+    "classify_error",
+    "RECOVERY_POLICY",
+    "recovery_action_for",
+    # followup
+    "FollowUpKind",
+    "classify_followup",
+    "STYLE_KEYWORDS",
+    "CONTINUATION_KEYWORDS",
+    "REF_REUSE_KEYWORDS",
+]

--- a/app/services/planning/capability.py
+++ b/app/services/planning/capability.py
@@ -1,0 +1,154 @@
+"""Tool capability derivation from registry metadata (design-v3 §capability).
+
+No LLM and no new registration annotations: capabilities are derived
+deterministically from what ``ToolRegistry`` already exposes — ``tier``,
+``domains``, ``execution_policy`` (registry.py:223-227) and the OpenAI-format
+parameter schema (``get_schemas_subset``) — plus one small, documented
+heuristic for ``requires_ref``. ``validate_plan_capabilities`` returns a
+deterministic issue list; an empty list means the plan is viable.
+
+The keyword-based domain detector in tool_catalog.py stays the runtime
+fallback — untouched by this slice.
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+from app.tools.registry import ToolRegistry
+
+from .models import CanonicalPlan
+
+# Domains whose tools produce a session-data ref (cursor) as their primary
+# output. Default for ``produces_ref``; override explicitly per tool when the
+# domain default is wrong (a ref-less tool tagged with one of these domains).
+PRODUCES_REF_DOMAINS: frozenset[str] = frozenset(
+    {
+        "osm",
+        "data_fabric",
+        "dataset",
+        "spatial_catalog",
+        "network",
+        "raster",
+        "statistics",
+        "spatial",
+        "temporal",
+        "remote_sensing",
+        "chinese",
+        "geocoding",
+    }
+)
+
+# Param-name tokens that suggest the argument receives an existing data ref
+# (ref_id / layer_ref / input_ref / source / target / asset_id ...).
+_REF_NAME_TOKENS = ("ref", "layer", "geojson", "source", "target", "asset")
+
+
+@dataclass
+class ToolCapability:
+    """Static capability digest of one registered tool.
+
+    ``destructive`` defaults to ``tier >= 3`` (the repo's existing derivation,
+    e.g. plan_mode.py:65,80); pass an explicit bool to override. ``produces_ref``
+    defaults to membership of any ``domains`` in ``PRODUCES_REF_DOMAINS``; pass
+    an explicit bool to override. ``requires_ref`` is set by ``capability_of``
+    from the documented param-name heuristic.
+    """
+
+    name: str
+    tier: int
+    domains: list[str]
+    execution_policy: str
+    destructive: Optional[bool] = None
+    requires_ref: bool = False
+    produces_ref: Optional[bool] = None
+
+    def __post_init__(self) -> None:
+        if self.destructive is None:
+            self.destructive = self.tier >= 3
+        if self.produces_ref is None:
+            self.produces_ref = bool(set(self.domains) & PRODUCES_REF_DOMAINS)
+
+
+def _requires_ref_heuristic(tool_name: str, registry: ToolRegistry) -> bool:
+    """``requires_ref`` heuristic over the tool's JSON-schema properties.
+
+    True when any parameter is named like a ref (contains one of
+    ``_REF_NAME_TOKENS``), or when any property's string content contains
+    ``ref:`` (e.g. a description documenting the ref syntax). Simple and
+    documented; ~90% accurate on the measured registry (swarm report B §8).
+    """
+    schemas = registry.get_schemas_subset({tool_name})
+    if not schemas:
+        return False
+    properties = schemas[0]["function"]["parameters"].get("properties", {})
+    for p_name, prop in properties.items():
+        name_l = p_name.lower()
+        if any(tok in name_l for tok in _REF_NAME_TOKENS):
+            return True
+        if "ref:" in str(prop):
+            return True
+    return False
+
+
+def capability_of(tool_name: str, registry: ToolRegistry) -> Optional[ToolCapability]:
+    """Derive a ToolCapability from registry metadata; None when unregistered."""
+    if tool_name not in registry.list_tools():
+        return None
+    meta = registry.metadata(tool_name)
+    policy = meta.get("execution_policy")
+    policy_str = policy.value if hasattr(policy, "value") else str(policy or "thread")
+    return ToolCapability(
+        name=tool_name,
+        tier=int(meta.get("tier", 1)),
+        domains=list(meta.get("domains", [])),
+        execution_policy=policy_str,
+        requires_ref=_requires_ref_heuristic(tool_name, registry),
+    )
+
+
+def validate_plan_capabilities(plan: CanonicalPlan, registry: ToolRegistry) -> list[str]:
+    """Deterministic capability validation; empty list = viable plan.
+
+    Issues (``error:``) and warnings (``warning:``) are emitted in plan step
+    order for:
+
+    - ``step.tool`` set but not registered                  → error
+    - ``step.tool_family`` set but no registered tool declares that domain
+                                                             → error
+      (``core`` is the universal fallback family — always accepted)
+    - ``step.tool`` registered but its domains do not cover
+      ``step.tool_family``                                  → warning
+
+    Steps with neither tool nor tool_family have nothing to check.
+    """
+    registered = set(registry.list_tools())
+    family_domains: set[str] = set()
+    for name in registered:
+        family_domains.update(registry.metadata(name).get("domains", []))
+
+    issues: list[str] = []
+    for step in plan.steps:
+        if step.tool:
+            if step.tool not in registered:
+                issues.append(
+                    f"error: step '{step.id}' references unregistered tool '{step.tool}'"
+                )
+            elif step.tool_family and step.tool_family != "core":
+                cap = capability_of(step.tool, registry)
+                # cap is not None: step.tool is registered (checked above).
+                tool_domains = set(cap.domains) if cap is not None else set()
+                if step.tool_family not in tool_domains:
+                    issues.append(
+                        f"warning: step '{step.id}' tool '{step.tool}' domains "
+                        f"{sorted(tool_domains)} do not cover tool_family "
+                        f"'{step.tool_family}'"
+                    )
+        if (
+            step.tool_family
+            and step.tool_family != "core"
+            and step.tool_family not in family_domains
+        ):
+            issues.append(
+                f"error: step '{step.id}' tool_family '{step.tool_family}' "
+                "has no registered tool in that domain"
+            )
+    return issues

--- a/app/services/planning/deps.py
+++ b/app/services/planning/deps.py
@@ -1,0 +1,179 @@
+"""Static dependency validation and ``${stepId[.path]}`` reference resolution.
+
+Typed companion to plan_mode.py's ``validate_plan`` / ``resolve_refs``
+(app/services/plan_mode.py:88-193). Two differences are the point of this
+module (design-v3 §deps):
+
+- ``validate_static_refs`` returns a *list* of issue strings (empty = valid)
+  instead of a single error, covering unknown ids, forward refs, self-deps and
+  cycles.
+- ``resolve_arg_refs`` raises ``MissingRefError`` instead of silently returning
+  ``None`` / ``""`` when a placeholder names an existing step but a bad path —
+  plan_mode.py:148-193 bug fixed here.
+"""
+import re
+from collections import deque
+from typing import Any, Optional
+
+from .models import CanonicalStep
+
+# Placeholder grammar — must stay in sync with plan_mode.py:70.
+REF_PATTERN = re.compile(r"\$\{([a-zA-Z_][\w]*?)(?:\.([\w\.]+))?\}")
+
+
+def _extract_refs(value: Any) -> set[str]:
+    """Recursively collect the ``${stepId...}`` step ids from an args value."""
+    refs: set[str] = set()
+    if isinstance(value, str):
+        for m in REF_PATTERN.finditer(value):
+            refs.add(m.group(1))
+    elif isinstance(value, dict):
+        for v in value.values():
+            refs.update(_extract_refs(v))
+    elif isinstance(value, list):
+        for v in value:
+            refs.update(_extract_refs(v))
+    return refs
+
+
+def validate_static_refs(steps: list[CanonicalStep]) -> list[str]:
+    """Validate step ids and dependency edges without executing anything.
+
+    Returns a deterministic list of issue strings (empty list = valid):
+
+    - duplicate step ids
+    - references to unknown step ids
+    - forward references (dependency declared after the referencing step)
+    - self-dependencies
+    - dependency cycles (explicit topological check; catches ref-only cycles)
+
+    Dependencies are taken from ``depends_on`` plus the ``${stepId}``
+    placeholders inside ``args`` (same union plan_mode uses).
+    """
+    issues: list[str] = []
+    order_index: dict[str, int] = {}
+    for i, step in enumerate(steps):
+        if step.id in order_index:
+            issues.append(f"duplicate step id '{step.id}'")
+        order_index[step.id] = i
+
+    for step in steps:
+        inferred = set(step.depends_on) | _extract_refs(step.args)
+        if step.id in inferred:
+            issues.append(f"step '{step.id}' depends on itself")
+        for ref in inferred - {step.id}:
+            if ref not in order_index:
+                issues.append(f"step '{step.id}' references unknown step '{ref}'")
+            elif order_index[ref] > order_index[step.id]:
+                issues.append(
+                    f"step '{step.id}' forward-references step '{ref}' declared later"
+                )
+
+    if _topological_order(steps, order_index) is None:
+        issues.append("dependency graph contains a cycle")
+    return issues
+
+
+def _topological_order(
+    steps: list[CanonicalStep], order_index: dict[str, int]
+) -> Optional[list[str]]:
+    """Kahn's algorithm over ``depends_on`` ∪ args refs; None when cyclic."""
+    in_degree: dict[str, int] = {sid: 0 for sid in order_index}
+    edges: dict[str, list[str]] = {sid: [] for sid in order_index}
+    for step in steps:
+        for dep in (set(step.depends_on) | _extract_refs(step.args)) - {step.id}:
+            if dep not in in_degree:
+                continue
+            edges[dep].append(step.id)
+            in_degree[step.id] += 1
+
+    queue: deque[str] = deque([sid for sid, d in in_degree.items() if d == 0])
+    order: list[str] = []
+    while queue:
+        sid = queue.popleft()
+        order.append(sid)
+        for nxt in edges[sid]:
+            in_degree[nxt] -= 1
+            if in_degree[nxt] == 0:
+                queue.append(nxt)
+    return order if len(order) == len(in_degree) else None
+
+
+class MissingRefError(Exception):
+    """A ``${stepId[.path]}`` placeholder could not be resolved at runtime.
+
+    Raised when the named step has no result yet, or an existing step's result
+    does not contain the requested path segment — never silently returning
+    ``None`` / ``""`` for a placeholder (kills the plan_mode.py:148-193 bug).
+
+    Attributes carry the structured facts for the caller to build a
+    MISSING_REF correction hint: ``step_id``, ``path`` and the keys actually
+    available in ``completed_results``.
+    """
+
+    def __init__(self, step_id: str, path: str, available_keys: list[str]):
+        self.step_id = step_id
+        self.path = path
+        self.available_keys = list(available_keys)
+        ref = f"${{{step_id}{('.' + path) if path else ''}}}"
+        super().__init__(
+            f"cannot resolve ref {ref}: step '{step_id}' has no resolvable value "
+            f"at path '{path or '<root>'}' "
+            f"(available step results: {self.available_keys})"
+        )
+
+
+def _resolve_path_ref(
+    step_id: str, path: str, completed_results: dict[str, Any]
+) -> Any:
+    """Resolve one placeholder against completed step results (raises on miss)."""
+    if step_id not in completed_results:
+        raise MissingRefError(step_id, path, list(completed_results))
+    cur = completed_results[step_id]
+    if not path:
+        return cur
+    for part in path.split("."):
+        if isinstance(cur, dict):
+            if part not in cur:
+                raise MissingRefError(step_id, path, list(completed_results))
+            cur = cur[part]
+        elif isinstance(cur, list):
+            try:
+                idx = int(part)
+            except ValueError:
+                raise MissingRefError(step_id, path, list(completed_results))
+            if idx < 0 or idx >= len(cur):
+                raise MissingRefError(step_id, path, list(completed_results))
+            cur = cur[idx]
+        else:
+            raise MissingRefError(step_id, path, list(completed_results))
+    return cur
+
+
+def resolve_arg_refs(value: Any, completed_results: dict[str, Any]) -> Any:
+    """Resolve ``${stepId}`` / ``${stepId.path.to.field}`` placeholders.
+
+    Happy-path semantics mirror plan_mode.py's ``resolve_refs``: a full-match
+    placeholder resolves to the referenced object (preserving dict/list
+    structure), an embedded placeholder stringifies it, and non-placeholder
+    values (including nested dicts/lists inside args) pass through untouched.
+
+    Any unresolvable placeholder — a step with no result yet, or an existing
+    step whose result lacks the requested path — raises ``MissingRefError``
+    instead of silently yielding ``None`` / ``""``.
+    """
+    if isinstance(value, str):
+        m = REF_PATTERN.fullmatch(value)
+        if m:
+            return _resolve_path_ref(m.group(1), m.group(2) or "", completed_results)
+
+        def _sub(m: re.Match[str]) -> str:
+            resolved = _resolve_path_ref(m.group(1), m.group(2) or "", completed_results)
+            return str(resolved)
+
+        return REF_PATTERN.sub(_sub, value)
+    if isinstance(value, dict):
+        return {k: resolve_arg_refs(v, completed_results) for k, v in value.items()}
+    if isinstance(value, list):
+        return [resolve_arg_refs(v, completed_results) for v in value]
+    return value

--- a/app/services/planning/followup.py
+++ b/app/services/planning/followup.py
@@ -1,0 +1,95 @@
+"""Deterministic follow-up message classification (design-v3 §followup).
+
+No LLM. A follow-up user message is classified into a ``FollowUpKind`` from
+small keyword lists plus session state (active plan, active domains, whether
+the session already holds data refs). Feeds ``should_plan`` and the supersede
+logic in the integration slice. Keyword lists are intentionally small,
+data-driven and unit-testable.
+"""
+import re
+from enum import Enum
+
+# Style-change signals: visual / cartographic tweaks to the current result.
+STYLE_KEYWORDS = [
+    "颜色", "蓝色", "红色", "绿色", "黄色", "样式", "风格", "透明", "大小",
+    "粗细", "标注", "配色", "加粗", "图例", "标签",
+    "color", "style", "size", "opacity", "label", "legend", "bold",
+]
+
+# Continue-the-current-plan signals (only meaningful with an active plan).
+CONTINUATION_KEYWORDS = [
+    "继续", "接着", "继续分析", "继续做", "continue", "next", "keep going",
+]
+
+# Reference-back-to-prior-results signals (only meaningful when the session
+# already holds data refs). Deliberately phrase-based ("这个结果"), so a bare
+# 再 / 那个 in a new request does not hijack the classifier.
+REF_REUSE_KEYWORDS = [
+    "刚才", "上一个", "那个", "该结果", "这个结果", "上次", "前一个",
+    "之前的结果", "上面的", "this result", "that result", "previous result",
+]
+
+
+class FollowUpKind(str, Enum):
+    """Classification of a follow-up message (design-v3 §followup)."""
+
+    new_goal = "new_goal"
+    style_change = "style_change"
+    ref_reuse = "ref_reuse"
+    continuation = "continuation"
+    unclear = "unclear"
+
+
+def _kw_in(kw: str, text: str) -> bool:
+    """CJK keywords match as substrings; ASCII keywords match on word boundary."""
+    if kw.isascii():
+        return re.search(rf"\b{re.escape(kw.lower())}\b", text) is not None
+    return kw in text
+
+
+def _has_any_keyword(keywords: list[str], text: str) -> bool:
+    return any(_kw_in(kw, text) for kw in keywords)
+
+
+def classify_followup(
+    message: str,
+    *,
+    has_active_plan: bool,
+    active_domains: list[str],
+    session_has_refs: bool,
+    domain_keywords: dict[str, list[str]],
+) -> FollowUpKind:
+    """Classify a follow-up message deterministically.
+
+    Rules, in priority order:
+
+    1. style keyword AND no new-domain keyword    → style_change
+    2. ref-reuse keyword AND ``session_has_refs`` → ref_reuse
+    3. continuation keyword AND active plan       → continuation
+    4. domain keyword outside ``active_domains``  → new_goal
+    5. otherwise                                  → unclear
+
+    A "new domain keyword" is a keyword from ``domain_keywords`` whose domain
+    is not in ``active_domains`` — style tweaks over the already-active domain
+    stay style_change (e.g. 热力图换成蓝色 with statistics active).
+    """
+    text = (message or "").lower()
+    active = set(active_domains or [])
+
+    has_new_domain = False
+    for domain, keywords in (domain_keywords or {}).items():
+        if domain in active:
+            continue
+        if _has_any_keyword(keywords, text):
+            has_new_domain = True
+            break
+
+    if _has_any_keyword(STYLE_KEYWORDS, text) and not has_new_domain:
+        return FollowUpKind.style_change
+    if session_has_refs and _has_any_keyword(REF_REUSE_KEYWORDS, text):
+        return FollowUpKind.ref_reuse
+    if has_active_plan and _has_any_keyword(CONTINUATION_KEYWORDS, text):
+        return FollowUpKind.continuation
+    if has_new_domain:
+        return FollowUpKind.new_goal
+    return FollowUpKind.unclear

--- a/app/services/planning/followup.py
+++ b/app/services/planning/followup.py
@@ -29,6 +29,16 @@ REF_REUSE_KEYWORDS = [
     "之前的结果", "上面的", "this result", "that result", "previous result",
 ]
 
+# Query/action signals (adversarial P2-6): a message carrying BOTH a style word
+# and a query/action word plus content (查一下蓝色区域的医院分布) is a real
+# request, NOT a style tweak. These take precedence over STYLE_KEYWORDS when
+# they co-occur, so the classifier never turns a fresh query into a no-op
+# style_change (which would skip planning / re-analysis).
+QUERY_ACTION_KEYWORDS = [
+    "查", "找", "搜索", "查询", "检索", "统计", "分析", "计算", "获取", "读取", "定位",
+    "search", "find", "query", "look", "count", "analyze", "compute", "get", "locate",
+]
+
 
 class FollowUpKind(str, Enum):
     """Classification of a follow-up message (design-v3 §followup)."""
@@ -63,7 +73,8 @@ def classify_followup(
 
     Rules, in priority order:
 
-    1. style keyword AND no new-domain keyword    → style_change
+    1. style keyword AND no new-domain keyword AND no query/action keyword
+       → style_change
     2. ref-reuse keyword AND ``session_has_refs`` → ref_reuse
     3. continuation keyword AND active plan       → continuation
     4. domain keyword outside ``active_domains``  → new_goal
@@ -72,6 +83,11 @@ def classify_followup(
     A "new domain keyword" is a keyword from ``domain_keywords`` whose domain
     is not in ``active_domains`` — style tweaks over the already-active domain
     stay style_change (e.g. 热力图换成蓝色 with statistics active).
+
+    Adversarial P2-6: a message with BOTH style words and query/action signals
+    (查一下蓝色区域的医院分布) must NOT classify as style_change — the query
+    takes precedence so the message falls through to ref_reuse / new_goal /
+    unclear instead of silently skipping planning.
     """
     text = (message or "").lower()
     active = set(active_domains or [])
@@ -84,7 +100,11 @@ def classify_followup(
             has_new_domain = True
             break
 
-    if _has_any_keyword(STYLE_KEYWORDS, text) and not has_new_domain:
+    if (
+        _has_any_keyword(STYLE_KEYWORDS, text)
+        and not has_new_domain
+        and not _has_any_keyword(QUERY_ACTION_KEYWORDS, text)
+    ):
         return FollowUpKind.style_change
     if session_has_refs and _has_any_keyword(REF_REUSE_KEYWORDS, text):
         return FollowUpKind.ref_reuse

--- a/app/services/planning/models.py
+++ b/app/services/planning/models.py
@@ -1,0 +1,216 @@
+"""Canonical planning model — the source of truth for plan state.
+
+This is the foundation of the planning-architecture convergence (design-v3
+§"New package app/services/planning/"): CanonicalPlan is the persisted source
+of truth via ``app.services.planning.store``, while the orchestrator ``Plan``
+dataclass and plan_mode ``PlanProposal`` become compatibility projections of it
+in a later integration slice.
+
+Pydantic v2 models (repo pins ``pydantic>=2.13.4``) — serialize / deserialize
+with ``.model_dump()`` / ``.model_validate()`` so plans round-trip through the
+session_data JSON store.
+"""
+import time
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class PlanStatus(str, Enum):
+    """Lifecycle status of a plan (state machine in design-v3 §models).
+
+    ``proposed → validated → running → (partially_completed | completed | failed)``
+    plus ``cancelled`` and ``superseded``. ``partially_completed`` is NOT a
+    terminal state on purpose: ``execute_plan`` resumes from it (completed
+    steps' result refs are reused, only remaining steps re-plan/execute).
+    """
+
+    proposed = "proposed"
+    validated = "validated"
+    running = "running"
+    partially_completed = "partially_completed"
+    completed = "completed"
+    failed = "failed"
+    cancelled = "cancelled"
+    superseded = "superseded"
+
+    def is_terminal(self) -> bool:
+        """True for states nothing can transition out of."""
+        return self in TERMINAL_STATUSES
+
+
+# Terminal plan states: completed / failed / cancelled / superseded.
+TERMINAL_STATUSES: frozenset[PlanStatus] = frozenset(
+    {
+        PlanStatus.completed,
+        PlanStatus.failed,
+        PlanStatus.cancelled,
+        PlanStatus.superseded,
+    }
+)
+
+
+class StepStatus(str, Enum):
+    """Per-step execution status (canonical replacement for plan_mode's
+    per-plan ``__status__`` + orchestrator's boolean ``done`` flag)."""
+
+    pending = "pending"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+    skipped = "skipped"
+    cancelled = "cancelled"
+
+
+class FailureClass(str, Enum):
+    """Classified tool-failure taxonomy (design-v3 §recovery).
+
+    Mirrors the dispatch codes that already exist in the repo
+    (VALIDATION_ERROR / NOT_FOUND / UNKNOWN_TOOL / TOOL_ERROR in
+    ``app/tools/registry.py``) plus message-level signals — each class maps to
+    a deterministic recovery policy (see ``app.services.planning.recovery``).
+    """
+
+    validation = "validation"
+    missing_ref = "missing_ref"
+    empty_result = "empty_result"
+    no_data = "no_data"
+    auth = "auth"
+    tool_unavailable = "tool_unavailable"
+    resource_limit = "resource_limit"
+    transient_network = "transient_network"
+    cancelled = "cancelled"
+    internal = "internal"
+
+
+class RecoveryAction(str, Enum):
+    """Structured recovery hint for the LLM / engine (no blind retry anywhere).
+
+    ``retry_transient`` is reserved for transient-network failures only; a
+    failed tool call is never automatically replayed for other classes.
+    """
+
+    correct_args = "correct_args"
+    reuse_ref = "reuse_ref"
+    alternate_tool = "alternate_tool"
+    replan_remaining = "replan_remaining"
+    retry_transient = "retry_transient"
+    stop = "stop"
+
+
+class StepError(BaseModel):
+    """Error payload attached to a failed step."""
+
+    failure_class: FailureClass
+    message: str
+    recovery_action: Optional[RecoveryAction] = None
+    tool_call_id: Optional[str] = None
+
+
+class CanonicalStep(BaseModel):
+    """One step of a canonical plan.
+
+    ``tool_family`` is the advisory domain the step belongs to (planner-side);
+    ``tool`` is the concrete registered tool name once the step is executable.
+    Args may carry ``${stepId}`` / ``${stepId.path.to.field}`` placeholders that
+    reference earlier steps' results (same grammar as plan_mode.py).
+    """
+
+    id: str = Field(..., min_length=1, max_length=64, description="短步骤 ID（如 s1）")
+    n: int = Field(..., description="1-based 步骤序号（与 orchestrator PlanStep.n 对齐）")
+    goal: str = Field(..., description="该步的自然语言意图")
+    tool_family: Optional[str] = Field(None, description="所属领域（tool_catalog domain）")
+    tool: Optional[str] = Field(None, description="具体调用的已注册工具名")
+    args: dict = Field(default_factory=dict, description="传给工具的参数（可含 ${} 占位符）")
+    depends_on: list[str] = Field(default_factory=list, description="前置步骤 ID 列表")
+    status: StepStatus = StepStatus.pending
+    result_ref: Optional[str] = Field(None, description="完成时产出的 session_data 引用")
+    error: Optional[StepError] = None
+
+
+class CanonicalPlan(BaseModel):
+    """The canonical, persisted plan — source of truth for plan state.
+
+    Persisted per session via ``app.services.planning.store`` (session_data
+    backend, deterministic ``plan-current`` key). ``created_at`` / ``updated_at``
+    are float epoch timestamps.
+    """
+
+    plan_id: str
+    session_id: str
+    intent: str
+    domains: list[str] = Field(default_factory=list)
+    steps: list[CanonicalStep] = Field(default_factory=list)
+    status: PlanStatus = PlanStatus.proposed
+    revision: int = 1
+    failure: Optional[StepError] = None
+    created_at: float = Field(default_factory=time.time)
+    updated_at: float = Field(default_factory=time.time)
+
+    def step_by_id(self, step_id: str) -> Optional[CanonicalStep]:
+        """Return the step with ``step_id``, or None when absent."""
+        for step in self.steps:
+            if step.id == step_id:
+                return step
+        return None
+
+    def next_pending_steps(self) -> list[CanonicalStep]:
+        """Steps ready to run now: pending and every ``depends_on`` completed.
+
+        Steps blocked on a failed / skipped / cancelled dependency are excluded
+        (they can never become ready on this revision). Order is plan order.
+        """
+        ready: list[CanonicalStep] = []
+        for step in self.steps:
+            if step.status != StepStatus.pending:
+                continue
+            deps_ok = True
+            for dep in step.depends_on:
+                dep_step = self.step_by_id(dep)
+                if dep_step is None or dep_step.status != StepStatus.completed:
+                    deps_ok = False
+                    break
+            if deps_ok:
+                ready.append(step)
+        return ready
+
+    def recompute_status(self) -> PlanStatus:
+        """Derive the plan status from step statuses (design-v3 state machine).
+
+        Pure: returns the derived status without mutating ``self.status`` so
+        callers can inspect before assigning. Rules, in priority order:
+
+        - no steps                  → keep current status
+        - all steps completed       → completed
+        - any failed, none pending/running → failed
+        - completed mixed with (failed | skipped), none pending/running
+                                    → partially_completed
+        - any running               → running
+        - otherwise                 → keep current status
+        """
+        if not self.steps:
+            return self.status
+        statuses = [s.status for s in self.steps]
+        if all(s == StepStatus.completed for s in statuses):
+            return PlanStatus.completed
+        has_pending_or_running = any(
+            s in (StepStatus.pending, StepStatus.running) for s in statuses
+        )
+        if any(s == StepStatus.failed for s in statuses) and not has_pending_or_running:
+            return PlanStatus.failed
+        has_completed = any(s == StepStatus.completed for s in statuses)
+        has_failed_or_skipped = any(
+            s in (StepStatus.failed, StepStatus.skipped) for s in statuses
+        )
+        if has_completed and has_failed_or_skipped and not has_pending_or_running:
+            return PlanStatus.partially_completed
+        if any(s == StepStatus.running for s in statuses):
+            return PlanStatus.running
+        return self.status
+
+    def bump_revision(self) -> int:
+        """Increment ``revision`` (and refresh ``updated_at``); returns the new value."""
+        self.revision += 1
+        self.updated_at = time.time()
+        return self.revision

--- a/app/services/planning/models.py
+++ b/app/services/planning/models.py
@@ -183,11 +183,18 @@ class CanonicalPlan(BaseModel):
 
         - no steps                  → keep current status
         - all steps completed       → completed
-        - any failed, none pending/running → failed
+        - any running               → running (in-flight beats derived terminal states)
         - completed mixed with (failed | skipped), none pending/running
-                                    → partially_completed
-        - any running               → running
+                                    → partially_completed (partial success is
+                                      resumable — NOT terminal; P3 #5)
+        - any failed, none completed/pending/running → failed
         - otherwise                 → keep current status
+
+        ``partially_completed`` intentionally beats plain ``failed`` whenever at
+        least one step completed: some-done-some-failed is a *partial success*
+        (``execute_plan`` resumes from it, reusing completed refs), while
+        ``failed`` is reserved for runs with no completed steps. Matches
+        plan_mode's ``_failure_status()`` semantics.
         """
         if not self.steps:
             return self.status
@@ -197,16 +204,16 @@ class CanonicalPlan(BaseModel):
         has_pending_or_running = any(
             s in (StepStatus.pending, StepStatus.running) for s in statuses
         )
-        if any(s == StepStatus.failed for s in statuses) and not has_pending_or_running:
-            return PlanStatus.failed
+        if any(s == StepStatus.running for s in statuses):
+            return PlanStatus.running
         has_completed = any(s == StepStatus.completed for s in statuses)
         has_failed_or_skipped = any(
             s in (StepStatus.failed, StepStatus.skipped) for s in statuses
         )
         if has_completed and has_failed_or_skipped and not has_pending_or_running:
             return PlanStatus.partially_completed
-        if any(s == StepStatus.running for s in statuses):
-            return PlanStatus.running
+        if any(s == StepStatus.failed for s in statuses) and not has_pending_or_running:
+            return PlanStatus.failed
         return self.status
 
     def bump_revision(self) -> int:

--- a/app/services/planning/recovery.py
+++ b/app/services/planning/recovery.py
@@ -1,0 +1,154 @@
+"""Failure classification and recovery policy (design-v3 §recovery).
+
+Maps the dispatch codes that already exist in the repo — ``VALIDATION_ERROR`` /
+``NOT_FOUND`` / ``UNKNOWN_TOOL`` / ``TOOL_ERROR`` (app/tools/registry.py:331-463,
+app/services/tool_dispatch_service.py:142-163) plus message-level signals and
+exceptions — onto ``FailureClass``, then picks the first recovery action from a
+static policy. No blind retry anywhere: ``retry_transient`` appears only for
+``transient_network`` failures; a failed call is never automatically replayed
+for other classes.
+"""
+from typing import Optional
+
+from app.services.jobs.cancellation import OperationCancelled
+
+from .models import FailureClass, RecoveryAction
+
+# Message-level signals, matched as lowercased substrings. Scan order inside a
+# class is fixed so the outcome is deterministic (network → auth → resource →
+# no_data → empty).
+_NETWORK_MARKERS = (
+    "timeout", "timed out", "connection", "network", "socket",
+    "refused", "reset", "超时", "网络", "连接",
+)
+_AUTH_MARKERS = (
+    "auth", "401", "403", "unauthorized", "forbidden", "permission",
+    "授权", "权限", "凭证",
+)
+_RESOURCE_MARKERS = (
+    "memory", "quota", "rate limit", "429", "resource", "配额",
+    "内存不足", "超限", "too large",
+)
+_NO_DATA_MARKERS = (
+    "no data", "无数据", "没有数据", "无任何", "未找到数据", "找不到数据", "no matching",
+)
+_EMPTY_MARKERS = (
+    "empty", "未返回任何", "无要素", "0 条", "零要素", "no features",
+)
+
+
+def _has_any(markers: tuple[str, ...], text: str) -> bool:
+    return any(marker in text for marker in markers)
+
+
+def classify_error(
+    *,
+    status: Optional[str] = None,
+    code: Optional[str] = None,
+    error_type: Optional[str] = None,
+    message: Optional[str] = None,
+    exception: Optional[Exception] = None,
+) -> FailureClass:
+    """Classify a dispatch failure into a ``FailureClass`` (deterministic).
+
+    Precedence (documented — first match wins):
+
+    1. cancellation — ``OperationCancelled`` exception, or ``cancelled`` in
+       status / code / error_type. Cancellation is never a tool fault
+       (tool_pipeline.py:34, ADR-0052).
+    2. exception type — ``TimeoutError``/``ConnectionError`` →
+       ``transient_network``; ``KeyError``/``FileNotFoundError`` →
+       ``missing_ref`` (registry maps these to NOT_FOUND); ``ValueError`` →
+       ``validation``.
+    3. dispatch code — ``VALIDATION_ERROR`` → validation; ``NOT_FOUND`` →
+       missing_ref; ``UNKNOWN_TOOL`` → tool_unavailable.
+    4. ``TOOL_ERROR`` (or absent code / ok / success) → message markers:
+       network → transient_network, auth → auth, resource → resource_limit,
+       no data → no_data, empty/suspicious → empty_result.
+    5. default → ``internal``.
+
+    ``status="ok"`` with empty-result markers still classifies as
+    ``empty_result`` (suspicious results are successful dispatches whose
+    payload contains no usable data — tool_dispatch_service.py:377-397).
+    """
+    code_l = (code or "").lower()
+    type_l = (error_type or "").lower()
+    status_l = (status or "").lower()
+    msg_l = (message or "").lower()
+
+    # 1. cancellation — never a tool fault
+    if (
+        isinstance(exception, OperationCancelled)
+        or code_l == "cancelled"
+        or status_l == "cancelled"
+        or "operationcancelled" in type_l
+        or "cancelled" in type_l
+    ):
+        return FailureClass.cancelled
+
+    # 2. exception types
+    if exception is not None:
+        if isinstance(exception, (TimeoutError, ConnectionError)):
+            return FailureClass.transient_network
+        if isinstance(exception, (KeyError, FileNotFoundError)):
+            return FailureClass.missing_ref
+        if isinstance(exception, ValueError):
+            return FailureClass.validation
+        # other exception types fall through to code/message classification
+
+    # 3. authoritative dispatch codes
+    if code_l == "validation_error":
+        return FailureClass.validation
+    if code_l == "not_found":
+        return FailureClass.missing_ref
+    if code_l == "unknown_tool":
+        return FailureClass.tool_unavailable
+
+    # 4. TOOL_ERROR / ok / no code → message-level signals
+    if code_l in ("tool_error", "ok", "success", ""):
+        if _has_any(_NETWORK_MARKERS, msg_l):
+            return FailureClass.transient_network
+        if _has_any(_AUTH_MARKERS, msg_l):
+            return FailureClass.auth
+        if _has_any(_RESOURCE_MARKERS, msg_l):
+            return FailureClass.resource_limit
+        if _has_any(_NO_DATA_MARKERS, msg_l):
+            return FailureClass.no_data
+        if _has_any(_EMPTY_MARKERS, msg_l):
+            return FailureClass.empty_result
+
+    # 5. default
+    return FailureClass.internal
+
+
+# Static recovery policy: preferred action first. No blind retry — only
+# transient_network may retry, and then only once (retry_transient is the sole
+# action there).
+RECOVERY_POLICY: dict[FailureClass, list[RecoveryAction]] = {
+    FailureClass.validation: [RecoveryAction.correct_args],
+    FailureClass.missing_ref: [RecoveryAction.reuse_ref, RecoveryAction.correct_args],
+    FailureClass.empty_result: [
+        RecoveryAction.alternate_tool,
+        RecoveryAction.replan_remaining,
+        RecoveryAction.stop,
+    ],
+    FailureClass.no_data: [
+        RecoveryAction.alternate_tool,
+        RecoveryAction.replan_remaining,
+        RecoveryAction.stop,
+    ],
+    FailureClass.auth: [RecoveryAction.stop],
+    FailureClass.tool_unavailable: [
+        RecoveryAction.alternate_tool,
+        RecoveryAction.replan_remaining,
+    ],
+    FailureClass.resource_limit: [RecoveryAction.replan_remaining, RecoveryAction.stop],
+    FailureClass.transient_network: [RecoveryAction.retry_transient],
+    FailureClass.cancelled: [RecoveryAction.stop],
+    FailureClass.internal: [RecoveryAction.replan_remaining, RecoveryAction.stop],
+}
+
+
+def recovery_action_for(failure_class: FailureClass) -> RecoveryAction:
+    """First (preferred) recovery action for a failure class."""
+    return RECOVERY_POLICY[failure_class][0]

--- a/app/services/planning/store.py
+++ b/app/services/planning/store.py
@@ -1,0 +1,225 @@
+"""PlanStore — per-session current-plan persistence over session_data_manager.
+
+The store is a thin write-through facade in front of the existing
+``session_data_manager`` (design-v3 §store). A process-local LRU (capacity 200)
+serves as cache-aside in front of the store: ``save`` writes through to both,
+``load_current`` checks cache → store → populates cache. The store survives
+worker restarts when Redis is present and degrades to in-memory without it —
+same semantics as the rest of the repo.
+
+Persistence reuses plan_mode's mechanism (app/services/plan_mode.py:199-233):
+plans live as ``ref:plan-*`` items. The *current* plan per session lives at a
+deterministic per-session ref registered under the alias ``plan-current``, so
+``overwrite()`` updates it in place — no new ref id is minted per save (the
+``store()``-mints-new-ref trap documented at plan_mode.py:216-221). History
+plans (superseded) are registered under a per-plan-id alias ``plan-id:<plan_id>``
+so ``get_by_id`` can address them deterministically.
+"""
+import logging
+import time
+from collections import OrderedDict
+from typing import Any, Optional
+
+from app.services.session_data import session_data_manager
+
+from .models import CanonicalPlan, PlanStatus
+
+logger = logging.getLogger(__name__)
+
+# Deterministic per-session ref alias for the "current" plan.
+CURRENT_PLAN_ALIAS = "plan-current"
+
+
+def _plan_id_alias(plan_id: str) -> str:
+    """Deterministic history key (alias) for a superseded plan."""
+    return f"plan-id:{plan_id}"
+
+
+class _PlanLRU:
+    """Tiny OrderedDict LRU — the process-local cache-aside in front of the store."""
+
+    def __init__(self, capacity: int = 200):
+        self._data: OrderedDict[str, Any] = OrderedDict()
+        self.capacity = max(1, capacity)
+
+    def get(self, key: str) -> Optional[Any]:
+        if key not in self._data:
+            return None
+        self._data.move_to_end(key)
+        return self._data[key]
+
+    def put(self, key: str, value: Any) -> None:
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = value
+        while len(self._data) > self.capacity:
+            self._data.popitem(last=False)
+
+    def pop(self, key: str) -> None:
+        self._data.pop(key, None)
+
+    def clear(self) -> None:
+        self._data.clear()
+
+
+class PlanStore:
+    """Per-session plan persistence with a process-local cache in front."""
+
+    def __init__(self, session_store: Any = None, capacity: int = 200):
+        # Defaults to the repo singleton (memory backend when USE_REDIS=false);
+        # injectable for tests.
+        self._session_store = session_store if session_store is not None else session_data_manager
+        self._cache = _PlanLRU(capacity=capacity)
+
+    # ── cache helpers (worker-local cache management / tests) ──────────────
+
+    def clear_cache(self) -> None:
+        """Drop the process-local cache (worker-restart simulation)."""
+        self._cache.clear()
+
+    def peek(self, session_id: str) -> Optional[CanonicalPlan]:
+        """Synchronous cache-aside peek — NEVER touches the session store.
+
+        For sync callers (orchestrator ``get_plan``, decision/metrics logging)
+        that only need the in-process canonical when one is already loaded.
+        Returns None on a cold cache; use ``load_current`` for the async
+        store read.
+        """
+        return self._cache.get(session_id)
+
+    def cache_put(self, plan: CanonicalPlan) -> None:
+        """Synchronous cache-aside write (mirrors the ``save`` write-through).
+
+        For sync callers (``AgentPlanOrchestrator.set_plan``) that update the
+        canonical before the async ``save`` lands. The persisted session-store
+        copy is refreshed on the next ``save`` / ``supersede``.
+        """
+        self._cache.put(plan.session_id, plan)
+
+    def forget(self, session_id: str) -> None:
+        """Synchronous cache-only drop (mirrors ``clear`` without the tombstone).
+
+        Used by the orchestrator's ``clear_plan``; the session-store tombstone
+        is handled by the session clear path.
+        """
+        self._cache.pop(session_id)
+
+    # ── persistence API ────────────────────────────────────────────────────
+
+    async def load_current(self, session_id: str) -> Optional[CanonicalPlan]:
+        """Load the session's current plan; None when absent. Never raises."""
+        cached = self._cache.get(session_id)
+        if cached is not None:
+            return cached
+        data = await self._safe_get(session_id, CURRENT_PLAN_ALIAS)
+        if data is None:
+            return None
+        plan = self._safe_validate(data)
+        if plan is None:
+            return None
+        self._cache.put(session_id, plan)
+        return plan
+
+    async def save(self, plan: CanonicalPlan) -> None:
+        """Persist ``plan`` as the session's current plan (write-through).
+
+        Refreshes ``updated_at`` in place, then writes the LRU cache and the
+        session store. The current ref key is deterministic per session (alias
+        ``plan-current``): the first save mints it via ``store()``, every later
+        save ``overwrite()``s the same ref in place.
+        """
+        plan.updated_at = time.time()
+        self._cache.put(plan.session_id, plan)
+        payload = plan.model_dump()
+
+        ref_id = await self._session_store.resolve_alias(plan.session_id, CURRENT_PLAN_ALIAS)
+        if ref_id != CURRENT_PLAN_ALIAS:
+            if await self._session_store.overwrite(plan.session_id, ref_id, payload):
+                return
+            # overwrite failed (ref evicted / backend degraded) → re-mint below
+        new_ref = await self._session_store.store(plan.session_id, payload, prefix="plan")
+        await self._session_store.set_alias(plan.session_id, new_ref, CURRENT_PLAN_ALIAS)
+
+    async def supersede(self, session_id: str, new_plan: CanonicalPlan) -> Optional[CanonicalPlan]:
+        """Mark the current plan superseded and promote ``new_plan``.
+
+        The old plan gets status ``superseded`` and is persisted under its
+        plan-id history key (alias ``plan-id:<plan_id>``, deterministic per
+        plan_id so re-superseding updates in place); ``new_plan`` becomes the
+        session's current plan. Returns the superseded plan, or None when there
+        was no current plan.
+        """
+        current = await self.load_current(session_id)
+        if current is not None:
+            current.status = PlanStatus.superseded
+            current.updated_at = time.time()
+            await self._save_history(session_id, current)
+        await self.save(new_plan)
+        return current
+
+    async def get_by_id(self, session_id: str, plan_id: str) -> Optional[CanonicalPlan]:
+        """Load a plan by id: the current plan, or a superseded history plan."""
+        if plan_id in (CURRENT_PLAN_ALIAS, "current"):
+            return await self.load_current(session_id)
+        current = await self.load_current(session_id)
+        if current is not None and current.plan_id == plan_id:
+            return current
+        alias = _plan_id_alias(plan_id)
+        ref_id = await self._session_store.resolve_alias(session_id, alias)
+        if ref_id != alias:
+            data = await self._safe_get(session_id, ref_id)
+            if data is not None:
+                plan = self._safe_validate(data)
+                if plan is not None:
+                    return plan
+        # Fallback: a history plan placed directly at ref:plan-<plan_id>.
+        data = await self._safe_get(session_id, f"ref:plan-{plan_id}")
+        return self._safe_validate(data)
+
+    async def clear(self, session_id: str) -> None:
+        """Drop the current plan for the session (cache + store).
+
+        ``session_data_manager`` has no single-key delete, so the current ref is
+        tombstoned with None — a later ``load_current`` returns None, and a
+        later ``save`` overwrites the tombstone in place. Superseded history
+        plans remain addressable via ``get_by_id``.
+        """
+        self._cache.pop(session_id)
+        ref_id = await self._session_store.resolve_alias(session_id, CURRENT_PLAN_ALIAS)
+        if ref_id != CURRENT_PLAN_ALIAS:
+            await self._session_store.overwrite(session_id, ref_id, None)
+
+    # ── internals ──────────────────────────────────────────────────────────
+
+    async def _save_history(self, session_id: str, plan: CanonicalPlan) -> None:
+        """Persist a superseded plan under its deterministic plan-id alias."""
+        payload = plan.model_dump()
+        alias = _plan_id_alias(plan.plan_id)
+        ref_id = await self._session_store.resolve_alias(session_id, alias)
+        if ref_id != alias:
+            if await self._session_store.overwrite(session_id, ref_id, payload):
+                return
+        new_ref = await self._session_store.store(session_id, payload, prefix="plan")
+        await self._session_store.set_alias(session_id, new_ref, alias)
+
+    async def _safe_get(self, session_id: str, key: str) -> Optional[Any]:
+        """Store read that never raises (store miss / backend error → None)."""
+        try:
+            return await self._session_store.get(session_id, key)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("PlanStore.get failed session=%s key=%s: %s", session_id, key, e)
+            return None
+
+    def _safe_validate(self, data: Any) -> Optional[CanonicalPlan]:
+        """Deserialize a stored payload; corrupt/missing payloads → None."""
+        if not isinstance(data, dict):
+            return None
+        try:
+            return CanonicalPlan.model_validate(data)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("PlanStore: stored payload is not a valid CanonicalPlan: %s", e)
+            return None
+
+
+# Module-level singleton, mirroring plan_orchestrator's pattern.
+plan_store = PlanStore()

--- a/app/services/planning/store.py
+++ b/app/services/planning/store.py
@@ -14,6 +14,25 @@ deterministic per-session ref registered under the alias ``plan-current``, so
 ``store()``-mints-new-ref trap documented at plan_mode.py:216-221). History
 plans (superseded) are registered under a per-plan-id alias ``plan-id:<plan_id>``
 so ``get_by_id`` can address them deterministically.
+
+Concurrency (P1-B / planning-reviewer P2-4 / adversarial P2-8):
+- The process-local cache has a short TTL (``L1_TTL_SECONDS``, mirrored from
+  session_data_redis.py) — in the multi-replica deployment a worker never
+  serves a cached plan older than ~2s, so a stale worker's turn-end flush
+  cannot silently revert a newer plan written by another worker.
+- ``save`` carries a revision guard: when the *persisted* current plan has a
+  different ``plan_id`` and a newer-or-equal ``revision`` than the plan being
+  saved, the write is refused (log warning) and the store's plan is re-read
+  into the process cache instead of clobbering. Last-writer-wins still holds
+  for same-``plan_id`` revisions. ``supersede`` promotes a brand-new plan by
+  design, so it bypasses the guard (``_promote=True``).
+
+Restart-continuity bound (persistence P3): plans persist only for the
+underlying session DATA_TTL (2h, ``session_data_redis.DATA_TTL``) — a worker
+restart within that window resumes the current plan; beyond it the plan is gone
+(``load_current`` returns None). History (superseded) plans are subject to the
+same DATA_TTL *and* to per-session LRU eviction like any other session ref:
+long-retired plans may be evicted and ``get_by_id`` then returns None.
 """
 import logging
 import time
@@ -29,6 +48,11 @@ logger = logging.getLogger(__name__)
 # Deterministic per-session ref alias for the "current" plan.
 CURRENT_PLAN_ALIAS = "plan-current"
 
+# Cache-aside TTL — mirrors session_data_redis.L1_TTL_SECONDS: short on purpose,
+# so a second worker's writes surface here within ~2s instead of being masked
+# by a long-lived process-local copy (P1-B cross-worker staleness).
+L1_TTL_SECONDS = 2.0
+
 
 def _plan_id_alias(plan_id: str) -> str:
     """Deterministic history key (alias) for a superseded plan."""
@@ -36,22 +60,33 @@ def _plan_id_alias(plan_id: str) -> str:
 
 
 class _PlanLRU:
-    """Tiny OrderedDict LRU — the process-local cache-aside in front of the store."""
+    """Tiny OrderedDict LRU with TTL — the process-local cache-aside.
+
+    Entries expire after ``L1_TTL_SECONDS``; an expired entry is dropped and
+    ``get`` returns None so the caller re-reads from the store (P1-B: a stale
+    worker never serves a long-stale plan).
+    """
 
     def __init__(self, capacity: int = 200):
-        self._data: OrderedDict[str, Any] = OrderedDict()
+        # key -> (value, expires_at_monotonic)
+        self._data: OrderedDict[str, tuple[Any, float]] = OrderedDict()
         self.capacity = max(1, capacity)
 
     def get(self, key: str) -> Optional[Any]:
-        if key not in self._data:
+        entry = self._data.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if time.monotonic() >= expires_at:
+            self._data.pop(key, None)
             return None
         self._data.move_to_end(key)
-        return self._data[key]
+        return value
 
     def put(self, key: str, value: Any) -> None:
         if key in self._data:
             self._data.move_to_end(key)
-        self._data[key] = value
+        self._data[key] = (value, time.monotonic() + L1_TTL_SECONDS)
         while len(self._data) > self.capacity:
             self._data.popitem(last=False)
 
@@ -120,13 +155,23 @@ class PlanStore:
         self._cache.put(session_id, plan)
         return plan
 
-    async def save(self, plan: CanonicalPlan) -> None:
+    async def save(self, plan: CanonicalPlan, *, _promote: bool = False) -> None:
         """Persist ``plan`` as the session's current plan (write-through).
 
         Refreshes ``updated_at`` in place, then writes the LRU cache and the
         session store. The current ref key is deterministic per session (alias
         ``plan-current``): the first save mints it via ``store()``, every later
         save ``overwrite()``s the same ref in place.
+
+        Revision guard (P1-B): when the *persisted* current plan belongs to a
+        different ``plan_id`` and carries a newer-or-equal ``revision`` than
+        ``plan``, this save refuses to clobber it — a stale worker must not
+        revert a newer plan. It logs a warning and re-reads the store's plan
+        into the process cache (converging the worker instead of fighting it).
+        Same-``plan_id`` saves stay last-writer-wins regardless of revision.
+
+        ``_promote`` (internal, used by ``supersede``) bypasses the guard: the
+        caller deliberately replaced the current plan with a brand-new one.
         """
         plan.updated_at = time.time()
         self._cache.put(plan.session_id, plan)
@@ -134,6 +179,23 @@ class PlanStore:
 
         ref_id = await self._session_store.resolve_alias(plan.session_id, CURRENT_PLAN_ALIAS)
         if ref_id != CURRENT_PLAN_ALIAS:
+            if not _promote:
+                persisted = await self._safe_get(plan.session_id, ref_id)
+                current = self._safe_validate(persisted) if persisted is not None else None
+                if (
+                    current is not None
+                    and current.plan_id != plan.plan_id
+                    and current.revision >= plan.revision
+                ):
+                    logger.warning(
+                        "PlanStore.save refused to clobber newer plan: session=%s "
+                        "persisted plan_id=%s rev=%d vs saved plan_id=%s rev=%d "
+                        "— re-reading persisted plan",
+                        plan.session_id, current.plan_id, current.revision,
+                        plan.plan_id, plan.revision,
+                    )
+                    self._cache.put(plan.session_id, current)
+                    return
             if await self._session_store.overwrite(plan.session_id, ref_id, payload):
                 return
             # overwrite failed (ref evicted / backend degraded) → re-mint below
@@ -154,7 +216,9 @@ class PlanStore:
             current.status = PlanStatus.superseded
             current.updated_at = time.time()
             await self._save_history(session_id, current)
-        await self.save(new_plan)
+        # _promote=True: 新计划取代旧计划是 supersede 的显式意图，不走
+        # save() 的跨 plan_id revision guard（否则会误拒绝自己的提升）。
+        await self.save(new_plan, _promote=True)
         return current
 
     async def get_by_id(self, session_id: str, plan_id: str) -> Optional[CanonicalPlan]:

--- a/app/services/subagent.py
+++ b/app/services/subagent.py
@@ -198,7 +198,12 @@ class SubagentDispatcher:
         from app.services.chat_engine import ChatEngine
 
         class _FrozenCatalog:
-            """只返回 tool_subset 的 catalog stub，禁用粘性 / 关键词匹配。"""
+            """只返回 tool_subset 的 catalog stub，禁用粘性 / 关键词匹配。
+
+            P2-7（Pi#1/#2）：引擎在 _maybe_plan / _log_tool_decision 里会调
+            ``reset_sticky`` / ``active_domains`` —— stub 必须提供 no-op 实现，
+            否则子代理轮次直接 AttributeError 崩溃。
+            """
 
             def __init__(self, schemas: list[dict]):
                 self._schemas = schemas
@@ -209,6 +214,16 @@ class SubagentDispatcher:
             def reset_session(self, session_id: str) -> None:
                 return
 
-        engine = ChatEngine(self.registry, tool_catalog=_FrozenCatalog(tool_subset))
+            def reset_sticky(self, session_id: str) -> None:
+                return
+
+            def active_domains(self, session_id: Optional[str]) -> set:
+                return set()
+
+        engine = ChatEngine(
+            self.registry,
+            tool_catalog=_FrozenCatalog(tool_subset),
+            is_subagent_engine=True,
+        )
         engine.max_rounds = max_rounds
         return engine

--- a/app/services/tool_catalog.py
+++ b/app/services/tool_catalog.py
@@ -150,8 +150,22 @@ class ToolCatalog:
         """清掉会话粘性（清理会话时调用）。"""
         self._sticky.pop(session_id, None)
 
+    def reset_sticky(self, session_id: str) -> None:
+        """design-v3 §5：明确换目标（followup 分类 new_goal）时清空会话粘性。
+
+        用户换了一个全新目标时，旧目标领域的 sticky domain 不应继续污染
+        本轮工具 schema 选择。由 execution_engine 在 new_goal 时调用。
+        """
+        self._sticky.pop(session_id, None)
+
     def decay_sticky_domain(self, session_id: str) -> None:
-        """手动衰减一轮会话 sticky domain TTL（plan_orchestrator 步骤完成后调用）。"""
+        """手动衰减一轮会话 sticky domain TTL。
+
+        保留（public API 兼容）。design-v3 §5 / R8：plan_orchestrator 的调用点
+        已移除——该分支在生产路径从不触发（引擎从未传过 tool_catalog），TTL
+        衰减由 ``_activate_domains`` 每轮自然进行（每次 select_schemas 都把
+        所有 sticky domain 减 1）。
+        """
         sticky = self._sticky.get(session_id)
         if not sticky:
             return

--- a/app/services/tool_dispatch_service.py
+++ b/app/services/tool_dispatch_service.py
@@ -204,6 +204,9 @@ class ToolDispatchService:
 
         # 1. 重复调用拦截 (并发安全：check-and-add 在锁内原子完成，否则两条并行
         #    dispatch 都会通过 in 检查后才 add，重复调用逃逸拦截)。
+        #    design-v3 §2（R-dedup）：先“占位”保证并发同参互斥，但**失败**的调用
+        #    会在下方释放占位 —— 失败的同参调用可被 LLM 重试，且绝不会收到
+        #    “已成功执行”的重复提示。
         tool_key = (tool_name, normalize_tool_args(tool_args_raw))
         async with self._dedup_lock:
             if tool_key in executed_tools:
@@ -222,7 +225,10 @@ class ToolDispatchService:
         try:
             result = await self._registry.dispatch(tool_name, tool_args_raw, session_id=session_id)
         except OperationCancelled:
-            # ADR-0052：取消上抛给工具管道处理（它会记成「已取消」而非工具故障）
+            # ADR-0052：取消上抛给工具管道处理（它会记成「已取消」而非工具故障）。
+            # 取消的调用不占用 dedup 槽位（本轮后续重试不被“已成功”谎言拦截）。
+            async with self._dedup_lock:
+                executed_tools.discard(tool_key)
             raise
         except Exception as e:
             from app.tools._utils import std_error_response
@@ -233,12 +239,17 @@ class ToolDispatchService:
                 error_type=type(e).__name__,
                 correction_hint=f"Execution error: {error_msg}",
             )
+            async with self._dedup_lock:
+                executed_tools.discard(tool_key)
 
         # 2b. V3: 为工具结果中的地图命令铸 action_id（写回 command dict，SSE 携带）。
         map_actions = self._mint_map_action_ids(result)
 
         # 3. registry 返回 std_error_response dict 的统一错误路径
         if is_error_dict(result):
+            # 失败调用不占用 dedup 槽位：同参重试放行，且不会谎报“已成功执行”。
+            async with self._dedup_lock:
+                executed_tools.discard(tool_key)
             error_msg = sanitize_error_msg(result.get("message", ""))
             result["message"] = error_msg
             if "correction_hint" in result and result["correction_hint"]:

--- a/app/services/tool_dispatch_service.py
+++ b/app/services/tool_dispatch_service.py
@@ -167,6 +167,15 @@ class ToolDispatchResult:
 # 重复调用拦截的 LLM 提示（独立常量，避免 ok/error 分支误用）
 _REPEAT_LLMPAYLOAD = "[重复调用拦截] {tool} 已在本任务中以相同参数成功执行，结果已生效。请直接基于既有结果汇报，不要再次调用。"
 
+# 并发在飞去重（adversarial P2-9 / recovery P2）：同一波次出现两条相同调用时，
+# 原调用可能仍在执行中——此时**绝不谎报"已成功执行"**。软化措辞：告知原调用
+# 已发起，让 LLM 以原调用的结果为准。原调用完成后（_completed_keys 命中）仍走
+# 上面的成功语义消息（post-success dedup 文案不变）。
+_REPEAT_INFLIGHT_LLMPAYLOAD = (
+    "[重复调用拦截] {tool} 的同参数调用已在本任务中发起（原调用仍在执行中），"
+    "请以原调用的结果为准并据此汇报，不要重复调用。"
+)
+
 
 class ToolDispatchService:
     """工具调度的单一拥有者。两条 agent 路径都应经由本服务。"""
@@ -185,6 +194,12 @@ class ToolDispatchService:
         # adds. Lock is held only for the microsecond check-and-add, released
         # before the heavy registry dispatch, so it never serializes execution.
         self._dedup_lock = asyncio.Lock()
+        # P2-9（adversarial P2-9 / recovery P2）：已完成（非在飞）的同参调用集合。
+        # 重复命中时若 key ∈ _completed_keys → post-success 语义（原文案）；
+        # 否则视为"并发在飞"→ 不谎报成功的软化文案。有界：超限整体清空只会
+        # 把个别后序重复从"成功文案"降级为"在飞文案"，去重本身不受影响。
+        self._completed_keys: set[tuple[str, str]] = set()
+        self._COMPLETED_KEYS_MAX = 4096
 
     async def dispatch(
         self,
@@ -210,7 +225,11 @@ class ToolDispatchService:
         tool_key = (tool_name, normalize_tool_args(tool_args_raw))
         async with self._dedup_lock:
             if tool_key in executed_tools:
-                note = _REPEAT_LLMPAYLOAD.format(tool=tool_name)
+                # P2-9：区分「并发在飞」与「已完成」——在飞时绝不谎报成功。
+                if tool_key in self._completed_keys:
+                    note = _REPEAT_LLMPAYLOAD.format(tool=tool_name)
+                else:
+                    note = _REPEAT_INFLIGHT_LLMPAYLOAD.format(tool=tool_name)
                 return ToolDispatchResult(
                     status="repeated",
                     llm_payload=note,
@@ -227,8 +246,7 @@ class ToolDispatchService:
         except OperationCancelled:
             # ADR-0052：取消上抛给工具管道处理（它会记成「已取消」而非工具故障）。
             # 取消的调用不占用 dedup 槽位（本轮后续重试不被“已成功”谎言拦截）。
-            async with self._dedup_lock:
-                executed_tools.discard(tool_key)
+            self._release_key(executed_tools, tool_key)
             raise
         except Exception as e:
             from app.tools._utils import std_error_response
@@ -239,8 +257,7 @@ class ToolDispatchService:
                 error_type=type(e).__name__,
                 correction_hint=f"Execution error: {error_msg}",
             )
-            async with self._dedup_lock:
-                executed_tools.discard(tool_key)
+            self._release_key(executed_tools, tool_key)
 
         # 2b. V3: 为工具结果中的地图命令铸 action_id（写回 command dict，SSE 携带）。
         map_actions = self._mint_map_action_ids(result)
@@ -248,8 +265,7 @@ class ToolDispatchService:
         # 3. registry 返回 std_error_response dict 的统一错误路径
         if is_error_dict(result):
             # 失败调用不占用 dedup 槽位：同参重试放行，且不会谎报“已成功执行”。
-            async with self._dedup_lock:
-                executed_tools.discard(tool_key)
+            self._release_key(executed_tools, tool_key)
             error_msg = sanitize_error_msg(result.get("message", ""))
             result["message"] = error_msg
             if "correction_hint" in result and result["correction_hint"]:
@@ -309,6 +325,9 @@ class ToolDispatchService:
             except Exception:
                 pass  # non-fatal: frontend falls back to full download
 
+        # P2-9：成功完成 → 标记 completed（后续同参重复走 post-success 文案）。
+        self._mark_completed(tool_key)
+
         return ToolDispatchResult(
             status="ok",
             llm_payload=llm_payload,
@@ -319,6 +338,23 @@ class ToolDispatchService:
             map_actions=map_actions,
             ref_descriptor=ref_descriptor,
         )
+
+    # ── P2-9: dedup 槽位生命周期 ─────────────────────────────────────
+
+    def _release_key(self, executed_tools: set, tool_key: tuple[str, str]) -> None:
+        """失败/取消的调用释放 dedup 槽位（同参可重试），并清掉 completed 标记。
+
+        ``executed_tools.discard`` / ``_completed_keys.discard`` 均为 set 原子
+        操作（GIL），无需持锁；check-and-add 的原子性由 _dedup_lock 保证。
+        """
+        executed_tools.discard(tool_key)
+        self._completed_keys.discard(tool_key)
+
+    def _mark_completed(self, tool_key: tuple[str, str]) -> None:
+        """成功完成的调用标记为 completed（post-success dedup 语义）。"""
+        self._completed_keys.add(tool_key)
+        if len(self._completed_keys) > self._COMPLETED_KEYS_MAX:
+            self._completed_keys.clear()
 
     # ── V3: 地图动作 action_id 铸造 ──────────────────────────────────────
 

--- a/app/services/tool_metrics.py
+++ b/app/services/tool_metrics.py
@@ -205,6 +205,12 @@ def record_tool_call(
     actual_execution_mode: Optional[str] = None,
     compute_ms: Optional[int] = None,
     queue_wait_ms: Optional[int] = None,
+    # design-v3 §6 observability（additive，无计划时为 None）：
+    plan_id: Optional[str] = None,
+    plan_revision: Optional[int] = None,
+    step_id: Optional[str] = None,
+    failure_class: Optional[str] = None,
+    recovery_action: Optional[str] = None,
 ) -> None:
     """落一行 JSONL（入队，异步落盘）+ 更新聚合器。失败不抛。
 
@@ -212,6 +218,10 @@ def record_tool_call(
     the harness evidence trail, this metrics log, and MapSpec/runtime evidence,
     so a single map's full chain (tool → ref → mapspec revision → checkpoint →
     compile → runtime) is reconstructable from logs (OBSERVABILITY-V2).
+
+    plan_id / plan_revision / step_id / failure_class / recovery_action
+    (design-v3 §6) are additive — registry.dispatch fills them from the
+    process-local plan cache when a plan is active and on classified failures.
     """
     row = {
         "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
@@ -229,6 +239,11 @@ def record_tool_call(
         "actual_execution_mode": actual_execution_mode,
         "compute_ms": compute_ms,
         "queue_wait_ms": queue_wait_ms,
+        "plan_id": plan_id,
+        "plan_revision": plan_revision,
+        "step_id": step_id,
+        "failure_class": failure_class,
+        "recovery_action": recovery_action,
     }
     line = json.dumps(row, separators=(",", ":")) + "\n"
     try:

--- a/app/tools/plan_mode.py
+++ b/app/tools/plan_mode.py
@@ -57,6 +57,19 @@ def register_plan_mode_tools(registry: ToolRegistry):
         if err:
             return {"success": False, "code": "VALIDATION_ERROR", "message": err}
 
+        # design-v3 §deps：静态引用校验（第二道闸，补充完整 issue 列表）
+        static_issues = plan_svc.validate_static_refs(plan)
+        if static_issues:
+            return {
+                "success": False,
+                "code": "VALIDATION_ERROR",
+                "message": "; ".join(static_issues),
+            }
+
+        # design-v3 §4：新计划提出时，该 session 其他 pending/running 计划
+        # 标记 superseded（绝不静默覆盖）。须在 store_plan 之前执行。
+        await plan_svc.supersede_active_plans(session_id)
+
         plan_id = await plan_svc.store_plan(session_id, plan)
 
         # 标记包含破坏性工具的步骤，便于 UI / LLM 提示用户

--- a/app/tools/plan_mode.py
+++ b/app/tools/plan_mode.py
@@ -128,7 +128,9 @@ def register_plan_mode_tools(registry: ToolRegistry):
         name="get_plan_status",
         tier=1,
         description=(
-            "查询一个已提交计划的当前状态：pending(待审) / running / completed / failed / cancelled。"
+            "查询一个已提交计划的当前状态。状态词表：pending(待审) / running(执行中) / "
+            "partially_completed(部分完成，可恢复执行) / completed / failed / "
+            "cancelled(已取消，拒绝恢复) / superseded(已被新计划取代)。"
             "用于在长时计划执行后回看哪一步失败 / 检查计划是否已经跑过避免重复执行。"
         ),
         param_descriptions={"plan_id": "propose_plan 返回的 plan_id"},

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -300,6 +300,7 @@ class ToolRegistry:
         token = cache_hit_var.set(False)  # 重置 — 每次 dispatch 都从未命中开始
         start = _time.perf_counter()
         error_cls: Optional[str] = None
+        active_exc: Optional[BaseException] = None
         result: Any = None
         # PERF-01: arg_bytes is a small dict (tool args). A cheap size estimate
         # avoids a full json.dumps on every dispatch just to measure bytes.
@@ -321,6 +322,7 @@ class ToolRegistry:
             result = await self._dispatch_impl(name, arguments, session_id)
         except Exception as e:  # noqa: BLE001
             error_cls = type(e).__name__
+            active_exc = e
             raise
         finally:
             duration_ms = int((_time.perf_counter() - start) * 1000)
@@ -343,6 +345,13 @@ class ToolRegistry:
                     if _canon is not None:
                         plan_id = _canon.plan_id
                         plan_revision = _canon.revision
+                        # P2-10(a)：计划里有 running / 匹配本工具的步骤时填 step_id
+                        # （running = 正在执行的步骤；tool 匹配 = 已绑定的步骤）。
+                        from app.services.planning.models import StepStatus as _StepStatus
+                        for _cs in _canon.steps:
+                            if _cs.status == _StepStatus.running or _cs.tool == name:
+                                step_id = _cs.id
+                                break
                 except Exception:  # noqa: BLE001
                     pass
             if error_cls is not None:
@@ -351,10 +360,15 @@ class ToolRegistry:
                         classify_error as _classify_error,
                         recovery_action_for as _recovery_action_for,
                     )
-                    _code = result.get("code") if isinstance(result, dict) else None
-                    _etype = result.get("error_type") if isinstance(result, dict) else None
-                    _emsg = result.get("message") if isinstance(result, dict) else None
-                    _fc = _classify_error(code=_code, error_type=_etype, message=_emsg)
+                    if active_exc is not None:
+                        # P2-10(b)：异常路径直接分类异常——OperationCancelled 等
+                        # 才能被正确分到 cancelled，而不是落到默认 internal。
+                        _fc = _classify_error(exception=active_exc)
+                    else:
+                        _code = result.get("code") if isinstance(result, dict) else None
+                        _etype = result.get("error_type") if isinstance(result, dict) else None
+                        _emsg = result.get("message") if isinstance(result, dict) else None
+                        _fc = _classify_error(code=_code, error_type=_etype, message=_emsg)
                     failure_class = _fc.value
                     recovery_action = _recovery_action_for(_fc).value
                 except Exception:  # noqa: BLE001

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -333,6 +333,32 @@ class ToolRegistry:
             # percent for typical JSON, never materializing the full string.
             result_bytes = _estimate_json_bytes(result) if result is not None else 0
             cache_hit = cache_hit_var.get()
+            # design-v3 §6 observability（additive）：只在 plan_store 进程缓存命中时
+            # 附带 plan_id/plan_revision；失败时附 failure_class/recovery_action。
+            plan_id = plan_revision = step_id = failure_class = recovery_action = None
+            if session_id:
+                try:
+                    from app.services.planning.store import plan_store as _plan_store
+                    _canon = _plan_store.peek(session_id)
+                    if _canon is not None:
+                        plan_id = _canon.plan_id
+                        plan_revision = _canon.revision
+                except Exception:  # noqa: BLE001
+                    pass
+            if error_cls is not None:
+                try:
+                    from app.services.planning.recovery import (
+                        classify_error as _classify_error,
+                        recovery_action_for as _recovery_action_for,
+                    )
+                    _code = result.get("code") if isinstance(result, dict) else None
+                    _etype = result.get("error_type") if isinstance(result, dict) else None
+                    _emsg = result.get("message") if isinstance(result, dict) else None
+                    _fc = _classify_error(code=_code, error_type=_etype, message=_emsg)
+                    failure_class = _fc.value
+                    recovery_action = _recovery_action_for(_fc).value
+                except Exception:  # noqa: BLE001
+                    pass
             tool_metrics.record_tool_call(
                 tool=name,
                 arg_bytes=arg_bytes,
@@ -344,6 +370,11 @@ class ToolRegistry:
                 requested_execution_policy=req_policy_str,
                 actual_execution_mode=actual_mode,
                 compute_ms=duration_ms if not cache_hit else 0,
+                plan_id=plan_id,
+                plan_revision=plan_revision,
+                step_id=step_id,
+                failure_class=failure_class,
+                recovery_action=recovery_action,
             )
             cache_hit_var.reset(token)
 

--- a/tests/benchmarks/_ctx_fixture.py
+++ b/tests/benchmarks/_ctx_fixture.py
@@ -1,0 +1,159 @@
+"""Shared synthetic-session fixture for the planning-v3 context benchmark.
+
+Imported by both ``bench_planning_v3.py`` (v3 worktree) and
+``_master_context_baseline.py`` (executed with cwd = the pristine master
+checkout, module resolved via PYTHONPATH). The fixture deliberately imports
+only APIs that are byte-identical between the two worktrees, so the assembled
+contexts are directly comparable:
+
+- ``app.services.session_data.session_data_manager`` (memory backend when
+  ``USE_REDIS=false``)
+- ``app.services.chat.plan_orchestrator`` (``Plan``/``PlanStep``/``plan_orchestrator``)
+- ``app.services.chat.prompt.SYSTEM_PROMPT``
+
+The fixture mirrors swarm-report C §5's synthetic session: 2 layers (5-feature
+GeoJSON schema inference), 3 tool events, a 4-step plan with 2 steps done,
+plus 4 user/assistant turns.
+"""
+from __future__ import annotations
+
+from app.services.session_data import session_data_manager
+from app.services.chat.plan_orchestrator import Plan, PlanStep, plan_orchestrator
+from app.services.chat.prompt import SYSTEM_PROMPT
+
+SESSION_ID = "bench-v3-session"
+
+
+def make_geojson(geom_type: str, n: int = 5) -> dict:
+    """Small realistic GeoJSON FeatureCollection (5 features)."""
+    feats = []
+    for i in range(n):
+        if geom_type == "Point":
+            coords = [104.0 + i * 0.01, 30.6 + i * 0.005]
+        else:
+            coords = [[104.0 + j * 0.01, 30.6 + j * 0.005] for j in range(4)]
+        feats.append({
+            "type": "Feature",
+            "properties": {"name": f"f{i}", "value": i},
+            "geometry": {"type": geom_type, "coordinates": coords},
+        })
+    return {"type": "FeatureCollection", "features": feats}
+
+
+async def build_fixture(
+    session_id: str = SESSION_ID,
+    n_turns: int = 4,
+    long_msgs: bool = False,
+):
+    """Populate the memory session store + orchestrator plan, return messages.
+
+    ``n_turns`` selects how many user/assistant pairs the message list holds;
+    ``long_msgs`` uses 150-250 char realistic messages (used for the
+    2-turn dedup measurement where short fixture messages would understate
+    the block bytes).
+    """
+    await session_data_manager.clear_session(session_id)
+
+    r1 = await session_data_manager.store(session_id, make_geojson("Point"), prefix="geojson")
+    r2 = await session_data_manager.store(session_id, make_geojson("LineString"), prefix="geojson")
+    await session_data_manager.set_alias(session_id, r1, "医院_成都")
+    await session_data_manager.set_alias(session_id, r2, "道路_成都")
+
+    await session_data_manager.set_map_state(session_id, "viewport", {
+        "center": [104.06, 30.67], "zoom": 12.0, "bearing": 0, "pitch": 0,
+        "bounds": [103.9, 30.5, 104.2, 30.8],
+    })
+    await session_data_manager.set_map_state(session_id, "base_layer", "OSM 地图")
+    await session_data_manager.set_map_state(session_id, "layers", [
+        {"id": r1, "name": "医院_成都", "type": "geojson", "visible": True, "featureCount": 5},
+        {"id": r2, "name": "道路_成都", "type": "geojson", "visible": True, "featureCount": 5},
+    ])
+    await session_data_manager.set_map_state(session_id, "selected_feature", None)
+
+    await session_data_manager.append_event(session_id, "tool_executed", {
+        "tool": "search_poi", "status": "completed", "ref": r1,
+        "feature_count": 5, "command": "search_poi",
+    })
+    await session_data_manager.append_event(session_id, "tool_executed", {
+        "tool": "spatial_filter", "status": "completed", "ref": r1,
+        "feature_count": 5, "command": "filter",
+    })
+    await session_data_manager.append_event(session_id, "tool_executed", {
+        "tool": "create_heatmap", "status": "completed", "ref": r2,
+        "feature_count": 5, "command": "heatmap",
+    })
+
+    plan = Plan(
+        intent="分析成都市医院分布并生成热力图",
+        domains=["statistics", "core"],
+        steps=[
+            PlanStep(n=1, goal="搜索成都市医院 POI 数据", tool_family="core", done=True),
+            PlanStep(n=2, goal="对医院点做空间过滤", tool_family="core", done=True),
+            PlanStep(n=3, goal="生成医院分布热力图", tool_family="statistics", done=False),
+            PlanStep(n=4, goal="叠加底图并返回结果", tool_family="core", done=False),
+        ],
+    )
+    plan_orchestrator.set_plan(session_id, plan)
+
+    if long_msgs:
+        user_msgs = [
+            ("帮我分析一下成都市各区县医院的分布情况，看看有没有明显聚集的区域，"
+             "如果聚集比较明显，我希望能看到每个聚集点的范围和大致数量，"
+             "顺便把结果和道路网叠加起来看"),
+            ("对刚才的医院点数据做一次热点分析，用核密度估计，"
+             "带宽选 800 米，输出热力图层，同时给我列出聚集最明显的三个区域"),
+        ]
+        asst_msgs = [
+            ("好的，我先搜索成都市的医院 POI 数据。已获取 215 个医院点，"
+             "保存在 ref:geojson-xxxx 中。接下来我会对数据做空间过滤，"
+             "去掉明显不属于主城区的点位，然后生成分布热力图。"),
+            ("热点分析已完成，结果已保存为 ref:geojson-xxxx。聚集最明显的三个区域是："
+             "春熙路商圈（约 42 个点）、华西坝（约 38 个点）、火车南站（约 31 个点）。"
+             "如果需要，我可以进一步计算这些区域的面积和重叠情况。"),
+        ]
+    else:
+        user_msgs = [
+            "帮我分析成都市医院的分布情况，看看有没有集中的区域",
+            "对医院点做热点分析，结果保存到 " + r1,
+            "把热力图叠加到底图上显示",
+            "把这些图层都显示出来",
+        ]
+        asst_msgs = [
+            "好的，我先搜索成都的医院 POI 数据。",
+            "热点分析完成，结果已保存为 " + r1 + "。",
+            "已叠加热力图到底图。",
+            "好的，图层已全部显示：" + r1 + "（医院）、" + r2 + "（道路）。",
+        ]
+
+    messages = [{"role": "system", "content": SYSTEM_PROMPT.format(skill_list="（暂无预置技能）")}]
+    for i in range(n_turns):
+        messages.append({"role": "user", "content": user_msgs[i % len(user_msgs)]})
+        messages.append({"role": "assistant", "content": asst_msgs[i % len(asst_msgs)]})
+    return messages
+
+
+def block_breakdown(messages: list[dict]) -> dict:
+    """Per-block char counts of an assembled message list (v3 / master shapes)."""
+    blocks = []
+    total = 0
+    for m in messages:
+        c = str(m.get("content", ""))
+        total += len(c)
+        blocks.append(len(c))
+    return {"blocks": blocks, "total_chars": total, "n_msgs": len(messages)}
+
+
+def plan_block_chars(messages: list[dict]) -> int:
+    """Chars of the [执行计划] block (second system message when a plan exists)."""
+    for m in messages:
+        if m.get("role") == "system" and str(m.get("content", "")).startswith("[执行计划]"):
+            return len(str(m.get("content", "")))
+    return 0
+
+
+def last_analysis_chars(messages: list[dict]) -> int:
+    """Chars of the [最近对话上下文] block, or 0 when absent."""
+    for m in messages:
+        if m.get("role") == "system" and str(m.get("content", "")).startswith("[最近对话上下文]"):
+            return len(str(m.get("content", "")))
+    return 0

--- a/tests/benchmarks/_master_context_baseline.py
+++ b/tests/benchmarks/_master_context_baseline.py
@@ -1,0 +1,108 @@
+"""Baseline runner — executes in the pristine master checkout, in-place.
+
+Run from the master worktree root (read-only checkout; nothing is written
+here, the module itself lives in the v3 worktree and is resolved via
+``PYTHONPATH``):
+
+    cd /home/kevin/projects/webgis/webgis-ai-agent
+    PYTHONPATH=<v3>/tests/benchmarks /opt/miniconda3/bin/python -m _master_context_baseline
+
+Prints one JSON object on stdout with:
+
+- ``registry`` — the real 149-tool registry build (master code; identical
+  tier/domain annotations to v3, since the tool modules are committed files).
+- ``selection`` — per-turn tool-schema selection for the three benchmark
+  turns (count / serialized chars / chars/4 tokens / active domains).
+- ``ctx_4turn`` — assembled context block breakdown for the representative
+  4-turn session (master: no ``tools_payload_chars``, ``estimated_tokens``
+  excludes the tools payload; ``[最近对话上下文]`` scans the full history).
+- ``ctx_2turn`` — same, for a 2-turn session with realistic-length messages
+  (used to measure the ``[最近对话上下文]`` duplication master emits).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+
+# Must be set before importing app modules (session_data singleton factory).
+os.environ["USE_REDIS"] = "false"
+
+from app.tools import init_tools  # noqa: E402
+from app.tools.registry import ToolRegistry  # noqa: E402
+from app.services.tool_catalog import ToolCatalog  # noqa: E402
+from app.services.chat.context_assembler import ChatContextAssembler  # noqa: E402
+
+import _ctx_fixture  # noqa: E402  (resolved via PYTHONPATH from the v3 worktree)
+
+
+def measure_selection(catalog: ToolCatalog) -> dict:
+    cases = {
+        "a_no_domain_first_turn": "帮我分析一下当前地图上的数据情况",
+        "b_network_turn": "帮我算一下从 A 到 B 的最短路径，看看开车多久能到",
+        "c_multi_domain_turn": "对比成都各区县的医院分布热点，评估通勤可达性，并结合遥感 NDVI 影像",
+    }
+    out = {}
+    for key, text in cases.items():
+        sid = f"bench-base-sel-{key}"
+        schemas = catalog.select_schemas(text, session_id=sid, declared_domains=None)
+        payload = json.dumps(schemas, ensure_ascii=False)
+        out[key] = {
+            "count": len(schemas),
+            "chars": len(payload),
+            "tokens": int(len(payload) / 4),
+            "active_domains": sorted(catalog.active_domains(sid)),
+        }
+    return out
+
+
+def measure_rep_turn_selection(catalog: ToolCatalog, session_id: str) -> dict:
+    """The selection _select_tools would make for the assembled fixture turn."""
+    schemas = catalog.select_schemas(
+        "把这些图层都显示出来",
+        session_id=session_id,
+        declared_domains={"statistics", "core"},
+    )
+    payload = json.dumps(schemas, ensure_ascii=False)
+    return {
+        "count": len(schemas),
+        "chars": len(payload),
+        "tokens": int(len(payload) / 4),
+    }
+
+
+async def assemble_baseline(n_turns: int, long_msgs: bool) -> dict:
+    sid = f"bench-base-{n_turns}t-{int(long_msgs)}"
+    messages = await _ctx_fixture.build_fixture(
+        session_id=sid, n_turns=n_turns, long_msgs=long_msgs
+    )
+    res = await ChatContextAssembler().assemble(sid, messages)
+    bb = _ctx_fixture.block_breakdown(res.messages)
+    bb["estimated_tokens"] = res.estimated_tokens
+    bb["plan_block_chars"] = _ctx_fixture.plan_block_chars(res.messages)
+    bb["last_analysis_chars"] = _ctx_fixture.last_analysis_chars(res.messages)
+    bb["history_turns_included"] = res.history_turns_included
+    return bb
+
+
+def main() -> None:
+    t0 = time.perf_counter()
+    registry = ToolRegistry()
+    init_tools(registry)
+    catalog = ToolCatalog(registry)
+    out = {
+        "registry": {
+            "n_tools": len(registry.list_tools()),
+            "build_seconds": round(time.perf_counter() - t0, 2),
+        },
+        "selection": measure_selection(catalog),
+        "rep_turn_selection": measure_rep_turn_selection(catalog, _ctx_fixture.SESSION_ID),
+        "ctx_4turn": asyncio.run(assemble_baseline(n_turns=4, long_msgs=False)),
+        "ctx_2turn": asyncio.run(assemble_baseline(n_turns=2, long_msgs=True)),
+    }
+    print(json.dumps(out, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/bench_planning_v3.py
+++ b/tests/benchmarks/bench_planning_v3.py
@@ -1,0 +1,501 @@
+"""planning-v3 performance measurement (design-v3 §21 / slice 4).
+
+Measures, not optimizes:
+
+1. Tool schemas selected per turn via the REAL ``ToolRegistry`` (149 tools,
+   tiers 92/47/10, built in-process with ``init_tools`` — no app startup):
+   (a) no-domain first turn (tier-1 floor), (b) a network-domain turn,
+   (c) a multi-domain turn. Reports count + serialized bytes
+   (``json.dumps(schemas, ensure_ascii=False)`` — the exact serialization
+   ``execution_engine`` feeds to ``assemble(..., tools_payload_chars=...)``)
+   + approx tokens (chars/4).
+2. Planning context bytes: assemble the representative context
+   (real system prompt + env block + 4-step plan block + recent-context +
+   history) via ``ChatContextAssembler`` with a populated memory session
+   store; per-block chars, total, and the tools payload INCLUDED in
+   ``estimated_tokens``.
+3. Plan load/save: ``PlanStore.save`` + cold ``load_current`` over the
+   in-memory session store (``MemorySessionStore`` — the ``USE_REDIS=false``
+   backend), 200 iterations, mean/p95 ms.
+4. Plan validation: ``validate_plan_capabilities`` over an 8-step plan
+   against the real registry, 200 iterations, mean/p95 ms.
+5. Baseline: runs the identical measurements against the pristine master
+   checkout (/home/kevin/projects/webgis/webgis-ai-agent) in a subprocess
+   (``python -m _master_context_baseline`` from the master cwd), so the
+   baseline is measured, not estimated.
+
+Usage:
+    USE_REDIS=false /opt/miniconda3/bin/python tests/benchmarks/bench_planning_v3.py
+
+Writes the result table to .planning/perf-v3.md (repo docs convention).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# ── process environment: memory session backend BEFORE any app import ──────
+os.environ.setdefault("USE_REDIS", "false")
+_ROOT = Path(__file__).resolve().parents[2]
+_MASTER_ROOT = Path(
+    os.environ.get("BENCH_MASTER_ROOT", "/home/kevin/projects/webgis/webgis-ai-agent")
+)
+sys.path.insert(0, str(_ROOT))
+
+from app.tools import init_tools  # noqa: E402
+from app.tools.registry import ToolRegistry  # noqa: E402
+from app.services.tool_catalog import ToolCatalog  # noqa: E402
+from app.services.session_data import MemorySessionStore, session_data_manager  # noqa: E402
+from app.services.chat.context_assembler import ChatContextAssembler  # noqa: E402
+
+import _ctx_fixture  # noqa: E402
+
+N_ITERS = 200
+
+# The three selection turns (identical text in both worktrees).
+SELECTION_CASES = {
+    "a_no_domain_first_turn": "帮我分析一下当前地图上的数据情况",
+    "b_network_turn": "帮我算一下从 A 到 B 的最短路径，看看开车多久能到",
+    "c_multi_domain_turn": "对比成都各区县的医院分布热点，评估通勤可达性，并结合遥感 NDVI 影像",
+}
+REP_TURN_TEXT = "把这些图层都显示出来"  # last user turn of the fixture session
+REP_TURN_DOMAINS = {"statistics", "core"}  # plan.declared_domains for that session
+
+
+def p95_ms(timings_ms: list[float]) -> float:
+    """Sorted 95th percentile (repo convention: EventLoopLagMonitor)."""
+    if not timings_ms:
+        return 0.0
+    s = sorted(timings_ms)
+    return s[int(len(s) * 0.95)]
+
+
+def summarize(timings_ms: list[float]) -> dict:
+    return {
+        "mean_ms": round(statistics.mean(timings_ms), 4),
+        "p95_ms": round(p95_ms(timings_ms), 4),
+        "min_ms": round(min(timings_ms), 4),
+        "max_ms": round(max(timings_ms), 4),
+    }
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Part 1 — tool schema selection per turn (real registry)
+# ────────────────────────────────────────────────────────────────────────────
+def measure_selection(catalog: ToolCatalog, rep_sid: str) -> dict:
+    rows = {}
+    for key, text in SELECTION_CASES.items():
+        sid = f"bench-v3-sel-{key}"
+        schemas = catalog.select_schemas(text, session_id=sid, declared_domains=None)
+        payload = json.dumps(schemas, ensure_ascii=False)
+        rows[key] = {
+            "count": len(schemas),
+            "chars": len(payload),
+            "tokens": int(len(payload) / 4),
+            "active_domains": sorted(catalog.active_domains(sid)),
+        }
+    # The exact selection the representative context turn would send
+    # (execution_engine._select_tools: last user msg + plan declared_domains).
+    schemas = catalog.select_schemas(
+        REP_TURN_TEXT, session_id=rep_sid, declared_domains=REP_TURN_DOMAINS
+    )
+    payload = json.dumps(schemas, ensure_ascii=False)
+    rows["rep_turn"] = {
+        "count": len(schemas),
+        "chars": len(payload),
+        "tokens": int(len(payload) / 4),
+        "active_domains": sorted(catalog.active_domains(rep_sid)),
+    }
+    return rows
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Part 2 — planning context bytes (v3 assembler, tools payload in estimate)
+# ────────────────────────────────────────────────────────────────────────────
+def label_messages(messages: list[dict]) -> list[tuple[str, int]]:
+    """Per-block (label, chars) for the assembled message list."""
+    out = []
+    for m in messages:
+        c = str(m.get("content", ""))
+        if c.startswith("[执行计划]"):
+            label = "plan_block"
+        elif c.startswith("[最近对话上下文]"):
+            label = "recent_context"
+        elif c.startswith("[历史折叠]"):
+            label = "truncation_notice"
+        elif m.get("role") == "system":
+            label = "system_env_overview"
+        else:
+            label = f"history({m.get('role')})"
+        out.append((label, len(c)))
+    return out
+
+
+async def assemble_v3(rep_chars: int) -> dict:
+    sid = _ctx_fixture.SESSION_ID
+    messages = await _ctx_fixture.build_fixture(session_id=sid, n_turns=4, long_msgs=False)
+    res = await ChatContextAssembler().assemble(sid, messages, tools_payload_chars=rep_chars)
+    return {
+        "messages": res.messages,
+        "estimated_tokens": res.estimated_tokens,
+        "history_turns_included": res.history_turns_included,
+    }
+
+
+async def dedup_2turn_v3() -> int:
+    """[最近对话上下文] chars for a 2-turn session (v3: empty by design)."""
+    sid = "bench-v3-2t"
+    messages = await _ctx_fixture.build_fixture(session_id=sid, n_turns=2, long_msgs=True)
+    res = await ChatContextAssembler().assemble(sid, messages, tools_payload_chars=0)
+    return _ctx_fixture.last_analysis_chars(res.messages)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Part 3 — plan load/save over the in-memory session store
+# ────────────────────────────────────────────────────────────────────────────
+async def bench_plan_store() -> dict:
+    from app.services.planning.store import PlanStore
+    from app.services.planning.models import CanonicalPlan, CanonicalStep
+
+    store = PlanStore(session_store=MemorySessionStore())
+    plan = CanonicalPlan(
+        plan_id="bench-plan",
+        session_id="bench-store",
+        intent="分析成都市医院分布并生成热力图",
+        domains=["statistics", "core"],
+        steps=[
+            CanonicalStep(id=f"s{i}", n=i + 1, goal=f"步骤 {i + 1}", tool_family="core")
+            for i in range(4)
+        ],
+    )
+    save_ms: list[float] = []
+    for _ in range(N_ITERS):
+        t0 = time.perf_counter()
+        await store.save(plan)
+        save_ms.append((time.perf_counter() - t0) * 1000)
+
+    load_ms: list[float] = []
+    for _ in range(N_ITERS):
+        store.clear_cache()  # cold read: cache-aside miss → store read + validate
+        t0 = time.perf_counter()
+        await store.load_current("bench-store")
+        load_ms.append((time.perf_counter() - t0) * 1000)
+
+    # warm-cache load (cache-aside hit) for reference
+    t0 = time.perf_counter()
+    await store.load_current("bench-store")
+    warm_ms = (time.perf_counter() - t0) * 1000
+
+    return {
+        "save": summarize(save_ms),
+        "load_cold": summarize(load_ms),
+        "load_warm_ms": round(warm_ms, 4),
+    }
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Part 4 — plan capability validation over the real registry
+# ────────────────────────────────────────────────────────────────────────────
+def build_8step_plan(registry: ToolRegistry):
+    from app.services.planning.models import CanonicalPlan, CanonicalStep
+
+    from app.services.planning.capability import validate_plan_capabilities
+
+    domains = ["network", "statistics", "raster", "osm", "temporal", "chinese", "what_if", "meta"]
+    chosen: list[tuple[str, str]] = []
+    for d in domains:
+        tool = None
+        for name, meta in registry.all_metadata().items():
+            if d in meta.get("domains", []):
+                tool = name
+                break
+        if tool:
+            chosen.append((tool, d))
+    steps = [
+        CanonicalStep(
+            id=f"s{i}", n=i + 1, goal=f"步骤 {i + 1}", tool=tool, tool_family=d
+        )
+        for i, (tool, d) in enumerate(chosen)
+    ]
+    plan = CanonicalPlan(
+        plan_id="bench-8step",
+        session_id="bench-val",
+        intent="8 步能力校验基准计划",
+        domains=[d for _, d in chosen],
+        steps=steps,
+    )
+    # correctness: the benchmark plan must validate cleanly
+    issues = validate_plan_capabilities(plan, registry)
+    if issues:
+        raise AssertionError(f"benchmark plan should validate cleanly, got: {issues[:3]}")
+    return plan
+
+
+def bench_validation(plan, registry: ToolRegistry) -> dict:
+    from app.services.planning.capability import validate_plan_capabilities
+
+    ms: list[float] = []
+    for _ in range(N_ITERS):
+        t0 = time.perf_counter()
+        validate_plan_capabilities(plan, registry)
+        ms.append((time.perf_counter() - t0) * 1000)
+    return summarize(ms)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Part 5 — master baseline (in-place subprocess; analytic fallback)
+# ────────────────────────────────────────────────────────────────────────────
+def run_master_baseline() -> dict:
+    bench_dir = Path(__file__).resolve().parent
+    env = dict(os.environ)
+    env["USE_REDIS"] = "false"
+    env["PYTHONPATH"] = str(bench_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    try:
+        proc = subprocess.run(
+            ["/opt/miniconda3/bin/python", "-m", "_master_context_baseline"],
+            cwd=str(_MASTER_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"baseline subprocess rc={proc.returncode}: {proc.stderr[-500:]}")
+        for line in reversed(proc.stdout.splitlines()):
+            line = line.strip()
+            if line.startswith("{"):
+                data = json.loads(line)
+                if "registry" in data:
+                    return data
+        raise RuntimeError(f"no JSON baseline in stdout: {proc.stdout[-300:]!r}")
+    except Exception as exc:  # noqa: BLE001 — analytic fallback below
+        print(f"[warn] master in-place baseline failed ({exc}); using analytic baseline")
+        return analytic_baseline()
+
+
+def analytic_baseline() -> dict:
+    """Fallback from swarm reports B/C when the master checkout is unusable."""
+    return {
+        "method": "analytic",
+        "selection": {
+            "a_no_domain_first_turn": {"count": 92, "chars": 79631, "tokens": 25462},
+            "b_network_turn": {"count": 104, "chars": 0, "tokens": 0},
+            "c_multi_domain_turn": {"count": 138, "chars": 124257, "tokens": 0},
+            "rep_turn": {"count": 103, "chars": 0, "tokens": 0},
+        },
+        "ctx_4turn": {
+            "blocks": None,
+            "total_chars": None,
+            "estimated_tokens": None,
+            "last_analysis_chars": None,
+            "note": "analytic: C-report blocks — system+env 4538, plan 195, recent-ctx 211, history <=6000t",
+        },
+        "ctx_2turn": {"last_analysis_chars": None, "note": "analytic: ~500 B block (C-report §2.1)"},
+    }
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Report
+# ────────────────────────────────────────────────────────────────────────────
+def render_report(
+    v3_selection: dict,
+    v3_ctx: dict,
+    v3_dedup_chars: int,
+    store_bench: dict,
+    val_bench: dict,
+    base: dict,
+) -> str:
+    method = "measured (in-place, both worktrees)" if base.get("method") != "analytic" else "analytic"
+    lines: list[str] = []
+
+    lines.append("# Perf — planning-v3 slice (design-v3 §21)\n")
+    lines.append(
+        "Measured with the real `ToolRegistry` (149 tools, tiers 92/47/10) built "
+        "in-process via `init_tools` — no app startup, no substitution. "
+        "Baseline = pristine master checkout run in-place (subprocess). "
+        "Timings: 200 iterations, mean/p95.\n"
+    )
+
+    lines.append("## Tool schema selection per turn\n")
+    lines.append("| Turn | Tools selected (master / v3) | Serialized bytes (master / v3) | ~tokens chars/4 (master / v3) | Method |")
+    lines.append("|---|---|---|---|---|")
+    for key, label in [
+        ("a_no_domain_first_turn", "(a) no-domain first turn (tier-1 floor)"),
+        ("b_network_turn", "(b) network-domain turn"),
+        ("c_multi_domain_turn", "(c) multi-domain turn (6 domains)"),
+    ]:
+        v = v3_selection[key]
+        b = base["selection"].get(key, {})
+        lines.append(
+            f"| {label} | {b.get('count', 'n/a')} / {v['count']} | "
+            f"{b.get('chars', 'n/a')} / {v['chars']} | "
+            f"{b.get('tokens', 'n/a')} / {v['tokens']} | {method} |"
+        )
+    # representative-context turn: master reports under its own key
+    v = v3_selection["rep_turn"]
+    b = base.get("rep_turn_selection", {})
+    lines.append(
+        f"| representative-context turn (+plan declared domains) | "
+        f"{b.get('count', 'n/a')} / {v['count']} | "
+        f"{b.get('chars', 'n/a')} / {v['chars']} | "
+        f"{b.get('tokens', 'n/a')} / {v['tokens']} | {method} |"
+    )
+    lines.append(
+        "Selection logic is identical in master and v3 (same `ToolCatalog` tiers/keywords; "
+        "v3 only adds `reset_sticky` + a docstring) — equal per-turn counts/bytes ⇒ "
+        "tool-selection accuracy unchanged. Tokens ≈ chars/4 for ASCII-heavy JSON "
+        "(`execution_engine` uses `int(chars/4)+1`).\n"
+    )
+
+    lines.append("## Planning context bytes (representative 4-turn session)\n")
+    lines.append("| Block | master chars | v3 chars | Method |")
+    lines.append("|---|---|---|---|")
+    base_blocks = base["ctx_4turn"].get("blocks")
+    v3_labels = label_messages(v3_ctx["messages"])
+    if base_blocks:
+        b0, b1, b2, *hist = base_blocks
+        v3_hist_chars = sum(c for lbl, c in v3_labels if lbl.startswith("history("))
+        b_hist = sum(hist)
+        lines.append(f"| system+env+overview | {b0} | {v3_labels[0][1]} | measured |")
+        lines.append(f"| plan block (4 steps) | {b1} | {v3_labels[1][1]} | measured |")
+        lines.append(
+            f"| [最近对话上下文] | {b2} | {v3_labels[2][1]} | measured |"
+        )
+        lines.append(f"| history messages | {b_hist} | {v3_hist_chars} | measured |")
+        lines.append(f"| **Total chars** | **{base['ctx_4turn']['total_chars']}** | **{v3_ctx['total_chars']}** | measured |")
+        base_tok = base["ctx_4turn"]["estimated_tokens"]
+        lines.append(
+            f"| **estimated_tokens (incl. tools payload)** | **{base_tok}** (tools NOT counted — "
+            f"param does not exist on master) | **{v3_ctx['estimated_tokens']}** "
+            f"(+{v3_ctx['tools_payload_tokens']} tools tokens) | measured |"
+        )
+    else:
+        lines.append("| (analytic baseline — see swarm C-report block table) | — | see v3 | analytic |")
+        lines.append(f"| **Total chars (v3)** | — | **{v3_ctx['total_chars']}** | measured |")
+        lines.append(
+            f"| **estimated_tokens (v3, incl. tools)** | — | **{v3_ctx['estimated_tokens']}** | measured |"
+        )
+    lines.append("")
+
+    lines.append("## [最近对话上下文] dedup (2-turn session, realistic-length messages)\n")
+    base_2t = base["ctx_2turn"].get("last_analysis_chars")
+    lines.append("| Worktree | block chars | Method |")
+    lines.append("|---|---|---|")
+    if base_2t is not None:
+        lines.append(f"| master | {base_2t} | measured |")
+    else:
+        lines.append("| master | ~500 (analytic, C-report §2.1) | analytic |")
+    lines.append(f"| v3 | {v3_dedup_chars} (block suppressed: history window covers last 2 turns) | measured |")
+    lines.append(
+        "v3's `build_last_analysis_context` scans only turns *before* the history window "
+        "(`HISTORY_MIN_TURNS=2`); master re-emits the last user/assistant exchange, duplicating "
+        "content already in the history block (~200-500 tokens/round of pure redundancy).\n"
+    )
+
+    lines.append("## Plan load / save / validation (v3-only code paths)\n")
+    lines.append("| Metric | Baseline (master) | v3 | Δ | Method |")
+    lines.append("|---|---|---|---|---|")
+    lines.append(
+        f"| PlanStore.save (200 it, memory store) | n/a — new code path | "
+        f"{store_bench['save']['mean_ms']} ms mean / {store_bench['save']['p95_ms']} ms p95 | — | measured |"
+    )
+    lines.append(
+        f"| PlanStore.load_current cold (200 it) | n/a — new code path | "
+        f"{store_bench['load_cold']['mean_ms']} ms mean / {store_bench['load_cold']['p95_ms']} ms p95 "
+        f"(warm cache-aside hit {store_bench['load_warm_ms']} ms) | — | measured |"
+    )
+    lines.append(
+        f"| validate_plan_capabilities, 8 steps (200 it) | n/a — new code path | "
+        f"{val_bench['mean_ms']} ms mean / {val_bench['p95_ms']} ms p95 | — | measured |"
+    )
+    lines.append("")
+    lines.append("## Notes / assumptions")
+    lines.append("- Registry: real `ToolRegistry` + `init_tools` (149 tools; tiers 1=92, 2=47, 3=10 — matches swarm B-report).")
+    lines.append("- Session store: `MemorySessionStore` (the `USE_REDIS=false` backend class); `PlanStore` gets an injected fresh instance.")
+    lines.append("- `load_current` cold = `clear_cache()` before each call (exercises store read + pydantic validate); the warm-cache hit is the cache-aside fast path.")
+    lines.append("- Tool payload bytes use `json.dumps(schemas, ensure_ascii=False)` — the exact serialization `execution_engine._compose_request_messages` measures for `tools_payload_chars`.")
+    lines.append(
+        "- Byte-count basis: the measured tier-1 floor is 61,464 chars (matches swarm C-report's 61,464; "
+        "tokens ≈ chars/4 = 15,366). Swarm B-report's 79,631 B / ~25.5k tokens used a different counting "
+        "basis (~30% higher; `ensure_ascii=True` escaping or utf-8 byte counting) — the in-place master run "
+        "uses the same serialization as v3, so the master-vs-v3 deltas are consistent regardless of basis."
+    )
+    lines.append("- The master checkout was not modified; all baseline runs happened via `cd` + subprocess.")
+    return "\n".join(lines)
+
+
+async def main() -> int:
+    print("== planning-v3 perf measurement (design-v3 §21) ==")
+    print(f"registry build + registry in worktree: {_ROOT}")
+    assert isinstance(session_data_manager, MemorySessionStore), (
+        f"expected memory session backend (USE_REDIS=false), got {type(session_data_manager).__name__}"
+    )
+
+    t0 = time.perf_counter()
+    registry = ToolRegistry()
+    init_tools(registry)
+    build_s = time.perf_counter() - t0
+    n_tools = len(registry.list_tools())
+    print(f"[1] real registry built in {build_s:.2f}s: {n_tools} tools")
+
+    catalog = ToolCatalog(registry)
+    rep_sid = "bench-v3-rep"
+    v3_selection = measure_selection(catalog, rep_sid)
+    for key, row in v3_selection.items():
+        print(
+            f"    selection {key}: count={row['count']} chars={row['chars']} "
+            f"tokens~{row['tokens']} domains={row['active_domains']}"
+        )
+
+    # Part 2 — context bytes (v3)
+    rep_chars = v3_selection["rep_turn"]["chars"]
+    v3_ctx_res = await assemble_v3(rep_chars)
+    v3_ctx = {
+        "messages": v3_ctx_res["messages"],
+        "total_chars": _ctx_fixture.block_breakdown(v3_ctx_res["messages"])["total_chars"],
+        "estimated_tokens": v3_ctx_res["estimated_tokens"],
+        "tools_payload_chars": rep_chars,
+        "tools_payload_tokens": int(rep_chars / 4),
+    }
+    print(f"[2] context: total chars={v3_ctx['total_chars']} "
+          f"estimated_tokens={v3_ctx['estimated_tokens']} "
+          f"(tools payload {rep_chars} chars = {v3_ctx['tools_payload_tokens']} tokens)")
+    for label, chars in label_messages(v3_ctx["messages"]):
+        print(f"      {label}: {chars}")
+
+    v3_dedup_chars = await dedup_2turn_v3()
+    print(f"[2b] 2-turn [最近对话上下文] block chars (v3): {v3_dedup_chars}")
+
+    # Part 3 — plan store timing
+    store_bench = await bench_plan_store()
+    print(f"[3] plan store: save mean={store_bench['save']['mean_ms']}ms "
+          f"p95={store_bench['save']['p95_ms']}ms | load cold mean={store_bench['load_cold']['mean_ms']}ms "
+          f"p95={store_bench['load_cold']['p95_ms']}ms | warm={store_bench['load_warm_ms']}ms")
+
+    # Part 4 — validation timing
+    plan8 = build_8step_plan(registry)
+    val_bench = bench_validation(plan8, registry)
+    print(f"[4] validate_plan_capabilities(8 steps): mean={val_bench['mean_ms']}ms "
+          f"p95={val_bench['p95_ms']}ms")
+
+    # Part 5 — master baseline
+    base = run_master_baseline()
+    print(f"[5] master baseline: n_tools={base['registry']['n_tools']} "
+          f"method={'measured' if base.get('method') != 'analytic' else 'analytic'}")
+
+    report = render_report(v3_selection, v3_ctx, v3_dedup_chars, store_bench, val_bench, base)
+    out_path = _ROOT / ".planning" / "perf-v3.md"
+    out_path.write_text(report, encoding="utf-8")
+    print(f"\nwrote {out_path}")
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/test_chat_engine_planning.py
+++ b/tests/test_chat_engine_planning.py
@@ -286,3 +286,87 @@ async def test_chat_stream_no_plan_events_when_plan_skipped(engine, monkeypatch)
     assert "event: plan_ready" not in joined
     assert "event: plan_step_done" not in joined
     assert "event: plan_finalized" not in joined
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_failed_tool_does_not_advance_plan(engine, monkeypatch):
+    """R2（design-v3 §2）：工具失败（status=error）绝不打勾计划步骤，也不发
+    plan_step_done；step_error 附带 failure_class/recovery_action（additive）。"""
+    test_plan = planner_mod.Plan(
+        intent="x", domains=["statistics"],
+        steps=[planner_mod.PlanStep(n=1, goal="热点", tool_family="statistics")],
+    )
+    planner_mod.set_plan("sess-EV5", test_plan)
+    async def fake_maybe_plan(self, *a, **k): return None
+    monkeypatch.setattr(engine, "_maybe_plan",
+                        fake_maybe_plan.__get__(engine, type(engine)))
+    monkeypatch.setattr(engine.registry, "metadata",
+                        lambda name: {"domains": ["statistics"]})
+
+    call_count = {"n": 0}
+    async def fake_llm_stream(*a, **k):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            yield ("done", {"message": {
+                "role": "assistant", "content": None,
+                "tool_calls": [{"id": "tc1", "type": "function",
+                                "function": {"name": "hotspot_analysis",
+                                             "arguments": "{}"}}],
+            }, "finish_reason": "tool_calls"})
+        else:
+            yield ("done", {"message": {"role": "assistant", "content": "done"},
+                            "finish_reason": "stop"})
+    monkeypatch.setattr(engine, "_call_llm_stream", fake_llm_stream)
+
+    from app.services.tool_dispatch_service import ToolDispatchResult
+    async def fake_dispatch(self, *a, **k):
+        return ToolDispatchResult(
+            status="error",
+            llm_payload="boom",
+            slim_event={"error": "boom"},
+            geojson_ref=None,
+            raw_result={"success": False, "code": "TOOL_ERROR", "message": "boom"},
+            error_msg="boom",
+        )
+    monkeypatch.setattr(engine, "_dispatch_tool",
+                        fake_dispatch.__get__(engine, type(engine)))
+
+    captured = []
+    async for ev in engine.chat_stream("热点分析", session_id="sess-EV5"):
+        captured.append(ev)
+
+    joined = "".join(captured)
+    assert "event: plan_step_done" not in joined
+    assert test_plan.steps[0].done is False  # 失败不打勾
+    assert "event: step_error" in joined
+    assert "failure_class" in joined  # additive 分类字段
+    planner_mod.clear_plan("sess-EV5")
+
+
+@pytest.mark.asyncio
+async def test_maybe_plan_new_goal_supersedes_old(engine, monkeypatch):
+    """design-v3 §2/§4：新目标（"换成查路线"）→ 旧 canonical 计划 superseded，
+    新计划接管（修复场景 8 短消息换目标被门控吞掉）。"""
+    from app.services.planning import PlanStatus
+    from app.services.planning.store import plan_store
+
+    old = planner_mod.Plan(
+        intent="旧", domains=["raster"],
+        steps=[planner_mod.PlanStep(n=1, goal="NDVI", tool_family="raster")],
+    )
+    planner_mod.set_plan("sess-S1", old)
+    old_canon = plan_store.peek("sess-S1")
+    old_id = old_canon.plan_id
+
+    async def fake_call_llm(_cfg, _messages, _tools=None):
+        return {"choices": [{"message": {"content":
+            '{"intent":"新","domains":["network"],"steps":[{"n":1,"goal":"路线","tool_family":"network"}]}'}}]}
+
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+
+    plan = await engine._maybe_plan("sess-S1", "换成查路线", [])
+    assert plan is not None and plan.intent == "新"
+    hist = await plan_store.get_by_id("sess-S1", old_id)
+    assert hist is not None and hist.status == PlanStatus.superseded
+    planner_mod.clear_plan("sess-S1")
+    await plan_store.clear("sess-S1")

--- a/tests/test_chat_engine_planning.py
+++ b/tests/test_chat_engine_planning.py
@@ -133,7 +133,7 @@ async def test_chat_stream_emits_plan_ready_when_plan_created(engine, monkeypatc
         domains=["core", "chinese"],
         steps=[
             planner_mod.PlanStep(n=1, goal="获取边界", tool_family="chinese"),
-            planner_mod.PlanStep(n=2, goal="出热力图", tool_family="core"),
+            planner_mod.PlanStep(n=2, goal="出热力图", tool_family="core", done=True),
         ],
     )
     async def fake_maybe_plan(self, session_id, message, messages):
@@ -166,7 +166,9 @@ async def test_chat_stream_emits_plan_ready_when_plan_created(engine, monkeypatc
     assert data["intent"] == "测试意图"
     assert data["domains"] == ["core", "chinese"]
     assert len(data["steps"]) == 2
+    # P3-2/P2-6：done 取投影真实状态（step2 已完成 → True），不硬编码 False
     assert data["steps"][0] == {"n": 1, "goal": "获取边界", "tool_family": "chinese", "done": False}
+    assert data["steps"][1] == {"n": 2, "goal": "出热力图", "tool_family": "core", "done": True}
     planner_mod.clear_plan("sess-EV1")
 
 

--- a/tests/test_chat_engine_planning.py
+++ b/tests/test_chat_engine_planning.py
@@ -372,3 +372,83 @@ async def test_maybe_plan_new_goal_supersedes_old(engine, monkeypatch):
     assert hist is not None and hist.status == PlanStatus.superseded
     planner_mod.clear_plan("sess-S1")
     await plan_store.clear("sess-S1")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# P3 延后项 #4：mid-turn tick flush——mark_step_done 打勾后立即 best-effort
+# 落盘，不依赖回合末 flush（崩溃/断连不丢已打勾步骤）
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_tick_flush_persists_step(engine, monkeypatch):
+    """工具打勾计划步骤后立即落盘：即使回合末 flush 崩溃（模拟），plan_store
+    里已能看到该步骤 completed——tick 持久化独立于回合末 flush。"""
+    from app.services.planning.models import PlanStatus, StepStatus
+    from app.services.planning.store import plan_store
+
+    # 两步计划：本轮只完成 step1 → 计划仍非终态，回合末 flush 会真正执行
+    # （若单步计划打勾后即 completed，回合末 flush 会被 get_plan 终态过滤
+    # 正确跳过，无法验证"崩溃后 tick 已落盘"）。
+    test_plan = planner_mod.Plan(
+        intent="x", domains=["core"],
+        steps=[
+            planner_mod.PlanStep(n=1, goal="缓冲", tool_family="core"),
+            planner_mod.PlanStep(n=2, goal="更多", tool_family="core"),
+        ],
+    )
+    planner_mod.set_plan("sess-EV6", test_plan)
+    async def fake_maybe_plan(self, *a, **k): return None
+    monkeypatch.setattr(engine, "_maybe_plan",
+                        fake_maybe_plan.__get__(engine, type(engine)))
+    monkeypatch.setattr(engine.registry, "metadata",
+                        lambda name: {"domains": ["core"]})
+
+    call_count = {"n": 0}
+    async def fake_call_llm(*a, **k):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return {"choices": [{"message": {
+                "role": "assistant", "content": None,
+                "tool_calls": [{"id": "tc1", "type": "function",
+                                "function": {"name": "buffer_analysis",
+                                             "arguments": "{}"}}],
+            }}]}
+        return {"choices": [{"message": {"role": "assistant", "content": "done"}}]}
+    monkeypatch.setattr(engine, "_call_llm", fake_call_llm)
+
+    from app.services.tool_dispatch_service import ToolDispatchResult
+    async def fake_dispatch(self, *a, **k):
+        return ToolDispatchResult(
+            status="ok", llm_payload="{}", slim_event={"ok": True},
+            geojson_ref=None, raw_result={"ok": True}, error_msg=None,
+        )
+    monkeypatch.setattr(engine, "_dispatch_tool",
+                        fake_dispatch.__get__(engine, type(engine)))
+
+    # 模拟"回合末 flush 崩溃"：第 2 次 flush（turn-end，finally）抛异常被吞；
+    # 第 1 次（tick flush——工具打勾后立即触发）正常落盘。
+    from app.services.chat.plan_orchestrator import plan_orchestrator
+    real_flush = plan_orchestrator.flush
+    flush_calls = {"n": 0}
+    async def flaky_flush(session_id):
+        flush_calls["n"] += 1
+        if flush_calls["n"] >= 2:
+            raise RuntimeError("simulated crash before turn-end flush")
+        await real_flush(session_id)
+    monkeypatch.setattr(plan_orchestrator, "flush", flaky_flush)
+
+    result = await engine.chat("缓冲分析", session_id="sess-EV6")
+    assert result["content"] == "done"
+    # 回合正常完成（best-effort：turn-end flush 崩溃只记 warning，不破坏回合）
+    assert flush_calls["n"] == 2
+
+    # 模拟重启：清空进程缓存后从 store 读回 → 步骤 completed（来自 tick flush）
+    plan_store.clear_cache()
+    persisted = await plan_store.load_current("sess-EV6")
+    assert persisted is not None
+    assert persisted.steps[0].status == StepStatus.completed
+    assert persisted.steps[1].status == StepStatus.pending
+    assert persisted.status == PlanStatus.proposed  # 仍有 pending → 非终态
+    planner_mod.clear_plan("sess-EV6")
+    await plan_store.clear("sess-EV6")

--- a/tests/test_session_message_cap.py
+++ b/tests/test_session_message_cap.py
@@ -53,7 +53,7 @@ async def test_session_messages_bounded_across_turns(monkeypatch):
          patch.object(engine, "_save_msg_async", new_callable=AsyncMock), \
          patch.object(engine, "_maybe_plan", new_callable=AsyncMock, return_value=None), \
          patch.object(engine, "_compose_request_messages", new_callable=AsyncMock,
-                      side_effect=lambda sid, msgs, project_id=None: msgs):
+                      side_effect=lambda sid, msgs, project_id=None, tools=None: msgs):
         for _ in range(20):
             await engine.chat("hi", session_id="s1")
 
@@ -71,7 +71,7 @@ async def test_trim_keeps_system_prompt_and_newest_turn(monkeypatch):
          patch.object(engine, "_save_msg_async", new_callable=AsyncMock), \
          patch.object(engine, "_maybe_plan", new_callable=AsyncMock, return_value=None), \
          patch.object(engine, "_compose_request_messages", new_callable=AsyncMock,
-                      side_effect=lambda sid, msgs, project_id=None: msgs):
+                      side_effect=lambda sid, msgs, project_id=None, tools=None: msgs):
         for _ in range(20):
             await engine.chat("hi", session_id="s1")
 
@@ -95,7 +95,7 @@ async def test_trim_evicts_only_oldest_turns_never_splits_a_turn(monkeypatch):
          patch.object(engine, "_save_msg_async", new_callable=AsyncMock), \
          patch.object(engine, "_maybe_plan", new_callable=AsyncMock, return_value=None), \
          patch.object(engine, "_compose_request_messages", new_callable=AsyncMock,
-                      side_effect=lambda sid, msgs, project_id=None: msgs):
+                      side_effect=lambda sid, msgs, project_id=None, tools=None: msgs):
         await engine.chat("hi", session_id="s1")
 
     # 1 + 10 turns + 1 new turn -> trimmed to system + newest 2 turns (5 msgs).
@@ -125,7 +125,7 @@ async def test_trim_drops_oversized_older_turn_whole(monkeypatch):
          patch.object(engine, "_save_msg_async", new_callable=AsyncMock), \
          patch.object(engine, "_maybe_plan", new_callable=AsyncMock, return_value=None), \
          patch.object(engine, "_compose_request_messages", new_callable=AsyncMock,
-                      side_effect=lambda sid, msgs, project_id=None: msgs):
+                      side_effect=lambda sid, msgs, project_id=None, tools=None: msgs):
         await engine.chat("hi", session_id="s1")
 
     tail = engine._sessions["s1"]
@@ -183,7 +183,7 @@ async def test_chat_stream_messages_bounded_across_turns(monkeypatch):
          patch.object(engine, "_save_msg_async", new_callable=AsyncMock), \
          patch.object(engine, "_maybe_plan", new_callable=AsyncMock, return_value=None), \
          patch.object(engine, "_compose_request_messages", new_callable=AsyncMock,
-                      side_effect=lambda sid, msgs, project_id=None: msgs), \
+                      side_effect=lambda sid, msgs, project_id=None, tools=None: msgs), \
          patch.object(engine, "_generate_title", fake_generate_title):
         for _ in range(20):
             async for _ev in engine.chat_stream("hi", session_id="s1"):

--- a/tests/unit/test_chat_context_builder.py
+++ b/tests/unit/test_chat_context_builder.py
@@ -9,9 +9,12 @@ import pytest
 from app.services.chat.context_builder import (
     build_last_analysis_context,
     build_map_state_summary,
+    build_plan_block,
     compose_request_messages,
     format_layer_lines,
 )
+from app.services.chat.context_assembler import ChatContextAssembler
+from app.services.chat.plan_orchestrator import render_plan_block
 from app.services.session_data import session_data_manager
 
 
@@ -58,6 +61,8 @@ class TestLastAnalysisContext:
         assert build_last_analysis_context([{"role": "system", "content": "..."}]) == ""
 
     def test_picks_most_recent_user_and_assistant(self):
+        # design-v3 §4 去重（行为变更）：历史窗口保证保留最近 2 轮，
+        # [最近对话上下文] 只覆盖窗口之前的轮次（这里是第一轮"你好"交换）。
         msgs = [
             {"role": "user", "content": "你好"},
             {"role": "assistant", "content": "你好"},
@@ -66,32 +71,42 @@ class TestLastAnalysisContext:
             {"role": "user", "content": "画热力图"},
         ]
         ctx = build_last_analysis_context(msgs)
-        assert "画热力图" in ctx
-        assert "已查到 312 家医院" in ctx
-        assert "查海淀医院" not in ctx  # 不是最新
+        assert "你好" in ctx  # 窗口之前的轮次被提炼
+        assert "画热力图" not in ctx  # 最新一轮在历史窗口内逐字可见，不再重复
+        assert "查海淀医院" not in ctx
 
     def test_collects_unique_refs(self):
+        # 3 轮：refs 放在窗口之前的首轮，验证去重采集仍生效。
         msgs = [
             {"role": "user", "content": "x"},
             {"role": "assistant", "content": "result at ref:data-aaa"},
             {"role": "tool", "content": "{ref: ref:data-bbb, ...}"},
             {"role": "assistant", "content": "ref:data-aaa is reused"},  # 与上面重复
+            {"role": "user", "content": "继续"},
+            {"role": "assistant", "content": "好的"},
+            {"role": "user", "content": "换个样式"},
         ]
         ctx = build_last_analysis_context(msgs)
         assert "ref:data-aaa" in ctx
         assert "ref:data-bbb" in ctx
 
     def test_truncates_long_messages(self):
+        # 3 轮：长消息在窗口之前的首轮，验证 200/300 截断仍生效。
         long_user = "X" * 500
         long_asst = "Y" * 500
         msgs = [
             {"role": "user", "content": long_user},
             {"role": "assistant", "content": long_asst},
+            {"role": "user", "content": "继续"},
+            {"role": "assistant", "content": "好的"},
+            {"role": "user", "content": "换个样式"},
         ]
         ctx = build_last_analysis_context(msgs)
         # 用户 200 截、助手 300 截
         assert ctx.count("X") <= 200
         assert ctx.count("Y") <= 300
+        assert ctx.count("X") > 0  # 确实提炼了窗口之前的长消息（非空断言）
+        assert ctx.count("Y") > 0
 
 
 # ─── build_map_state_summary（接 session_data_manager） ──────────
@@ -170,6 +185,8 @@ class TestComposeRequestMessages:
         assert any(m["role"] == "user" and m["content"] == "hi" for m in out)
 
     async def test_appends_last_ctx_when_history_nonempty(self, clean_session):
+        # design-v3 §4 去重（行为变更）：仅 2 轮对话全部落在历史窗口内
+        # （min 2 轮保证），[最近对话上下文] 不再重复注入同一批消息。
         msgs = [
             {"role": "system", "content": "BASE"},
             {"role": "user", "content": "查海淀医院"},
@@ -177,12 +194,40 @@ class TestComposeRequestMessages:
             {"role": "user", "content": "画热力图"},
         ]
         out = await compose_request_messages(clean_session, msgs)
-        # 第二条应该是"最近对话上下文"系统消息
-        assert out[1]["role"] == "system"
-        assert "[最近对话上下文]" in out[1]["content"]
-        # 用户消息全部还原顺序
+        joined = " ".join(m["content"] for m in out if m.get("role") == "system")
+        assert "[最近对话上下文]" not in joined
+        # 用户消息全部还原顺序（历史窗口逐字保留）
         user_msgs = [m["content"] for m in out if m["role"] == "user"]
         assert user_msgs == ["查海淀医院", "画热力图"]
 
     async def test_empty_messages_returns_empty(self, clean_session):
         assert await compose_request_messages(clean_session, []) == []
+
+
+# ─── design-v3 §4：计划块单一渲染 + tools payload 软计入 ─────────
+
+
+def test_plan_block_single_render_source():
+    """[执行计划] 单一渲染来源：build_plan_block 与 render_plan_block 等价。"""
+    from app.services.chat.planner import Plan, PlanStep
+    plan = Plan(intent="x", domains=["core"], steps=[
+        PlanStep(n=1, goal="a", tool_family="core", done=True),
+        PlanStep(n=2, goal="b", tool_family="core", done=False),
+    ])
+    assert build_plan_block(plan) == render_plan_block(plan)
+    assert "[执行计划]" in render_plan_block(plan)
+
+
+class TestEstimatedTokens:
+    async def test_tools_payload_counted_in_estimate(self, clean_session):
+        msgs = [
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ]
+        base = await ChatContextAssembler().assemble(clean_session, msgs)
+        with_tools = await ChatContextAssembler().assemble(
+            clean_session, msgs, tools_payload_chars=8000
+        )
+        # 8000 ASCII chars ≈ 2000 tokens（软计入，只影响估算）
+        assert with_tools.estimated_tokens > base.estimated_tokens
+        assert with_tools.estimated_tokens - base.estimated_tokens >= 2000

--- a/tests/unit/test_chat_context_builder.py
+++ b/tests/unit/test_chat_context_builder.py
@@ -231,3 +231,27 @@ class TestEstimatedTokens:
         # 8000 ASCII chars ≈ 2000 tokens（软计入，只影响估算）
         assert with_tools.estimated_tokens > base.estimated_tokens
         assert with_tools.estimated_tokens - base.estimated_tokens >= 2000
+
+    async def test_cjk_tools_payload_weighted_higher_than_ascii(self, clean_session):
+        """P3 #3：等字符数的 CJK-heavy tools payload 估算 ≥ 纯 ASCII payload——
+        _estimate_tokens 权重（CJK 1 char ≈ 1.5 tokens，ASCII 4 char ≈ 1 token）。"""
+        msgs = [
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": "hi"},
+        ]
+        ascii_payload = "tool text " * 160         # 1600 chars，全 ASCII
+        cjk_payload = "空间分析工具描述示例" * 160   # 同字符数（10×160），CJK-heavy
+        assert len(ascii_payload) == len(cjk_payload) == 1600
+
+        base = (await ChatContextAssembler().assemble(clean_session, msgs)).estimated_tokens
+        ascii_delta = (
+            await ChatContextAssembler().assemble(clean_session, msgs, tools_payload=ascii_payload)
+        ).estimated_tokens - base
+        cjk_delta = (
+            await ChatContextAssembler().assemble(clean_session, msgs, tools_payload=cjk_payload)
+        ).estimated_tokens - base
+        # 同字符数：CJK 权重（1.5/char）显著高于 ASCII（0.25/char）
+        assert cjk_delta >= ascii_delta
+        assert cjk_delta > ascii_delta
+        # CJK 估算必须高于旧的 chars/4 近似（1600/4 = 400）
+        assert cjk_delta > 400

--- a/tests/unit/test_plan_mode.py
+++ b/tests/unit/test_plan_mode.py
@@ -296,6 +296,109 @@ async def test_execute_unknown_plan_id_returns_error(registry):
     assert "找不到" in result["error"]
 
 
+# ─── design-v3：resume / typed refs / supersede ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_execute_resume_skips_completed_steps_and_reuses_refs(registry):
+    """design-v3 §4：失败后 resume——已完成步骤不重跑、其结果继续供 ${} 引用，
+    只有 pending/failed 步骤执行。"""
+    sid = "sess-plan-resume"
+    calls = {"s2": 0}
+
+    @registry.tool(name="fake_flaky_hotspot", description="第一次失败第二次成功")
+    def fake_flaky_hotspot(points: list) -> dict:
+        calls["s2"] += 1
+        if calls["s2"] == 1:
+            return {"success": False, "code": "TOOL_ERROR", "message": "第一次失败"}
+        return {"success": True, "data": {"hot_count": len(points), "from": points}}
+
+    plan = svc.PlanProposal(
+        title="resume",
+        steps=[
+            svc.PlanStep(id="s1", tool="fake_get_bbox", args={"area": "海淀"}),
+            svc.PlanStep(id="s2", tool="fake_flaky_hotspot",
+                         args={"points": "${s1.data.bbox}"}),
+            svc.PlanStep(id="s3", tool="fake_hotspot",
+                         args={"points": [1, 2, 3]}, depends_on=["s2"]),
+        ],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    r1 = await svc.execute_plan_async(sid, plan_id, registry)
+    assert r1["success"] is False
+    assert r1["failed_step"] == "s2"
+    assert r1["executed"] == ["s1"]
+    # 失败也持久化了已完成结果（resume 的数据基础）
+    data = await svc.load_plan(sid, plan_id)
+    assert "s1" in data["__step_results__"]
+    assert data["__status__"] == "failed"
+
+    # resume：s1 跳过（复用结果）、s2 重试成功、s3 执行
+    r2 = await svc.execute_plan_async(sid, plan_id, registry)
+    assert r2["success"] is True
+    assert r2["executed"] == ["s1", "s2", "s3"]
+    assert r2["results"]["s3"]["data"]["hot_count"] == 3
+    assert calls["s2"] == 2  # 只重试了一次
+    data2 = await svc.load_plan(sid, plan_id)
+    assert data2["__status__"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_execute_bad_path_ref_fails_with_missing_ref(registry):
+    """design-v3 §deps：${s1.bad.path} 坏路径 → 立即失败 + failure_class=missing_ref
+    + 修正提示（命名坏路径与可用 keys），不再静默 None/""。"""
+    sid = "sess-plan-badpath"
+    plan = svc.PlanProposal(
+        title="badpath",
+        steps=[
+            svc.PlanStep(id="s1", tool="fake_get_bbox", args={"area": "北京"}),
+            svc.PlanStep(id="s2", tool="fake_query_points",
+                         args={"bbox": "${s1.bad.path}", "count": 3}),
+        ],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    result = await svc.execute_plan_async(sid, plan_id, registry)
+    assert result["success"] is False
+    assert result["failed_step"] == "s2"
+    assert result["failure_class"] == "missing_ref"
+    assert "bad.path" in result["error"]      # 提示里带坏路径
+    assert "s1" in result["error"]            # 及可用 keys
+    assert result["recovery_action"] == "reuse_ref"
+    data = await svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "failed"
+    assert data["__failure_class__"] == "missing_ref"
+
+
+@pytest.mark.asyncio
+async def test_propose_supersedes_old_pending_plan(registry):
+    """design-v3 §4：新 propose 把旧 pending 计划标记 superseded；superseded
+    计划不重放（返回已存状态）。"""
+    sid = "sess-plan-super"
+    p1 = await registry.dispatch("propose_plan", {
+        "title": "旧计划",
+        "steps": [{"id": "s1", "tool": "fake_get_bbox", "args": {"area": "A"}}],
+    }, session_id=sid)
+    assert p1["success"] is True
+
+    p2 = await registry.dispatch("propose_plan", {
+        "title": "新计划",
+        "steps": [{"id": "s1", "tool": "fake_get_bbox", "args": {"area": "B"}}],
+    }, session_id=sid)
+    assert p2["success"] is True
+
+    old_data = await svc.load_plan(sid, p1["plan_id"])
+    assert old_data["__status__"] == "superseded"
+    status = await registry.dispatch("get_plan_status", {"plan_id": p1["plan_id"]}, session_id=sid)
+    assert status["status"] == "superseded"
+    # superseded 计划不重放
+    r = await svc.execute_plan_async(sid, p1["plan_id"], registry)
+    assert r["success"] is True
+    assert r["status"] == "superseded"
+    assert r["executed"] == []  # 未重新 dispatch 任何步骤
+
+
 # ─── 工具入口集成 ─────────────────────────────────────────────
 
 

--- a/tests/unit/test_plan_mode.py
+++ b/tests/unit/test_plan_mode.py
@@ -213,7 +213,7 @@ async def test_execute_halts_on_first_failure(registry):
     assert result["failed_step"] == "s2"
     assert result["executed"] == ["s1"]  # s1 跑完，s2 失败，s3（依赖 s2）没跑
     plan_data = await svc.load_plan(sid, plan_id)
-    assert plan_data["__status__"] == "failed"
+    assert plan_data["__status__"] == "partially_completed"  # s1 已成功（P2-1）
     assert plan_data["__failed_step__"] == "s2"
 
 
@@ -285,7 +285,7 @@ async def test_execute_failure_in_wave_keeps_completed_siblings(registry):
     assert "s3" in result["executed"]           # 同波兄弟，先于失败完成
     assert "s2" not in result["executed"]       # 失败步骤不计入
     plan_data = await svc.load_plan(sid, plan_id)
-    assert plan_data["__status__"] == "failed"
+    assert plan_data["__status__"] == "partially_completed"  # s1/s3 已成功（P2-1）
     assert plan_data["__failed_step__"] == "s2"
 
 
@@ -310,7 +310,8 @@ async def test_execute_resume_skips_completed_steps_and_reuses_refs(registry):
     def fake_flaky_hotspot(points: list) -> dict:
         calls["s2"] += 1
         if calls["s2"] == 1:
-            return {"success": False, "code": "TOOL_ERROR", "message": "第一次失败"}
+            # 瞬时网络失败（transient_network）→ 可恢复重试，不触发 livelock guard
+            return {"success": False, "code": "TOOL_ERROR", "message": "网络超时 连接失败"}
         return {"success": True, "data": {"hot_count": len(points), "from": points}}
 
     plan = svc.PlanProposal(
@@ -328,11 +329,12 @@ async def test_execute_resume_skips_completed_steps_and_reuses_refs(registry):
     r1 = await svc.execute_plan_async(sid, plan_id, registry)
     assert r1["success"] is False
     assert r1["failed_step"] == "s2"
+    assert r1["failure_class"] == "transient_network"
     assert r1["executed"] == ["s1"]
     # 失败也持久化了已完成结果（resume 的数据基础）
     data = await svc.load_plan(sid, plan_id)
     assert "s1" in data["__step_results__"]
-    assert data["__status__"] == "failed"
+    assert data["__status__"] == "partially_completed"  # s1 已成功（P2-1）
 
     # resume：s1 跳过（复用结果）、s2 重试成功、s3 执行
     r2 = await svc.execute_plan_async(sid, plan_id, registry)
@@ -367,7 +369,7 @@ async def test_execute_bad_path_ref_fails_with_missing_ref(registry):
     assert "s1" in result["error"]            # 及可用 keys
     assert result["recovery_action"] == "reuse_ref"
     data = await svc.load_plan(sid, plan_id)
-    assert data["__status__"] == "failed"
+    assert data["__status__"] == "partially_completed"  # s1 已成功（P2-1）
     assert data["__failure_class__"] == "missing_ref"
 
 
@@ -392,11 +394,11 @@ async def test_propose_supersedes_old_pending_plan(registry):
     assert old_data["__status__"] == "superseded"
     status = await registry.dispatch("get_plan_status", {"plan_id": p1["plan_id"]}, session_id=sid)
     assert status["status"] == "superseded"
-    # superseded 计划不重放
+    # superseded 计划**从未执行过**（无已存结果）→ 明确失败，不假装成功（P2-3）
     r = await svc.execute_plan_async(sid, p1["plan_id"], registry)
-    assert r["success"] is True
+    assert r["success"] is False
     assert r["status"] == "superseded"
-    assert r["executed"] == []  # 未重新 dispatch 任何步骤
+    assert "取代" in r["error"]
 
 
 # ─── 工具入口集成 ─────────────────────────────────────────────
@@ -466,3 +468,43 @@ async def test_propose_plan_requires_session(registry):
     result = await registry.dispatch("propose_plan", args, session_id=None)
     assert result["success"] is False
     assert "session_id" in result["message"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# P2-1 / P2-3 补充：superseded 但有已存结果 → 返回结果（不重放）；失败无结果 → failed
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_superseded_plan_with_stored_results_still_returns_them(registry):
+    """superseded 且已执行过部分步骤（有 __step_results__）→ success=True 返回
+    已存结果，不重放；与"从没跑过"的空 superseded（P2-3）区分。"""
+    sid = "sess-plan-super-results"
+    plan = svc.PlanProposal(
+        title="ran-then-superseded",
+        steps=[svc.PlanStep(id="s1", tool="fake_get_bbox", args={"area": "x"})],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+    await svc.execute_plan_async(sid, plan_id, registry)  # 先跑完 → completed
+    await svc.update_plan_status(sid, plan_id, __status__="superseded")  # 再被取代
+    r = await svc.execute_plan_async(sid, plan_id, registry)
+    assert r["success"] is True
+    assert r["status"] == "superseded"
+    assert r["executed"] == ["s1"]  # 结果复用，不重放
+    assert "s1" in r["results"]
+
+
+@pytest.mark.asyncio
+async def test_failure_with_no_results_writes_failed(registry):
+    """第一个步骤就失败（无任何已存结果）→ 状态写 failed（不是 partially_completed）。"""
+    sid = "sess-plan-fail-first"
+    plan = svc.PlanProposal(
+        title="fail-first",
+        steps=[svc.PlanStep(id="s1", tool="fake_always_fail", args={})],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+    r = await svc.execute_plan_async(sid, plan_id, registry)
+    assert r["success"] is False
+    data = await svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "failed"
+    assert data["__failure_class__"] == "internal"

--- a/tests/unit/test_plan_mode.py
+++ b/tests/unit/test_plan_mode.py
@@ -508,3 +508,72 @@ async def test_failure_with_no_results_writes_failed(registry):
     data = await svc.load_plan(sid, plan_id)
     assert data["__status__"] == "failed"
     assert data["__failure_class__"] == "internal"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# P3 延后项 #1：__step_results__ slim 持久化（完整结果存 ref:planresult-*，
+# payload 有界；resume 水合回完整结果，${stepId.path} 解析不受影响）
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_step_results_slim_persisted_and_resume_resolves(registry):
+    """大结果不嵌入 plan payload；resume 按 ref 水合后 ${s1.data.bbox} 正确解析。"""
+    import json as _json
+
+    sid = "sess-plan-slim"
+    big_blob = "x" * 200_000  # 大对象（≈200KB，模拟大 GeoJSON）
+    s1_calls = {"n": 0}
+    s2_calls = {"n": 0}
+
+    @registry.tool(name="fake_big_bbox", description="返回带大 blob 的 bbox")
+    def fake_big_bbox(area: str) -> dict:
+        s1_calls["n"] += 1
+        return {
+            "success": True,
+            "data": {"area": area, "bbox": [116, 39, 117, 40], "blob": big_blob},
+        }
+
+    @registry.tool(name="fake_ref_consumer", description="消费 bbox 引用")
+    def fake_ref_consumer(bbox: list) -> dict:
+        s2_calls["n"] += 1
+        if s2_calls["n"] == 1:
+            # 瞬时网络失败（transient_network）→ 可恢复重试，不触发 livelock guard
+            return {"success": False, "code": "TOOL_ERROR", "message": "网络超时 连接失败"}
+        return {"success": True, "data": {"bbox": bbox}}
+
+    plan = svc.PlanProposal(
+        title="slim",
+        steps=[
+            svc.PlanStep(id="s1", tool="fake_big_bbox", args={"area": "海淀"}),
+            svc.PlanStep(id="s2", tool="fake_ref_consumer",
+                         args={"bbox": "${s1.data.bbox}"}),
+        ],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    r1 = await svc.execute_plan_async(sid, plan_id, registry)
+    assert r1["success"] is False
+    assert r1["failed_step"] == "s2"
+
+    data = await svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "partially_completed"
+    # slim 形状：完整结果不在 plan payload 里（大 blob 绝不嵌入）
+    s1_entry = data["__step_results__"]["s1"]
+    assert s1_entry.get("__slim__") is True
+    assert s1_entry["ref"].startswith("ref:planresult-")
+    assert "keys" in s1_entry
+    assert big_blob not in _json.dumps(data)
+
+    # resume：s1 跳过（水合回完整结果），s2 用 ${s1.data.bbox} 重试成功
+    r2 = await svc.execute_plan_async(sid, plan_id, registry)
+    assert r2["success"] is True, f"resume failed: {r2}"
+    assert r2["executed"] == ["s1", "s2"]
+    assert s1_calls["n"] == 1  # s1 绝不被重新 dispatch
+    assert r2["results"]["s2"]["data"]["bbox"] == [116, 39, 117, 40]
+    data2 = await svc.load_plan(sid, plan_id)
+    assert data2["__status__"] == "completed"
+    # 完成态 payload 同样有界
+    assert data2["__step_results__"]["s1"].get("__slim__") is True
+    assert data2["__step_results__"]["s2"].get("__slim__") is True
+    assert big_blob not in _json.dumps(data2)

--- a/tests/unit/test_plan_orchestrator.py
+++ b/tests/unit/test_plan_orchestrator.py
@@ -1,11 +1,16 @@
 """Unit tests for AgentPlanOrchestrator."""
+import pytest
+
 from app.services.chat.plan_orchestrator import (
+    MAX_PLAN_STEPS,
     AgentPlanOrchestrator,
     Plan,
     PlanStep,
     parse_plan,
     should_plan,
 )
+from app.services.planning import FollowUpKind, PlanStatus
+from app.services.planning.store import plan_store
 
 
 def test_parse_plan_valid_json():
@@ -78,3 +83,251 @@ def test_orchestrator_step_advancement():
     # Clean up
     orchestrator.clear_plan(session_id)
     assert orchestrator.get_plan(session_id) is None
+
+
+# ─── design-v3：parse_plan 防御（R4） ────────────────────────────
+
+
+def test_parse_plan_defensive_n_and_tool_family():
+    """R4: n=null / "1.0" / "abc" 稳健转 int；非法 tool_family → None（步骤保留）。"""
+    raw = (
+        '{"intent":"x","domains":["core"],"steps":['
+        '{"n":null,"goal":"a","tool_family":"raster"},'
+        '{"n":"1.0","goal":"b","tool_family":"rasterz"},'
+        '{"n":"abc","goal":"c","tool_family":"chinese"},'
+        '{"goal":"d"}]}'
+    )
+    plan = parse_plan(raw)
+    assert plan is not None
+    assert [s.n for s in plan.steps] == [1, 1, 3, 4]
+    assert plan.steps[0].tool_family == "raster"   # raster ∈ VALID_DOMAINS
+    assert plan.steps[1].tool_family is None       # rasterz 非法 → None
+    assert plan.steps[2].tool_family == "chinese"
+    assert plan.steps[3].tool_family == "core"     # 缺失默认 core
+
+
+def test_parse_plan_caps_steps_at_max():
+    """R4: 步骤数超过 MAX_PLAN_STEPS 时截断，绝不崩溃。"""
+    steps = ",".join(
+        '{"n":%d,"goal":"g%d","tool_family":"core"}' % (i, i) for i in range(1, 13)
+    )
+    raw = '{"intent":"x","domains":["core"],"steps":[%s]}' % steps
+    plan = parse_plan(raw)
+    assert plan is not None
+    assert len(plan.steps) == MAX_PLAN_STEPS
+
+
+def test_parse_plan_accepts_registry_declared_domains():
+    """registry 声明的 domain（不在 DOMAIN_KEYWORDS 里）也合法。"""
+    from app.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+    reg.register("custom_tool", "custom", func=lambda **_: {}, tier=2, domains=["custom_domain"])
+    raw = '{"intent":"x","domains":["custom_domain"],"steps":[{"n":1,"goal":"a","tool_family":"custom_domain"}]}'
+    plan = parse_plan(raw, registry=reg)
+    assert plan is not None
+    assert plan.domains == ["custom_domain"]
+    assert plan.steps[0].tool_family == "custom_domain"
+
+
+# ─── design-v3：should_plan + followup_kind ─────────────────────
+
+
+def test_should_plan_with_followup_kind():
+    # new_goal → 必须规划（即使短消息含追问词——"换成查路线" 场景 8）
+    assert should_plan("换成查路线", [], has_active_plan=True, followup_kind=FollowUpKind.new_goal) is True
+    # style_change / continuation + 活跃计划 → 跳过
+    assert should_plan("换成蓝色", [], has_active_plan=True, followup_kind=FollowUpKind.style_change) is False
+    assert should_plan("继续", [], has_active_plan=True, followup_kind=FollowUpKind.continuation) is False
+    # 无活跃计划时 style_change 回落到旧启发式 → 规划
+    assert should_plan("换个颜色", [], has_active_plan=False, followup_kind=FollowUpKind.style_change) is True
+    # unclear + 活跃计划 → 旧长度/关键词启发式
+    assert should_plan("放大一下", [], has_active_plan=True, followup_kind=FollowUpKind.unclear) is False
+    # followup_kind=None → 与旧版完全一致
+    assert should_plan("放大一下", [], has_active_plan=True) is False
+    assert should_plan("放大一下", [], has_active_plan=False) is True
+
+
+# ─── design-v3：advance_step 修复（R1/R6/R7） ───────────────────
+
+
+def test_core_wildcard_removed_style_tool_does_not_tick_core_step():
+    """R1: 样式工具（domains=[]）不再通过 "core" 通配打勾 core 步骤。"""
+    orchestrator = AgentPlanOrchestrator()
+    session_id = "sess_core_wildcard"
+
+    plan = Plan(
+        intent="制图",
+        domains=["core"],
+        steps=[PlanStep(n=1, goal="加图层", tool_family="core")],
+    )
+    orchestrator.set_plan(session_id, plan)
+
+    class StyleRegistry:
+        def metadata(self, name):
+            return {"domains": []}  # 样式/视图类工具不声明任何 domain
+
+    assert orchestrator.advance_step(session_id, "webgis_layer_upsert", StyleRegistry()) is None
+    assert plan.steps[0].done is False
+    orchestrator.clear_plan(session_id)
+
+
+def test_advance_step_normalizes_legacy_tool_name():
+    """R7: 遗留名（set_layer_style）规范化后匹配 canonical 工具 domain。"""
+    orchestrator = AgentPlanOrchestrator()
+    session_id = "sess_legacy_name"
+
+    plan = Plan(
+        intent="制图",
+        domains=["core"],
+        steps=[PlanStep(n=1, goal="加图层", tool_family="core")],
+    )
+    orchestrator.set_plan(session_id, plan)
+
+    class LegacyRegistry:
+        def metadata(self, name):
+            # canonical 工具 webgis_layer_upsert 无 domain，但这里给它 core 声明
+            return {"domains": ["core"]}
+
+    assert orchestrator.advance_step(session_id, "set_layer_style", LegacyRegistry()) == 1
+    assert plan.steps[0].done is True
+    orchestrator.clear_plan(session_id)
+
+
+# ─── design-v3：store 恢复（R5/R10 重启续接） ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_restore_plan_from_store_after_process_restart(monkeypatch):
+    """R5/R10: 清空进程 LRU（模拟重启）后，从 store 恢复计划与 done 进度。"""
+    from app.services.chat import planner as planner_mod
+    from app.services.chat.llm_client import LLMConfig
+
+    # 全量套件里别的测试可能注入过全局 ToolRegistry；这里显式禁用能力校验，
+    # 保证测试与注册表状态无关（tool_family 保持 parse 结果）。
+    monkeypatch.setattr("app.services.chat.plan_orchestrator._get_registry", lambda: None)
+
+    orch = AgentPlanOrchestrator()
+    sid = "sess-restart-1"
+    cfg = LLMConfig(base_url="http://x", model="m", api_key="k")
+
+    async def fake_call_llm(_cfg, _messages, _tools=None):
+        return {"choices": [{"message": {"content":
+            '{"intent":"恢复测试","domains":["statistics","report"],"steps":['
+            '{"n":1,"goal":"热点","tool_family":"statistics"},'
+            '{"n":2,"goal":"报告","tool_family":"report"}]}'}}]}
+
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+    plan = await orch.make_plan(cfg, sid, "分析热点", "[环境感知]")
+    assert plan is not None
+
+    class Reg:
+        def metadata(self, name):
+            return {"domains": ["statistics"]}
+
+    assert orch.advance_step(sid, "hotspot_analysis", Reg()) == 1
+    await orch.flush(sid)
+
+    # 模拟重启：全新 orchestrator 实例（空 LRU），从 store 恢复
+    fresh = AgentPlanOrchestrator()
+    restored = await fresh.restore_plan(sid)
+    assert restored is not None
+    assert restored.intent == "恢复测试"
+    assert restored.steps[0].done is True
+    assert restored.steps[1].done is False
+    await plan_store.clear(sid)
+
+
+@pytest.mark.asyncio
+async def test_restore_terminal_plan_returns_none(monkeypatch):
+    """R5: 恢复出的终态计划（全部步骤完成）视为无活跃计划。"""
+    from app.services.chat import planner as planner_mod
+    from app.services.chat.llm_client import LLMConfig
+
+    # 与注册表状态解耦（全量套件可能注入了全局 registry）
+    monkeypatch.setattr("app.services.chat.plan_orchestrator._get_registry", lambda: None)
+
+    orch = AgentPlanOrchestrator()
+    sid = "sess-restart-2"
+    cfg = LLMConfig(base_url="http://x", model="m", api_key="k")
+
+    async def fake_call_llm(_cfg, _messages, _tools=None):
+        return {"choices": [{"message": {"content":
+            '{"intent":"x","domains":["statistics"],"steps":[{"n":1,"goal":"热点","tool_family":"statistics"}]}'}}]}
+
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+    plan = await orch.make_plan(cfg, sid, "热点", "[环境感知]")
+    assert plan is not None
+
+    class Reg:
+        def metadata(self, name):
+            return {"domains": ["statistics"]}
+
+    assert orch.advance_step(sid, "hotspot_analysis", Reg()) == 1
+    await orch.flush(sid)  # 全部步骤 done → canonical status = completed
+
+    fresh = AgentPlanOrchestrator()
+    assert await fresh.restore_plan(sid) is None
+    await plan_store.clear(sid)
+
+
+# ─── design-v3：换目标 → 旧计划 superseded ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_make_plan_supersedes_old_active_plan(monkeypatch):
+    """design-v3: 新计划替换旧非终态计划时，旧 canonical 标记 superseded。"""
+    from app.services.chat import planner as planner_mod
+    from app.services.chat.llm_client import LLMConfig
+
+    orch = AgentPlanOrchestrator()
+    sid = "sess-super-1"
+    cfg = LLMConfig(base_url="http://x", model="m", api_key="k")
+    responses = iter([
+        '{"intent":"旧计划","domains":["raster"],"steps":[{"n":1,"goal":"NDVI","tool_family":"raster"}]}',
+        '{"intent":"新计划","domains":["network"],"steps":[{"n":1,"goal":"路线","tool_family":"network"}]}',
+    ])
+
+    async def fake_call_llm(_cfg, _messages, _tools=None):
+        return {"choices": [{"message": {"content": next(responses)}}]}
+
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+
+    old = await orch.make_plan(cfg, sid, "算一下 NDVI", "[环境感知]")
+    assert old is not None
+    old_canon = await plan_store.load_current(sid)
+    old_id = old_canon.plan_id
+
+    new = await orch.make_plan(cfg, sid, "换成查路线", "[环境感知]")
+    assert new is not None and new.intent == "新计划"
+
+    hist = await plan_store.get_by_id(sid, old_id)
+    assert hist is not None
+    assert hist.status == PlanStatus.superseded
+    assert (await plan_store.load_current(sid)).plan_id != old_id
+    await plan_store.clear(sid)
+
+
+def test_capability_validation_nulls_family_with_no_registered_tool():
+    """design-v3 §capability：tool_family 无任何已注册工具 → 置 None（步骤保留，
+    失去打勾能力，避免死步骤）。"""
+    from app.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+    reg.register("hotspot_analysis", "hotspot", func=lambda **_: {},
+                 tier=2, domains=["statistics"])
+    orch = AgentPlanOrchestrator()
+    sid = "sess-cap-1"
+    plan = Plan(
+        intent="x",
+        domains=["statistics", "report"],
+        steps=[
+            PlanStep(n=1, goal="热点", tool_family="statistics"),
+            PlanStep(n=2, goal="报告", tool_family="report"),  # report 无已注册工具
+        ],
+    )
+    orch.set_plan(sid, plan)
+    orch._apply_capability_validation(plan, reg)
+    assert plan.steps[0].tool_family == "statistics"  # 有工具支撑 → 保留
+    assert plan.steps[1].tool_family is None          # 无工具支撑 → None
+    orch.clear_plan(sid)

--- a/tests/unit/test_plan_orchestrator.py
+++ b/tests/unit/test_plan_orchestrator.py
@@ -9,7 +9,12 @@ from app.services.chat.plan_orchestrator import (
     parse_plan,
     should_plan,
 )
-from app.services.planning import FollowUpKind, PlanStatus, TERMINAL_STATUSES
+from app.services.planning import (
+    FollowUpKind,
+    PlanStatus,
+    StepStatus,
+    TERMINAL_STATUSES,
+)
 from app.services.planning.store import plan_store
 
 
@@ -273,6 +278,61 @@ async def test_restore_terminal_plan_returns_none(monkeypatch):
 
     fresh = AgentPlanOrchestrator()
     assert await fresh.restore_plan(sid) is None
+    await plan_store.clear(sid)
+
+
+# ─── P3 #5：advisory 计划的部分完成语义 ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_flush_partially_completed_survives_restart_as_active(monkeypatch):
+    """P3 延后项 #5：2/3 步骤完成 + 1 步失败 → flush 后 canonical status ==
+    partially_completed（部分成功 = 非终态）；重启后 restore_plan 仍作为活跃
+    计划返回（不过滤，可继续推进剩余步骤）。"""
+    from app.services.chat import planner as planner_mod
+    from app.services.chat.llm_client import LLMConfig
+
+    monkeypatch.setattr("app.services.chat.plan_orchestrator._get_registry", lambda: None)
+
+    orch = AgentPlanOrchestrator()
+    sid = "sess-partial-1"
+    cfg = LLMConfig(base_url="http://x", model="m", api_key="k")
+
+    async def fake_call_llm(_cfg, _messages, _tools=None):
+        return {"choices": [{"message": {"content":
+            '{"intent":"热点","domains":["statistics","report"],"steps":['
+            '{"n":1,"goal":"热点","tool_family":"statistics"},'
+            '{"n":2,"goal":"报告","tool_family":"report"},'
+            '{"n":3,"goal":"导出","tool_family":"report"}]}'}}]}
+
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+    plan = await orch.make_plan(cfg, sid, "热点", "[环境感知]")
+    assert plan is not None
+
+    class Reg:
+        def metadata(self, name):
+            return {"domains": ["statistics", "report"]}
+
+    assert orch.advance_step(sid, "hotspot_analysis", Reg()) == 1
+    assert orch.advance_step(sid, "export_batch_maps", Reg()) == 2
+    # 步骤 3 失败（模拟：直接置 canonical 状态，等价未来"失败步骤写回"路径）
+    canon = plan_store.peek(sid)
+    canon.steps[2].status = StepStatus.failed
+    # flush 前 status 必须是 recompute 推导的（不靠调用方手动设置）
+    await orch.flush(sid)
+
+    persisted = await plan_store.load_current(sid)
+    assert persisted.status == PlanStatus.partially_completed
+    assert persisted.status not in TERMINAL_STATUSES  # 非终态：可恢复
+
+    # 模拟重启：清空进程缓存，从 store 恢复 → 仍为活跃计划（不过滤）
+    plan_store.clear_cache()
+    fresh = AgentPlanOrchestrator()
+    restored = await fresh.restore_plan(sid)
+    assert restored is not None
+    assert restored.steps[0].done is True
+    assert restored.steps[1].done is True
+    assert restored.steps[2].done is False
     await plan_store.clear(sid)
 
 

--- a/tests/unit/test_plan_orchestrator.py
+++ b/tests/unit/test_plan_orchestrator.py
@@ -9,7 +9,7 @@ from app.services.chat.plan_orchestrator import (
     parse_plan,
     should_plan,
 )
-from app.services.planning import FollowUpKind, PlanStatus
+from app.services.planning import FollowUpKind, PlanStatus, TERMINAL_STATUSES
 from app.services.planning.store import plan_store
 
 
@@ -56,27 +56,32 @@ def test_orchestrator_step_advancement():
         domains=["statistics"],
         steps=[
             PlanStep(n=1, goal="计算热点", tool_family="statistics"),
-            PlanStep(n=2, goal="生成地图", tool_family="core"),
+            PlanStep(n=2, goal="做缓冲", tool_family="core"),
         ],
     )
     orchestrator.set_plan(session_id, plan)
 
-    # Mock registry
+    # Mock registry（带 list_tools：P1-A 限定通配需要"已注册"判定）
     class MockRegistry:
         def metadata(self, name):
             if name == "hotspot_analysis":
                 return {"domains": ["statistics"]}
-            return {"domains": ["core"]}
+            if name == "buffer_analysis":
+                return {"domains": []}
+            return {"domains": []}
+
+        def list_tools(self):
+            return ["hotspot_analysis", "buffer_analysis"]
 
     reg = MockRegistry()
 
-    # Advance step 1
+    # Advance step 1（domain 重叠）
     step_n = orchestrator.advance_step(session_id, "hotspot_analysis", reg)
     assert step_n == 1
     assert plan.steps[0].done is True
 
-    # Advance step 2
-    step_n2 = orchestrator.advance_step(session_id, "webgis_layer_upsert", reg)
+    # Advance step 2（core 限定通配：已注册 ∧ 非展示类 的分析工具打勾）
+    step_n2 = orchestrator.advance_step(session_id, "buffer_analysis", reg)
     assert step_n2 == 2
     assert plan.steps[1].done is True
 
@@ -331,3 +336,82 @@ def test_capability_validation_nulls_family_with_no_registered_tool():
     assert plan.steps[0].tool_family == "statistics"  # 有工具支撑 → 保留
     assert plan.steps[1].tool_family is None          # 无工具支撑 → None
     orch.clear_plan(sid)
+
+
+# ─── P2-5：get_plan 热缓存路径的终态过滤 ──────────────────────
+
+
+def test_get_plan_warm_cache_filters_terminal_plan():
+    """P2-5：本轮 flush 把 canonical 算成 completed 后，下轮 get_plan 不得再把
+    它当活跃计划返回（进程内"已完成即失效"，与 restore 冷路径一致）。"""
+    orch = AgentPlanOrchestrator()
+    sid = "sess-term-warm"
+    plan = Plan(
+        intent="x", domains=["core"],
+        steps=[PlanStep(n=1, goal="a", tool_family="core")],
+    )
+    orch.set_plan(sid, plan)
+    assert orch.get_plan(sid) is not None
+
+    class Reg:
+        def metadata(self, name):
+            return {"domains": ["core"]}
+        def list_tools(self):
+            return ["buffer_analysis"]
+
+    # 打勾全部步骤 + flush → canonical 变 completed
+    assert orch.advance_step(sid, "buffer_analysis", Reg()) == 1
+    # 手动完成 canonical（模拟 flush 的 recompute_status 效果）
+    canon = orch._canonical.get(sid)
+    from app.services.planning import StepStatus
+    for s in canon.steps:
+        s.status = StepStatus.completed
+    canon.status = canon.recompute_status()
+    assert canon.status in TERMINAL_STATUSES  # completed
+
+    assert orch.get_plan(sid) is None  # 热缓存路径同样终态过滤
+    orch.clear_plan(sid)
+
+
+# ─── P1-B(3)：make_plan 在 canonical 缓存未命中时回落到 store ─────
+
+
+@pytest.mark.asyncio
+async def test_make_plan_supersedes_after_process_cache_miss(monkeypatch):
+    """P1-B(3)：_canonical 缓存未命中（evicted / 重启后的新 worker）时，
+    make_plan 的 supersede 判定必须回落到 store 的当前计划——否则新 worker
+    会静默 overwrite 掉更新计划而不是把它 supersede。"""
+    from app.services.chat import planner as planner_mod
+    from app.services.chat.llm_client import LLMConfig
+
+    monkeypatch.setattr("app.services.chat.plan_orchestrator._get_registry", lambda: None)
+
+    orch = AgentPlanOrchestrator()
+    sid = "sess-cache-miss"
+    cfg = LLMConfig(base_url="http://x", model="m", api_key="k")
+    responses = iter([
+        '{"intent":"旧计划","domains":["raster"],"steps":[{"n":1,"goal":"NDVI","tool_family":"raster"}]}',
+        '{"intent":"新计划","domains":["network"],"steps":[{"n":1,"goal":"路线","tool_family":"network"}]}',
+    ])
+
+    async def fake_call_llm(_cfg, _messages, _tools=None):
+        return {"choices": [{"message": {"content": next(responses)}}]}
+
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+
+    old = await orch.make_plan(cfg, sid, "算一下 NDVI", "[环境感知]")
+    assert old is not None
+    old_canon = await plan_store.load_current(sid)
+    old_id = old_canon.plan_id
+
+    # 模拟 worker 重启/缓存被逐出：全新 orchestrator（空 canonical 缓存）
+    fresh = AgentPlanOrchestrator()
+    new = await fresh.make_plan(cfg, sid, "换成查路线", "[环境感知]")
+    assert new is not None and new.intent == "新计划"
+
+    # 旧计划被 superseded（而不是被静默覆盖后无从查起）
+    hist = await plan_store.get_by_id(sid, old_id)
+    assert hist is not None
+    assert hist.status == PlanStatus.superseded
+    assert (await plan_store.load_current(sid)).plan_id != old_id
+    await plan_store.clear(sid)

--- a/tests/unit/test_planner.py
+++ b/tests/unit/test_planner.py
@@ -43,17 +43,28 @@ def test_parse_plan_valid():
 
 
 def test_parse_plan_strips_code_fence():
-    raw = '```json\n{"intent":"x","domains":["core"],"steps":[]}\n```'
+    raw = '```json\n{"intent":"x","domains":["core"],"steps":[{"n":1,"goal":"a","tool_family":"core"}]}\n```'
     plan = parse_plan(raw)
     assert plan is not None
     assert plan.intent == "x"
+    assert len(plan.steps) == 1
 
 
 def test_parse_plan_filters_invalid_domains():
-    raw = '{"intent":"x","domains":["chinese","nonsense"],"steps":[]}'
+    raw = '{"intent":"x","domains":["chinese","nonsense"],"steps":[{"n":1,"goal":"a","tool_family":"chinese"}]}'
     plan = parse_plan(raw)
     assert plan is not None
     assert plan.domains == ["chinese"]  # 越界 domain 被丢弃
+
+
+def test_parse_plan_empty_steps_returns_none():
+    """P2-4（adversarial P2-7 zombie plan）：解析出的步骤列表为空
+    （steps:[] 或全部步骤非法被跳过）→ 返回 None，绝不产出"活着的空计划"。"""
+    assert parse_plan('{"intent":"x","domains":["core"],"steps":[]}') is None
+    # 全部步骤非法（非 dict）被跳过 → 同样 None
+    assert parse_plan(
+        '{"intent":"x","domains":["core"],"steps":[42, "bad"]}'
+    ) is None
 
 
 def test_parse_plan_malformed_json_returns_none():

--- a/tests/unit/test_planning_foundation.py
+++ b/tests/unit/test_planning_foundation.py
@@ -1,0 +1,530 @@
+"""Foundation tests for the canonical planning package (app/services/planning).
+
+Covers (design-v3 §"New package app/services/planning/", this slice):
+- state machine: recompute_status matrix, terminal statuses, next_pending_steps
+- PlanStore: save / load_current / supersede / clear over the in-memory
+  session store (conftest sets USE_REDIS=false) + cache-miss restore
+- capability validation: unknown tool, unknown family, domain-mismatch warning
+- static ref validation: unknown id, forward ref, self-dep, cycle
+- resolve_arg_refs: happy path + MissingRefError on bad paths
+- classify_error for each dispatch code + message signals
+- recovery policy sanity (no blind retry)
+- classify_followup for each kind incl. the Chinese examples
+"""
+import pytest
+
+from app.services.jobs.cancellation import OperationCancelled
+from app.services.planning import (
+    CONTINUATION_KEYWORDS,
+    REF_REUSE_KEYWORDS,
+    STYLE_KEYWORDS,
+    TERMINAL_STATUSES,
+    CanonicalPlan,
+    CanonicalStep,
+    FailureClass,
+    PlanStatus,
+    RecoveryAction,
+    StepStatus,
+    classify_error,
+    classify_followup,
+    recovery_action_for,
+    validate_plan_capabilities,
+)
+from app.services.planning import FollowUpKind
+from app.services.planning.capability import capability_of
+from app.services.planning.deps import MissingRefError, resolve_arg_refs, validate_static_refs
+from app.services.planning.recovery import RECOVERY_POLICY
+from app.services.planning.store import PlanStore
+from app.tools.registry import ToolRegistry
+
+
+# ─── helpers ──────────────────────────────────────────────────────────
+
+
+def _plan(steps):
+    """CanonicalPlan with steps given as (id, StepStatus) tuples."""
+    return CanonicalPlan(
+        plan_id="p1",
+        session_id="sess-f",
+        intent="test",
+        steps=[
+            CanonicalStep(id=sid, n=i + 1, goal="", status=status)
+            for i, (sid, status) in enumerate(steps)
+        ],
+    )
+
+
+# ─── models: status machine ───────────────────────────────────────────
+
+
+def test_plan_status_terminal_and_serialization():
+    for status in (PlanStatus.completed, PlanStatus.failed, PlanStatus.cancelled, PlanStatus.superseded):
+        assert status.is_terminal()
+    for status in (PlanStatus.proposed, PlanStatus.validated, PlanStatus.running, PlanStatus.partially_completed):
+        assert not status.is_terminal()
+    assert TERMINAL_STATUSES == frozenset(
+        {PlanStatus.completed, PlanStatus.failed, PlanStatus.cancelled, PlanStatus.superseded}
+    )
+    # str-enum round-trips through model_dump / model_validate
+    p = _plan([("s1", StepStatus.completed)])
+    dumped = p.model_dump()
+    assert isinstance(dumped, dict)
+    assert dumped["steps"][0]["status"] == "completed"
+    restored = CanonicalPlan.model_validate(dumped)
+    assert restored == p
+
+
+def test_recompute_status_matrix():
+    cases = [
+        ([("s1", StepStatus.completed), ("s2", StepStatus.completed)], PlanStatus.completed),
+        # failed with none pending/running → failed (beats partially_completed)
+        ([("s1", StepStatus.completed), ("s2", StepStatus.failed)], PlanStatus.failed),
+        ([("s1", StepStatus.failed), ("s2", StepStatus.completed)], PlanStatus.failed),
+        # completed mixed with failed/skipped, none pending/running → partially_completed
+        ([("s1", StepStatus.completed), ("s2", StepStatus.skipped)], PlanStatus.partially_completed),
+        ([("s1", StepStatus.completed), ("s2", StepStatus.failed), ("s3", StepStatus.skipped)], PlanStatus.failed),
+        # any running → running
+        ([("s1", StepStatus.running), ("s2", StepStatus.completed)], PlanStatus.running),
+        ([("s1", StepStatus.completed), ("s2", StepStatus.running), ("s3", StepStatus.pending)], PlanStatus.running),
+        # nothing done / pending present → keep current status
+        ([("s1", StepStatus.pending)], PlanStatus.proposed),
+        ([("s1", StepStatus.failed), ("s2", StepStatus.pending)], PlanStatus.proposed),
+        ([("s1", StepStatus.cancelled)], PlanStatus.proposed),
+    ]
+    for steps, expected in cases:
+        assert _plan(steps).recompute_status() == expected
+    # empty steps → keep current status
+    p = CanonicalPlan(plan_id="p1", session_id="s", intent="", status=PlanStatus.validated)
+    assert p.recompute_status() == PlanStatus.validated
+
+
+def test_next_pending_steps_respects_dependencies():
+    p = CanonicalPlan(
+        plan_id="p1",
+        session_id="s",
+        intent="",
+        steps=[
+            CanonicalStep(id="s1", n=1, goal="", status=StepStatus.completed),
+            CanonicalStep(id="s2", n=2, goal="", depends_on=["s1"]),
+            CanonicalStep(id="s3", n=3, goal="", depends_on=["s2"]),
+            CanonicalStep(id="s4", n=4, goal=""),
+        ],
+    )
+    assert [s.id for s in p.next_pending_steps()] == ["s2", "s4"]
+    p.steps[1].status = StepStatus.completed
+    assert [s.id for s in p.next_pending_steps()] == ["s3", "s4"]
+    # blocked on a failed dependency → never ready
+    p.steps[2].depends_on = ["s2"]
+    p.steps[1].status = StepStatus.failed
+    assert [s.id for s in p.next_pending_steps()] == ["s4"]
+
+
+def test_step_by_id_and_bump_revision():
+    p = _plan([("s1", StepStatus.pending)])
+    assert p.step_by_id("s1") is p.steps[0]
+    assert p.step_by_id("nope") is None
+    assert p.bump_revision() == 2
+    assert p.revision == 2
+
+
+# ─── store: save / load / supersede / clear ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_store_save_load_current_roundtrip():
+    store = PlanStore()  # default session_data_manager (in-memory under conftest)
+    sid = "sess-foundation-1"
+    await store.save(CanonicalPlan(plan_id="p-001", session_id=sid, intent="hotspot"))
+    loaded = await store.load_current(sid)
+    assert loaded is not None
+    assert loaded.plan_id == "p-001"
+    assert loaded.intent == "hotspot"
+    assert loaded.status == PlanStatus.proposed
+
+
+@pytest.mark.asyncio
+async def test_store_save_overwrites_in_place_no_new_ref():
+    """Repeated saves must NOT mint a new ref per save (plan_mode trap)."""
+    from app.services.session_data import session_data_manager
+
+    store = PlanStore()
+    sid = "sess-foundation-2"
+    await store.save(CanonicalPlan(plan_id="p-002", session_id=sid, intent="a"))
+    refs_before = await session_data_manager.list_refs(sid)
+    await store.save(
+        CanonicalPlan(plan_id="p-002", session_id=sid, intent="b", status=PlanStatus.running)
+    )
+    refs_after = await session_data_manager.list_refs(sid)
+    assert set(refs_before) == set(refs_after)
+    loaded = await store.load_current(sid)
+    assert loaded.intent == "b"
+    assert loaded.status == PlanStatus.running
+
+
+@pytest.mark.asyncio
+async def test_store_cache_miss_restores_from_session_store():
+    """Worker restart: fresh process-local cache, same session store."""
+    sid = "sess-foundation-3"
+    store = PlanStore()
+    await store.save(CanonicalPlan(plan_id="p-003", session_id=sid, intent="restore"))
+    store.clear_cache()
+    fresh = PlanStore()
+    loaded = await fresh.load_current(sid)
+    assert loaded is not None
+    assert loaded.plan_id == "p-003"
+    assert loaded.intent == "restore"
+
+
+@pytest.mark.asyncio
+async def test_store_supersede_moves_old_to_history():
+    sid = "sess-foundation-4"
+    store = PlanStore()
+    await store.save(CanonicalPlan(plan_id="p-old", session_id=sid, intent="first"))
+    new = CanonicalPlan(plan_id="p-new", session_id=sid, intent="second")
+    superseded = await store.supersede(sid, new)
+    assert superseded is not None and superseded.plan_id == "p-old"
+    assert (await store.load_current(sid)).plan_id == "p-new"
+    history = await store.get_by_id(sid, "p-old")
+    assert history is not None
+    assert history.status == PlanStatus.superseded
+    assert history.intent == "first"
+    # the current plan is also addressable by id
+    assert (await store.get_by_id(sid, "p-new")).plan_id == "p-new"
+    assert (await store.get_by_id(sid, "current")).plan_id == "p-new"
+
+
+@pytest.mark.asyncio
+async def test_store_clear_removes_current_but_save_resurrects():
+    sid = "sess-foundation-5"
+    store = PlanStore()
+    await store.save(CanonicalPlan(plan_id="p-005", session_id=sid, intent="x"))
+    await store.clear(sid)
+    assert await store.load_current(sid) is None
+    await store.save(CanonicalPlan(plan_id="p-006", session_id=sid, intent="y"))
+    loaded = await store.load_current(sid)
+    assert loaded is not None and loaded.intent == "y"
+
+
+@pytest.mark.asyncio
+async def test_store_miss_does_not_raise():
+    store = PlanStore()
+    assert await store.load_current("sess-ghost") is None
+    assert await store.get_by_id("sess-ghost", "p-missing") is None
+
+
+# ─── capability validation ────────────────────────────────────────────
+
+
+@pytest.fixture
+def registry():
+    r = ToolRegistry()
+
+    @r.tool(name="hotspot_analysis", description="热点分析", domains=["statistics"], tier=2)
+    def hotspot_analysis(points: list) -> dict:
+        return {"success": True}
+
+    @r.tool(name="osm_query", description="OSM 查询", domains=["osm"], tier=2)
+    def osm_query(bbox: list) -> dict:
+        return {"success": True}
+
+    @r.tool(name="plain_tool", description="无域工具")
+    def plain_tool(name: str) -> dict:
+        return {"success": True}
+
+    return r
+
+
+def test_capability_of_derives_metadata(registry):
+    cap = capability_of("hotspot_analysis", registry)
+    assert cap is not None
+    assert cap.tier == 2
+    assert cap.domains == ["statistics"]
+    assert cap.execution_policy == "thread"
+    assert cap.destructive is False
+    assert cap.produces_ref is True  # statistics ∈ PRODUCES_REF_DOMAINS
+    assert cap.requires_ref is False
+    # no domains → does not produce a ref
+    assert capability_of("plain_tool", registry).produces_ref is False
+    # unregistered → None
+    assert capability_of("does_not_exist", registry) is None
+
+
+def test_capability_requires_ref_heuristic(registry):
+    @registry.tool(name="layer_styler", description="图层样式")
+    def layer_styler(layer_ref: str, color: str) -> dict:
+        return {"success": True}
+
+    @registry.tool(
+        name="ref_desc_tool",
+        description="带 ref 描述的工具",
+        param_descriptions={"source": "传 ref:geojson-xxx 引用"},
+    )
+    def ref_desc_tool(source: str) -> dict:
+        return {"success": True}
+
+    assert capability_of("layer_styler", registry).requires_ref is True
+    assert capability_of("ref_desc_tool", registry).requires_ref is True
+    assert capability_of("plain_tool", registry).requires_ref is False
+
+
+def test_capability_destructive_tier3(registry):
+    @registry.tool(name="heavy_tool", description="重型工具", tier=3)
+    def heavy_tool(x: int) -> dict:
+        return {"success": True}
+
+    assert capability_of("heavy_tool", registry).destructive is True
+    assert capability_of("hotspot_analysis", registry).destructive is False
+
+
+def test_validate_plan_capabilities_issues(registry):
+    p = CanonicalPlan(
+        plan_id="p1",
+        session_id="s",
+        intent="",
+        steps=[
+            CanonicalStep(id="s1", n=1, goal="", tool="ghost_tool"),
+            CanonicalStep(id="s2", n=2, goal="", tool_family="raster"),
+            CanonicalStep(id="s3", n=3, goal="", tool="osm_query", tool_family="statistics"),
+        ],
+    )
+    issues = validate_plan_capabilities(p, registry)
+    assert any("unregistered tool 'ghost_tool'" in i for i in issues)
+    assert any("tool_family 'raster' has no registered tool" in i for i in issues)
+    assert any("do not cover tool_family 'statistics'" in i for i in issues)
+
+
+def test_validate_plan_capabilities_clean(registry):
+    p = CanonicalPlan(
+        plan_id="p1",
+        session_id="s",
+        intent="",
+        steps=[
+            CanonicalStep(id="s1", n=1, goal="", tool="osm_query", tool_family="osm"),
+            CanonicalStep(id="s2", n=2, goal="", tool_family="core"),
+        ],
+    )
+    assert validate_plan_capabilities(p, registry) == []
+
+
+# ─── static ref validation ────────────────────────────────────────────
+
+
+def _steps(*defs):
+    """Build steps from (id, depends_on, args) tuples."""
+    return [
+        CanonicalStep(id=d[0], n=i + 1, goal="", depends_on=d[1], args=d[2])
+        for i, d in enumerate(defs)
+    ]
+
+
+def test_validate_static_refs_clean():
+    steps = _steps(("s1", [], {}), ("s2", ["s1"], {"bbox": "${s1.data.bbox}"}))
+    assert validate_static_refs(steps) == []
+
+
+def test_validate_static_refs_unknown_id():
+    steps = _steps(("s1", ["ghost"], {}), ("s2", [], {"src": "${ghost.path}"}))
+    issues = validate_static_refs(steps)
+    assert sum("unknown step 'ghost'" in i for i in issues) == 2
+
+
+def test_validate_static_refs_forward_ref():
+    steps = _steps(("s1", ["s2"], {}), ("s2", [], {}))
+    assert any("forward-references step 's2'" in i for i in validate_static_refs(steps))
+
+
+def test_validate_static_refs_self_dep():
+    steps = _steps(("s1", ["s1"], {}))
+    assert any("depends on itself" in i for i in validate_static_refs(steps))
+
+
+def test_validate_static_refs_cycle():
+    steps = _steps(("s1", ["s2"], {}), ("s2", ["s1"], {}))
+    assert any("cycle" in i for i in validate_static_refs(steps))
+    # cycle via args placeholders only
+    steps2 = _steps(("s1", [], {"a": "${s2}"}), ("s2", [], {"a": "${s1}"}))
+    assert any("cycle" in i for i in validate_static_refs(steps2))
+
+
+def test_validate_static_refs_duplicate_id():
+    steps = _steps(("s1", [], {}), ("s1", [], {}))
+    assert any("duplicate step id 's1'" in i for i in validate_static_refs(steps))
+
+
+# ─── reference resolution ─────────────────────────────────────────────
+
+
+def test_resolve_arg_refs_happy_path():
+    results = {"s1": {"data": {"bbox": [1, 2, 3, 4]}}}
+    assert resolve_arg_refs("${s1.data.bbox}", results) == [1, 2, 3, 4]
+    assert resolve_arg_refs("${s1}", results) == {"data": {"bbox": [1, 2, 3, 4]}}
+    assert resolve_arg_refs("查询 ${s1.data.bbox.0} 到 ${s1.data.bbox.1}", results) == "查询 1 到 2"
+    args = {"list": ["${s1.data.bbox}", "static"], "nested": {"x": "${s1.data.bbox.0}"}}
+    out = resolve_arg_refs(args, results)
+    assert out["list"][0] == [1, 2, 3, 4]
+    assert out["list"][1] == "static"
+    assert out["nested"]["x"] == 1
+    # non-placeholder values pass through untouched
+    assert resolve_arg_refs(42, results) == 42
+    assert resolve_arg_refs("plain", results) == "plain"
+    assert resolve_arg_refs({"k": [None, True, 1.5]}, results) == {"k": [None, True, 1.5]}
+
+
+def test_resolve_arg_refs_missing_ref_raises():
+    results = {"s1": {"data": {"bbox": [1, 2, 3, 4]}}}
+    with pytest.raises(MissingRefError) as ei:
+        resolve_arg_refs("${s1.data.missing}", results)
+    assert ei.value.step_id == "s1"
+    assert ei.value.path == "data.missing"
+    assert ei.value.available_keys == ["s1"]
+    # a placeholder naming a step with no result raises too (never silent None)
+    with pytest.raises(MissingRefError):
+        resolve_arg_refs("${ghost}", results)
+    # embedded placeholder with a bad path raises (no silent "")
+    with pytest.raises(MissingRefError):
+        resolve_arg_refs("prefix-${s1.nope}-suffix", results)
+    # list index out of range
+    with pytest.raises(MissingRefError):
+        resolve_arg_refs("${s1.data.bbox.9}", results)
+    # path segment into a non-dict / non-list
+    with pytest.raises(MissingRefError):
+        resolve_arg_refs("${s1.data.bbox.0.x}", results)
+
+
+# ─── failure classification ───────────────────────────────────────────
+
+
+def test_classify_error_dispatch_codes():
+    assert classify_error(code="VALIDATION_ERROR") == FailureClass.validation
+    assert classify_error(code="NOT_FOUND") == FailureClass.missing_ref
+    assert classify_error(code="UNKNOWN_TOOL") == FailureClass.tool_unavailable
+    assert classify_error(code="TOOL_ERROR", message="boom") == FailureClass.internal
+    assert classify_error(code="TOOL_ERROR", message="连接超时") == FailureClass.transient_network
+    assert classify_error(code="TOOL_ERROR", message="network timeout") == FailureClass.transient_network
+    assert classify_error(code="cancelled") == FailureClass.cancelled
+    assert classify_error(status="cancelled") == FailureClass.cancelled
+
+
+def test_classify_error_exceptions():
+    assert classify_error(exception=TimeoutError()) == FailureClass.transient_network
+    assert classify_error(exception=ConnectionError()) == FailureClass.transient_network
+    assert classify_error(exception=KeyError("x")) == FailureClass.missing_ref
+    assert classify_error(exception=FileNotFoundError()) == FailureClass.missing_ref
+    assert classify_error(exception=ValueError("bad")) == FailureClass.validation
+    assert classify_error(exception=OperationCancelled()) == FailureClass.cancelled
+
+
+def test_classify_error_message_signals():
+    assert classify_error(message="permission denied") == FailureClass.auth
+    assert classify_error(message="quota exceeded (429)") == FailureClass.resource_limit
+    assert classify_error(message="未返回任何空间要素或有效数据") == FailureClass.empty_result
+    assert classify_error(message="no data found") == FailureClass.no_data
+    # suspicious (successful but empty) results classify as empty_result
+    assert classify_error(status="ok", message="no features returned") == FailureClass.empty_result
+    assert classify_error(status="ok", code="ok", message="empty result") == FailureClass.empty_result
+    assert classify_error(message="something else entirely") == FailureClass.internal
+    assert classify_error() == FailureClass.internal
+
+
+# ─── recovery policy ──────────────────────────────────────────────────
+
+
+def test_recovery_policy_sanity():
+    for fc in FailureClass:
+        assert fc in RECOVERY_POLICY
+        assert RECOVERY_POLICY[fc], f"{fc} has an empty recovery policy"
+        assert len(RECOVERY_POLICY[fc]) == len(set(RECOVERY_POLICY[fc]))
+        assert recovery_action_for(fc) == RECOVERY_POLICY[fc][0]
+    # no blind retry: retry_transient only for transient_network failures
+    for fc, actions in RECOVERY_POLICY.items():
+        if fc is not FailureClass.transient_network:
+            assert RecoveryAction.retry_transient not in actions
+    assert RECOVERY_POLICY[FailureClass.transient_network] == [RecoveryAction.retry_transient]
+    assert recovery_action_for(FailureClass.validation) == RecoveryAction.correct_args
+    assert recovery_action_for(FailureClass.cancelled) == RecoveryAction.stop
+
+
+# ─── follow-up classification ─────────────────────────────────────────
+
+
+_DOMAIN_KEYWORDS = {
+    "poi": ["医院", "学校", "POI"],
+    "statistics": ["热点", "热力", "聚类"],
+}
+
+
+def test_classify_followup_style_change():
+    assert classify_followup(
+        "把颜色换成蓝色",
+        has_active_plan=True,
+        active_domains=[],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.style_change
+    # style tweak over an already-active domain is still style_change
+    assert classify_followup(
+        "热力图换成蓝色",
+        has_active_plan=True,
+        active_domains=["statistics"],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.style_change
+    assert any(kw in STYLE_KEYWORDS for kw in ("颜色", "蓝色", "样式", "style"))
+
+
+def test_classify_followup_new_goal():
+    assert classify_followup(
+        "再算一下医院",
+        has_active_plan=True,
+        active_domains=[],
+        session_has_refs=True,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.new_goal
+
+
+def test_classify_followup_ref_reuse():
+    assert classify_followup(
+        "刚才那个结果做热点",
+        has_active_plan=True,
+        active_domains=[],
+        session_has_refs=True,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.ref_reuse
+    # ref-reuse signals without session refs fall through (no refs to reuse)
+    assert classify_followup(
+        "刚才那个结果",
+        has_active_plan=False,
+        active_domains=[],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.unclear
+    assert any(kw in REF_REUSE_KEYWORDS for kw in ("刚才", "那个", "该结果"))
+
+
+def test_classify_followup_continuation():
+    assert classify_followup(
+        "继续",
+        has_active_plan=True,
+        active_domains=[],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.continuation
+    # continuation without an active plan → unclear
+    assert classify_followup(
+        "继续",
+        has_active_plan=False,
+        active_domains=[],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.unclear
+    assert "继续" in CONTINUATION_KEYWORDS
+
+
+def test_classify_followup_unclear():
+    assert classify_followup(
+        "今天天气不错",
+        has_active_plan=False,
+        active_domains=[],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.unclear

--- a/tests/unit/test_planning_foundation.py
+++ b/tests/unit/test_planning_foundation.py
@@ -77,12 +77,16 @@ def test_plan_status_terminal_and_serialization():
 def test_recompute_status_matrix():
     cases = [
         ([("s1", StepStatus.completed), ("s2", StepStatus.completed)], PlanStatus.completed),
-        # failed with none pending/running → failed (beats partially_completed)
-        ([("s1", StepStatus.completed), ("s2", StepStatus.failed)], PlanStatus.failed),
-        ([("s1", StepStatus.failed), ("s2", StepStatus.completed)], PlanStatus.failed),
+        # P3 #5：部分成功（有完成 + 有失败，无 pending/running）→ partially_completed
+        # （可恢复，非终态）——优先于裸 failed（failed 保留给"无任何完成步骤"）。
+        ([("s1", StepStatus.completed), ("s2", StepStatus.failed)], PlanStatus.partially_completed),
+        ([("s1", StepStatus.failed), ("s2", StepStatus.completed)], PlanStatus.partially_completed),
         # completed mixed with failed/skipped, none pending/running → partially_completed
         ([("s1", StepStatus.completed), ("s2", StepStatus.skipped)], PlanStatus.partially_completed),
-        ([("s1", StepStatus.completed), ("s2", StepStatus.failed), ("s3", StepStatus.skipped)], PlanStatus.failed),
+        ([("s1", StepStatus.completed), ("s2", StepStatus.failed), ("s3", StepStatus.skipped)], PlanStatus.partially_completed),
+        # 无完成步骤的纯失败 → failed
+        ([("s1", StepStatus.failed), ("s2", StepStatus.failed)], PlanStatus.failed),
+        ([("s1", StepStatus.failed), ("s2", StepStatus.skipped)], PlanStatus.failed),
         # any running → running
         ([("s1", StepStatus.running), ("s2", StepStatus.completed)], PlanStatus.running),
         ([("s1", StepStatus.completed), ("s2", StepStatus.running), ("s3", StepStatus.pending)], PlanStatus.running),

--- a/tests/unit/test_planning_foundation.py
+++ b/tests/unit/test_planning_foundation.py
@@ -528,3 +528,104 @@ def test_classify_followup_unclear():
         session_has_refs=False,
         domain_keywords=_DOMAIN_KEYWORDS,
     ) == FollowUpKind.unclear
+
+
+# ─── P1-B：cache TTL 重新读取 + save revision guard ──────────────
+
+
+@pytest.mark.asyncio
+async def test_store_cache_ttl_expiry_rereads_from_store():
+    """P1-B(1)：进程缓存条目超过 L1_TTL_SECONDS 后视为过期，load_current 重新
+    从 session store 读取——模拟另一 worker 写入后，本进程在 ~2s 内感知新值，
+    而不是一直服务陈旧副本。"""
+    from app.services.session_data import session_data_manager as _sdm
+    from app.services.planning.store import L1_TTL_SECONDS
+
+    store = PlanStore()
+    sid = "sess-foundation-ttl"
+    await store.save(CanonicalPlan(plan_id="p-ttl-a", session_id=sid, intent="local"))
+    # 模拟另一个 worker 直接在 session store 里写入了更新计划
+    ref_id = await _sdm.resolve_alias(sid, "plan-current")
+    await _sdm.overwrite(sid, ref_id, CanonicalPlan(
+        plan_id="p-ttl-b", session_id=sid, intent="remote",
+        revision=5,
+    ).model_dump())
+    # 把进程缓存条目时间戳拨回 TTL 之前 → 必须重新读取 store（拿到 remote）
+    entry = store._cache._data[sid]
+    store._cache._data[sid] = (entry[0], entry[1] - L1_TTL_SECONDS - 1.0)
+    loaded = await store.load_current(sid)
+    assert loaded is not None
+    assert loaded.plan_id == "p-ttl-b"
+    assert loaded.intent == "remote"
+
+
+@pytest.mark.asyncio
+async def test_store_save_revision_guard_refuses_stale_clobber():
+    """P1-B(2)：持久化的 current plan 是**不同 plan_id** 且 revision 更新/相等时，
+    save 拒绝覆盖（日志 + 重新读取）；同 plan_id 仍 last-writer-wins。"""
+    import io
+    import logging as _logging
+
+    store = PlanStore()
+    sid = "sess-foundation-revguard"
+    # 先把"更新计划"立为 current（模拟另一 worker 已推进）
+    await store.save(CanonicalPlan(
+        plan_id="p-new", session_id=sid, intent="newer", revision=3,
+    ), _promote=True)
+    store.clear_cache()  # 让 load_current 走 store（避免缓存掩盖）
+    # 陈旧 worker 想用旧计划覆盖
+    stale = CanonicalPlan(plan_id="p-stale", session_id=sid, intent="stale", revision=2)
+    buf = io.StringIO()
+    h = _logging.StreamHandler(buf)
+    _logging.getLogger("app.services.planning.store").addHandler(h)
+    try:
+        await store.save(stale)
+    finally:
+        _logging.getLogger("app.services.planning.store").removeHandler(h)
+    assert "refused to clobber" in buf.getvalue()
+    # current 仍是更新计划（没被覆盖）
+    current = await store.load_current(sid)
+    assert current.plan_id == "p-new"
+    assert current.intent == "newer"
+
+    # 同 plan_id 仍 last-writer-wins（revision 更低也允许，同一计划的进化）
+    await store.save(CanonicalPlan(plan_id="p-new", session_id=sid, intent="newer-v2", revision=1))
+    current2 = await store.load_current(sid)
+    assert current2.intent == "newer-v2"
+    assert current2.plan_id == "p-new"
+
+
+# ─── P2-3（adversarial P2-6）：style + query 共存时不判 style_change ──
+
+
+def test_classify_followup_style_plus_query_is_not_style_change():
+    """消息同时含样式词与查询/动作词（查一下蓝色区域的医院分布）→ 不得判为
+    style_change（否则会跳过规划/重分析）。"""
+    from app.services.planning.followup import QUERY_ACTION_KEYWORDS
+
+    kind = classify_followup(
+        "查一下蓝色区域的医院分布",
+        has_active_plan=True,
+        active_domains=["statistics"],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    )
+    assert kind != FollowUpKind.style_change
+    # 有内容词 + 查询信号 → 落到 new_goal / unclear，绝不 style_change
+    kind2 = classify_followup(
+        "找一下红色区域里的学校",
+        has_active_plan=True,
+        active_domains=["statistics"],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    )
+    assert kind2 != FollowUpKind.style_change
+    # 纯样式追问（无查询信号）仍是 style_change
+    assert classify_followup(
+        "换成蓝色",
+        has_active_plan=True,
+        active_domains=["statistics"],
+        session_has_refs=False,
+        domain_keywords=_DOMAIN_KEYWORDS,
+    ) == FollowUpKind.style_change
+    assert any(kw in QUERY_ACTION_KEYWORDS for kw in ("查", "找", "search", "分析"))

--- a/tests/unit/test_planning_v3_scenarios.py
+++ b/tests/unit/test_planning_v3_scenarios.py
@@ -80,7 +80,7 @@ def env():
         return {"success": True, "data": {"keyword": keyword, "count": count}}
 
     @r.tool(name="buffer_analysis", description="缓冲分析",
-            tier=1, domains=["core"])
+            tier=1, domains=[])
     def buffer_analysis(radius: float, source: dict) -> dict:
         _record("buffer_analysis")
         received["buffer_analysis"] = {"radius": radius, "source": source}
@@ -121,6 +121,14 @@ def env():
         _record("webgis_layer_upsert")
         received["webgis_layer_upsert"] = {"layer_ref": layer_ref, "color": color}
         return {"success": True, "layer_id": f"lyr-{layer_ref}", "color": color}
+
+    # 视图/相机类工具：与真实 map_view.set_map_view 一致，不声明任何 domain。
+    @r.tool(name="set_map_view", description="调整视图",
+            tier=1, domains=[])
+    def set_map_view(zoom: float = 12) -> dict:
+        _record("set_map_view")
+        received["set_map_view"] = {"zoom": zoom}
+        return {"success": True, "command": "set_map_view", "params": {"zoom": zoom}}
 
     return SimpleNamespace(
         registry=r,
@@ -408,7 +416,7 @@ async def test_scenario06_missing_ref_fails_with_hint(env):
     assert "s1" in result["error"]                 # 及可用 step keys
     assert "None" not in str(result["results"])    # 没有任何静默 None 落进结果
     data = await plan_mode_svc.load_plan(sid, plan_id)
-    assert data["__status__"] == "failed"
+    assert data["__status__"] == "partially_completed"  # s1 已成功 → 部分完成（P2-1）
     assert data["__failure_class__"] == "missing_ref"
 
 
@@ -427,7 +435,8 @@ async def test_scenario07_partial_success_resume_reuses_refs(env):
         env.calls["flaky_hotspot"] = env.calls.get("flaky_hotspot", 0) + 1
         s2_received["points"] = points
         if env.calls["flaky_hotspot"] == 1:
-            return {"success": False, "code": "TOOL_ERROR", "message": "第一次失败"}
+            # 瞬时网络失败（transient_network）→ 可恢复重试，不触发 livelock guard
+            return {"success": False, "code": "TOOL_ERROR", "message": "网络超时 连接失败"}
         return {"success": True, "data": {"hot_count": len(points)}}
 
     plan = plan_mode_svc.PlanProposal(
@@ -446,10 +455,11 @@ async def test_scenario07_partial_success_resume_reuses_refs(env):
     r1 = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
     assert r1["success"] is False
     assert r1["failed_step"] == "s2"
+    assert r1["failure_class"] == "transient_network"
     assert r1["executed"] == ["s1"]
     # 失败也持久化了已完成结果（resume 的数据基础）
     data = await plan_mode_svc.load_plan(sid, plan_id)
-    assert data["__status__"] == "failed"
+    assert data["__status__"] == "partially_completed"  # s1 已成功（P2-1）
     assert "s1" in data["__step_results__"]
 
     r2 = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
@@ -655,4 +665,382 @@ async def test_scenario10_terminal_plan_not_resurrected_as_active(env):
     fresh = AgentPlanOrchestrator()
     assert await fresh.restore_plan(sid) is None   # 终态计划不作为活跃计划恢复
     assert fresh.get_plan(sid) is None
+    await plan_store.clear(sid)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# P1-A：core 限定通配（qualified wildcard）——已注册非展示分析工具打勾 core 步骤；
+# 展示类/幻觉工具绝不打勾。fixture 已与生产对齐（tier-1 分析工具 domains=[]）。
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_p1a_core_step_ticks_on_registered_no_domain_analysis_tool(env):
+    """(a) core 步骤：已注册、无 domain 的分析工具（buffer_analysis）必须打勾——
+    生产注册表没有工具声明 core domain，纯 domain 重叠会让 core 步骤永远无法推进。"""
+    orch = AgentPlanOrchestrator()
+    sid = "sess-p1a-tick"
+    plan = Plan(
+        intent="缓冲分析", domains=["core"],
+        steps=[PlanStep(n=1, goal="做缓冲", tool_family="core")],
+    )
+    orch.set_plan(sid, plan)
+    assert env.registry.metadata("buffer_analysis")["domains"] == []  # 与生产一致
+    assert orch.advance_step(sid, "buffer_analysis", env.registry) == 1
+    assert plan.steps[0].done is True
+    orch.clear_plan(sid)
+
+
+def test_p1a_core_step_does_not_tick_on_presentation_tool(env):
+    """(b) core 步骤：展示类工具（webgis_layer_upsert，样式/图层更新）绝不打勾。"""
+    orch = AgentPlanOrchestrator()
+    sid = "sess-p1a-presentation"
+    plan = Plan(
+        intent="缓冲分析", domains=["core"],
+        steps=[PlanStep(n=1, goal="做缓冲", tool_family="core")],
+    )
+    orch.set_plan(sid, plan)
+    assert orch.advance_step(sid, "webgis_layer_upsert", env.registry) is None
+    assert plan.steps[0].done is False
+    # 视图类同样不打勾
+    assert orch.advance_step(sid, "set_map_view", env.registry) is None
+    assert plan.steps[0].done is False
+    orch.clear_plan(sid)
+
+
+def test_p1a_core_step_does_not_tick_on_unregistered_hallucinated_tool(env):
+    """(c) core 步骤：幻觉/未注册工具名绝不打勾。"""
+    orch = AgentPlanOrchestrator()
+    sid = "sess-p1a-halluc"
+    plan = Plan(
+        intent="缓冲分析", domains=["core"],
+        steps=[PlanStep(n=1, goal="做缓冲", tool_family="core")],
+    )
+    orch.set_plan(sid, plan)
+    assert orch.advance_step(sid, "hallucinated_tool_xyz", env.registry) is None
+    assert plan.steps[0].done is False
+    orch.clear_plan(sid)
+
+
+def test_p1a_presentation_tool_normalized_legacy_name_still_excluded(env):
+    """展示类工具经 legacy 名规范化后（set_layer_style → webgis_layer_upsert）
+    依然在排除集内，core 步骤不打勾。"""
+    orch = AgentPlanOrchestrator()
+    sid = "sess-p1a-legacy"
+    plan = Plan(
+        intent="制图", domains=["core"],
+        steps=[PlanStep(n=1, goal="加图层", tool_family="core")],
+    )
+    orch.set_plan(sid, plan)
+    assert orch.advance_step(sid, "set_layer_style", env.registry) is None
+    assert plan.steps[0].done is False
+    orch.clear_plan(sid)
+
+
+def test_p1a_real_registry_metadata_check():
+    """对真实注册表（init_tools）做聚焦元数据检查，防止 fixture/排除集与生产漂移：
+    - 没有任何工具声明 domain "core"（0/149）；
+    - tier-1 分析工具（buffer_analysis）已注册且 domains=[]；
+    - PRESENTATION_TOOLS 里每个名字都是真实注册工具（防打字错误）；"""
+    from app.tools import init_tools as _init_tools
+    from app.services.chat.plan_orchestrator import PRESENTATION_TOOLS
+
+    r = ToolRegistry()
+    _init_tools(r)
+    metas = r.all_metadata()
+    registered = set(r.list_tools())
+    assert "buffer_analysis" in registered
+    assert metas["buffer_analysis"]["domains"] == []
+    # 生产无任何工具声明 core domain（core 通配必须靠 qualified 规则）
+    assert not any("core" in m.get("domains", []) for m in metas.values())
+    unknown = PRESENTATION_TOOLS - registered
+    assert not unknown, f"PRESENTATION_TOOLS 含未注册工具: {sorted(unknown)}"
+    # 展示类工具本身无 domain，靠排除集拦截
+    for t in ("webgis_layer_upsert", "set_map_view", "fly_to_location", "webgis_view_set"):
+        assert t in registered
+        assert metas[t]["domains"] == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# P0-1：update_plan_status 在 ref 被逐出（LRU 容量淘汰）后重新 mint + 别名，
+# 绝不静默丢写；持有旧 plan_id 的调用方仍能读到最新 payload。
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_p0_1_update_status_remints_after_eviction(env):
+    """模拟 overwrite() 返回 False（ref 在读写间隙被逐出/后端降级）：update_plan_status
+    必须重新 mint + set_alias，load_plan(旧 plan_id) 仍可寻址到最新 payload——绝不静默丢写。"""
+    from app.services.session_data import MemorySessionStore
+    from app.services import plan_mode as _svc
+
+    class _EvictingOverwriteStore(MemorySessionStore):
+        """get 能读到，但 overwrite 一律失败（模拟 ref 在 read→write 间隙被逐出）。"""
+
+        async def overwrite(self, session_id, ref_id, data):
+            return False
+
+    tiny = _EvictingOverwriteStore(capacity=100)
+    sid = "sess-p01-evict"
+    payload = {
+        "__kind__": "plan_proposal", "__status__": "pending", "__updated_at__": 1.0,
+        "title": "t", "summary": "", "steps": [{"id": "s1", "tool": "x", "args": {}}],
+    }
+    plan_id = await tiny.store(sid, payload, prefix="plan")
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("app.services.plan_mode.session_data_manager", tiny)
+    try:
+        await _svc.update_plan_status(sid, plan_id, __status__="completed")
+        loaded = await _svc.load_plan(sid, plan_id)
+        assert loaded is not None, "update_plan_status 在 overwrite 失败后不得静默丢写"
+        assert loaded["__status__"] == "completed"
+        assert loaded["__updated_at__"] > 1.0
+        # 新 ref 是 ref:plan-*（重新 mint），旧 plan_id 经别名可寻址
+        refs = await tiny.list_refs(sid)
+        assert any(str(r).startswith("ref:plan-") for r in refs)
+        assert any(a == plan_id for a in refs.values())
+    finally:
+        monkeypatch.undo()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# P1-C：per-plan 执行锁（TOCTOU 双派发）、stale-running 可恢复、
+# 终态写入不覆盖 superseded/cancelled、OperationCancelled → cancelled。
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_p1c_concurrent_execute_serialized_per_plan(env):
+    """同一计划的两个并发 execute_plan：第一个拿到 per-plan 锁执行；第二个阻塞到
+    锁释放后重读，直接返回已完成结果——**绝无双派发**（TOCTOU 修复）。"""
+    sid = "sess-p1c-lock"
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = {"n": 0}
+
+    @env.registry.tool(name="slow_lock_tool", description="慢工具")
+    async def slow_lock_tool(tag: str) -> dict:
+        calls["n"] += 1
+        entered.set()
+        await asyncio.wait_for(release.wait(), timeout=5.0)
+        return {"success": True, "data": {"tag": tag}}
+
+    plan = plan_mode_svc.PlanProposal(
+        title="lock",
+        steps=[plan_mode_svc.PlanStep(id="s1", tool="slow_lock_tool", args={"tag": "a"})],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+
+    async def _run() -> dict:
+        return await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+
+    t1 = asyncio.create_task(_run())
+    await asyncio.wait_for(entered.wait(), timeout=5.0)  # t1 已进入执行（持有锁）
+    t2 = asyncio.create_task(_run())  # 并发第二发：阻塞等锁
+    release.set()  # 放行 t1
+    r1 = await asyncio.wait_for(t1, timeout=5.0)
+    r2 = await asyncio.wait_for(t2, timeout=5.0)
+    assert r1["success"] is True and r1["status"] == "completed"
+    # t2 在锁后重读 → 直接返回已存结果（completed），不重新 dispatch
+    assert r2["success"] is True and r2["status"] == "completed"
+    assert calls["n"] == 1  # 绝无双派发
+
+
+@pytest.mark.asyncio
+async def test_p1c_stale_running_is_resumable(env):
+    """running 状态超过阈值（或 __updated_at__ 缺失）→ 视为 crashed，允许 resume。"""
+    sid = "sess-p1c-stale"
+    plan = plan_mode_svc.PlanProposal(
+        title="stale",
+        steps=[
+            plan_mode_svc.PlanStep(id="s1", tool="fetch_data", args={"keyword": "医院"}),
+        ],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    # 人为写成 running + 陈旧时间戳（crashed 形态）
+    import time as _time
+    await plan_mode_svc.update_plan_status(
+        sid, plan_id, __status__="running", __updated_at__=_time.time() - 1000,
+    )
+    r = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r["success"] is True
+    assert r["status"] == "completed"
+    data = await plan_mode_svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_p1c_fresh_running_still_blocks(env):
+    """running + 新鲜时间戳 → 拒绝执行（在飞）。"""
+    sid = "sess-p1c-fresh"
+    plan = plan_mode_svc.PlanProposal(
+        title="fresh",
+        steps=[plan_mode_svc.PlanStep(id="s1", tool="fetch_data", args={"keyword": "x"})],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    await plan_mode_svc.update_plan_status(sid, plan_id, __status__="running")
+    r = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r["success"] is False
+    assert "已在执行中" in r["error"]
+
+
+@pytest.mark.asyncio
+async def test_p1c_cancelled_plan_refuses_resume(env):
+    """cancelled（terminal）计划：resume 必须拒绝，绝不重跑。"""
+    sid = "sess-p1c-cancelled"
+    plan = plan_mode_svc.PlanProposal(
+        title="cancel",
+        steps=[plan_mode_svc.PlanStep(id="s1", tool="fetch_data", args={"keyword": "x"})],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    await plan_mode_svc.update_plan_status(sid, plan_id, __status__="cancelled")
+    r = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r["success"] is False
+    assert r["status"] == "cancelled"
+    assert "已取消" in r["error"]
+    assert env.calls.get("fetch_data", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_p1c_operation_cancelled_writes_terminal_cancelled(env):
+    """工具抛 OperationCancelled → 写终态 cancelled（不是 failed），返回 status=cancelled。"""
+    from app.services.jobs.cancellation import OperationCancelled
+
+    sid = "sess-p1c-opcancel"
+
+    @env.registry.tool(name="cancel_tool", description="抛取消")
+    def cancel_tool() -> dict:
+        raise OperationCancelled("用户取消")
+
+    plan = plan_mode_svc.PlanProposal(
+        title="opcancel",
+        steps=[plan_mode_svc.PlanStep(id="s1", tool="cancel_tool", args={})],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    r = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r["success"] is False
+    assert r["status"] == "cancelled"
+    assert r["failure_class"] == "cancelled"
+    data = await plan_mode_svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "cancelled"  # terminal，不是 failed
+
+
+@pytest.mark.asyncio
+async def test_p1c_terminal_write_does_not_overwrite_superseded(env):
+    """执行中途计划被 supersede → 终态写入（completed）不得覆盖 superseded。"""
+    sid = "sess-p1c-super-mid"
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    @env.registry.tool(name="slow_super_tool", description="慢工具")
+    async def slow_super_tool(tag: str) -> dict:
+        entered.set()
+        await asyncio.wait_for(release.wait(), timeout=5.0)
+        return {"success": True, "data": {"tag": tag}}
+
+    plan = plan_mode_svc.PlanProposal(
+        title="mid-super",
+        steps=[plan_mode_svc.PlanStep(id="s1", tool="slow_super_tool", args={"tag": "a"})],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+
+    async def _run() -> dict:
+        return await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+
+    t1 = asyncio.create_task(_run())
+    await asyncio.wait_for(entered.wait(), timeout=5.0)
+    # 运行中被 supersede（模拟：直接改状态，等价 supersede_active_plans 的效果）
+    await plan_mode_svc.update_plan_status(sid, plan_id, __status__="superseded")
+    release.set()
+    await asyncio.wait_for(t1, timeout=5.0)
+    data = await plan_mode_svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "superseded"  # 终态写入未覆盖
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# P2-1：失败状态 partially_completed / failed；确定性失败 livelock guard；
+# superseded 且无结果 → success=False。
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_p2_1_deterministic_failure_not_rerun_on_resume(env):
+    """livelock guard：首次失败为确定性失败（failure_class != transient_network）时，
+    resume 直接返回存储的失败，绝不重跑同一工具。"""
+    sid = "sess-p2-1-livelock"
+    env.calls["deterministic_fail"] = 0
+
+    @env.registry.tool(name="deterministic_fail", description="永远失败")
+    def deterministic_fail() -> dict:
+        env.calls["deterministic_fail"] += 1
+        return {"success": False, "code": "VALIDATION_ERROR", "message": "参数非法"}
+
+    plan = plan_mode_svc.PlanProposal(
+        title="livelock",
+        steps=[
+            plan_mode_svc.PlanStep(id="s1", tool="fetch_data", args={"keyword": "医院"}),
+            plan_mode_svc.PlanStep(id="s2", tool="deterministic_fail", args={}),
+        ],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+
+    r1 = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r1["success"] is False
+    assert r1["failed_step"] == "s2"
+    assert r1["failure_class"] == "validation"
+    assert env.calls["deterministic_fail"] == 1
+
+    r2 = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r2["success"] is False
+    assert r2["failed_step"] == "s2"
+    assert r2["failure_class"] == "validation"
+    assert env.calls["deterministic_fail"] == 1  # 绝不被重跑
+    data = await plan_mode_svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "partially_completed"
+
+
+@pytest.mark.asyncio
+async def test_p2_1_superseded_with_empty_results_returns_failure(env):
+    """superseded / legacy 计划且无任何已存结果 → success=False + 明确消息
+    （不再假装 success=True + executed=[]）。"""
+    sid = "sess-p2-1-super-empty"
+    plan = plan_mode_svc.PlanProposal(
+        title="old",
+        steps=[plan_mode_svc.PlanStep(id="s1", tool="fetch_data", args={"keyword": "x"})],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    await plan_mode_svc.update_plan_status(sid, plan_id, __status__="superseded")
+    r = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r["success"] is False
+    assert r["status"] == "superseded"
+    assert "取代" in r["error"]
+    assert env.calls.get("fetch_data", 0) == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# P2-6：session_has_refs 必须排除计划自身 ref（ref:plan-* / plan 别名）
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_p2_6_session_has_refs_excludes_plan_refs(env):
+    """仅存了计划 ref（ref:plan-* / plan-current 别名）的会话 → session_has_refs
+    必须为 False，不得把"刚规划完"误判成 ref_reuse 承接。"""
+    from app.services.chat.execution_engine import _has_non_plan_refs
+    from app.services.planning.models import CanonicalPlan as _CP
+
+    sid = "sess-p2-6-planrefs"
+    # 存一个 plan-mode 计划（ref:plan-* 前缀）+ canonical 计划（plan-current 别名）
+    await plan_mode_svc.store_plan(
+        sid, plan_mode_svc.PlanProposal(
+            title="p", steps=[plan_mode_svc.PlanStep(id="s1", tool="fetch_data", args={})],
+        )
+    )
+    await plan_store.save(_CP(plan_id="p-can", session_id=sid, intent="x"))
+    refs = await session_data_manager.list_refs(sid)
+    assert _has_non_plan_refs(refs) is False, f"计划 ref 不应算作数据 ref: {refs}"
+    # 存一条真实数据 ref → True
+    await session_data_manager.store(sid, {"geojson": 1}, prefix="geojson")
+    refs2 = await session_data_manager.list_refs(sid)
+    assert _has_non_plan_refs(refs2) is True
     await plan_store.clear(sid)

--- a/tests/unit/test_planning_v3_scenarios.py
+++ b/tests/unit/test_planning_v3_scenarios.py
@@ -847,6 +847,43 @@ async def test_p1c_concurrent_execute_serialized_per_plan(env):
 
 
 @pytest.mark.asyncio
+async def test_p3_execute_claims_cross_process_plan_lock(env, monkeypatch):
+    """P3 延后项 #2：execute_plan 的 claim+run 关键段必须套在分布式锁
+    session_lock(f"plan:{plan_id}") 内——Redis 在时跨进程/跨 pod 原子 claim，
+    测试（in-process 兜底）行为不变。此处用记录型 stub 断言锁键与加锁路径。"""
+    from app.services import plan_mode as _svc
+
+    acquired: list[str] = []
+
+    class _AioLock:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeLockRegistry:
+        def lock(self, key):
+            acquired.append(key)
+            return _AioLock()
+
+    monkeypatch.setattr("app.services.plan_mode.session_lock_registry", _FakeLockRegistry())
+
+    sid = "sess-p3-planlock"
+    plan = plan_mode_svc.PlanProposal(
+        title="lock-claim",
+        steps=[plan_mode_svc.PlanStep(id="s1", tool="fetch_data", args={"keyword": "医院"})],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    r = await _svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r["success"] is True
+    # 锁键按 plan_id 全局唯一（无需 session 前缀）
+    assert acquired == [f"plan:{plan_id}"]
+    # 进程内 per-plan 锁仍保留（双保险，单 worker 不退化）
+    assert f"{sid}\0{plan_id}" in _svc._PLAN_EXEC_LOCKS
+
+
+@pytest.mark.asyncio
 async def test_p1c_stale_running_is_resumable(env):
     """running 状态超过阈值（或 __updated_at__ 缺失）→ 视为 crashed，允许 resume。"""
     sid = "sess-p1c-stale"

--- a/tests/unit/test_planning_v3_scenarios.py
+++ b/tests/unit/test_planning_v3_scenarios.py
@@ -1,0 +1,658 @@
+"""Deterministic scenario suite for the planning-architecture convergence.
+
+Implements the 10 adversarial scenarios from goal §20 /
+``.planning/swarm/G-report.md`` against the integrated implementation
+(``app/services/planning/*`` + ``plan_orchestrator`` + ``plan_mode`` +
+``execution_engine`` + ``tool_dispatch_service``).
+
+Determinism constraints (see ``.planning/swarm/F-report.md`` §3-4, §6):
+- The LLM boundary is mocked at ``app.services.chat.planner.call_llm`` ONLY —
+  never ``app.services.chat.llm_client.call_llm`` (planner.py re-exports the
+  name; patching the wrong seam silently hits the network).
+- A real ``ToolRegistry`` with a small set of inline-registered fake tools
+  carrying proper tier/domains metadata (mirrors tests/unit/test_plan_mode.py:21-47).
+- In-memory session store (conftest sets ``USE_REDIS=false``) — no network,
+  no Redis, no DB.
+- No timing assertions: concurrency is proven structurally (a rendezvous
+  event) and execution order via call logs / counters.
+- The module-level ``plan_orchestrator`` / ``plan_store`` singletons are shared
+  across the whole suite: unique ``sess-*`` ids per test + explicit teardown.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.tools.registry import ToolRegistry
+from app.services import plan_mode as plan_mode_svc
+from app.services.tool_catalog import DOMAIN_KEYWORDS, ToolCatalog
+from app.services.chat import planner as planner_mod
+from app.services.chat.context_assembler import ChatContextAssembler
+from app.services.chat.execution_engine import ChatExecutionEngine
+from app.services.chat.llm_client import LLMConfig
+from app.services.chat.plan_orchestrator import (
+    AgentPlanOrchestrator,
+    Plan,
+    PlanStep,
+    should_plan,
+)
+from app.services.planning import (
+    CanonicalPlan,
+    CanonicalStep,
+    FollowUpKind,
+    PlanStatus,
+    StepStatus,
+    classify_followup,
+)
+from app.services.planning.capability import validate_plan_capabilities
+from app.services.planning.store import plan_store
+from app.services.session_data import session_data_manager
+from app.services.tool_dispatch_service import ToolDispatchService
+
+
+# ─── shared fixtures / helpers ─────────────────────────────────────────
+
+
+@pytest.fixture
+def env():
+    """Real ToolRegistry with a small set of inline fake tools + call log.
+
+    Tools carry tier/domains metadata (design-v3 §capability derives from it).
+    ``calls`` counts dispatches per tool, ``log`` records dispatch order,
+    ``received`` records the args each tool actually saw (for ref-resolution
+    assertions). All three are fresh per test.
+    """
+    r = ToolRegistry()
+    calls: dict[str, int] = {}
+    log: list[str] = []
+    received: dict = {}
+
+    def _record(name: str) -> None:
+        calls[name] = calls.get(name, 0) + 1
+        log.append(name)
+
+    @r.tool(name="fetch_data", description="获取指定关键词的 POI 数据",
+            tier=2, domains=["chinese"])
+    def fetch_data(keyword: str, count: int = 10) -> dict:
+        _record("fetch_data")
+        received["fetch_data"] = {"keyword": keyword, "count": count}
+        return {"success": True, "data": {"keyword": keyword, "count": count}}
+
+    @r.tool(name="buffer_analysis", description="缓冲分析",
+            tier=1, domains=["core"])
+    def buffer_analysis(radius: float, source: dict) -> dict:
+        _record("buffer_analysis")
+        received["buffer_analysis"] = {"radius": radius, "source": source}
+        return {"success": True, "data": {"radius": radius, "source": source}}
+
+    @r.tool(name="hotspot_analysis", description="热点分析",
+            tier=2, domains=["statistics"])
+    def hotspot_analysis(points: list) -> dict:
+        _record("hotspot_analysis")
+        received["hotspot_analysis"] = {"points": points}
+        return {"success": True, "data": {"hot_count": len(points), "points": points}}
+
+    @r.tool(name="cartography_render", description="制图渲染",
+            tier=2, domains=["report"])
+    def cartography_render(layers: list) -> dict:
+        _record("cartography_render")
+        received["cartography_render"] = {"layers": layers}
+        return {"success": True, "data": {"rendered": len(layers)}}
+
+    @r.tool(name="compute_ndvi", description="NDVI 计算",
+            tier=2, domains=["raster"])
+    def compute_ndvi(area: str) -> dict:
+        _record("compute_ndvi")
+        received["compute_ndvi"] = {"area": area}
+        return {"success": True, "data": {"ndvi": 0.42, "area": area}}
+
+    @r.tool(name="plan_route", description="驾车路线规划",
+            tier=2, domains=["network"])
+    def plan_route(origin: str, destination: str) -> dict:
+        _record("plan_route")
+        received["plan_route"] = {"origin": origin, "destination": destination}
+        return {"success": True, "data": {"origin": origin, "destination": destination}}
+
+    # 样式/图层类工具：与真实 webgis_layer_upsert 一致，不声明任何 domain。
+    @r.tool(name="webgis_layer_upsert", description="图层样式/更新",
+            tier=1, domains=[])
+    def webgis_layer_upsert(layer_ref: str, color: str = "blue") -> dict:
+        _record("webgis_layer_upsert")
+        received["webgis_layer_upsert"] = {"layer_ref": layer_ref, "color": color}
+        return {"success": True, "layer_id": f"lyr-{layer_ref}", "color": color}
+
+    return SimpleNamespace(
+        registry=r,
+        catalog=ToolCatalog(r),
+        calls=calls,
+        log=log,
+        received=received,
+    )
+
+
+def _make_engine(env) -> ChatExecutionEngine:
+    """Minimal ChatExecutionEngine without deps (F-report §4: __new__ + attrs)."""
+    engine = ChatExecutionEngine.__new__(ChatExecutionEngine)
+    engine.base_url = "http://localhost:9999"
+    engine.model = "m"
+    engine.api_key = "k"
+    engine.use_prompt_caching = False
+    engine.catalog = env.catalog
+    engine.registry = env.registry
+    return engine
+
+
+@pytest.fixture
+def cfg():
+    return LLMConfig(base_url="http://x", model="m", api_key="k")
+
+
+def _patch_registry(monkeypatch, env):
+    """Route orchestrator capability validation to OUR fake registry so results
+    are independent of any globally injected registry (F-report §6)."""
+    monkeypatch.setattr(
+        "app.services.chat.plan_orchestrator._get_registry", lambda: env.registry
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 1：单工具简单任务 —— should_plan 不过度规划；无计划时不污染 prompt
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_scenario01_short_simple_followup_does_not_overplan():
+    """短简单消息 + 活跃计划 → False（承接追问，不重新规划）。"""
+    assert should_plan("换个颜色", [], has_active_plan=True) is False
+    assert should_plan("放大一点", [], has_active_plan=True) is False
+    # 无活跃计划时同样的短消息反而要规划（没有上文可承接）
+    assert should_plan("换个颜色", [], has_active_plan=False) is True
+
+
+@pytest.mark.asyncio
+async def test_scenario01_single_tool_task_produces_single_step_plan(env, cfg, monkeypatch):
+    """简单请求产出 1 步计划，而非过度拆分。"""
+    _patch_registry(monkeypatch, env)
+
+    async def fake_call_llm(_cfg, _messages, _tools=None):
+        return {"choices": [{"message": {"content":
+            '{"intent":"画个热力图","domains":["statistics"],'
+            '"steps":[{"n":1,"goal":"热点分析","tool_family":"statistics"}]}'}}]}
+
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+    sid = "sess-s01-single"
+    plan = await planner_mod.make_plan(cfg, sid, "画个热力图", "[环境感知]")
+    assert plan is not None
+    assert len(plan.steps) == 1  # 不过度规划：简单任务只有 1 步
+    assert plan.domains == ["statistics"]
+    planner_mod.clear_plan(sid)
+    await plan_store.clear(sid)
+
+
+@pytest.mark.asyncio
+async def test_scenario01_no_plan_block_pollutes_prompt(env):
+    """无计划时 [执行计划] 块不出现；有计划时才渲染（context_assembler 门控）。"""
+    sid = "sess-s01-prompt"
+    assembler = ChatContextAssembler()
+    messages = [
+        {"role": "system", "content": "你是 WebGIS 助手"},
+        {"role": "user", "content": "画个热力图"},
+    ]
+
+    res = await assembler.assemble(sid, messages)
+    joined = "\n".join(m.get("content", "") for m in res.to_messages())
+    assert "[执行计划]" not in joined  # 无计划 → 无计划块
+
+    planner_mod.set_plan(sid, Plan(
+        intent="画个热力图", domains=["statistics"],
+        steps=[PlanStep(n=1, goal="热点分析", tool_family="statistics")],
+    ))
+    res2 = await assembler.assemble(sid, messages)
+    joined2 = "\n".join(m.get("content", "") for m in res2.to_messages())
+    assert "[执行计划]" in joined2
+    planner_mod.clear_plan(sid)
+    await plan_store.clear(sid)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 2：多步链（获取数据 → buffer → hotspot → cartography），${stepId} 引用
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scenario02_multi_step_chain_executes_in_order_with_refs(env):
+    sid = "sess-s02-chain"
+    plan = plan_mode_svc.PlanProposal(
+        title="数据链路",
+        steps=[
+            plan_mode_svc.PlanStep(id="s1", tool="fetch_data",
+                                   args={"keyword": "医院", "count": 5}),
+            plan_mode_svc.PlanStep(id="s2", tool="buffer_analysis",
+                                   args={"radius": 500, "source": "${s1.data}"}),
+            plan_mode_svc.PlanStep(id="s3", tool="hotspot_analysis",
+                                   args={"points": ["${s2.data.source.count}"]}),
+            plan_mode_svc.PlanStep(id="s4", tool="cartography_render",
+                                   args={"layers": ["${s3.data.hot_count}"]}),
+        ],
+    )
+    # propose 期校验通过（DAG + 静态引用均干净）
+    assert plan_mode_svc.validate_plan(plan, set(env.registry.list_tools())) is None
+    assert plan_mode_svc.validate_static_refs(plan) == []
+
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    result = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert result["success"] is True
+    assert result["executed"] == ["s1", "s2", "s3", "s4"]
+    # 严格串行链 → dispatch 顺序即声明顺序
+    assert env.log == ["fetch_data", "buffer_analysis", "hotspot_analysis", "cartography_render"]
+    # ${stepId[.path]} 引用逐级解析
+    assert env.received["buffer_analysis"]["source"] == {"keyword": "医院", "count": 5}
+    assert env.received["hotspot_analysis"]["points"] == [5]      # s2.data.source.count
+    assert env.received["cartography_render"]["layers"] == [1]    # s3.data.hot_count
+    data = await plan_mode_svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "completed"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 3：两个独立步骤并发，join 步骤收到两者结果
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scenario03_independent_steps_run_concurrently_then_join(env):
+    sid = "sess-s03-concurrent"
+    both_entered = asyncio.Event()
+    entered = {"n": 0}
+
+    async def _rendezvous(name: str) -> None:
+        """两个独立步骤必须同时在飞行中；串行实现会在此处超时失败。"""
+        entered["n"] += 1
+        if entered["n"] == 2:
+            both_entered.set()
+        try:
+            await asyncio.wait_for(both_entered.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            raise AssertionError(f"step {name} was not dispatched concurrently")
+
+    @env.registry.tool(name="slow_fetch_a", description="独立步骤 A")
+    async def slow_fetch_a(tag: str) -> dict:
+        await _rendezvous("s1")
+        env.log.append("slow_fetch_a")
+        return {"success": True, "data": {"tag": tag}}
+
+    @env.registry.tool(name="slow_fetch_b", description="独立步骤 B")
+    async def slow_fetch_b(tag: str) -> dict:
+        await _rendezvous("s2")
+        env.log.append("slow_fetch_b")
+        return {"success": True, "data": {"tag": tag}}
+
+    plan = plan_mode_svc.PlanProposal(
+        title="并发+join",
+        steps=[
+            plan_mode_svc.PlanStep(id="s1", tool="slow_fetch_a", args={"tag": "a"}),
+            plan_mode_svc.PlanStep(id="s2", tool="slow_fetch_b", args={"tag": "b"}),
+            plan_mode_svc.PlanStep(id="s3", tool="hotspot_analysis",
+                                   args={"points": ["${s1.data.tag}", "${s2.data.tag}"]},
+                                   depends_on=["s1", "s2"]),
+        ],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    result = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert result["success"] is True, f"plan failed: {result}"
+    assert result["executed"] == ["s1", "s2", "s3"]
+    # join 步骤同时收到 s1、s2 的结果（ref 解析证明）
+    assert result["results"]["s3"]["data"]["hot_count"] == 2
+    assert sorted(env.log[:2]) == ["slow_fetch_a", "slow_fetch_b"]
+    assert env.log[2:] == ["hotspot_analysis"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 4：第 2 步参数校验失败 → validation / correct_args，修正后重试放行
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scenario04_validation_failure_classified_and_retry_allowed(env):
+    sid = "sess-s04-validate"
+    service = ToolDispatchService(registry=env.registry)
+    executed: set = set()
+
+    bad_tc = {"id": "c1", "function": {"name": "fetch_data",
+                                       "arguments": json.dumps({"keyword": "医院", "count": "oops"})}}
+    r1 = await service.dispatch(bad_tc, sid, executed)
+    assert r1.status == "error"
+    assert r1.raw_result.get("code") == "VALIDATION_ERROR"
+    failure_class, recovery_action = ChatExecutionEngine._classify_failure(r1)
+    assert failure_class == "validation"
+    assert recovery_action == "correct_args"
+
+    # dedup 在失败后释放：同 (name, args) 重试绝不会被谎报"已成功执行"
+    r2 = await service.dispatch(bad_tc, sid, executed)
+    assert r2.status == "error"
+    assert "重复调用" not in r2.llm_payload
+
+    # 修正参数后的重试放行并成功
+    ok_tc = {"id": "c3", "function": {"name": "fetch_data",
+                                      "arguments": json.dumps({"keyword": "医院", "count": 3})}}
+    r3 = await service.dispatch(ok_tc, sid, executed)
+    assert r3.status == "ok"
+    assert env.received["fetch_data"]["count"] == 3
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 5：工具不可用（未注册）—— 能力校验拦截 + 分类 + 绝不打勾
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_scenario05_capability_validation_flags_unregistered_tool(env):
+    plan = CanonicalPlan(
+        plan_id="p-unknown",
+        session_id="sess-s05-cap",
+        intent="x",
+        steps=[CanonicalStep(id="s1", n=1, goal="g", tool="nonexistent_tool",
+                             tool_family="statistics")],
+    )
+    issues = validate_plan_capabilities(plan, env.registry)
+    assert any("unregistered tool 'nonexistent_tool'" in i for i in issues)
+
+
+@pytest.mark.asyncio
+async def test_scenario05_dispatch_unregistered_tool_classifies_unavailable(env):
+    service = ToolDispatchService(registry=env.registry)
+    tc = {"id": "c1", "function": {"name": "nonexistent_tool_xyz", "arguments": "{}"}}
+    r = await service.dispatch(tc, "sess-s05-disp", set())
+    assert r.status == "error"
+    assert r.raw_result.get("code") == "UNKNOWN_TOOL"
+    failure_class, recovery_action = ChatExecutionEngine._classify_failure(r)
+    assert failure_class == "tool_unavailable"
+    assert recovery_action in ("alternate_tool", "replan_remaining")
+
+
+def test_scenario05_unregistered_tool_does_not_tick_plan_step(env):
+    """R1/R5：幻觉工具绝不打勾计划步骤（metadata 兜底不再伪装成 core 域）。"""
+    orch = AgentPlanOrchestrator()
+    sid = "sess-s05-tick"
+    plan = Plan(
+        intent="热点分析", domains=["statistics"],
+        steps=[PlanStep(n=1, goal="热点", tool_family="statistics")],
+    )
+    orch.set_plan(sid, plan)
+    assert orch.advance_step(sid, "nonexistent_tool_xyz", env.registry) is None
+    assert plan.steps[0].done is False
+    orch.clear_plan(sid)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 6：悬空引用 ${s1.nonexistent.path} → missing_ref + 修正提示（不静默 None）
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scenario06_missing_ref_fails_with_hint(env):
+    sid = "sess-s06-ref"
+    plan = plan_mode_svc.PlanProposal(
+        title="badpath",
+        steps=[
+            plan_mode_svc.PlanStep(id="s1", tool="fetch_data", args={"keyword": "医院"}),
+            plan_mode_svc.PlanStep(id="s2", tool="buffer_analysis",
+                                   args={"radius": 500, "source": "${s1.nonexistent.path}"}),
+        ],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+    result = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert result["success"] is False
+    assert result["failed_step"] == "s2"
+    assert result["failure_class"] == "missing_ref"
+    assert result["recovery_action"] == "reuse_ref"
+    assert "nonexistent.path" in result["error"]   # 修正提示点名坏路径
+    assert "s1" in result["error"]                 # 及可用 step keys
+    assert "None" not in str(result["results"])    # 没有任何静默 None 落进结果
+    data = await plan_mode_svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "failed"
+    assert data["__failure_class__"] == "missing_ref"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 7：部分成功 → resume：已完成步骤不重跑、引用复用、剩余步骤完成
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scenario07_partial_success_resume_reuses_refs(env):
+    sid = "sess-s07-resume"
+    s2_received: dict = {}
+
+    @env.registry.tool(name="flaky_hotspot", description="第一次失败第二次成功")
+    def flaky_hotspot(points: list) -> dict:
+        env.calls["flaky_hotspot"] = env.calls.get("flaky_hotspot", 0) + 1
+        s2_received["points"] = points
+        if env.calls["flaky_hotspot"] == 1:
+            return {"success": False, "code": "TOOL_ERROR", "message": "第一次失败"}
+        return {"success": True, "data": {"hot_count": len(points)}}
+
+    plan = plan_mode_svc.PlanProposal(
+        title="resume",
+        steps=[
+            plan_mode_svc.PlanStep(id="s1", tool="fetch_data",
+                                   args={"keyword": "医院", "count": 5}),
+            plan_mode_svc.PlanStep(id="s2", tool="flaky_hotspot",
+                                   args={"points": ["${s1.data.count}"]}),
+            plan_mode_svc.PlanStep(id="s3", tool="cartography_render",
+                                   args={"layers": ["${s2.data.hot_count}"]}),
+        ],
+    )
+    plan_id = await plan_mode_svc.store_plan(sid, plan)
+
+    r1 = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r1["success"] is False
+    assert r1["failed_step"] == "s2"
+    assert r1["executed"] == ["s1"]
+    # 失败也持久化了已完成结果（resume 的数据基础）
+    data = await plan_mode_svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "failed"
+    assert "s1" in data["__step_results__"]
+
+    r2 = await plan_mode_svc.execute_plan_async(sid, plan_id, env.registry)
+    assert r2["success"] is True, f"resume failed: {r2}"
+    assert r2["executed"] == ["s1", "s2", "s3"]
+    assert r2["results"]["s3"]["data"]["rendered"] == 1
+    # s1 绝不被重新 dispatch（引用从上次结果复用）
+    assert env.calls["fetch_data"] == 1
+    assert env.calls["flaky_hotspot"] == 2
+    assert env.calls["cartography_render"] == 1
+    # resume 用的 s1 结果即上次持久化的结果
+    assert s2_received["points"] == [5]
+    data2 = await plan_mode_svc.load_plan(sid, plan_id)
+    assert data2["__status__"] == "completed"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 8：纯样式追问（换成蓝色）→ style_change → 不重规划、不重跑分析、
+#         样式工具调用不打勾任何计划步骤（core 通配移除）
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_scenario08_style_followup_classified_and_skips_planning(env):
+    kind = classify_followup(
+        "换成蓝色",
+        has_active_plan=True,
+        active_domains=["statistics"],
+        session_has_refs=True,
+        domain_keywords=DOMAIN_KEYWORDS,
+    )
+    assert kind == FollowUpKind.style_change
+    assert should_plan("换成蓝色", [], has_active_plan=True, followup_kind=kind) is False
+    # 旧启发式路径（不传 followup_kind）同样不重规划
+    assert should_plan("换成蓝色", [], has_active_plan=True) is False
+
+
+@pytest.mark.asyncio
+async def test_scenario08_style_turn_no_reanalysis_and_no_new_plan(env, monkeypatch):
+    _patch_registry(monkeypatch, env)
+    sid = "sess-s08-style"
+    # 已完成分析部分、计划仍活跃（step2 pending → 非终态）+ 会话已有数据 ref
+    plan = Plan(
+        intent="热点分析", domains=["statistics"],
+        steps=[
+            PlanStep(n=1, goal="热点", tool_family="statistics", done=True),
+            PlanStep(n=2, goal="再热点", tool_family="statistics"),
+        ],
+    )
+    orch = AgentPlanOrchestrator()
+    orch.set_plan(sid, plan)
+    await orch.flush(sid)
+    plan_id = plan_store.peek(sid).plan_id
+    await session_data_manager.store(sid, {"geojson": "fc"}, prefix="geojson")
+
+    called = {"n": 0}
+    async def fake_call_llm(*_a, **_k):
+        called["n"] += 1
+        return {"choices": [{"message": {"content": "{}"}}]}
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+
+    engine = _make_engine(env)
+    result = await engine._maybe_plan(sid, "换成蓝色", [])
+    assert result is None
+    assert called["n"] == 0            # 规划 LLM 绝未被调用（无重分析）
+    canon = await plan_store.load_current(sid)
+    assert canon is not None and canon.plan_id == plan_id  # 原计划原封未动
+    assert canon.steps[1].status == StepStatus.pending
+    planner_mod.clear_plan(sid)
+    await plan_store.clear(sid)
+
+
+def test_scenario08_style_tool_call_does_not_tick_plan_step(env):
+    """R1：样式/视图类工具（无 domain）不通过 core 通配打勾任何步骤。"""
+    orch = AgentPlanOrchestrator()
+    sid = "sess-s08-tick"
+    plan = Plan(
+        intent="热点分析", domains=["statistics"],
+        steps=[
+            PlanStep(n=1, goal="热点", tool_family="statistics"),
+            PlanStep(n=2, goal="再热点", tool_family="statistics"),
+        ],
+    )
+    orch.set_plan(sid, plan)
+    assert orch.advance_step(sid, "hotspot_analysis", env.registry) == 1
+    # 样式工具调用：无 domain 重叠 → 不打勾，返回 None
+    assert orch.advance_step(sid, "webgis_layer_upsert", env.registry) is None
+    assert plan.steps[1].done is False
+    orch.clear_plan(sid)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 9：用户改目标 → new_goal → 强制重规划；旧计划 superseded；sticky 重置
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_scenario09_new_goal_classified_and_forces_planning(env):
+    # 短消息换目标："换成查路线" —— 含计划域（raster）之外的 network 关键词
+    kind = classify_followup(
+        "换成查路线",
+        has_active_plan=True,
+        active_domains=["raster"],
+        session_has_refs=True,
+        domain_keywords=DOMAIN_KEYWORDS,
+    )
+    assert kind == FollowUpKind.new_goal
+    assert should_plan("换成查路线", [], has_active_plan=True, followup_kind=kind) is True
+    # 新领域关键词（路线 → network ∉ active raster）同样强制重规划
+    kind2 = classify_followup(
+        "再查一下成都到重庆的路线",
+        has_active_plan=True,
+        active_domains=["raster"],
+        session_has_refs=False,
+        domain_keywords=DOMAIN_KEYWORDS,
+    )
+    assert kind2 == FollowUpKind.new_goal
+
+
+@pytest.mark.asyncio
+async def test_scenario09_new_goal_supersedes_and_resets_sticky(env, monkeypatch):
+    _patch_registry(monkeypatch, env)
+    sid = "sess-s09-goal"
+    responses = iter([
+        '{"intent":"NDVI 分析","domains":["raster"],"steps":[{"n":1,"goal":"计算 NDVI","tool_family":"raster"}]}',
+        '{"intent":"路线规划","domains":["network"],"steps":[{"n":1,"goal":"规划路线","tool_family":"network"}]}',
+    ])
+
+    async def fake_call_llm(_cfg, _messages, _tools=None):
+        return {"choices": [{"message": {"content": next(responses)}}]}
+
+    monkeypatch.setattr(planner_mod, "call_llm", fake_call_llm)
+    engine = _make_engine(env)
+
+    # 第 1 轮：raster 计划 + raster 领域 sticky
+    p1 = await engine._maybe_plan(sid, "分析一下植被覆盖", [])
+    assert p1 is not None and p1.domains == ["raster"]
+    old_id = (await plan_store.load_current(sid)).plan_id
+    env.catalog.select_schemas("NDVI", session_id=sid)  # 模拟 raster 粘性
+    assert env.catalog.active_domains(sid) == {"raster"}
+
+    # 第 2 轮：换成查路线 → new_goal → 强制重规划
+    p2 = await engine._maybe_plan(sid, "换成查路线", [])
+    assert p2 is not None and p2.intent == "路线规划"
+    # 旧 canonical 绝不静默覆盖：标记 superseded 并可寻址
+    hist = await plan_store.get_by_id(sid, old_id)
+    assert hist is not None and hist.status == PlanStatus.superseded
+    assert (await plan_store.load_current(sid)).plan_id != old_id
+    # design-v3 §5：换目标 → 旧领域 sticky 重置，不再污染工具选择
+    assert env.catalog.active_domains(sid) == set()
+    planner_mod.clear_plan(sid)
+    await plan_store.clear(sid)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 场景 10：模拟重启 → 从 store 恢复计划（步骤/状态完整）；终态计划不复活
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scenario10_restart_restores_plan_with_step_status(env, monkeypatch):
+    _patch_registry(monkeypatch, env)
+    sid = "sess-s10-restart"
+    orch = AgentPlanOrchestrator()
+    plan = Plan(
+        intent="热点分析", domains=["statistics"],
+        steps=[
+            PlanStep(n=1, goal="热点", tool_family="statistics"),
+            PlanStep(n=2, goal="再热点", tool_family="statistics"),
+        ],
+    )
+    orch.set_plan(sid, plan)
+    assert orch.advance_step(sid, "hotspot_analysis", env.registry) == 1
+    await orch.flush(sid)  # 只完成 step1 → 计划保持非终态（proposed）
+    # 模拟 worker 重启：进程内缓存（orchestrator LRU + plan_store cache）全清
+    plan_store.clear_cache()
+    orch.clear_plan(sid)
+
+    fresh = AgentPlanOrchestrator()
+    restored = await fresh.restore_plan(sid)
+    assert restored is not None
+    assert restored.intent == "热点分析"
+    assert restored.steps[0].done is True          # 打勾进度保留
+    assert restored.steps[1].done is False         # 未完成步骤保持未完成
+
+    loaded = await plan_store.load_current(sid)
+    assert loaded is not None
+    assert loaded.steps[0].status == StepStatus.completed
+    assert loaded.steps[1].status == StepStatus.pending
+    assert loaded.status == PlanStatus.proposed     # 非终态 → 可继续推进
+    await plan_store.clear(sid)
+
+
+@pytest.mark.asyncio
+async def test_scenario10_terminal_plan_not_resurrected_as_active(env):
+    sid = "sess-s10-terminal"
+    await plan_store.save(CanonicalPlan(
+        plan_id="p-terminal",
+        session_id=sid,
+        intent="已完成的分析",
+        status=PlanStatus.completed,
+        steps=[CanonicalStep(id="s1", n=1, goal="g", status=StepStatus.completed)],
+    ))
+    plan_store.clear_cache()  # 模拟重启：store 缓存清空，只留持久化副本
+    fresh = AgentPlanOrchestrator()
+    assert await fresh.restore_plan(sid) is None   # 终态计划不作为活跃计划恢复
+    assert fresh.get_plan(sid) is None
+    await plan_store.clear(sid)

--- a/tests/unit/test_subagent.py
+++ b/tests/unit/test_subagent.py
@@ -211,3 +211,50 @@ async def test_spawn_subagent_happy_path(registry):
         )
     assert result["success"] is True
     assert result["summary"] == "完工。"
+
+
+# ─── P2-7（Pi#1/#2）：子代理引擎绝不推进父会话计划 ──────────────
+
+
+@pytest.mark.asyncio
+async def test_subagent_engine_never_advances_parent_plan(registry, monkeypatch):
+    """子代理引擎：is_subagent_engine=True → _maybe_plan 直接返回 None（不触发
+    规划 LLM），_flush_plan 不 flush 父会话计划；_FrozenCatalog 提供
+    reset_sticky / active_domains no-op（否则 _log_tool_decision 崩溃）。"""
+    from app.services.chat import planner as planner_mod
+    from app.services.chat.plan_orchestrator import plan_orchestrator
+
+    dispatcher = SubagentDispatcher(registry, parent_session_id="parent-sess-p27")
+    sub_engine = dispatcher._build_sub_engine(
+        select_tools_for_subagent(registry), max_rounds=5,
+    )
+    assert sub_engine.is_subagent_engine is True
+
+    # 1) _maybe_plan：即使父会话已有活跃计划，子代理也绝不重新规划/触碰
+    parent_plan = planner_mod.Plan(
+        intent="父计划", domains=["statistics"],
+        steps=[planner_mod.PlanStep(n=1, goal="热点", tool_family="statistics")],
+    )
+    planner_mod.set_plan("parent-sess-p27", parent_plan)
+
+    make_plan_calls = {"n": 0}
+    async def fake_make_plan(*a, **k):
+        make_plan_calls["n"] += 1
+        return None
+    monkeypatch.setattr(planner_mod, "make_plan", fake_make_plan)
+    result = await sub_engine._maybe_plan("parent-sess-p27", "复杂请求需要规划的内容", [])
+    assert result is None
+    assert make_plan_calls["n"] == 0
+
+    # 2) _flush_plan：不 flush 父会话计划（即便父计划存在）
+    flush_calls = {"n": 0}
+    async def fake_flush(sid):
+        flush_calls["n"] += 1
+    monkeypatch.setattr(plan_orchestrator, "flush", fake_flush)
+    await sub_engine._flush_plan("parent-sess-p27")
+    assert flush_calls["n"] == 0
+
+    # 3) _FrozenCatalog no-op 方法（引擎会调用的新接口）
+    assert sub_engine.catalog.active_domains("parent-sess-p27") == set()
+    sub_engine.catalog.reset_sticky("parent-sess-p27")  # 不抛异常即通过
+    planner_mod.clear_plan("parent-sess-p27")

--- a/tests/unit/test_tool_catalog.py
+++ b/tests/unit/test_tool_catalog.py
@@ -130,6 +130,18 @@ def test_reset_session(catalog):
     assert catalog.active_domains("abc") == set()
 
 
+def test_reset_sticky_on_new_goal(catalog):
+    """design-v3 §5：new_goal 时 reset_sticky 清空旧领域粘性，
+    旧领域不再污染后续工具选择。"""
+    catalog.select_schemas("NDVI 计算", session_id="abc")
+    assert catalog.active_domains("abc") == {"raster"}
+    catalog.reset_sticky("abc")
+    assert catalog.active_domains("abc") == set()
+    # 后续无关键词轮次不再被旧领域污染
+    names = _names(catalog.select_schemas("换个颜色", session_id="abc"))
+    assert "compute_ndvi" not in names
+
+
 def test_unannotated_tools_default_tier1():
     """未标注 tier 的工具默认 tier 1 (向后兼容)。"""
     r = ToolRegistry()

--- a/tests/unit/test_tool_dispatch_service.py
+++ b/tests/unit/test_tool_dispatch_service.py
@@ -184,6 +184,29 @@ async def test_suspicious_result_appends_hint(service, fake_registry, clean_sess
     assert "未返回任何空间要素" in result.llm_payload
 
 
+@pytest.mark.asyncio
+async def test_failed_dispatch_does_not_occupy_dedup_slot(service, fake_registry, clean_session):
+    """R-dedup（design-v3 §2）：失败调用不占用 dedup 槽位——同参重试放行，
+    且绝不会收到「已成功执行」的重复提示；成功后的同参重复仍被拦截。"""
+    executed: set = set()
+    tc = _tc("query_osm", {"area": "北京"})
+    fake_registry.dispatch.side_effect = [
+        {"success": False, "code": "VALIDATION_ERROR", "message": "参数校验失败"},
+        {"summary": "ok"},
+    ]
+    r1 = await service.dispatch(tc, clean_session, executed)
+    assert r1.status == "error"
+    # 失败后同参重试 → 正常 dispatch（不是 repeated，不谎报成功）
+    r2 = await service.dispatch(tc, clean_session, executed)
+    assert r2.status == "ok"
+    assert fake_registry.dispatch.call_count == 2
+    # 成功后同参再调 → repeated（成功重复语义不变）
+    r3 = await service.dispatch(tc, clean_session, executed)
+    assert r3.status == "repeated"
+    assert "[重复调用拦截]" in r3.llm_payload
+    assert fake_registry.dispatch.call_count == 2
+
+
 def test_tool_name_normalization_table():
     """断言 legacy 工具名被正确映射为 webgis_* canonical 名称。"""
     assert normalize_tool_name("add_layer") == "webgis_layer_upsert"

--- a/tests/unit/test_tool_dispatch_service.py
+++ b/tests/unit/test_tool_dispatch_service.py
@@ -230,3 +230,45 @@ async def test_dispatch_normalizes_legacy_tool_names(service, fake_registry, cle
     called_tool_name = fake_registry.dispatch.call_args[0][0]
     assert called_tool_name == "webgis_layer_upsert"
 
+
+
+# ─── P2-9（adversarial P2-9 / recovery P2）：并发在飞去重不谎报成功 ──
+
+
+@pytest.mark.asyncio
+async def test_concurrent_inflight_duplicate_does_not_claim_success(service, fake_registry, clean_session):
+    """同一波次并发同参调用：原调用仍在执行中时，重复调用被拦截但**绝不声称
+    "已成功执行"**——消息软化说明原调用已发起，让 LLM 以原调用结果为准。
+    原调用完成后，post-success dedup 文案保持不变。"""
+    import asyncio
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_dispatch(name, args, session_id=None):
+        entered.set()
+        await asyncio.wait_for(release.wait(), timeout=5.0)
+        return {"summary": "ok"}
+
+    fake_registry.dispatch.side_effect = slow_dispatch
+    executed: set = set()
+    tc = _tc("geocode_cn", {"q": "北京"})
+
+    first = asyncio.create_task(service.dispatch(tc, clean_session, executed))
+    await asyncio.wait_for(entered.wait(), timeout=5.0)  # 原调用在飞
+
+    dup = await service.dispatch(tc, clean_session, executed)  # 并发第二发
+    assert dup.status == "repeated"
+    assert "[重复调用拦截]" in dup.llm_payload
+    # 关键：不得谎报成功（旧文案含"已成功执行"）
+    assert "已成功执行" not in dup.llm_payload
+    assert "仍在执行中" in dup.llm_payload
+
+    release.set()
+    r1 = await asyncio.wait_for(first, timeout=5.0)
+    assert r1.status == "ok"
+
+    # 原调用完成后，同参再调 → post-success 文案（保持原文案，含"成功执行"）
+    r2 = await service.dispatch(tc, clean_session, executed)
+    assert r2.status == "repeated"
+    assert "以相同参数成功执行" in r2.llm_payload


### PR DESCRIPTION
# feat(agent): converge planning, tool selection and execution recovery

## Summary

Converges the two parallel plan architectures onto a **canonical planning model**, adds session-level **plan persistence**, **capability-aware plan validation**, **typed step dependencies**, **classified failure recovery**, **partial-success resume**, an explicit **plan state machine**, **follow-up semantics reuse**, and **context budget accounting** — with a 10-scenario deterministic test suite and a perf benchmark.

- **Baseline SHA:** `c4260ab909c2e22844d079c4bd6fe729388fbf49` (origin/master at task start)
- **Final SHA:** `3fa89aa2fde216822648a786e36c6e90ce35f798` (rebased onto `84c73fa` / #346)
- All verification is local (pytest + ruff + benchmark); no CI relied upon.

## Architecture before / after

**Before** — two independent plan systems sharing only `session_id`:
- Advisory `Plan`/`PlanStep` dataclasses (`plan_orchestrator.py`): planner-LLM checklist, process-local LRU only (lost on restart), steps ticked by domain overlap **including a `"core"` wildcard that let any tool — even failed or hallucinated calls — check off steps**.
- Executable `PlanProposal` DAG (`plan_mode.py`): `${stepId}` refs, topo waves, fail-fast, persisted in session_data — but **full replay on every execute**, silent `None`/`""` on `${stepId.bad.path}` typos, `cancelled`/`partially_completed` unreachable.

**After** — one source of truth with projections:

```
Planner LLM output → parse_plan (defensive + capability-validated)
      → CanonicalPlan  (SOURCE OF TRUTH, persisted via session_data_manager; LRU = TTL-capped cache)
          ├→ orchestrator Plan/PlanStep dataclass  (COMPATIBILITY PROJECTION — SSE plan_ready/plan_step_done/plan_finalized + frontend AgentPlanState unchanged)
          ├→ plan_mode PlanProposal                (EXECUTABLE FORM — resume, typed refs, lifecycle)
          └→ [执行计划] prompt block                (PRESENTATION ONLY — single render source)
```

State machine: `proposed → validated → running → (partially_completed | completed | failed)`, plus `cancelled` and `superseded` (goal change supersedes — never silent overwrite; terminal writes never clobber `superseded`/`cancelled`).

## What landed (by goal section)

- **Dual-plan convergence (§8):** new `app/services/planning/` package (`models/store/capability/deps/recovery/followup`); orchestrator persists `CanonicalPlan` via `PlanStore` and projects the legacy dataclasses from it; public APIs (`planner.py`, plan_mode tools, SSE payloads, frontend types) unchanged.
- **Persistence (§9):** `PlanStore` over the existing `session_data_manager` (no new DB): deterministic per-session current-plan alias, `overwrite()` in place, re-mint on eviction; 2s-TTL cache-aside + revision guard so a stale worker cannot clobber a newer plan; superseded plans kept addressable via `plan-id:<plan_id>` aliases. Survives worker restart/Pi reconnect within the session-store TTL (Redis DATA_TTL 2h, documented).
- **Capability model (§10/§11):** `ToolCapability` derived from existing registry metadata (tier/domains/execution_policy; destructive=tier≥3; requires_ref heuristic; produces_ref by domain); `validate_plan_capabilities` deterministically flags unknown tools / unsatisfiable tool families before execution. Keyword detector untouched as fallback.
- **Typed step dependencies (§12):** `${stepId.path}` resolution via `planning/deps.py` — bad paths fail loudly with `failure_class=missing_ref` + a correction hint naming available keys (no more silent `None`); static DAG validation (unknown ids, forward refs, cycles) at propose time.
- **Recovery loop (§13):** `FailureClass` taxonomy (validation/missing_ref/empty_result/no_data/auth/tool_unavailable/resource_limit/transient_network/cancelled/internal) + `RECOVERY_POLICY` (correct_args/reuse_ref/alternate_tool/replan_remaining/retry_transient/stop — no blind retry); failures surface `failure_class`/`recovery_action` on step events and metrics; failed dispatches release the dedup slot so corrected retries work (in-flight duplicates no longer claim false success).
- **Partial success (§14):** `execute_plan` resumes failed/partially_completed plans — completed steps are not re-dispatched, their stored results/refs are reused; deterministic-failure livelock guard; stale `running` (>300s) treated as crashed and resumable; per-plan async lock kills the TOCTOU double-dispatch.
- **Plan state machine (§15):** as above; `execute_plan` writes `partially_completed` when partial results exist; user cancellation writes terminal `cancelled` (not `failed`).
- **Follow-up semantics (§16):** deterministic `classify_followup` (new_goal/style_change/ref_reuse/continuation) drives `should_plan`; 换成蓝色-style turns reuse refs and never re-run analysis; goal changes supersede + reset sticky tool domains; query/action signals (查一下蓝色区域的医院) take precedence over style words.
- **Context budget (§17):** tools payload counted in `estimated_tokens`; `[最近对话上下文]` no longer duplicates the history window; plan block single-source. Measured: **−296 chars/round (≈200–500 tokens) on short sessions**, no growth anywhere else.
- **Tool catalog (§18):** `reset_sticky` on new-goal turns stops old-domain pollution; sticky TTL semantics otherwise unchanged; plan double-decay coupling removed.
- **Observability (§19):** `plan_id`/`plan_revision`/`step_id`/`failure_class`/`recovery_action` on tool metrics + decision log; no payloads logged.
- **Compatibility (§22):** `planner.py` API, plan_mode tool contract, SSE payload shapes (verified byte-level vs `agent-plan.ts`/`hud-types.ts`), Pi path and legacy path all preserved; subagent engines are now isolated from parent plan state.

## Deterministic scenario suite (§20)

`tests/unit/test_planning_v3_scenarios.py` — mock LLM boundary (`planner.call_llm`), real `ToolRegistry`, in-memory session store, no network, no timing asserts:
1. single-tool task → no over-planning · 2. 获取数据→buffer→hotspot→cartography chain with refs · 3. independent steps concurrent + join · 4. validation failure → classified + corrected retry allowed · 5. tool unavailable → capability flag, no step tick · 6. missing ref → loud `missing_ref` + hint · 7. partial success → resume without replay · 8. style follow-up → no re-analysis · 9. goal change → supersede + sticky reset · 10. restart → persisted plan restored (terminal plans not resurrected).

## Context / performance evidence (§21)

`tests/benchmarks/bench_planning_v3.py` (real 149-tool registry; master baseline run in-place):
- Tool selection **unchanged** (tier-1 floor 92 tools / 61,464 chars ≈ 15.4k tokens; network turn 104; multi-domain 134) — no accuracy loss.
- Prompt total 6,474 → 6,449 chars; 2-turn sessions drop a 296-char duplicated recent-context block; `estimated_tokens` now honestly includes the ~17k-token tools payload (soft metric only).
- `PlanStore.save` 0.025 ms mean / 0.035 p95; `load_current` cold 0.012 ms; `validate_plan_capabilities` (8 steps) 0.187 ms mean.

## Tests

- **2,546 passed, 5 skipped, 1 failed** locally (`pytest tests/ --ignore=tests/benchmarks --ignore=tests/jobs`); the single failure (`test_h3_lisa_rejects_constant_values`) is a pre-existing environment issue (optional `h3`/numpy) that fails identically on master.
- `ruff check app/ tests/` — clean.
- New/updated suites: `test_planning_foundation` (35), `test_planning_v3_scenarios` (34), plus updates across plan_mode/planner/plan_orchestrator/tool_catalog/tool_dispatch_service/context/chat-engine suites.
- Follow-up P2/P3 tests (this slice): cross-process plan-claim lock key (`test_p3_execute_claims_cross_process_plan_lock`), slim `__step_results__` persist + resume resolution (`test_step_results_slim_persisted_and_resume_resolves`), CJK tools-token weighting (`test_cjk_tools_payload_weighted_higher_than_ascii`), mid-turn tick flush survival (`test_mid_turn_tick_flush_persists_step`), `partially_completed` flush + restart-as-active (`test_flush_partially_completed_survives_restart_as_active`), and the recompute-status matrix updated for the new partial-success semantics.

## Review findings (§24)

7-reviewer swarm (planning, tool-contract, persistence, recovery/concurrency, context/token, Pi/legacy, adversarial-test): **1 P0 + 3 P1 found and all fixed** (commit `fix(agent): address planning review swarm findings`):
- P0: plan_mode terminal write silently lost on ref eviction → re-mint + re-alias.
- P1: `"core"`-family steps structurally un-tickable in production (wildcard removed without replacement) → qualified match (registered tool, presentation tools excluded) + real-registry regression test.
- P1: PlanStore unbounded cross-worker staleness (lost update) → TTL-capped cache + revision guard + store-fallback supersede.
- P1: execute_plan running-guard TOCTOU double dispatch → per-plan lock + stale-running resume + terminal-write protection.

## Deferred (P2/P3)

All deferred items are now implemented — see **Follow-up (post-review)** below. No open deferrals remain.

## Follow-up (post-review) — deferred P2/P3 items implemented

All five previously-deferred items from the review swarm landed in follow-up commits:

- **`__step_results__` payload slimming (P2 #1):** plan-mode step results no longer embed full tool outputs (MB-scale GeoJSON) in the Redis plan payload. Each completed step's full result is stored under a deterministic `ref:planresult-*` alias (first `store()` + `set_alias`, then in-place `overwrite()` — no ref growth per re-run), and the plan payload persists only a bounded slim summary `{__slim__, ref, keys}`. On resume, slim entries hydrate back to full results from the session store, so `${stepId}` / `${stepId.path}` resolution is unchanged; an evicted/expired result ref fails loudly as `missing_ref` (never a silent `None`).
- **Cross-process atomic plan claim (P2 #2):** `execute_plan`'s status-check → running-write → execution critical section is now wrapped in `session_lock_registry.lock(f"plan:{plan_id}")` (Redis-backed across pods with the module's in-process fallback), stacked on the existing per-plan `asyncio.Lock` — double dispatch is impossible even across workers.
- **CJK-aware tools-token conversion (P3 #3):** the assembler now estimates the tools payload with the same `_estimate_tokens` weighting as history compression (CJK ≈ 1.5 tokens/char, ASCII 4 chars ≈ 1 token) instead of a flat `chars/4`; the engine passes the already-serialized JSON (no re-serialization). Soft metric only — no consumer, no truncation behavior change; the legacy `tools_payload_chars` int path remains for tests/benchmarks.
- **Mid-turn tick flush (P3 #4):** after `mark_step_done` successfully ticks a plan step, the canonical plan is best-effort persisted immediately (both streaming and non-streaming paths) — a crash/disconnect mid-turn no longer loses ticks. The turn-end flush stays (idempotent overwrite; correctly skipped once the plan is terminal).
- **`partially_completed` for the chat-level advisory plan (P3 #5):** `CanonicalPlan.recompute_status` now derives `partially_completed` when some steps completed and the rest failed/skipped (with none pending/running) — `failed` is reserved for runs with no completed steps, matching plan_mode's `_failure_status` semantics. `orchestrator.flush` recomputes status before every save, and `partially_completed` remains NON-terminal so `get_plan`/`restore_plan` keep returning the plan as active (resumable) after a restart.

Nothing remains on the deferred list.

## Notes

- PR #344 (perf/map large ref layers) still open at PR creation; this branch does not touch RefDescriptor/MVT/tile/MapSpec-COW paths. Overlap with merged #346 is one additive hunk in `registry.py` (tool version metadata), semantically compatible.
