### PR TITLE
feat(workflow): add run recovery, comparison and lineage workspace

### DIFF
--- a/frontend/components/sidebar/project-tab.test.tsx
+++ b/frontend/components/sidebar/project-tab.test.tsx
@@ -1,25 +1,36 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
-// Selector-style store mock（同 layers/data-sources 测试的既有模式）：vi.mock
-// 工厂只在渲染时才惰性读取 toastStore，hoisting 安全。
 const toastStore = { toasts: [] as unknown[], addToast: vi.fn(), removeToast: vi.fn() };
 vi.mock('@/components/ui/toast', () => ({
-  useToastStore: (selector: (s: typeof toastStore) => any) => selector(toastStore),
+  useToastStore: (selector: (s: typeof toastStore) => unknown) => selector(toastStore),
 }));
 
-vi.mock('@/lib/api/project', () => ({
+const api = vi.hoisted(() => ({
   fetchProjects: vi.fn(),
-  createProject: vi.fn(),
   fetchProjectDatasets: vi.fn(),
   fetchProjectWorkflows: vi.fn(),
+  fetchWorkflowRuns: vi.fn(),
+  fetchWorkflowRevisions: vi.fn(),
+  fetchWorkflowRun: vi.fn(),
+  fetchArtifactLineage: vi.fn(),
+  fetchRunComparison: vi.fn(),
+  replayWorkflowRun: vi.fn(),
+  resumeWorkflowRun: vi.fn(),
   runWorkflow: vi.fn(),
+  createProject: vi.fn(),
+  invalidateProjectRunCaches: vi.fn(),
 }));
 
-// Import AFTER the mocks are registered so the component picks them up.
+vi.mock('@/lib/api/project', () => api);
+
 import { ProjectTab } from './project-tab';
-import { fetchProjects, fetchProjectDatasets, fetchProjectWorkflows, runWorkflow } from '@/lib/api/project';
-import type { Project, Workflow } from '@/lib/api/project';
+import { ApiError } from '@/lib/api/transport';
+import type { Project, WorkflowSummary } from '@/lib/api/project';
+
+function page<T>(items: T[]) {
+  return { items, total: items.length, limit: 50, offset: 0, has_more: false };
+}
 
 function makeProject(overrides: Partial<Project> = {}): Project {
   return {
@@ -33,51 +44,85 @@ function makeProject(overrides: Partial<Project> = {}): Project {
   };
 }
 
-function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+function makeWorkflow(overrides: Partial<WorkflowSummary> = {}): WorkflowSummary {
   return {
     id: 'wf1',
     project_id: 'p1',
     name: '洪水风险分析',
     version: 1,
-    graph_spec: { steps: [{ step_id: 's1', tool_name: 'buffer' }] },
-    inputs_schema: {},
+    step_count: 1,
     created_at: '2026-08-12T00:00:00Z',
     updated_at: '2026-08-12T00:00:00Z',
     ...overrides,
   };
 }
 
-describe('ProjectTab — 加载 / 错误 / 空态', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(fetchProjects).mockResolvedValue([]);
-    vi.mocked(fetchProjectDatasets).mockResolvedValue([]);
-    vi.mocked(fetchProjectWorkflows).mockResolvedValue([]);
-  });
+function makeRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'run1',
+    workflow_id: 'wf1',
+    workflow_version: 1,
+    project_id: 'p1',
+    workflow_revision_id: 'rev1',
+    input_bindings: {},
+    input_dataset_fingerprints: { ds1: 'fp-ds' },
+    status: 'failed',
+    execution_trace: [],
+    outputs: {},
+    error_message: 'step 2 exploded',
+    cost_perf_summary: { elapsed_ms: 12 },
+    completed_steps: ['s1'],
+    run_fingerprint: 'run-fp',
+    run_manifest: {
+      workflow_revision_id: 'rev1',
+      graph_fingerprint: 'graph-fp',
+      steps: [
+        { step_id: 's1', tool_name: 'buffer', tool_version: '1.0', status: 'completed' },
+        { step_id: 's2', tool_name: 'clip', status: 'failed' },
+      ],
+      artifacts: [
+        { id: 'art1', producing_step: 's1', artifact_type: 'geojson', crs: null, content_fingerprint: 'cfp' },
+      ],
+    },
+    created_at: '2026-08-12T00:00:00Z',
+    ...overrides,
+  };
+}
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.fetchProjects.mockResolvedValue([]);
+  api.fetchProjectDatasets.mockResolvedValue([]);
+  api.fetchProjectWorkflows.mockResolvedValue([]);
+  api.fetchWorkflowRuns.mockResolvedValue(page([]));
+  api.fetchWorkflowRevisions.mockResolvedValue(page([]));
+  api.fetchWorkflowRun.mockResolvedValue(makeRun());
+});
+
+describe('ProjectTab — 加载 / 错误 / 空态', () => {
   it('(a) 首屏加载渲染 LoadingState「加载项目…」', () => {
-    vi.mocked(fetchProjects).mockImplementation(() => new Promise<Project[]>(() => {}));
+    api.fetchProjects.mockImplementation(() => new Promise<Project[]>(() => {}));
     render(<ProjectTab />);
     expect(screen.getByText('加载项目…')).toBeInTheDocument();
     expect(screen.queryByText('暂无挂载数据集')).not.toBeInTheDocument();
   });
 
   it('(b) 项目列表加载失败渲染 InlineNotice 错误文本', async () => {
-    vi.mocked(fetchProjects).mockRejectedValue(new Error('项目列表加载失败'));
+    api.fetchProjects.mockRejectedValue(new Error('项目列表加载失败'));
     render(<ProjectTab />);
     expect(await screen.findByText('项目列表加载失败')).toBeInTheDocument();
     expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 
   it('(c) 空数据集与空工作流渲染 EmptyState 文案', async () => {
-    vi.mocked(fetchProjects).mockResolvedValue([makeProject()]);
+    api.fetchProjects.mockResolvedValue([makeProject()]);
     render(<ProjectTab />);
     expect(await screen.findByText('暂无挂载数据集')).toBeInTheDocument();
     expect(screen.getByText('暂无已保存工作流')).toBeInTheDocument();
   });
 
   it('空数据集时不渲染数据集条目', async () => {
-    vi.mocked(fetchProjects).mockResolvedValue([makeProject()]);
+    api.fetchProjects.mockResolvedValue([makeProject()]);
     render(<ProjectTab />);
     await screen.findByText('暂无挂载数据集');
     expect(screen.queryByText('道路中心线')).not.toBeInTheDocument();
@@ -88,21 +133,10 @@ describe('ProjectTab — 工作流重新运行走 toast 而非 alert', () => {
   let alertSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(fetchProjects).mockResolvedValue([makeProject()]);
-    vi.mocked(fetchProjectDatasets).mockResolvedValue([]);
-    vi.mocked(fetchProjectWorkflows).mockResolvedValue([makeWorkflow()]);
-    vi.mocked(runWorkflow).mockResolvedValue({
-      id: 'run1',
-      workflow_id: 'wf1',
-      workflow_version: 1,
-      input_bindings: {},
-      status: 'queued',
-      execution_trace: [],
-      outputs: {},
-      cost_perf_summary: {},
-      created_at: '2026-08-12T00:00:00Z',
-    });
+    api.fetchProjects.mockResolvedValue([makeProject()]);
+    api.fetchProjectDatasets.mockResolvedValue([]);
+    api.fetchProjectWorkflows.mockResolvedValue([makeWorkflow()]);
+    api.runWorkflow.mockResolvedValue(makeRun({ id: 'run-new', status: 'completed', error_message: null }));
     alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
   });
 
@@ -110,23 +144,155 @@ describe('ProjectTab — 工作流重新运行走 toast 而非 alert', () => {
     alertSpy.mockRestore();
   });
 
-  it('(d) 点击「重新运行」触发成功 toast，且不调用 window.alert', async () => {
+  it('(d) 两段确认后「重新运行」触发状态诚实的 toast，且不调用 window.alert', async () => {
     render(<ProjectTab />);
     fireEvent.click(await screen.findByRole('button', { name: '重新运行' }));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 260));
+    });
+    fireEvent.click(screen.getByRole('button', { name: '确认重新运行？' }));
 
     await waitFor(() => expect(toastStore.addToast).toHaveBeenCalled());
-    expect(toastStore.addToast).toHaveBeenCalledWith('工作流已成功触发重新运行', 'success');
-    expect(runWorkflow).toHaveBeenCalledWith('p1', 'wf1');
+    expect(toastStore.addToast).toHaveBeenCalledWith('运行结束，后端状态：已完成', 'success');
+    expect(api.runWorkflow).toHaveBeenCalledWith('p1', 'wf1');
     expect(alertSpy).not.toHaveBeenCalled();
   });
 
   it('运行失败时触发 error toast，且不调用 window.alert', async () => {
-    vi.mocked(runWorkflow).mockRejectedValue(new Error('后端拒绝'));
+    api.runWorkflow.mockRejectedValue(new Error('后端拒绝'));
     render(<ProjectTab />);
     fireEvent.click(await screen.findByRole('button', { name: '重新运行' }));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 260));
+    });
+    fireEvent.click(screen.getByRole('button', { name: '确认重新运行？' }));
 
     await waitFor(() => expect(toastStore.addToast).toHaveBeenCalled());
-    expect(toastStore.addToast).toHaveBeenCalledWith('重新运行失败：后端拒绝', 'error');
+    expect(toastStore.addToast).toHaveBeenCalledWith('后端拒绝', 'error');
     expect(alertSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProjectTab — run inspector / recovery', () => {
+  beforeEach(() => {
+    api.fetchProjects.mockResolvedValue([makeProject()]);
+    api.fetchProjectDatasets.mockResolvedValue([
+      {
+        id: 'ds1',
+        project_id: 'p1',
+        name: '道路中心线',
+        source_type: 'upload',
+        crs: null,
+        quality_status: 'valid',
+        created_at: '2026-08-12T00:00:00Z',
+      },
+    ]);
+    api.fetchProjectWorkflows.mockResolvedValue([makeWorkflow()]);
+    api.fetchWorkflowRuns.mockResolvedValue(
+      page([
+        { id: 'run1', workflow_id: 'wf1', workflow_version: 1, status: 'failed', created_at: '' },
+        { id: 'run0', workflow_id: 'wf1', workflow_version: 1, status: 'completed', created_at: '' },
+      ]),
+    );
+    api.fetchWorkflowRevisions.mockResolvedValue(
+      page([{ id: 'rev1', workflow_id: 'wf1', revision_no: 1, graph_fingerprint: 'graph-fp', created_at: '' }]),
+    );
+    api.fetchWorkflowRun.mockResolvedValue(makeRun());
+  });
+
+  async function openRun() {
+    render(<ProjectTab />);
+    fireEvent.click(await screen.findByRole('button', { name: /洪水风险分析/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /run1/ }));
+    expect(await screen.findByText('step 2 exploded')).toBeInTheDocument();
+  }
+
+  it('shows unknown CRS instead of fabricating EPSG:4326', async () => {
+    render(<ProjectTab />);
+    expect(await screen.findByText(/未知/)).toBeInTheDocument();
+    expect(screen.queryByText(/EPSG:4326/)).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: /洪水风险分析/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /run1/ }));
+    expect(await screen.findByText(/CRS 未知/)).toBeInTheDocument();
+    expect(screen.queryByText(/EPSG:4326/)).not.toBeInTheDocument();
+  });
+
+  it('does not fetch lineage until the user asks', async () => {
+    await openRun();
+    expect(api.fetchArtifactLineage).not.toHaveBeenCalled();
+    api.fetchArtifactLineage.mockResolvedValue({ artifact_id: 'art1', parents: [], consumers: [] });
+    fireEvent.click(screen.getByRole('button', { name: '查看血统' }));
+    await waitFor(() => expect(api.fetchArtifactLineage).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('无血统')).toBeInTheDocument();
+  });
+
+  it('replay exact posts exact and quotes backend status', async () => {
+    api.replayWorkflowRun.mockResolvedValue(makeRun({ id: 'run2', status: 'completed', error_message: null }));
+    await openRun();
+    fireEvent.click(screen.getByRole('button', { name: '精确回放' }));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 260));
+    });
+    fireEvent.click(screen.getByRole('button', { name: '确认精确回放？' }));
+    await waitFor(() => expect(api.replayWorkflowRun).toHaveBeenCalledWith('p1', 'run1', 'exact'));
+    expect(toastStore.addToast).toHaveBeenCalledWith('回放结束，后端状态：已完成', 'success');
+  });
+
+  it('replay latest posts latest', async () => {
+    api.replayWorkflowRun.mockResolvedValue(makeRun({ id: 'run2', status: 'failed' }));
+    await openRun();
+    fireEvent.click(screen.getByLabelText(/最新修订回放/));
+    fireEvent.click(screen.getByRole('button', { name: '最新修订回放' }));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 260));
+    });
+    fireEvent.click(screen.getByRole('button', { name: '确认最新修订回放？' }));
+    await waitFor(() => expect(api.replayWorkflowRun).toHaveBeenCalledWith('p1', 'run1', 'latest'));
+    expect(toastStore.addToast).toHaveBeenCalledWith('回放结束，后端状态：失败', 'error');
+  });
+
+  it('resume 409 surfaces the backend reason and does not toast success', async () => {
+    api.resumeWorkflowRun.mockRejectedValue(
+      new ApiError(409, 'Conflict', { detail: 'cannot resume run run1: input dataset fingerprints changed' }),
+    );
+    await openRun();
+    fireEvent.click(screen.getByRole('button', { name: '尝试续跑' }));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 260));
+    });
+    fireEvent.click(screen.getByRole('button', { name: '确认从已完成步骤续跑？' }));
+    expect(await screen.findByText(/input dataset fingerprints changed/)).toBeInTheDocument();
+    expect(toastStore.addToast).not.toHaveBeenCalledWith(expect.stringMatching(/成功/), expect.anything());
+  });
+
+  it('compare renders backend fingerprint.same and does not infer equality', async () => {
+    api.fetchRunComparison.mockResolvedValue({
+      run_a_id: 'run1',
+      run_b_id: 'run0',
+      revision: { graph_same: false, run_a_revision: 'rev1', run_b_revision: 'rev2' },
+      inputs_changed: { diff_keys: [] },
+      dataset_versions_changed: { diff_keys: ['ds1'] },
+      tool_versions_changed: {},
+      params_changed: {},
+      output_artifacts_changed: {},
+      metrics_changed: {},
+      warnings_changed: {},
+      run_fingerprint: { run_a: 'aaa', run_b: 'bbb', same: false },
+    });
+    await openRun();
+    fireEvent.change(screen.getByLabelText('对比运行'), { target: { value: 'run0' } });
+    fireEvent.click(screen.getByRole('button', { name: '对比' }));
+    expect(await screen.findByText('后端判定运行指纹不相同')).toBeInTheDocument();
+    expect(screen.getByText('数据集版本')).toBeInTheDocument();
+    expect(screen.queryByText('后端判定运行指纹相同')).not.toBeInTheDocument();
+  });
+
+  it('back is keyboard accessible', async () => {
+    await openRun();
+    const back = screen.getByRole('button', { name: '返回运行列表' });
+    back.focus();
+    expect(back).toHaveFocus();
+    fireEvent.click(back);
+    expect(await screen.findByText('不可变修订')).toBeInTheDocument();
   });
 });

--- a/frontend/components/sidebar/project-tab.tsx
+++ b/frontend/components/sidebar/project-tab.tsx
@@ -1,253 +1,340 @@
 'use client';
 
-import React, { useId, useState, useEffect } from 'react';
+import React, { useId, useState } from 'react';
 import {
-  Play,
   Plus,
   Layers,
   Activity,
   Database,
   Workflow as WorkflowIcon,
+  ChevronRight,
 } from 'lucide-react';
-import {
-  Project,
-  ProjectDataset,
-  Workflow,
-  fetchProjects,
-  createProject,
-  fetchProjectDatasets,
-  fetchProjectWorkflows,
-  runWorkflow
-} from '@/lib/api/project';
+import { ConfirmAction } from '@/components/shared/confirm-action';
 import { EmptyState } from '@/components/shared/empty-state';
 import { IconButton } from '@/components/shared/icon-button';
 import { InlineNotice } from '@/components/shared/inline-notice';
 import { LoadingState } from '@/components/shared/loading-state';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { useToastStore } from '@/components/ui/toast';
+import { useWorkflowWorkspace } from '@/lib/hooks/use-workflow-workspace';
+import { formatCrs, formatOutcomeMessage, outcomeToastVariant, shortId } from '@/lib/workflow/recovery';
+import { RunInspector } from './workflow/run-inspector';
 
 export function ProjectTab() {
   const uid = useId();
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState<string>("");
-  const [datasets, setDatasets] = useState<ProjectDataset[]>([]);
-  const [workflows, setWorkflows] = useState<Workflow[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-  const [newProjName, setNewProjName] = useState<string>("");
-  const [showCreate, setShowCreate] = useState<boolean>(false);
+  const [newProjName, setNewProjName] = useState('');
+  const [showCreate, setShowCreate] = useState(false);
   const addToast = useToastStore((s) => s.addToast);
-
-  // Load once on mount; loadProjects is a stable component function.
-  useEffect(() => {
-    loadProjects();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (selectedProjectId) {
-      loadProjectDetails(selectedProjectId);
-    }
-  }, [selectedProjectId]);
-
-  const loadProjects = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await fetchProjects();
-      setProjects(data);
-      if (data.length > 0 && !selectedProjectId) {
-        setSelectedProjectId(data[0].id);
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "加载项目列表失败");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const loadProjectDetails = async (projId: string) => {
-    // Review P2 修复：成功路径要清掉上一次失败的残留错误横幅。
-    setError(null);
-    try {
-      const [ds, wf] = await Promise.all([
-        fetchProjectDatasets(projId),
-        fetchProjectWorkflows(projId)
-      ]);
-      setDatasets(ds);
-      setWorkflows(wf);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "加载项目详情失败");
-    }
-  };
+  const ws = useWorkflowWorkspace();
 
   const handleCreateProject = async () => {
     if (!newProjName.trim()) return;
     try {
-      const proj = await createProject(newProjName);
-      setProjects([proj, ...projects]);
-      setSelectedProjectId(proj.id);
-      setNewProjName("");
+      await ws.createProject(newProjName.trim());
+      setNewProjName('');
       setShowCreate(false);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "创建项目失败");
+      addToast(e instanceof Error ? e.message : '创建项目失败', 'error');
     }
   };
 
   const handleRerunWorkflow = async (wfId: string) => {
-    if (!selectedProjectId) return;
-    try {
-      await runWorkflow(selectedProjectId, wfId);
-      addToast("工作流已成功触发重新运行", "success");
-      loadProjectDetails(selectedProjectId);
-    } catch (e) {
-      addToast(`重新运行失败：${e instanceof Error ? e.message : "未知错误"}`, "error");
+    const result = await ws.triggerRun(wfId);
+    if (result.ok) {
+      if (result.applied) {
+        addToast(formatOutcomeMessage('run', result.run), outcomeToastVariant(result.run.status));
+      }
+    } else if (result.error) {
+      addToast(result.error, 'error');
+    }
+  };
+
+  const handleReplay = async (mode: 'exact' | 'latest') => {
+    const result = await ws.replay(mode);
+    if (result.ok && result.applied) {
+      addToast(formatOutcomeMessage('replay', result.run), outcomeToastVariant(result.run.status));
+    }
+  };
+
+  const handleResume = async () => {
+    const result = await ws.resume();
+    if (result.ok && result.applied) {
+      addToast(formatOutcomeMessage('resume', result.run), outcomeToastVariant(result.run.status));
     }
   };
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* 细工具栏：标题 + 新建项目（面板头部由 PanelHeader 提供） */}
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--theme-border)] px-3 py-1.5">
         <span className="text-[12px] font-semibold text-[var(--theme-text-secondary)]">项目工作区</span>
-        <IconButton
-          label="新建项目"
-          icon={Plus}
-          iconSize={15}
-          active={showCreate}
-          onClick={() => setShowCreate(!showCreate)}
-        />
+        {ws.view === 'project' && (
+          <IconButton
+            label="新建项目"
+            icon={Plus}
+            iconSize={15}
+            active={showCreate}
+            onClick={() => setShowCreate(!showCreate)}
+          />
+        )}
       </div>
 
       <div className="flex-1 space-y-4 overflow-y-auto p-3 text-[13px]">
-        {loading ? (
+        {ws.loading ? (
           <LoadingState label="加载项目…" />
         ) : (
           <>
-            {error && <InlineNotice variant="error">{error}</InlineNotice>}
+            {ws.error && <InlineNotice variant="error">{ws.error}</InlineNotice>}
 
-            {showCreate && (
-              <div className="space-y-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-3">
-                <label
-                  htmlFor={`${uid}-project-name`}
-                  className="block text-[12px] font-medium text-[var(--theme-text-secondary)]"
-                >
-                  项目名称
-                </label>
-                <input
-                  id={`${uid}-project-name`}
-                  type="text"
-                  placeholder="项目名称…"
-                  value={newProjName}
-                  onChange={(e) => setNewProjName(e.target.value)}
-                  className="w-full rounded border px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
-                  style={{
-                    backgroundColor: "var(--theme-bg-input)",
-                    borderColor: "var(--theme-border)",
-                    color: "var(--theme-text-primary)",
-                  }}
-                />
+            {ws.view === 'project' && (
+              <>
+                {showCreate && (
+                  <div className="space-y-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-3">
+                    <label
+                      htmlFor={`${uid}-project-name`}
+                      className="block text-[12px] font-medium text-[var(--theme-text-secondary)]"
+                    >
+                      项目名称
+                    </label>
+                    <input
+                      id={`${uid}-project-name`}
+                      type="text"
+                      placeholder="项目名称…"
+                      value={newProjName}
+                      onChange={(e) => setNewProjName(e.target.value)}
+                      className="w-full rounded border px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
+                      style={{
+                        backgroundColor: 'var(--theme-bg-input)',
+                        borderColor: 'var(--theme-border)',
+                        color: 'var(--theme-text-primary)',
+                      }}
+                    />
+                    <button
+                      type="button"
+                      onClick={handleCreateProject}
+                      className="w-full rounded py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+                      style={{ background: 'var(--agent-accent, #16a34a)' }}
+                    >
+                      创建项目
+                    </button>
+                  </div>
+                )}
+
+                <div>
+                  <label
+                    htmlFor={`${uid}-project-select`}
+                    className="mb-1 block text-xs font-medium text-[var(--theme-text-secondary)]"
+                  >
+                    当前项目
+                  </label>
+                  <select
+                    id={`${uid}-project-select`}
+                    value={ws.selectedProjectId}
+                    onChange={(e) => ws.selectProject(e.target.value)}
+                    className="w-full rounded border px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
+                    style={{
+                      backgroundColor: 'var(--theme-bg-input)',
+                      borderColor: 'var(--theme-border)',
+                      color: 'var(--theme-text-primary)',
+                    }}
+                  >
+                    {ws.projects.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name} ({p.status})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-xs font-medium text-[var(--theme-text-secondary)]">
+                    <span className="flex items-center gap-1.5">
+                      <Layers className="h-3.5 w-3.5 text-emerald-500" /> 挂载数据集 ({ws.datasets.length})
+                    </span>
+                  </div>
+                  {ws.datasets.length === 0 ? (
+                    <EmptyState icon={Database} title="暂无挂载数据集" />
+                  ) : (
+                    <div className="space-y-1.5">
+                      {ws.datasets.map((d) => (
+                        <div
+                          key={d.id}
+                          className="flex items-center justify-between rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-2.5"
+                        >
+                          <div className="min-w-0">
+                            <div className="text-xs font-medium text-[var(--theme-text-primary)]">{d.name}</div>
+                            <div className="text-[10px] text-[var(--theme-text-muted)]">
+                              {formatCrs(d.crs)} • {d.source_type}
+                            </div>
+                          </div>
+                          <StatusBadge status={d.quality_status} />
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-xs font-medium text-[var(--theme-text-secondary)]">
+                    <span className="flex items-center gap-1.5">
+                      <Activity className="h-3.5 w-3.5 text-amber-500" /> 已保存工作流 ({ws.workflows.length})
+                    </span>
+                  </div>
+                  {ws.workflows.length === 0 ? (
+                    <EmptyState icon={WorkflowIcon} title="暂无已保存工作流" description="保存一份 Plan 即可创建" />
+                  ) : (
+                    <div className="space-y-2">
+                      {ws.workflows.map((w) => (
+                        <div
+                          key={w.id}
+                          className="space-y-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-3"
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <button
+                              type="button"
+                              onClick={() => ws.openWorkflow(w.id)}
+                              className="flex min-w-0 items-center gap-1 text-left text-xs font-medium text-[var(--theme-text-primary)] hover:underline"
+                            >
+                              <span className="truncate">
+                                {w.name} (v{w.version})
+                              </span>
+                              <ChevronRight className="h-3 w-3 shrink-0" aria-hidden />
+                            </button>
+                            <ConfirmAction
+                              label="重新运行"
+                              confirmLabel="确认重新运行？"
+                              onConfirm={() => {
+                                void handleRerunWorkflow(w.id);
+                              }}
+                              disabled={ws.actionBusy}
+                              className="border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] text-[var(--theme-text-primary)] hover:bg-[var(--theme-bg-hover)] hover:text-[var(--theme-text-primary)] dark:text-[var(--theme-text-primary)]"
+                            />
+                          </div>
+                          <div className="text-[10px] text-[var(--theme-text-muted)]">步骤 {w.step_count}</div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+
+            {ws.view === 'workflow' && ws.selectedWorkflow && (
+              <div className="space-y-3">
                 <button
                   type="button"
-                  onClick={handleCreateProject}
-                  className="w-full rounded py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
-                  style={{ background: "var(--agent-accent, #16a34a)" }}
+                  onClick={ws.back}
+                  className="text-[11px] text-[var(--theme-text-secondary)] hover:underline"
                 >
-                  创建项目
+                  ← 返回项目
                 </button>
+                <div>
+                  <div className="text-[13px] font-semibold text-[var(--theme-text-primary)]">
+                    {ws.selectedWorkflow.name}
+                  </div>
+                  <div className="text-[10px] text-[var(--theme-text-muted)]">
+                    v{ws.selectedWorkflow.version} · {ws.selectedWorkflow.step_count} 步
+                  </div>
+                </div>
+                <section aria-labelledby="wf-rev-heading" className="space-y-1">
+                  <h3 id="wf-rev-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+                    不可变修订
+                  </h3>
+                  {ws.revisions.length === 0 ? (
+                    <p className="text-[11px] text-[var(--theme-text-muted)]">暂无修订</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {ws.revisions.map((rev) => (
+                        <li
+                          key={rev.id}
+                          className="flex justify-between gap-2 rounded border border-[var(--theme-border)] px-2 py-1 font-mono text-[10px] text-[var(--theme-text-secondary)]"
+                        >
+                          <span>r{rev.revision_no}</span>
+                          <span>{shortId(rev.graph_fingerprint, 10)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+                <section aria-labelledby="wf-runs-heading" className="space-y-1">
+                  <h3 id="wf-runs-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+                    运行
+                  </h3>
+                  {ws.detailLoading && ws.runs.length === 0 ? (
+                    <LoadingState label="加载运行…" />
+                  ) : ws.runs.length === 0 ? (
+                    <EmptyState icon={Activity} title="暂无运行" />
+                  ) : (
+                    <ul className="space-y-1.5">
+                      {ws.runs.map((r) => (
+                        <li key={r.id}>
+                          <button
+                            type="button"
+                            onClick={() => ws.openRun(r.id)}
+                            className="flex w-full items-center justify-between gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-2.5 py-2 text-left hover:bg-[var(--theme-bg-hover)]"
+                          >
+                            <span className="min-w-0">
+                              <span className="block font-mono text-[11px] text-[var(--theme-text-primary)]">
+                                {shortId(r.id, 10)}
+                              </span>
+                              {r.error_message && (
+                                <span className="block truncate text-[10px] text-red-600 dark:text-red-300">
+                                  {r.error_message}
+                                </span>
+                              )}
+                            </span>
+                            <span className="flex items-center gap-1">
+                              <StatusBadge status={r.status} />
+                              <ChevronRight className="h-3 w-3 text-[var(--theme-text-muted)]" aria-hidden />
+                            </span>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  {ws.runsHasMore && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void ws.loadMoreRuns();
+                      }}
+                      className="w-full rounded border border-[var(--theme-border)] py-1 text-[11px] text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-hover)]"
+                    >
+                      加载更多运行
+                    </button>
+                  )}
+                </section>
               </div>
             )}
 
-            {/* Project Selector */}
-            <div>
-              <label
-                htmlFor={`${uid}-project-select`}
-                className="mb-1 block text-xs font-medium text-[var(--theme-text-secondary)]"
-              >
-                当前项目
-              </label>
-              <select
-                id={`${uid}-project-select`}
-                value={selectedProjectId}
-                onChange={(e) => setSelectedProjectId(e.target.value)}
-                className="w-full rounded border px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
-                style={{
-                  backgroundColor: "var(--theme-bg-input)",
-                  borderColor: "var(--theme-border)",
-                  color: "var(--theme-text-primary)",
+            {(ws.view === 'run' || ws.view === 'compare') && (
+              <RunInspector
+                workflow={ws.selectedWorkflow}
+                run={ws.runDetail}
+                runs={ws.runs}
+                loading={ws.detailLoading}
+                actionBusy={ws.actionBusy}
+                actionError={ws.actionError}
+                compare={ws.compare}
+                compareError={ws.compareError}
+                compareBusy={ws.compareBusy}
+                comparePeerId={ws.comparePeerId}
+                onComparePeerChange={ws.setComparePeerId}
+                onCompare={() => {
+                  void ws.openCompare();
                 }}
-              >
-                {projects.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name} ({p.status})
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* Datasets Section */}
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-xs font-medium text-[var(--theme-text-secondary)]">
-                <span className="flex items-center gap-1.5">
-                  <Layers className="h-3.5 w-3.5 text-emerald-500" /> 挂载数据集 ({datasets.length})
-                </span>
-              </div>
-              {datasets.length === 0 ? (
-                <EmptyState icon={Database} title="暂无挂载数据集" />
-              ) : (
-                <div className="space-y-1.5">
-                  {datasets.map((d) => (
-                    <div
-                      key={d.id}
-                      className="flex items-center justify-between rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-2.5"
-                    >
-                      <div>
-                        <div className="text-xs font-medium text-[var(--theme-text-primary)]">{d.name}</div>
-                        <div className="text-[10px] text-[var(--theme-text-muted)]">{d.crs} • {d.source_type}</div>
-                      </div>
-                      {/* 质量状态复用 StatusBadge（未知值回退原始文案） */}
-                      <StatusBadge status={d.quality_status} />
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* 已保存工作流区块 */}
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-xs font-medium text-[var(--theme-text-secondary)]">
-                <span className="flex items-center gap-1.5">
-                  <Activity className="h-3.5 w-3.5 text-amber-500" /> 已保存工作流 ({workflows.length})
-                </span>
-              </div>
-              {workflows.length === 0 ? (
-                <EmptyState icon={WorkflowIcon} title="暂无已保存工作流" description="保存一份 Plan 即可创建" />
-              ) : (
-                <div className="space-y-2">
-                  {workflows.map((w) => (
-                    <div
-                      key={w.id}
-                      className="space-y-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-3"
-                    >
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-medium text-[var(--theme-text-primary)]">{w.name} (v{w.version})</span>
-                        <button
-                          type="button"
-                          onClick={() => handleRerunWorkflow(w.id)}
-                          className="flex items-center gap-1 rounded px-2 py-1 text-[10px] font-medium text-white transition-opacity hover:opacity-85"
-                          style={{ background: "var(--agent-accent, #16a34a)" }}
-                        >
-                          <Play className="h-3 w-3" /> 重新运行
-                        </button>
-                      </div>
-                      <div className="text-[10px] text-[var(--theme-text-muted)]">
-                        步骤 ({w.graph_spec.steps?.length || 0})：{w.graph_spec.steps?.map((s) => s.tool_name).join(" → ")}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
+                lineageByArtifact={ws.lineageByArtifact}
+                onLoadLineage={(id) => {
+                  void ws.loadLineage(id);
+                }}
+                onBack={ws.back}
+                onReplay={(mode) => {
+                  void handleReplay(mode);
+                }}
+                onResume={() => {
+                  void handleResume();
+                }}
+              />
+            )}
           </>
         )}
       </div>

--- a/frontend/components/sidebar/workflow/compare-panel.test.tsx
+++ b/frontend/components/sidebar/workflow/compare-panel.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ComparePanel } from './compare-panel';
+import type { RunComparison } from '@/lib/api/project';
+
+const base: RunComparison = {
+  run_a_id: 'a',
+  run_b_id: 'b',
+  revision: { graph_same: true, run_a_revision: 'r', run_b_revision: 'r' },
+  inputs_changed: { diff_keys: [] },
+  dataset_versions_changed: { diff_keys: [] },
+  tool_versions_changed: {},
+  params_changed: {},
+  output_artifacts_changed: {},
+  metrics_changed: {},
+  warnings_changed: {},
+  run_fingerprint: { run_a: 'x', run_b: 'x', same: false },
+};
+
+describe('ComparePanel', () => {
+  it('does not treat matching display fields as fingerprint equality', () => {
+    render(
+      <ComparePanel
+        runs={[
+          { id: 'a', workflow_id: 'w', workflow_version: 1, status: 'completed', created_at: '' },
+          { id: 'b', workflow_id: 'w', workflow_version: 1, status: 'completed', created_at: '' },
+        ]}
+        selectedRunId="a"
+        peerId="b"
+        onPeerChange={vi.fn()}
+        onCompare={vi.fn()}
+        result={base}
+      />,
+    );
+    expect(screen.getByText('后端判定运行指纹不相同')).toBeInTheDocument();
+    expect(screen.queryByText('后端判定运行指纹相同')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/sidebar/workflow/compare-panel.tsx
+++ b/frontend/components/sidebar/workflow/compare-panel.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { InlineNotice } from '@/components/shared/inline-notice';
+import type { RunComparison, WorkflowRunSummary } from '@/lib/api/project';
+import { runFingerprintsEqual, shortId, summarizeCompare } from '@/lib/workflow/recovery';
+
+export interface ComparePanelProps {
+  runs: WorkflowRunSummary[];
+  selectedRunId: string;
+  peerId: string;
+  onPeerChange: (id: string) => void;
+  onCompare: () => void;
+  result: RunComparison | null;
+  busy?: boolean;
+  error?: string | null;
+}
+
+export function ComparePanel({
+  runs,
+  selectedRunId,
+  peerId,
+  onPeerChange,
+  onCompare,
+  result,
+  busy,
+  error,
+}: ComparePanelProps) {
+  const peers = runs.filter((r) => r.id !== selectedRunId);
+  const same = result ? runFingerprintsEqual(result) : null;
+  const rows = result ? summarizeCompare(result) : [];
+
+  return (
+    <section aria-labelledby="wf-compare-heading" className="space-y-2">
+      <h3 id="wf-compare-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+        对比
+      </h3>
+      {peers.length === 0 ? (
+        <p className="text-[11px] text-[var(--theme-text-muted)]">没有其他运行可对比</p>
+      ) : (
+        <div className="flex gap-1.5">
+          <label className="sr-only" htmlFor="wf-compare-peer">
+            对比运行
+          </label>
+          <select
+            id="wf-compare-peer"
+            value={peerId}
+            onChange={(e) => onPeerChange(e.target.value)}
+            className="min-w-0 flex-1 rounded border px-2 py-1 text-[11px] focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
+            style={{
+              backgroundColor: 'var(--theme-bg-input)',
+              borderColor: 'var(--theme-border)',
+              color: 'var(--theme-text-primary)',
+            }}
+          >
+            <option value="">选择另一次运行…</option>
+            {peers.map((r) => (
+              <option key={r.id} value={r.id}>
+                {shortId(r.id, 10)} · {r.status}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={onCompare}
+            disabled={!peerId || busy}
+            className="shrink-0 rounded px-2 py-1 text-[11px] font-medium text-white disabled:opacity-40"
+            style={{ background: 'var(--agent-accent, #16a34a)' }}
+          >
+            {busy ? '对比中…' : '对比'}
+          </button>
+        </div>
+      )}
+      {error && <InlineNotice variant="warning">{error}</InlineNotice>}
+
+      {result && (
+        <div className="space-y-1.5">
+          {same === true ? (
+            <InlineNotice variant="success">后端判定运行指纹相同</InlineNotice>
+          ) : (
+            <InlineNotice variant="info">后端判定运行指纹不相同</InlineNotice>
+          )}
+          {rows.length === 0 && same !== true ? (
+            <p className="text-[11px] text-[var(--theme-text-muted)]">无可列出的差异字段</p>
+          ) : (
+            <ul className="space-y-1">
+              {rows.map((row) => (
+                <li
+                  key={row.key}
+                  className="rounded border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-2 py-1.5"
+                >
+                  <div className="text-[11px] font-medium text-[var(--theme-text-primary)]">{row.label}</div>
+                  <div className="break-all text-[10px] text-[var(--theme-text-muted)]">{row.detail}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default ComparePanel;

--- a/frontend/components/sidebar/workflow/lineage-list.test.tsx
+++ b/frontend/components/sidebar/workflow/lineage-list.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LineageList } from './lineage-list';
+
+describe('LineageList', () => {
+  it('does not fetch until the user asks', () => {
+    const onLoad = vi.fn();
+    render(<LineageList artifactId="a1" state={undefined} onLoad={onLoad} />);
+    expect(onLoad).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: '加载血统' }));
+    expect(onLoad).toHaveBeenCalledWith('a1');
+  });
+
+  it('renders empty lineage without fabricating nodes', () => {
+    render(
+      <LineageList
+        artifactId="a1"
+        artifactCrs={null}
+        state={{ artifact_id: 'a1', parents: [], consumers: [] }}
+        onLoad={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('无血统')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/sidebar/workflow/lineage-list.tsx
+++ b/frontend/components/sidebar/workflow/lineage-list.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { GitBranch } from 'lucide-react';
+import { EmptyState } from '@/components/shared/empty-state';
+import { InlineNotice } from '@/components/shared/inline-notice';
+import { LoadingState } from '@/components/shared/loading-state';
+import type { LineageGraph } from '@/lib/api/project';
+import { buildLineageRows, formatCrs, lineageTruncated, shortId } from '@/lib/workflow/recovery';
+
+export interface LineageListProps {
+  artifactId: string;
+  artifactCrs?: string | null;
+  state: LineageGraph | 'loading' | 'empty' | 'error' | undefined;
+  onLoad: (artifactId: string) => void;
+}
+
+export function LineageList({ artifactId, artifactCrs, state, onLoad }: LineageListProps) {
+  if (!state) {
+    return (
+      <button
+        type="button"
+        onClick={() => onLoad(artifactId)}
+        className="rounded px-2 py-1 text-[11px] font-medium text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-hover)]"
+      >
+        加载血统
+      </button>
+    );
+  }
+  if (state === 'loading') return <LoadingState label="加载血统…" />;
+  if (state === 'error') return <InlineNotice variant="error">血统加载失败</InlineNotice>;
+  if (state === 'empty') {
+    return <EmptyState icon={GitBranch} title="无血统" description="后端未返回上游或下游边" />;
+  }
+
+  const rows = buildLineageRows(state);
+  if (rows.length === 0) {
+    return <EmptyState icon={GitBranch} title="无血统" description="后端未返回上游或下游边" />;
+  }
+
+  return (
+    <ul className="space-y-1" aria-label="产物血统">
+      <li className="text-[10px] text-[var(--theme-text-muted)]">
+        当前产物 CRS {formatCrs(artifactCrs)}
+      </li>
+      {lineageTruncated(state) && (
+        <li className="text-[10px] text-[var(--theme-text-muted)]">仅显示前 {rows.length} 条血统边</li>
+      )}
+      {rows.map((row) => (
+        <li
+          key={row.key}
+          className="rounded border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-2 py-1.5"
+          style={{ marginLeft: Math.min(row.depth, 4) * 8 }}
+        >
+          <div className="text-[11px] font-medium text-[var(--theme-text-primary)]">
+            {row.direction === 'upstream' ? '上游' : '下游'} · {row.tool}
+          </div>
+          <div className="font-mono text-[10px] text-[var(--theme-text-muted)]">
+            {shortId(row.nodeId, 12)}
+            {row.toolVersion ? ` · ${row.toolVersion}` : ''}
+          </div>
+          {row.sourceDatasetFingerprint && (
+            <div className="text-[10px] text-[var(--theme-text-muted)]">
+              数据集 {shortId(row.sourceDatasetId, 8)} · {shortId(row.sourceDatasetFingerprint, 10)}
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default LineageList;

--- a/frontend/components/sidebar/workflow/recovery-actions.test.tsx
+++ b/frontend/components/sidebar/workflow/recovery-actions.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { RecoveryActions } from './recovery-actions';
+import type { WorkflowRunDetail } from '@/lib/api/project';
+
+function run(overrides: Partial<WorkflowRunDetail> = {}): WorkflowRunDetail {
+  return {
+    id: 'r1',
+    workflow_id: 'wf',
+    workflow_version: 1,
+    input_bindings: {},
+    input_dataset_fingerprints: {},
+    status: 'failed',
+    execution_trace: [],
+    outputs: {},
+    cost_perf_summary: {},
+    completed_steps: ['s1'],
+    created_at: '',
+    ...overrides,
+  };
+}
+
+describe('RecoveryActions', () => {
+  it('does not offer resume for a completed run', () => {
+    render(
+      <RecoveryActions
+        run={run({ status: 'completed' })}
+        busy={false}
+        error={null}
+        onReplay={vi.fn()}
+        onResume={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: '尝试续跑' })).not.toBeInTheDocument();
+  });
+
+  it('disables actions while waiting for the backend', () => {
+    render(
+      <RecoveryActions run={run()} busy error={null} onReplay={vi.fn()} onResume={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: '精确回放' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '尝试续跑' })).toBeDisabled();
+    expect(screen.getByRole('status')).toHaveTextContent('正在等待后端确认');
+  });
+
+  it('keeps exact vs latest distinct before confirm', async () => {
+    const onReplay = vi.fn();
+    render(
+      <RecoveryActions run={run()} busy={false} error={null} onReplay={onReplay} onResume={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByLabelText(/最新修订回放/));
+    fireEvent.click(screen.getByRole('button', { name: '最新修订回放' }));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 260));
+    });
+    fireEvent.click(screen.getByRole('button', { name: '确认最新修订回放？' }));
+    expect(onReplay).toHaveBeenCalledWith('latest');
+  });
+});

--- a/frontend/components/sidebar/workflow/recovery-actions.tsx
+++ b/frontend/components/sidebar/workflow/recovery-actions.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { ConfirmAction } from '@/components/shared/confirm-action';
+import { InlineNotice } from '@/components/shared/inline-notice';
+import type { ReplayMode, WorkflowRunDetail } from '@/lib/api/project';
+import { REPLAY_MODE_COPY, shouldOfferResume } from '@/lib/workflow/recovery';
+
+export interface RecoveryActionsProps {
+  run: WorkflowRunDetail | null;
+  busy: boolean;
+  error: string | null;
+  onReplay: (mode: ReplayMode) => void;
+  onResume: () => void;
+}
+
+export function RecoveryActions({ run, busy, error, onReplay, onResume }: RecoveryActionsProps) {
+  const [mode, setMode] = useState<ReplayMode>('exact');
+  const offerResume = shouldOfferResume(run);
+
+  return (
+    <section aria-labelledby="wf-recovery-heading" className="space-y-2">
+      <h3 id="wf-recovery-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+        恢复
+      </h3>
+      <fieldset className="space-y-1.5" disabled={busy}>
+        <legend className="sr-only">回放模式</legend>
+        {(Object.keys(REPLAY_MODE_COPY) as ReplayMode[]).map((key) => {
+          const copy = REPLAY_MODE_COPY[key];
+          const id = `replay-mode-${key}`;
+          return (
+            <label
+              key={key}
+              htmlFor={id}
+              className="flex cursor-pointer gap-2 rounded-md border border-[var(--theme-border)] bg-[var(--theme-bg-input)] px-2 py-1.5"
+            >
+              <input
+                id={id}
+                type="radio"
+                name="replay-mode"
+                value={key}
+                checked={mode === key}
+                onChange={() => setMode(key)}
+                className="mt-0.5"
+              />
+              <span className="min-w-0">
+                <span className="block text-[12px] font-medium text-[var(--theme-text-primary)]">{copy.label}</span>
+                <span className="block text-[11px] leading-snug text-[var(--theme-text-muted)]">{copy.description}</span>
+              </span>
+            </label>
+          );
+        })}
+      </fieldset>
+      <div className="flex flex-wrap gap-2">
+        <ConfirmAction
+          label={REPLAY_MODE_COPY[mode].label}
+          confirmLabel={`确认${REPLAY_MODE_COPY[mode].label}？`}
+          onConfirm={() => onReplay(mode)}
+          disabled={busy || !run}
+          className="border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] text-[var(--theme-text-primary)] hover:bg-[var(--theme-bg-hover)] hover:text-[var(--theme-text-primary)] dark:text-[var(--theme-text-primary)]"
+        />
+        {offerResume && (
+          <ConfirmAction
+            label="尝试续跑"
+            confirmLabel="确认从已完成步骤续跑？"
+            onConfirm={onResume}
+            disabled={busy || !run}
+          />
+        )}
+      </div>
+      {busy && (
+        <p role="status" className="text-[11px] text-[var(--theme-text-muted)]">
+          正在等待后端确认…
+        </p>
+      )}
+      {error && <InlineNotice variant="warning">{error}</InlineNotice>}
+    </section>
+  );
+}
+
+export default RecoveryActions;

--- a/frontend/components/sidebar/workflow/run-inspector.tsx
+++ b/frontend/components/sidebar/workflow/run-inspector.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { IconButton } from '@/components/shared/icon-button';
+import { InlineNotice } from '@/components/shared/inline-notice';
+import { LoadingState } from '@/components/shared/loading-state';
+import { StatusBadge } from '@/components/shared/status-badge';
+import type {
+  LineageGraph,
+  ReplayMode,
+  RunComparison,
+  WorkflowRunDetail,
+  WorkflowRunSummary,
+  WorkflowSummary,
+} from '@/lib/api/project';
+import {
+  formatCrs,
+  isPartialRun,
+  shortId,
+} from '@/lib/workflow/recovery';
+import { ComparePanel } from './compare-panel';
+import { LineageList } from './lineage-list';
+import { RecoveryActions } from './recovery-actions';
+
+export interface RunInspectorProps {
+  workflow: WorkflowSummary | null;
+  run: WorkflowRunDetail | null;
+  runs: WorkflowRunSummary[];
+  loading: boolean;
+  actionBusy: boolean;
+  actionError: string | null;
+  compare: RunComparison | null;
+  compareError?: string | null;
+  compareBusy?: boolean;
+  comparePeerId: string;
+  onComparePeerChange: (id: string) => void;
+  onCompare: () => void;
+  lineageByArtifact: Record<string, LineageGraph | 'loading' | 'empty' | 'error'>;
+  onLoadLineage: (artifactId: string) => void;
+  onBack: () => void;
+  onReplay: (mode: ReplayMode) => void;
+  onResume: () => void;
+}
+
+function kv(label: string, value: string) {
+  return (
+    <div className="flex min-w-0 justify-between gap-2 text-[11px]">
+      <span className="shrink-0 text-[var(--theme-text-muted)]">{label}</span>
+      <span className="min-w-0 break-all text-right font-mono text-[var(--theme-text-primary)]">{value}</span>
+    </div>
+  );
+}
+
+export function RunInspector({
+  workflow,
+  run,
+  runs,
+  loading,
+  actionBusy,
+  actionError,
+  compare,
+  compareError,
+  compareBusy,
+  comparePeerId,
+  onComparePeerChange,
+  onCompare,
+  lineageByArtifact,
+  onLoadLineage,
+  onBack,
+  onReplay,
+  onResume,
+}: RunInspectorProps) {
+  const [showManifest, setShowManifest] = useState(false);
+  const [openArtifact, setOpenArtifact] = useState<string | null>(null);
+
+  if (loading && !run) return <LoadingState label="加载运行…" />;
+  if (!run) {
+    return <InlineNotice variant="error">未找到运行详情</InlineNotice>;
+  }
+
+  const manifest = run.run_manifest;
+  const steps = manifest?.steps ?? [];
+  const artifacts = manifest?.artifacts ?? [];
+  const fingerprints = run.input_dataset_fingerprints ?? {};
+  const fpEntries = Object.entries(fingerprints);
+  const partial = isPartialRun(run);
+  const perf = run.cost_perf_summary ?? {};
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-1.5">
+        <IconButton label="返回运行列表" icon={ArrowLeft} onClick={onBack} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[12px] font-semibold text-[var(--theme-text-primary)]">
+            {workflow?.name ?? '工作流'} · {shortId(run.id, 10)}
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <StatusBadge status={run.status} />
+            {partial && (
+              <span className="text-[10px] text-[var(--theme-text-muted)]">
+                部分完成 {run.completed_steps.length} 步
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {run.error_message && <InlineNotice variant="error">{run.error_message}</InlineNotice>}
+
+      <section aria-labelledby="wf-identity-heading" className="space-y-1">
+        <h3 id="wf-identity-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+          身份
+        </h3>
+        {kv('修订', run.workflow_revision_id ? shortId(run.workflow_revision_id, 12) : '—')}
+        {kv('图指纹', manifest?.graph_fingerprint ? shortId(manifest.graph_fingerprint, 12) : '—')}
+        {kv('运行指纹', run.run_fingerprint ? shortId(run.run_fingerprint, 12) : '—')}
+      </section>
+
+      <section aria-labelledby="wf-inputs-heading" className="space-y-1">
+        <h3 id="wf-inputs-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+          输入数据集版本
+        </h3>
+        {fpEntries.length === 0 ? (
+          <p className="text-[11px] text-[var(--theme-text-muted)]">未记录数据集指纹</p>
+        ) : (
+          <ul className="space-y-1">
+            {fpEntries.map(([id, fp]) => (
+              <li key={id} className="flex justify-between gap-2 font-mono text-[10px] text-[var(--theme-text-secondary)]">
+                <span className="truncate">{shortId(id, 10)}</span>
+                <span>{shortId(String(fp), 10)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section aria-labelledby="wf-steps-heading" className="space-y-1">
+        <h3 id="wf-steps-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+          步骤 / 工具
+        </h3>
+        {steps.length === 0 ? (
+          <p className="text-[11px] text-[var(--theme-text-muted)]">清单中无步骤</p>
+        ) : (
+          <ol className="space-y-1">
+            {steps.map((s) => (
+              <li
+                key={s.step_id ?? s.tool_name}
+                className="flex items-center justify-between gap-2 rounded border border-[var(--theme-border)] px-2 py-1"
+              >
+                <span className="min-w-0 truncate text-[11px] text-[var(--theme-text-primary)]">
+                  {s.step_id} · {s.tool_name}
+                  {s.tool_version ? ` @${s.tool_version}` : ''}
+                </span>
+                {s.status && <StatusBadge status={s.status} />}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <section aria-labelledby="wf-arts-heading" className="space-y-1">
+        <h3 id="wf-arts-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+          产物
+        </h3>
+        {artifacts.length === 0 ? (
+          <p className="text-[11px] text-[var(--theme-text-muted)]">无产物</p>
+        ) : (
+          <ul className="space-y-1.5">
+            {artifacts.map((art, idx) => {
+              const aid = art.id;
+              const missing = !aid;
+              return (
+                <li key={aid ?? `missing-${idx}`} className="rounded border border-[var(--theme-border)] px-2 py-1.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] text-[var(--theme-text-primary)]">
+                      {art.producing_step || art.artifact_type || '产物'}
+                    </span>
+                    <span className="text-[10px] text-[var(--theme-text-muted)]">CRS {formatCrs(art.crs)}</span>
+                  </div>
+                  {missing ? (
+                    <p className="text-[10px] text-red-600 dark:text-red-300">产物缺失</p>
+                  ) : (
+                    <>
+                      <div className="font-mono text-[10px] text-[var(--theme-text-muted)]">
+                        {shortId(aid, 12)}
+                        {art.content_fingerprint ? ` · ${shortId(art.content_fingerprint, 8)}` : ''}
+                      </div>
+                      <button
+                        type="button"
+                        className="mt-1 text-[11px] text-[var(--theme-text-secondary)] underline-offset-2 hover:underline"
+                        onClick={() => {
+                          setOpenArtifact(aid);
+                          onLoadLineage(aid);
+                        }}
+                      >
+                        {openArtifact === aid ? '血统' : '查看血统'}
+                      </button>
+                      {openArtifact === aid && (
+                        <div className="mt-1">
+                          <LineageList
+                            artifactId={aid}
+                            artifactCrs={art.crs}
+                            state={lineageByArtifact[aid]}
+                            onLoad={onLoadLineage}
+                          />
+                        </div>
+                      )}
+                    </>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section aria-labelledby="wf-runtime-heading" className="space-y-1">
+        <h3 id="wf-runtime-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+          运行指标
+        </h3>
+        {Object.keys(perf).length === 0 ? (
+          <p className="text-[11px] text-[var(--theme-text-muted)]">无运行指标</p>
+        ) : (
+          <div className="space-y-0.5 text-[11px] text-[var(--theme-text-secondary)]">
+            {perf.total_steps != null && <div>步骤 {String(perf.total_steps)}</div>}
+            {perf.total_duration_seconds != null && (
+              <div>耗时 {String(perf.total_duration_seconds)}s</div>
+            )}
+            {perf.elapsed_ms != null && <div>耗时 {String(perf.elapsed_ms)}ms</div>}
+          </div>
+        )}
+      </section>
+
+      <RecoveryActions
+        run={run}
+        busy={actionBusy}
+        error={actionError}
+        onReplay={onReplay}
+        onResume={onResume}
+      />
+
+      <ComparePanel
+        runs={runs}
+        selectedRunId={run.id}
+        peerId={comparePeerId}
+        onPeerChange={onComparePeerChange}
+        onCompare={onCompare}
+        result={compare}
+        busy={compareBusy}
+        error={compareError}
+      />
+
+      <details
+        className="rounded border border-[var(--theme-border)] px-2 py-1.5"
+        open={showManifest}
+        onToggle={(e) => setShowManifest((e.target as HTMLDetailsElement).open)}
+      >
+        <summary className="cursor-pointer text-[11px] text-[var(--theme-text-secondary)]">原始清单</summary>
+        <pre className="mt-1 max-h-40 overflow-auto font-mono text-[10px] text-[var(--theme-text-muted)]">
+          {JSON.stringify(manifest ?? run, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+export default RunInspector;

--- a/frontend/lib/api/project.test.ts
+++ b/frontend/lib/api/project.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { clearCache } from './get-fast-path';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const jsonOk = (body: unknown, status = 200) => ({
+  ok: true,
+  status,
+  statusText: 'OK',
+  headers: { get: () => null },
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+const jsonErr = (status: number, body: unknown) => ({
+  ok: false,
+  status,
+  statusText: 'Error',
+  headers: { get: () => null },
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+import {
+  fetchProjects,
+  fetchProjectWorkflows,
+  fetchWorkflowRuns,
+  fetchWorkflowRun,
+  replayWorkflowRun,
+  resumeWorkflowRun,
+  fetchRunComparison,
+  fetchArtifactLineage,
+} from './project';
+import { ApiError } from './transport';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearCache();
+});
+
+afterEach(() => {
+  clearCache();
+});
+
+function lastUrl(): string {
+  const arg = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]?.[0];
+  return String(arg);
+}
+
+describe('project API — Page unwrap + /api/v1 prefix', () => {
+  it('unwraps Page.items and hits /api/v1/projects', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({
+        items: [{ id: 'p1', name: 'A', status: 'active', created_at: '', updated_at: '' }],
+        total: 1,
+        limit: 50,
+        offset: 0,
+        has_more: false,
+      }),
+    );
+    const items = await fetchProjects();
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe('p1');
+    expect(lastUrl()).toContain('/api/v1/projects');
+    expect(lastUrl()).not.toMatch(/:8001\/projects(\?|$)/);
+  });
+
+  it('does not treat a Page object as a list of workflows', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({
+        items: [{ id: 'wf1', project_id: 'p1', name: 'W', version: 1, step_count: 3, created_at: '', updated_at: '' }],
+        total: 1,
+        limit: 50,
+        offset: 0,
+        has_more: false,
+      }),
+    );
+    const wfs = await fetchProjectWorkflows('p1');
+    expect(wfs[0].step_count).toBe(3);
+    expect(lastUrl()).toContain('/api/v1/projects/p1/workflows');
+  });
+});
+
+describe('run detail / replay / resume / compare / lineage', () => {
+  it('loads run detail without caching a heavy payload across forceRefresh', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({
+        id: 'r1',
+        workflow_id: 'wf1',
+        workflow_version: 1,
+        status: 'completed',
+        input_bindings: {},
+        input_dataset_fingerprints: {},
+        execution_trace: [],
+        outputs: {},
+        cost_perf_summary: {},
+        completed_steps: ['s1'],
+        run_fingerprint: 'fp',
+        created_at: '',
+      }),
+    );
+    const run = await fetchWorkflowRun('p1', 'r1');
+    expect(run.run_fingerprint).toBe('fp');
+    expect(lastUrl()).toContain('/api/v1/projects/p1/runs/r1');
+  });
+
+  it('posts replay with the chosen mode and does not retry', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({
+        id: 'r2',
+        workflow_id: 'wf1',
+        workflow_version: 1,
+        status: 'completed',
+        input_bindings: {},
+        input_dataset_fingerprints: {},
+        execution_trace: [],
+        outputs: {},
+        cost_perf_summary: {},
+        completed_steps: [],
+        created_at: '',
+      }),
+    );
+    await replayWorkflowRun('p1', 'r1', 'latest');
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(String(init.body))).toEqual({ mode: 'latest' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts resume with allow_rerun false and surfaces 409 detail', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonErr(409, { detail: 'cannot resume run r1: input dataset fingerprints changed' }),
+    );
+    const err = await resumeWorkflowRun('p1', 'r1').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(409);
+    expect((err as ApiError).body).toEqual({
+      detail: 'cannot resume run r1: input dataset fingerprints changed',
+    });
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({ allow_rerun: false });
+  });
+
+  it('compare uses query params, not inferred equality', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({
+        run_a_id: 'a',
+        run_b_id: 'b',
+        revision: {},
+        inputs_changed: {},
+        dataset_versions_changed: {},
+        tool_versions_changed: {},
+        params_changed: {},
+        output_artifacts_changed: {},
+        metrics_changed: {},
+        warnings_changed: {},
+        run_fingerprint: { run_a: 'x', run_b: 'y', same: false },
+      }),
+    );
+    const cmp = await fetchRunComparison('p1', 'a', 'b');
+    expect(cmp.run_fingerprint.same).toBe(false);
+    expect(lastUrl()).toContain('run_a_id=a');
+    expect(lastUrl()).toContain('run_b_id=b');
+    expect((mockFetch.mock.calls[0][1] as RequestInit).method).toBe('POST');
+  });
+
+  it('lineage is a GET per artifact (no N+1 helper here)', async () => {
+    mockFetch.mockResolvedValueOnce(jsonOk({ artifact_id: 'art1', parents: [], consumers: [] }));
+    const g = await fetchArtifactLineage('art1');
+    expect(g.parents).toEqual([]);
+    expect(lastUrl()).toContain('/api/v1/projects/artifacts/art1/lineage');
+  });
+
+  it('run list is paginated and scoped by workflow_id', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({ items: [], total: 0, limit: 50, offset: 0, has_more: false }),
+    );
+    const page = await fetchWorkflowRuns('p1', { workflowId: 'wf1', limit: 20 });
+    expect(page.items).toEqual([]);
+    expect(lastUrl()).toContain('workflow_id=wf1');
+    expect(lastUrl()).toContain('limit=20');
+  });
+});

--- a/frontend/lib/api/project.ts
+++ b/frontend/lib/api/project.ts
@@ -5,10 +5,24 @@
  * request correlation, abort propagation, and timeout. GETs go through the
  * Fast Path (in-flight dedup + 5s LRU) so parallel mounts / tab switches
  * collapse to a single roundtrip.
+ *
+ * List endpoints return a Page envelope (F-FE-SD). Helpers unwrap `items`
+ * so callers never iterate a Page as if it were an array. Artifact.crs is
+ * `string | null` — unknown CRS is null, never a fabricated EPSG:4326.
  */
 
 import { apiFetch } from './transport';
 import { fastGet, invalidateCache } from './get-fast-path';
+
+const API = '/api/v1/projects';
+
+export interface Page<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
 
 export interface Project {
   id: string;
@@ -17,7 +31,7 @@ export interface Project {
   name: string;
   description?: string;
   status: string;
-  metadata_json: Record<string, any>;
+  metadata_json?: Record<string, unknown>;
   created_at: string;
   updated_at: string;
 }
@@ -27,47 +41,111 @@ export interface ProjectDataset {
   project_id: string;
   name: string;
   source_type: string;
-  source_ref: string;
-  schema_profile: Record<string, any>;
-  crs: string;
+  source_ref?: string | null;
+  schema_profile?: Record<string, unknown>;
+  /** Dataset CRS may be missing; do not default it. */
+  crs: string | null;
   quality_status: string;
-  version_fingerprint: string;
+  version_fingerprint?: string | null;
   created_at: string;
 }
 
 export interface WorkflowStepSpec {
   step_id: string;
   tool_name: string;
-  args_template?: Record<string, any>;
+  args_template?: Record<string, unknown>;
   input_bindings?: Record<string, string>;
   dependencies?: string[];
 }
 
-export interface Workflow {
+/** Slim list row — graph_spec lives on the save/detail payload, not the list. */
+export interface WorkflowSummary {
   id: string;
   project_id: string;
   name: string;
   description?: string;
   version: number;
-  graph_spec: { steps: WorkflowStepSpec[] };
-  inputs_schema: Record<string, any>;
+  step_count: number;
   created_at: string;
   updated_at: string;
 }
 
-export interface WorkflowRun {
+/** Full workflow (POST save). Kept for callers that still hold a recipe. */
+export interface Workflow extends WorkflowSummary {
+  graph_spec?: { steps: WorkflowStepSpec[] };
+  inputs_schema?: Record<string, unknown>;
+  current_revision_id?: string | null;
+}
+
+export type WorkflowRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface WorkflowRunSummary {
   id: string;
   workflow_id: string;
   workflow_version: number;
-  input_bindings: Record<string, any>;
-  status: string;
-  started_at?: string;
-  completed_at?: string;
-  execution_trace: Array<Record<string, any>>;
-  outputs: Record<string, any>;
-  error_message?: string;
-  cost_perf_summary: Record<string, any>;
+  status: WorkflowRunStatus | string;
+  started_at?: string | null;
+  completed_at?: string | null;
+  error_message?: string | null;
   created_at: string;
+}
+
+export interface RunManifestStep {
+  step_id?: string;
+  tool_name?: string;
+  tool_version?: string;
+  status?: string;
+  args?: Record<string, unknown>;
+}
+
+export interface RunManifestArtifact {
+  id?: string;
+  producing_step?: string;
+  artifact_type?: string;
+  format?: string | null;
+  /** Truthful CRS; null/omitted means unknown — never invent EPSG:4326. */
+  crs?: string | null;
+  content_fingerprint?: string | null;
+  storage_ref?: string | null;
+}
+
+export interface RunManifest {
+  workflow_revision_id?: string | null;
+  graph_fingerprint?: string | null;
+  inputs?: Record<string, unknown>;
+  input_dataset_fingerprints?: Record<string, string>;
+  steps?: RunManifestStep[];
+  tool_versions?: Record<string, string>;
+  artifacts?: RunManifestArtifact[];
+}
+
+export interface WorkflowRunDetail extends WorkflowRunSummary {
+  project_id?: string | null;
+  workflow_revision_id?: string | null;
+  input_bindings: Record<string, unknown>;
+  input_dataset_fingerprints: Record<string, unknown>;
+  execution_trace: Array<Record<string, unknown>>;
+  outputs: Record<string, unknown>;
+  cost_perf_summary: Record<string, unknown>;
+  completed_steps: string[];
+  run_manifest?: RunManifest | null;
+  run_fingerprint?: string | null;
+}
+
+/** @deprecated Use WorkflowRunDetail. Kept so existing tests compile. */
+export type WorkflowRun = WorkflowRunDetail;
+
+export interface WorkflowRevisionSummary {
+  id: string;
+  workflow_id: string;
+  revision_no: number;
+  graph_fingerprint: string;
+  created_at: string;
+}
+
+export interface WorkflowRevisionDetail extends WorkflowRevisionSummary {
+  inputs_schema?: Record<string, unknown> | null;
+  created_by?: string | null;
 }
 
 export interface Artifact {
@@ -75,9 +153,11 @@ export interface Artifact {
   project_id: string;
   name: string;
   artifact_type: string;
-  format: string;
-  crs: string;
-  storage_ref?: string;
+  format?: string | null;
+  /** Unknown CRS is null. Do not default to EPSG:4326. */
+  crs: string | null;
+  storage_ref?: string | null;
+  content_fingerprint?: string | null;
   created_at: string;
 }
 
@@ -92,87 +172,297 @@ export interface QualityReport {
     level: string;
     message: string;
     feature_index?: number;
-    details?: Record<string, any>;
+    details?: Record<string, unknown>;
   }>;
 }
 
-/** GET /projects — short-lived cached, dedupe across parallel mounts. */
+export type ReplayMode = 'exact' | 'latest';
+
+export interface DictDiff {
+  run_a?: Record<string, unknown>;
+  run_b?: Record<string, unknown>;
+  diff_keys?: string[];
+}
+
+export interface RunComparison {
+  run_a_id: string;
+  run_b_id: string;
+  revision: {
+    run_a_revision?: string | null;
+    run_b_revision?: string | null;
+    run_a_graph_fingerprint?: string | null;
+    run_b_graph_fingerprint?: string | null;
+    graph_same?: boolean;
+  };
+  inputs_changed: DictDiff;
+  dataset_versions_changed: DictDiff;
+  tool_versions_changed: Record<string, [unknown, unknown] | unknown>;
+  params_changed: Record<string, { tool_a?: string; tool_b?: string; args_diff?: string[] }>;
+  output_artifacts_changed: {
+    run_a_status?: string;
+    run_b_status?: string;
+    run_a_artifact_count?: number;
+    run_b_artifact_count?: number;
+    run_a_fingerprints?: string[];
+    run_b_fingerprints?: string[];
+  };
+  metrics_changed: Record<string, unknown>;
+  warnings_changed: Record<string, unknown>;
+  run_fingerprint: {
+    run_a?: string | null;
+    run_b?: string | null;
+    same: boolean;
+  };
+}
+
+export interface LineageParent {
+  lineage_id: string;
+  artifact_id: string;
+  parent_artifact_id: string;
+  producing_tool?: string | null;
+  tool_version?: string | null;
+  workflow_run_id?: string | null;
+  parameters?: Record<string, unknown> | null;
+  source_dataset_id?: string | null;
+  source_dataset_fingerprint?: string | null;
+  depth?: number;
+  created_at?: string | null;
+}
+
+export interface LineageConsumer {
+  lineage_id: string;
+  consumer_artifact_id: string;
+  parent_artifact_id: string | null;
+  producing_tool?: string | null;
+  tool_version?: string | null;
+  workflow_run_id?: string | null;
+  parameters?: Record<string, unknown> | null;
+  depth?: number;
+  created_at?: string | null;
+}
+
+export interface LineageGraph {
+  artifact_id: string;
+  parents: LineageParent[];
+  consumers: LineageConsumer[];
+}
+
+function asPage<T>(data: Page<T> | T[] | undefined): Page<T> {
+  if (!data) return { items: [], total: 0, limit: 50, offset: 0, has_more: false };
+  if (Array.isArray(data)) {
+    return { items: data, total: data.length, limit: data.length || 50, offset: 0, has_more: false };
+  }
+  return {
+    items: Array.isArray(data.items) ? data.items : [],
+    total: data.total ?? 0,
+    limit: data.limit ?? 50,
+    offset: data.offset ?? 0,
+    has_more: Boolean(data.has_more),
+  };
+}
+
 export async function fetchProjects(opts?: {
   forceRefresh?: boolean;
   signal?: AbortSignal;
+  limit?: number;
+  offset?: number;
 }): Promise<Project[]> {
-  const result = await fastGet<Project[]>('/projects', {
+  const result = await fastGet<Page<Project> | Project[]>(API, {
     forceRefresh: opts?.forceRefresh,
     signal: opts?.signal,
+    params: { limit: opts?.limit, offset: opts?.offset },
     label: 'Project list error',
   });
-  return result.data;
+  return asPage(result.data).items;
 }
 
 export async function createProject(name: string, description?: string): Promise<Project> {
-  const project = await apiFetch<Project>('/projects', {
+  const project = await apiFetch<Project>(API, {
     method: 'POST',
     body: { name, description },
     label: 'Project create error',
   });
-  // New project → bust the list cache so the next fetchProjects is fresh.
-  invalidateCache('/projects');
+  invalidateCache(API);
   return project;
 }
 
 export async function fetchProjectDatasets(
   projectId: string,
-  opts?: { forceRefresh?: boolean; signal?: AbortSignal },
+  opts?: { forceRefresh?: boolean; signal?: AbortSignal; limit?: number; offset?: number },
 ): Promise<ProjectDataset[]> {
-  const path = `/projects/${projectId}/datasets`;
-  const result = await fastGet<ProjectDataset[]>(path, {
+  const path = `${API}/${projectId}/datasets`;
+  const result = await fastGet<Page<ProjectDataset> | ProjectDataset[]>(path, {
     forceRefresh: opts?.forceRefresh,
     signal: opts?.signal,
+    params: { limit: opts?.limit, offset: opts?.offset },
     label: 'Project datasets error',
   });
-  return result.data;
+  return asPage(result.data).items;
 }
 
 export async function fetchProjectWorkflows(
   projectId: string,
-  opts?: { forceRefresh?: boolean; signal?: AbortSignal },
-): Promise<Workflow[]> {
-  const path = `/projects/${projectId}/workflows`;
-  const result = await fastGet<Workflow[]>(path, {
+  opts?: { forceRefresh?: boolean; signal?: AbortSignal; limit?: number; offset?: number },
+): Promise<WorkflowSummary[]> {
+  const path = `${API}/${projectId}/workflows`;
+  const result = await fastGet<Page<WorkflowSummary> | WorkflowSummary[]>(path, {
     forceRefresh: opts?.forceRefresh,
     signal: opts?.signal,
+    params: { limit: opts?.limit, offset: opts?.offset },
     label: 'Project workflows error',
   });
+  return asPage(result.data).items;
+}
+
+export async function fetchWorkflowRuns(
+  projectId: string,
+  opts?: {
+    workflowId?: string;
+    forceRefresh?: boolean;
+    signal?: AbortSignal;
+    limit?: number;
+    offset?: number;
+  },
+): Promise<Page<WorkflowRunSummary>> {
+  const path = `${API}/${projectId}/runs`;
+  const result = await fastGet<Page<WorkflowRunSummary> | WorkflowRunSummary[]>(path, {
+    forceRefresh: opts?.forceRefresh,
+    signal: opts?.signal,
+    params: {
+      workflow_id: opts?.workflowId,
+      limit: opts?.limit ?? 50,
+      offset: opts?.offset ?? 0,
+    },
+    label: 'Workflow runs error',
+  });
+  return asPage(result.data);
+}
+
+export async function fetchWorkflowRun(
+  projectId: string,
+  runId: string,
+  opts?: { forceRefresh?: boolean; signal?: AbortSignal },
+): Promise<WorkflowRunDetail> {
+  const path = `${API}/${projectId}/runs/${runId}`;
+  const result = await fastGet<WorkflowRunDetail>(path, {
+    forceRefresh: opts?.forceRefresh,
+    signal: opts?.signal,
+    ttlMs: 0,
+    label: 'Workflow run detail error',
+  });
   return result.data;
+}
+
+export async function fetchWorkflowRevisions(
+  projectId: string,
+  workflowId: string,
+  opts?: { forceRefresh?: boolean; signal?: AbortSignal; limit?: number; offset?: number },
+): Promise<Page<WorkflowRevisionSummary>> {
+  const path = `${API}/${projectId}/workflows/${workflowId}/revisions`;
+  const result = await fastGet<Page<WorkflowRevisionSummary> | WorkflowRevisionSummary[]>(path, {
+    forceRefresh: opts?.forceRefresh,
+    signal: opts?.signal,
+    params: { limit: opts?.limit ?? 50, offset: opts?.offset ?? 0 },
+    label: 'Workflow revisions error',
+  });
+  return asPage(result.data);
 }
 
 export async function runWorkflow(
   projectId: string,
   workflowId: string,
-  inputBindings: Record<string, any> = {}
-): Promise<WorkflowRun> {
-  const run = await apiFetch<WorkflowRun>(
-    `/projects/${projectId}/workflows/${workflowId}/run`,
+  inputBindings: Record<string, unknown> = {},
+): Promise<WorkflowRunDetail> {
+  const run = await apiFetch<WorkflowRunDetail>(
+    `${API}/${projectId}/workflows/${workflowId}/run`,
     {
       method: 'POST',
       body: { input_bindings: inputBindings },
+      timeoutMs: 120_000,
       label: 'Workflow run error',
-    }
+    },
   );
-  // A new run invalidates the runs list cache and the workflow list cache.
-  invalidateCache(`/projects/${projectId}/workflows`);
-  invalidateCache(`/projects/${projectId}/runs`);
+  invalidateWorkflowCaches(projectId);
   return run;
+}
+
+export async function replayWorkflowRun(
+  projectId: string,
+  runId: string,
+  mode: ReplayMode,
+): Promise<WorkflowRunDetail> {
+  const run = await apiFetch<WorkflowRunDetail>(`${API}/${projectId}/runs/${runId}/replay`, {
+    method: 'POST',
+    body: { mode },
+    timeoutMs: 120_000,
+    label: 'Workflow replay error',
+  });
+  invalidateWorkflowCaches(projectId);
+  return run;
+}
+
+export async function resumeWorkflowRun(
+  projectId: string,
+  runId: string,
+): Promise<WorkflowRunDetail> {
+  const run = await apiFetch<WorkflowRunDetail>(`${API}/${projectId}/runs/${runId}/resume`, {
+    method: 'POST',
+    body: { allow_rerun: false },
+    timeoutMs: 120_000,
+    label: 'Workflow resume error',
+  });
+  invalidateWorkflowCaches(projectId);
+  return run;
+}
+
+/** Compare two runs. POST with query params (backend contract). */
+export async function fetchRunComparison(
+  projectId: string,
+  runAId: string,
+  runBId: string,
+  opts?: { signal?: AbortSignal },
+): Promise<RunComparison> {
+  const qs = new URLSearchParams({ run_a_id: runAId, run_b_id: runBId });
+  return apiFetch<RunComparison>(`${API}/${projectId}/runs/compare?${qs.toString()}`, {
+    method: 'POST',
+    signal: opts?.signal,
+    label: 'Workflow compare error',
+  });
+}
+
+export async function fetchArtifactLineage(
+  artifactId: string,
+  opts?: { signal?: AbortSignal; forceRefresh?: boolean },
+): Promise<LineageGraph> {
+  const path = `${API}/artifacts/${artifactId}/lineage`;
+  const result = await fastGet<LineageGraph>(path, {
+    forceRefresh: opts?.forceRefresh,
+    signal: opts?.signal,
+    ttlMs: 5_000,
+    label: 'Artifact lineage error',
+  });
+  return result.data;
 }
 
 export async function auditQuality(
   projectId: string,
-  geojson: Record<string, any>
+  geojson: Record<string, unknown>,
 ): Promise<QualityReport> {
-  return apiFetch<QualityReport>(`/projects/${projectId}/quality-audit`, {
+  return apiFetch<QualityReport>(`${API}/${projectId}/quality-audit`, {
     method: 'POST',
     body: { geojson },
-    timeoutMs: 60_000, // quality audit can take longer than the default 30s
+    timeoutMs: 60_000,
     label: 'Quality audit error',
   });
 }
+
+export function invalidateProjectRunCaches(projectId: string): void {
+  invalidateCache(`${API}/${projectId}/workflows`);
+  invalidateCache(`${API}/${projectId}/runs`);
+}
+
+function invalidateWorkflowCaches(projectId: string): void {
+  invalidateProjectRunCaches(projectId);
+}
+
+export { fetchRunComparison as compareRuns };

--- a/frontend/lib/hooks/use-workflow-workspace.test.ts
+++ b/frontend/lib/hooks/use-workflow-workspace.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+const api = vi.hoisted(() => ({
+  fetchProjects: vi.fn(),
+  fetchProjectDatasets: vi.fn(),
+  fetchProjectWorkflows: vi.fn(),
+  fetchWorkflowRuns: vi.fn(),
+  fetchWorkflowRevisions: vi.fn(),
+  fetchWorkflowRun: vi.fn(),
+  fetchArtifactLineage: vi.fn(),
+  fetchRunComparison: vi.fn(),
+  replayWorkflowRun: vi.fn(),
+  resumeWorkflowRun: vi.fn(),
+  runWorkflow: vi.fn(),
+  createProject: vi.fn(),
+  invalidateProjectRunCaches: vi.fn(),
+}));
+
+vi.mock('@/lib/api/project', () => api);
+
+import { ApiError } from '@/lib/api/transport';
+import { RUN_POLL_INTERVAL_MS, useWorkflowWorkspace } from './use-workflow-workspace';
+
+function page<T>(items: T[]) {
+  return { items, total: items.length, limit: 50, offset: 0, has_more: false };
+}
+
+const project = {
+  id: 'p1',
+  name: 'P',
+  status: 'active',
+  created_at: '',
+  updated_at: '',
+};
+const workflow = {
+  id: 'wf1',
+  project_id: 'p1',
+  name: 'W',
+  version: 1,
+  step_count: 2,
+  created_at: '',
+  updated_at: '',
+};
+
+function detail(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'r1',
+    workflow_id: 'wf1',
+    workflow_version: 1,
+    status: 'completed',
+    input_bindings: {},
+    input_dataset_fingerprints: {},
+    execution_trace: [],
+    outputs: {},
+    cost_perf_summary: {},
+    completed_steps: ['s1'],
+    created_at: '',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.fetchProjects.mockResolvedValue([project]);
+  api.fetchProjectDatasets.mockResolvedValue([]);
+  api.fetchProjectWorkflows.mockResolvedValue([workflow]);
+  api.fetchWorkflowRuns.mockResolvedValue(page([{ id: 'r1', workflow_id: 'wf1', workflow_version: 1, status: 'completed', created_at: '' }]));
+  api.fetchWorkflowRevisions.mockResolvedValue(page([]));
+  api.fetchWorkflowRun.mockResolvedValue(detail());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useWorkflowWorkspace — request discipline', () => {
+  it('does not fetch runs until a workflow is opened', async () => {
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await waitFor(() => expect(result.current.projects).toHaveLength(1));
+    await waitFor(() => expect(api.fetchProjectWorkflows).toHaveBeenCalled());
+    expect(api.fetchWorkflowRuns).not.toHaveBeenCalled();
+    expect(api.fetchWorkflowRun).not.toHaveBeenCalled();
+    expect(api.fetchArtifactLineage).not.toHaveBeenCalled();
+  });
+
+  it('drops a stale project-detail response after switch', async () => {
+    let resolveFirst: (v: unknown) => void = () => {};
+    api.fetchProjectDatasets.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+    api.fetchProjectWorkflows.mockImplementationOnce(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await waitFor(() => expect(result.current.selectedProjectId).toBe('p1'));
+
+    api.fetchProjects.mockResolvedValue([
+      project,
+      { id: 'p2', name: 'P2', status: 'active', created_at: '', updated_at: '' },
+    ]);
+    await act(async () => {
+      result.current.selectProject('p2');
+    });
+    await waitFor(() => expect(api.fetchProjectDatasets).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolveFirst([{ id: 'stale-ds', project_id: 'p1', name: 'STALE', source_type: 'x', crs: null, quality_status: 'ok', created_at: '' }]);
+    });
+    expect(result.current.datasets.find((d) => d.name === 'STALE')).toBeUndefined();
+  });
+
+  it('does not fetch lineage until requested', async () => {
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+    await act(async () => {
+      result.current.openWorkflow('wf1');
+    });
+    await waitFor(() => expect(api.fetchWorkflowRuns).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      result.current.openRun('r1');
+    });
+    await waitFor(() => expect(result.current.runDetail?.id).toBe('r1'));
+    expect(api.fetchArtifactLineage).not.toHaveBeenCalled();
+    api.fetchArtifactLineage.mockResolvedValue({ artifact_id: 'a1', parents: [], consumers: [] });
+    await act(async () => {
+      await result.current.loadLineage('a1');
+    });
+    expect(api.fetchArtifactLineage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useWorkflowWorkspace — recoverability truth', () => {
+  it('locks a second replay while the first POST is in flight', async () => {
+    let resolveReplay: (v: unknown) => void = () => {};
+    api.replayWorkflowRun.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveReplay = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+    await act(async () => {
+      result.current.openWorkflow('wf1');
+    });
+    await act(async () => {
+      result.current.openRun('r1');
+    });
+    await waitFor(() => expect(result.current.runDetail).not.toBeNull());
+
+    let first: Promise<unknown> | undefined;
+    let second: Promise<unknown> | undefined;
+    await act(async () => {
+      first = result.current.replay('exact');
+      second = result.current.replay('exact');
+    });
+    expect(api.replayWorkflowRun).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveReplay(detail({ id: 'r2', status: 'completed' }));
+      await first;
+      await second;
+    });
+    expect(api.replayWorkflowRun).toHaveBeenCalledTimes(1);
+    expect(await first).toMatchObject({ ok: true, run: { id: 'r2' }, applied: true });
+    expect(await second).toEqual({ ok: false, error: null });
+  });
+
+  it('records a 409 resume as actionError and does not pretend success', async () => {
+    api.resumeWorkflowRun.mockRejectedValueOnce(
+      new ApiError(409, 'Conflict', { detail: 'cannot resume run r1: prior step outputs are no longer reconstructable' }),
+    );
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+    await act(async () => {
+      result.current.openWorkflow('wf1');
+    });
+    await act(async () => {
+      result.current.openRun('r1');
+    });
+    await waitFor(() => expect(result.current.runDetail).not.toBeNull());
+
+    let out: unknown;
+    await act(async () => {
+      out = await result.current.resume();
+    });
+    expect(out).toMatchObject({ ok: false, error: expect.stringContaining('no longer reconstructable') });
+    expect(result.current.actionError).toContain('no longer reconstructable');
+    expect(result.current.runDetail?.id).toBe('r1');
+  });
+
+  it('does not paint a late replay onto a run the user selected mid-flight', async () => {
+    let resolveReplay: (v: unknown) => void = () => {};
+    api.replayWorkflowRun.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveReplay = resolve;
+        }),
+    );
+    api.fetchWorkflowRun.mockImplementation(async (_p: string, runId: string) =>
+      detail({ id: runId, status: 'completed' }),
+    );
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+    await act(async () => {
+      result.current.openWorkflow('wf1');
+    });
+    await act(async () => {
+      result.current.openRun('r1');
+    });
+    await waitFor(() => expect(result.current.runDetail?.id).toBe('r1'));
+
+    let pending: Promise<unknown> | undefined;
+    await act(async () => {
+      pending = result.current.replay('exact');
+    });
+    await act(async () => {
+      result.current.openRun('run0');
+    });
+    await waitFor(() => expect(result.current.selectedRunId).toBe('run0'));
+    await act(async () => {
+      resolveReplay(detail({ id: 'r-late', status: 'failed', error_message: 'boom' }));
+      await pending;
+    });
+    expect(result.current.runDetail?.id).toBe('run0');
+    expect(result.current.runDetail?.status).toBe('completed');
+    expect(await pending).toMatchObject({ ok: true, applied: false });
+  });
+
+  it('on timeout invalidates caches and does not report success', async () => {
+    const { ApiTimeoutError } = await import('@/lib/api/transport');
+    api.replayWorkflowRun.mockRejectedValueOnce(new ApiTimeoutError(120000));
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+    await act(async () => {
+      result.current.openWorkflow('wf1');
+    });
+    await act(async () => {
+      result.current.openRun('r1');
+    });
+    await waitFor(() => expect(result.current.runDetail).not.toBeNull());
+    let out: unknown;
+    await act(async () => {
+      out = await result.current.replay('exact');
+    });
+    expect(out).toMatchObject({ ok: false, error: expect.stringContaining('超时') });
+    expect(api.invalidateProjectRunCaches).toHaveBeenCalledWith('p1');
+    expect(api.fetchWorkflowRuns).toHaveBeenCalled();
+    expect(result.current.runDetail?.id).toBe('r1');
+  });
+});
+
+describe('useWorkflowWorkspace — bounded poll', () => {
+  it('polls a running run once per interval and stops when completed', async () => {
+    vi.useFakeTimers();
+    api.fetchWorkflowRun
+      .mockResolvedValueOnce(detail({ status: 'running' }))
+      .mockResolvedValueOnce(detail({ status: 'completed' }));
+
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      result.current.openWorkflow('wf1');
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      result.current.openRun('r1');
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(api.fetchWorkflowRun).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_POLL_INTERVAL_MS);
+    });
+    expect(api.fetchWorkflowRun).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RUN_POLL_INTERVAL_MS);
+    });
+    expect(api.fetchWorkflowRun).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('useWorkflowWorkspace — compare binding', () => {
+  it('clears a previous compare verdict when the peer changes', async () => {
+    api.fetchRunComparison.mockResolvedValue({
+      run_a_id: 'r1',
+      run_b_id: 'run0',
+      revision: {},
+      inputs_changed: {},
+      dataset_versions_changed: {},
+      tool_versions_changed: {},
+      params_changed: {},
+      output_artifacts_changed: {},
+      metrics_changed: {},
+      warnings_changed: {},
+      run_fingerprint: { run_a: 'x', run_b: 'x', same: true },
+    });
+    const { result } = renderHook(() => useWorkflowWorkspace());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+    await act(async () => {
+      result.current.openWorkflow('wf1');
+    });
+    await act(async () => {
+      result.current.openRun('r1');
+    });
+    await act(async () => {
+      result.current.setComparePeerId('run0');
+    });
+    await act(async () => {
+      await result.current.openCompare();
+    });
+    expect(result.current.compare?.run_fingerprint.same).toBe(true);
+    await act(async () => {
+      result.current.setComparePeerId('other');
+    });
+    expect(result.current.compare).toBeNull();
+  });
+});

--- a/frontend/lib/hooks/use-workflow-workspace.ts
+++ b/frontend/lib/hooks/use-workflow-workspace.ts
@@ -1,0 +1,567 @@
+/**
+ * Project / workflow / run workspace data.
+ *
+ * Guards:
+ *   - AbortController per project / workflow / run switch
+ *   - monotonic generation so a stale response cannot overwrite the current view
+ *   - action lock so replay/resume cannot double-submit
+ *   - bounded poll only while the selected run is pending/running
+ *   - lineage / compare fetched only when requested
+ */
+
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  createProject as apiCreateProject,
+  fetchArtifactLineage,
+  fetchProjectDatasets,
+  fetchProjectWorkflows,
+  fetchProjects,
+  fetchRunComparison,
+  fetchWorkflowRevisions,
+  fetchWorkflowRun,
+  fetchWorkflowRuns,
+  invalidateProjectRunCaches,
+  replayWorkflowRun,
+  resumeWorkflowRun,
+  runWorkflow,
+  type LineageGraph,
+  type Project,
+  type ProjectDataset,
+  type ReplayMode,
+  type RunComparison,
+  type WorkflowRevisionSummary,
+  type WorkflowRunDetail,
+  type WorkflowRunSummary,
+  type WorkflowSummary,
+} from '@/lib/api/project';
+import { ApiTimeoutError } from '@/lib/api/transport';
+import { isAbortError, isActiveRunStatus, parseApiErrorDetail } from '@/lib/workflow/recovery';
+
+export const RUN_POLL_INTERVAL_MS = 3000;
+export const RUN_POLL_MAX = 40;
+
+export type WorkspaceView = 'project' | 'workflow' | 'run' | 'compare';
+
+export interface UseWorkflowWorkspaceResult {
+  projects: Project[];
+  selectedProjectId: string;
+  selectProject: (id: string) => void;
+  createProject: (name: string) => Promise<void>;
+  datasets: ProjectDataset[];
+  workflows: WorkflowSummary[];
+  revisions: WorkflowRevisionSummary[];
+  runs: WorkflowRunSummary[];
+  runsHasMore: boolean;
+  loadMoreRuns: () => Promise<void>;
+  selectedWorkflow: WorkflowSummary | null;
+  selectedRunId: string;
+  runDetail: WorkflowRunDetail | null;
+  view: WorkspaceView;
+  loading: boolean;
+  detailLoading: boolean;
+  error: string | null;
+  actionError: string | null;
+  actionBusy: boolean;
+  compare: RunComparison | null;
+  compareError: string | null;
+  compareBusy: boolean;
+  comparePeerId: string;
+  setComparePeerId: (id: string) => void;
+  lineageByArtifact: Record<string, LineageGraph | 'loading' | 'empty' | 'error'>;
+  loadLineage: (artifactId: string) => Promise<void>;
+  openWorkflow: (id: string) => void;
+  openRun: (id: string) => void;
+  back: () => void;
+  openCompare: () => Promise<void>;
+  triggerRun: (workflowId: string) => Promise<ActionResult>;
+  replay: (mode: ReplayMode) => Promise<ActionResult>;
+  resume: () => Promise<ActionResult>;
+}
+
+export type ActionResult =
+  | { ok: true; run: WorkflowRunDetail; applied: boolean }
+  | { ok: false; error: string }
+  | { ok: false; error: null };
+
+export function useWorkflowWorkspace(): UseWorkflowWorkspaceResult {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState('');
+  const [datasets, setDatasets] = useState<ProjectDataset[]>([]);
+  const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
+  const [revisions, setRevisions] = useState<WorkflowRevisionSummary[]>([]);
+  const [runs, setRuns] = useState<WorkflowRunSummary[]>([]);
+  const [runsHasMore, setRunsHasMore] = useState(false);
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState('');
+  const [selectedRunId, setSelectedRunId] = useState('');
+  const [runDetail, setRunDetail] = useState<WorkflowRunDetail | null>(null);
+  const [view, setView] = useState<WorkspaceView>('project');
+  const [loading, setLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionBusy, setActionBusy] = useState(false);
+  const [compare, setCompare] = useState<RunComparison | null>(null);
+  const [compareError, setCompareError] = useState<string | null>(null);
+  const [compareBusy, setCompareBusy] = useState(false);
+  const [comparePeerId, setComparePeerId] = useState('');
+  const [lineageByArtifact, setLineageByArtifact] = useState<
+    Record<string, LineageGraph | 'loading' | 'empty' | 'error'>
+  >({});
+
+  const listGen = useRef(0);
+  const detailGen = useRef(0);
+  const workflowGen = useRef(0);
+  const runGen = useRef(0);
+  const projectAbort = useRef<AbortController | null>(null);
+  const workflowAbort = useRef<AbortController | null>(null);
+  const runAbort = useRef<AbortController | null>(null);
+  const lineageAbort = useRef<AbortController | null>(null);
+  const compareAbort = useRef<AbortController | null>(null);
+  const actionLock = useRef(false);
+  const actionEpoch = useRef(0);
+  const selectedProjectIdRef = useRef('');
+  const selectedWorkflowIdRef = useRef('');
+  const selectedRunIdRef = useRef('');
+  const comparePeerIdRef = useRef('');
+  const pollCount = useRef(0);
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mounted = useRef(true);
+
+  selectedProjectIdRef.current = selectedProjectId;
+  selectedWorkflowIdRef.current = selectedWorkflowId;
+  selectedRunIdRef.current = selectedRunId;
+  comparePeerIdRef.current = comparePeerId;
+
+  const selectedWorkflow = workflows.find((w) => w.id === selectedWorkflowId) ?? null;
+
+  const selectProject = useCallback((id: string) => {
+    detailGen.current += 1;
+    workflowGen.current += 1;
+    runGen.current += 1;
+    actionEpoch.current += 1;
+    setSelectedProjectId(id);
+    setSelectedWorkflowId('');
+    setSelectedRunId('');
+    setRunDetail(null);
+    setRevisions([]);
+    setRuns([]);
+    setCompare(null);
+    setCompareError(null);
+    setComparePeerId('');
+    setLineageByArtifact({});
+    setActionError(null);
+    setView('project');
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    const ac = new AbortController();
+    const gen = ++listGen.current;
+    setLoading(true);
+    setError(null);
+    void fetchProjects({ signal: ac.signal })
+      .then((list) => {
+        if (gen !== listGen.current) return;
+        setProjects(list);
+        setSelectedProjectId((cur) => cur || list[0]?.id || '');
+      })
+      .catch((err: unknown) => {
+        if (ac.signal.aborted || isAbortError(err) || gen !== listGen.current) return;
+        setError(parseApiErrorDetail(err, '加载项目列表失败'));
+      })
+      .finally(() => {
+        if (gen === listGen.current) setLoading(false);
+      });
+    return () => {
+      ac.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedProjectId) {
+      setDatasets([]);
+      setWorkflows([]);
+      return;
+    }
+    projectAbort.current?.abort();
+    const ac = new AbortController();
+    projectAbort.current = ac;
+    const gen = ++detailGen.current;
+    setError(null);
+    void Promise.all([
+      fetchProjectDatasets(selectedProjectId, { signal: ac.signal }),
+      fetchProjectWorkflows(selectedProjectId, { signal: ac.signal }),
+    ])
+      .then(([ds, wf]) => {
+        if (gen !== detailGen.current) return;
+        setDatasets(ds);
+        setWorkflows(wf);
+      })
+      .catch((err: unknown) => {
+        if (ac.signal.aborted || isAbortError(err) || gen !== detailGen.current) return;
+        setError(parseApiErrorDetail(err, '加载项目详情失败'));
+      });
+    return () => ac.abort();
+  }, [selectedProjectId]);
+
+  const openWorkflow = useCallback(
+    (id: string) => {
+      setSelectedWorkflowId(id);
+      setSelectedRunId('');
+      setRunDetail(null);
+      setCompare(null);
+      setComparePeerId('');
+      setLineageByArtifact({});
+      setActionError(null);
+      setView('workflow');
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!selectedProjectId || !selectedWorkflowId) return;
+    workflowAbort.current?.abort();
+    const ac = new AbortController();
+    workflowAbort.current = ac;
+    const gen = ++workflowGen.current;
+    setDetailLoading(true);
+    void Promise.all([
+      fetchWorkflowRuns(selectedProjectId, { workflowId: selectedWorkflowId, signal: ac.signal }),
+      fetchWorkflowRevisions(selectedProjectId, selectedWorkflowId, { signal: ac.signal }),
+    ])
+      .then(([runPage, revPage]) => {
+        if (!mounted.current || gen !== workflowGen.current) return;
+        setRuns(runPage.items);
+        setRunsHasMore(runPage.has_more);
+        setRevisions(revPage.items);
+      })
+      .catch((err: unknown) => {
+        if (ac.signal.aborted || isAbortError(err) || gen !== workflowGen.current) return;
+        setError(parseApiErrorDetail(err, '加载运行列表失败'));
+      })
+      .finally(() => {
+        if (gen === workflowGen.current && mounted.current) setDetailLoading(false);
+      });
+    return () => ac.abort();
+  }, [selectedProjectId, selectedWorkflowId]);
+
+  const openRun = useCallback((id: string) => {
+    lineageAbort.current?.abort();
+    compareAbort.current?.abort();
+    setSelectedRunId(id);
+    setCompare(null);
+    setCompareError(null);
+    setLineageByArtifact({});
+    setActionError(null);
+    setView('run');
+  }, []);
+
+  const loadRunDetail = useCallback(
+    async (projectId: string, runId: string, signal: AbortSignal, gen: number) => {
+      const detail = await fetchWorkflowRun(projectId, runId, { forceRefresh: true, signal });
+      if (!mounted.current || gen !== runGen.current) return null;
+      setRunDetail(detail);
+      return detail;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!selectedProjectId || !selectedRunId) {
+      setRunDetail(null);
+      return;
+    }
+    runAbort.current?.abort();
+    const ac = new AbortController();
+    runAbort.current = ac;
+    const gen = ++runGen.current;
+    pollCount.current = 0;
+    setDetailLoading(true);
+    void loadRunDetail(selectedProjectId, selectedRunId, ac.signal, gen)
+      .catch((err: unknown) => {
+        if (ac.signal.aborted || isAbortError(err) || gen !== runGen.current) return;
+        setError(parseApiErrorDetail(err, '加载运行详情失败'));
+      })
+      .finally(() => {
+        if (gen === runGen.current && mounted.current) setDetailLoading(false);
+      });
+    return () => ac.abort();
+  }, [selectedProjectId, selectedRunId, loadRunDetail]);
+
+  useEffect(() => {
+    if (pollTimer.current) {
+      clearTimeout(pollTimer.current);
+      pollTimer.current = null;
+    }
+    if (!selectedProjectId || !selectedRunId) return;
+    if (!isActiveRunStatus(runDetail?.status)) return;
+    if (typeof document !== 'undefined' && document.hidden) return;
+    if (pollCount.current >= RUN_POLL_MAX) return;
+
+    pollTimer.current = setTimeout(() => {
+      pollCount.current += 1;
+      const ac = new AbortController();
+      runAbort.current = ac;
+      const gen = runGen.current;
+      void loadRunDetail(selectedProjectId, selectedRunId, ac.signal, gen).catch((err: unknown) => {
+        if (ac.signal.aborted || isAbortError(err) || gen !== runGen.current) return;
+        setError(parseApiErrorDetail(err, '刷新运行状态失败'));
+      });
+    }, RUN_POLL_INTERVAL_MS);
+
+    return () => {
+      if (pollTimer.current) clearTimeout(pollTimer.current);
+    };
+  }, [selectedProjectId, selectedRunId, runDetail?.status, loadRunDetail]);
+
+  const back = useCallback(() => {
+    setActionError(null);
+    if (view === 'compare') {
+      setView('run');
+      setCompare(null);
+      return;
+    }
+    if (view === 'run') {
+      setView('workflow');
+      setSelectedRunId('');
+      setRunDetail(null);
+      return;
+    }
+    setView('project');
+    setSelectedWorkflowId('');
+    setRuns([]);
+    setRevisions([]);
+  }, [view]);
+
+  const createProject = useCallback(async (name: string) => {
+    const proj = await apiCreateProject(name);
+    if (!mounted.current) return;
+    setProjects((prev) => [proj, ...prev]);
+    selectProject(proj.id);
+  }, [selectProject]);
+
+  const loadLineage = useCallback(
+    async (artifactId: string) => {
+      if (!artifactId) return;
+      const existing = lineageByArtifact[artifactId];
+      if (existing && existing !== 'error') return;
+      lineageAbort.current?.abort();
+      const ac = new AbortController();
+      lineageAbort.current = ac;
+      const gen = runGen.current;
+      const projectId = selectedProjectId;
+      const runId = selectedRunId;
+      setLineageByArtifact((prev) => ({ ...prev, [artifactId]: 'loading' }));
+      try {
+        const graph = await fetchArtifactLineage(artifactId, { signal: ac.signal });
+        if (!mounted.current || gen !== runGen.current || selectedProjectId !== projectId || selectedRunId !== runId) {
+          return;
+        }
+        const empty = (graph.parents?.length ?? 0) === 0 && (graph.consumers?.length ?? 0) === 0;
+        setLineageByArtifact((prev) => ({ ...prev, [artifactId]: empty ? 'empty' : graph }));
+      } catch (err: unknown) {
+        if (ac.signal.aborted || isAbortError(err) || gen !== runGen.current) return;
+        setLineageByArtifact((prev) => ({ ...prev, [artifactId]: 'error' }));
+      }
+    },
+    [lineageByArtifact, selectedProjectId, selectedRunId],
+  );
+
+  const openCompare = useCallback(async () => {
+    if (!selectedProjectId || !selectedRunId || !comparePeerId) return;
+    if (comparePeerId === selectedRunId) {
+      setCompareError('请选择另一次运行进行对比');
+      return;
+    }
+    compareAbort.current?.abort();
+    const ac = new AbortController();
+    compareAbort.current = ac;
+    const gen = runGen.current;
+    const requestedA = selectedRunId;
+    const requestedB = comparePeerId;
+    setCompareError(null);
+    setCompareBusy(true);
+    try {
+      const result = await fetchRunComparison(selectedProjectId, selectedRunId, comparePeerId, {
+        signal: ac.signal,
+      });
+      if (!mounted.current || gen !== runGen.current) return;
+      if (selectedRunIdRef.current !== requestedA || comparePeerIdRef.current !== requestedB) return;
+      setCompare(result);
+      setView('compare');
+    } catch (err: unknown) {
+      if (ac.signal.aborted || isAbortError(err) || gen !== runGen.current) return;
+      setCompareError(parseApiErrorDetail(err, '对比失败'));
+    } finally {
+      if (gen === runGen.current && mounted.current) setCompareBusy(false);
+    }
+  }, [selectedProjectId, selectedRunId, comparePeerId]);
+
+  const loadMoreRuns = useCallback(async () => {
+    if (!selectedProjectId || !selectedWorkflowId || !runsHasMore) return;
+    const gen = workflowGen.current;
+    const offset = runs.length;
+    try {
+      const page = await fetchWorkflowRuns(selectedProjectId, {
+        workflowId: selectedWorkflowId,
+        offset,
+        forceRefresh: true,
+      });
+      if (gen !== workflowGen.current) return;
+      setRuns((prev) => {
+        const seen = new Set(prev.map((r) => r.id));
+        return [...prev, ...page.items.filter((r) => !seen.has(r.id))];
+      });
+      setRunsHasMore(page.has_more);
+    } catch (err: unknown) {
+      if (isAbortError(err) || gen !== workflowGen.current) return;
+      setError(parseApiErrorDetail(err, '加载更多运行失败'));
+    }
+  }, [selectedProjectId, selectedWorkflowId, runsHasMore, runs.length]);
+
+  const refreshRunsIfCurrent = useCallback(async (projectId: string, workflowId: string, epoch: number) => {
+    if (!projectId || !workflowId) return;
+    try {
+      const page = await fetchWorkflowRuns(projectId, {
+        workflowId,
+        forceRefresh: true,
+      });
+      if (!mounted.current || epoch !== actionEpoch.current) return;
+      if (selectedProjectIdRef.current !== projectId) return;
+      setRuns(page.items);
+      setRunsHasMore(page.has_more);
+    } catch {
+      /* list refresh is best-effort after a mutation */
+    }
+  }, []);
+
+  const withActionLock = useCallback(
+    async (fn: () => Promise<WorkflowRunDetail>): Promise<ActionResult> => {
+      if (actionLock.current) return { ok: false, error: null };
+      actionLock.current = true;
+      setActionBusy(true);
+      setActionError(null);
+      const epoch = actionEpoch.current;
+      const sourceProjectId = selectedProjectIdRef.current;
+      const sourceWorkflowId = selectedWorkflowIdRef.current;
+      const sourceRunId = selectedRunIdRef.current;
+      try {
+        const result = await fn();
+        if (!mounted.current) return { ok: true, run: result, applied: false };
+        const stillSameProject =
+          epoch === actionEpoch.current && selectedProjectIdRef.current === sourceProjectId;
+        const stillSameWorkflow = selectedWorkflowIdRef.current === sourceWorkflowId;
+        const applied = stillSameProject && selectedRunIdRef.current === sourceRunId;
+        if (applied) {
+          setRunDetail(result);
+          setSelectedRunId(result.id);
+          setView('run');
+        }
+        if (stillSameProject && stillSameWorkflow) {
+          await refreshRunsIfCurrent(sourceProjectId, sourceWorkflowId, epoch);
+        }
+        return { ok: true, run: result, applied };
+      } catch (err: unknown) {
+        if (sourceProjectId) invalidateProjectRunCaches(sourceProjectId);
+        if (!mounted.current) return { ok: false, error: null };
+        if (isAbortError(err)) return { ok: false, error: null };
+        const timedOut = err instanceof ApiTimeoutError;
+        const message = timedOut
+          ? '请求超时，已刷新运行列表（后端可能已创建新运行）'
+          : parseApiErrorDetail(err, '操作被后端拒绝');
+        const stillSameProject =
+          epoch === actionEpoch.current && selectedProjectIdRef.current === sourceProjectId;
+        if (stillSameProject) {
+          setActionError(message);
+          await refreshRunsIfCurrent(sourceProjectId, sourceWorkflowId, epoch);
+        }
+        return { ok: false, error: stillSameProject ? message : null };
+      } finally {
+        actionLock.current = false;
+        if (mounted.current) setActionBusy(false);
+      }
+    },
+    [refreshRunsIfCurrent],
+  );
+
+  const triggerRun = useCallback(
+    (workflowId: string) => {
+      if (!selectedProjectId) return Promise.resolve({ ok: false, error: null } as ActionResult);
+      return withActionLock(() => runWorkflow(selectedProjectId, workflowId));
+    },
+    [selectedProjectId, withActionLock],
+  );
+
+  const replay = useCallback(
+    (mode: ReplayMode) => {
+      if (!selectedProjectId || !selectedRunId) {
+        return Promise.resolve({ ok: false, error: null } as ActionResult);
+      }
+      return withActionLock(() => replayWorkflowRun(selectedProjectId, selectedRunId, mode));
+    },
+    [selectedProjectId, selectedRunId, withActionLock],
+  );
+
+  const resume = useCallback(() => {
+    if (!selectedProjectId || !selectedRunId) {
+      return Promise.resolve({ ok: false, error: null } as ActionResult);
+    }
+    return withActionLock(() => resumeWorkflowRun(selectedProjectId, selectedRunId));
+  }, [selectedProjectId, selectedRunId, withActionLock]);
+
+  useEffect(
+    () => () => {
+      mounted.current = false;
+      projectAbort.current?.abort();
+      workflowAbort.current?.abort();
+      runAbort.current?.abort();
+      lineageAbort.current?.abort();
+      compareAbort.current?.abort();
+      if (pollTimer.current) clearTimeout(pollTimer.current);
+    },
+    [],
+  );
+
+  return {
+    projects,
+    selectedProjectId,
+    selectProject,
+    createProject,
+    datasets,
+    workflows,
+    revisions,
+    runs,
+    runsHasMore,
+    loadMoreRuns,
+    selectedWorkflow,
+    selectedRunId,
+    runDetail,
+    view,
+    loading,
+    detailLoading,
+    error,
+    actionError,
+    actionBusy,
+    compare,
+    compareError,
+    compareBusy,
+    comparePeerId,
+    setComparePeerId: (id: string) => {
+      setComparePeerId(id);
+      setCompare(null);
+      setCompareError(null);
+    },
+    lineageByArtifact,
+    loadLineage,
+    openWorkflow,
+    openRun,
+    back,
+    openCompare,
+    triggerRun,
+    replay,
+    resume,
+  };
+}

--- a/frontend/lib/workflow/recovery.test.ts
+++ b/frontend/lib/workflow/recovery.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import { ApiError, ApiTimeoutError } from '@/lib/api/transport';
+import type { RunComparison, WorkflowRunDetail } from '@/lib/api/project';
+import {
+  buildLineageRows,
+  formatCrs,
+  formatOutcomeMessage,
+  isAbortError,
+  isActiveRunStatus,
+  isPartialRun,
+  outcomeToastVariant,
+  parseApiErrorDetail,
+  runFingerprintsEqual,
+  shouldOfferResume,
+  summarizeCompare,
+  unwrapPage,
+} from './recovery';
+
+function run(overrides: Partial<WorkflowRunDetail> = {}): WorkflowRunDetail {
+  return {
+    id: 'run_1',
+    workflow_id: 'wf_1',
+    workflow_version: 1,
+    project_id: 'p1',
+    workflow_revision_id: 'rev_1',
+    input_bindings: {},
+    input_dataset_fingerprints: {},
+    status: 'failed',
+    execution_trace: [],
+    outputs: {},
+    cost_perf_summary: {},
+    completed_steps: ['s1'],
+    created_at: '2026-08-13T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('formatCrs (INV-ART1)', () => {
+  it('never fabricates EPSG:4326 for null or empty CRS', () => {
+    expect(formatCrs(null)).toBe('未知');
+    expect(formatCrs(undefined)).toBe('未知');
+    expect(formatCrs('')).toBe('未知');
+    expect(formatCrs('   ')).toBe('未知');
+  });
+
+  it('passes through a truthful CRS string', () => {
+    expect(formatCrs('EPSG:3857')).toBe('EPSG:3857');
+  });
+});
+
+describe('partial / resume offer — backend-derived only', () => {
+  it('treats failed + completed steps as partial, not as a backend status', () => {
+    expect(isPartialRun(run({ status: 'failed', completed_steps: ['s1'] }))).toBe(true);
+    expect(isPartialRun(run({ status: 'cancelled', completed_steps: ['s1'] }))).toBe(true);
+    expect(isPartialRun(run({ status: 'completed', completed_steps: ['s1'] }))).toBe(false);
+    expect(isPartialRun(run({ status: 'failed', completed_steps: [] }))).toBe(false);
+  });
+
+  it('offers resume only for failed/cancelled with completed steps — never as a fact of resumability', () => {
+    expect(shouldOfferResume(run({ status: 'failed', completed_steps: ['s1'] }))).toBe(true);
+    expect(shouldOfferResume(run({ status: 'cancelled', completed_steps: ['s1'] }))).toBe(true);
+    expect(shouldOfferResume(run({ status: 'failed', completed_steps: [] }))).toBe(false);
+    expect(shouldOfferResume(run({ status: 'completed', completed_steps: ['s1'] }))).toBe(false);
+    expect(shouldOfferResume(run({ status: 'running', completed_steps: ['s1'] }))).toBe(false);
+    expect(shouldOfferResume(null)).toBe(false);
+    expect(shouldOfferResume({ status: 'failed' } as WorkflowRunDetail)).toBe(false);
+  });
+});
+
+describe('formatOutcomeMessage — never claim success against backend status', () => {
+  it('quotes the returned status instead of saying the action succeeded', () => {
+    expect(formatOutcomeMessage('replay', run({ status: 'failed' }))).toBe(
+      '回放结束，后端状态：失败',
+    );
+    expect(formatOutcomeMessage('resume', run({ status: 'failed' }))).toBe(
+      '续跑结束，后端状态：失败',
+    );
+    expect(formatOutcomeMessage('replay', run({ status: 'completed' }))).toBe(
+      '回放结束，后端状态：已完成',
+    );
+    expect(formatOutcomeMessage('run', run({ status: 'failed' }))).toBe(
+      '运行结束，后端状态：失败',
+    );
+  });
+
+  it('does not contain 成功 or 已提交 when the returned run is not completed', () => {
+    const msg = formatOutcomeMessage('resume', run({ status: 'cancelled' }));
+    expect(msg).not.toMatch(/成功/);
+    expect(msg).not.toMatch(/已提交/);
+    expect(msg).toContain('已取消');
+  });
+
+  it('maps toast chrome from run status, not from HTTP', () => {
+    expect(outcomeToastVariant('failed')).toBe('error');
+    expect(outcomeToastVariant('cancelled')).toBe('warning');
+    expect(outcomeToastVariant('completed')).toBe('success');
+    expect(outcomeToastVariant('running')).toBe('info');
+  });
+});
+
+describe('runFingerprintsEqual', () => {
+  it('uses only the backend same flag — never infers from display fields', () => {
+    const cmp: RunComparison = {
+      run_a_id: 'a',
+      run_b_id: 'b',
+      revision: {
+        run_a_revision: 'r1',
+        run_b_revision: 'r1',
+        run_a_graph_fingerprint: 'g',
+        run_b_graph_fingerprint: 'g',
+        graph_same: true,
+      },
+      inputs_changed: { run_a: {}, run_b: {}, diff_keys: [] },
+      dataset_versions_changed: { run_a: {}, run_b: {}, diff_keys: [] },
+      tool_versions_changed: {},
+      params_changed: {},
+      output_artifacts_changed: {},
+      metrics_changed: {},
+      warnings_changed: {},
+      run_fingerprint: { run_a: 'fp1', run_b: 'fp1', same: false },
+    };
+    expect(runFingerprintsEqual(cmp)).toBe(false);
+    expect(runFingerprintsEqual({ ...cmp, run_fingerprint: { run_a: 'x', run_b: 'y', same: true } })).toBe(
+      true,
+    );
+    expect(runFingerprintsEqual({ ...cmp, run_fingerprint: { run_a: null, run_b: null, same: false } })).toBe(
+      false,
+    );
+    const missingFp: RunComparison = {
+      ...cmp,
+      revision: {
+        ...cmp.revision,
+        graph_same: true,
+        run_a_graph_fingerprint: null,
+        run_b_graph_fingerprint: null,
+      },
+      run_fingerprint: { run_a: null, run_b: null, same: false },
+    };
+    expect(runFingerprintsEqual(missingFp)).toBe(false);
+  });
+});
+
+describe('summarizeCompare', () => {
+  it('lists only sections the backend reports as changed', () => {
+    const rows = summarizeCompare({
+      run_a_id: 'a',
+      run_b_id: 'b',
+      revision: {
+        run_a_revision: 'r1',
+        run_b_revision: 'r2',
+        run_a_graph_fingerprint: 'g1',
+        run_b_graph_fingerprint: 'g2',
+        graph_same: false,
+      },
+      inputs_changed: { run_a: { aoi: 'A' }, run_b: { aoi: 'B' }, diff_keys: ['aoi'] },
+      dataset_versions_changed: { run_a: {}, run_b: {}, diff_keys: [] },
+      tool_versions_changed: { buffer: ['1', '2'] },
+      params_changed: {},
+      output_artifacts_changed: { run_a_artifact_count: 1, run_b_artifact_count: 2 },
+      metrics_changed: { run_a_perf: { ms: 1 }, run_b_perf: { ms: 2 } },
+      warnings_changed: { run_a_error: 'x', run_b_error: null },
+      run_fingerprint: { run_a: 'aa', run_b: 'bb', same: false },
+    });
+    const labels = rows.map((r) => r.label);
+    expect(labels).toContain('工作流修订 / 图指纹');
+    expect(labels).toContain('输入参数');
+    expect(labels).toContain('工具版本');
+    expect(labels).not.toContain('数据集版本');
+  });
+});
+
+describe('parseApiErrorDetail', () => {
+  it('surfaces FastAPI detail so a 409 reason is not swallowed', () => {
+    const err = new ApiError(409, 'Conflict', {
+      detail: 'cannot resume run r1: input dataset fingerprints changed',
+    });
+    expect(parseApiErrorDetail(err, 'fallback')).toContain('input dataset fingerprints changed');
+  });
+
+  it('does not treat abort as a user-facing error', () => {
+    const abort = new DOMException('Aborted', 'AbortError');
+    expect(isAbortError(abort)).toBe(true);
+    expect(parseApiErrorDetail(abort, 'fallback')).toBe('fallback');
+  });
+
+  it('does not treat timeout as abort — the server may have created a run', () => {
+    expect(isAbortError(new ApiTimeoutError(120000))).toBe(false);
+  });
+});
+
+describe('unwrapPage', () => {
+  it('reads items from the Page envelope and accepts a bare array for tests', () => {
+    expect(unwrapPage({ items: [{ id: '1' }], total: 1, limit: 50, offset: 0, has_more: false })).toEqual([
+      { id: '1' },
+    ]);
+    expect(unwrapPage([{ id: '2' }])).toEqual([{ id: '2' }]);
+    expect(unwrapPage(null)).toEqual([]);
+  });
+});
+
+describe('lineage rows', () => {
+  it('builds a bounded accessible list and reports empty when the graph has no edges', () => {
+    expect(buildLineageRows({ artifact_id: 'a1', parents: [], consumers: [] }, 32)).toEqual([]);
+    const rows = buildLineageRows(
+      {
+        artifact_id: 'child',
+        parents: [
+          {
+            lineage_id: 'l1',
+            artifact_id: 'child',
+            parent_artifact_id: 'parent',
+            producing_tool: 'buffer',
+            tool_version: '1.0',
+            depth: 1,
+            source_dataset_id: 'ds1',
+            source_dataset_fingerprint: 'fp1',
+          },
+        ],
+        consumers: [
+          {
+            lineage_id: 'l2',
+            consumer_artifact_id: 'next',
+            parent_artifact_id: 'child',
+            producing_tool: 'clip',
+            depth: 1,
+          },
+        ],
+      },
+      2,
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0].direction).toBe('upstream');
+    expect(rows[1].direction).toBe('downstream');
+  });
+});
+
+describe('active run status', () => {
+  it('only pending/running are pollable', () => {
+    expect(isActiveRunStatus('pending')).toBe(true);
+    expect(isActiveRunStatus('running')).toBe(true);
+    expect(isActiveRunStatus('failed')).toBe(false);
+    expect(isActiveRunStatus('completed')).toBe(false);
+  });
+});

--- a/frontend/lib/workflow/recovery.ts
+++ b/frontend/lib/workflow/recovery.ts
@@ -1,0 +1,288 @@
+/**
+ * Workflow recoverability helpers.
+ *
+ * Pure functions over backend contracts. They never invent resume availability,
+ * fingerprint equality, or a CRS default — those come from the API.
+ */
+
+import { ApiError } from '@/lib/api/transport';
+import type {
+  LineageGraph,
+  Page,
+  RunComparison,
+  WorkflowRunDetail,
+  WorkflowRunStatus,
+} from '@/lib/api/project';
+
+const RUN_STATUS_LABEL: Record<WorkflowRunStatus, string> = {
+  pending: '等待中',
+  running: '运行中',
+  completed: '已完成',
+  failed: '失败',
+  cancelled: '已取消',
+};
+
+export function formatCrs(crs: string | null | undefined): string {
+  if (typeof crs !== 'string') return '未知';
+  const trimmed = crs.trim();
+  return trimmed ? trimmed : '未知';
+}
+
+export function isPartialRun(
+  run: Pick<WorkflowRunDetail, 'status' | 'completed_steps'> | null | undefined,
+): boolean {
+  if (!run) return false;
+  if (run.status !== 'failed' && run.status !== 'cancelled') return false;
+  return (run.completed_steps?.length ?? 0) > 0;
+}
+
+/**
+ * Necessary (not sufficient) preconditions to *offer* resume.
+ * The backend still decides; a 409 is the authority.
+ */
+export function shouldOfferResume(
+  run: Pick<WorkflowRunDetail, 'status' | 'completed_steps'> | null | undefined,
+): boolean {
+  if (!run) return false;
+  if (run.status !== 'failed' && run.status !== 'cancelled') return false;
+  return (run.completed_steps?.length ?? 0) > 0;
+}
+
+export function runStatusLabel(status: string): string {
+  return RUN_STATUS_LABEL[status as WorkflowRunStatus] ?? status;
+}
+
+export type OutcomeToastVariant = 'success' | 'info' | 'warning' | 'error';
+
+/** Toast chrome follows run status, not HTTP 2xx. */
+export function outcomeToastVariant(status: string): OutcomeToastVariant {
+  if (status === 'completed') return 'success';
+  if (status === 'cancelled') return 'warning';
+  if (status === 'pending' || status === 'running') return 'info';
+  return 'error';
+}
+
+export function formatOutcomeMessage(
+  action: 'replay' | 'resume' | 'run',
+  run: Pick<WorkflowRunDetail, 'status'>,
+): string {
+  const verb = action === 'replay' ? '回放' : action === 'resume' ? '续跑' : '运行';
+  return `${verb}结束，后端状态：${runStatusLabel(run.status)}`;
+}
+
+export function runFingerprintsEqual(cmp: Pick<RunComparison, 'run_fingerprint'>): boolean {
+  return cmp.run_fingerprint?.same === true;
+}
+
+export interface CompareRow {
+  key: string;
+  label: string;
+  changed: boolean;
+  detail: string;
+}
+
+function dictDiffKeys(block: { diff_keys?: string[] } | undefined): string[] {
+  return Array.isArray(block?.diff_keys) ? block.diff_keys : [];
+}
+
+export function summarizeCompare(cmp: RunComparison): CompareRow[] {
+  const rows: CompareRow[] = [];
+  const bothGraphFp =
+    Boolean(cmp.revision?.run_a_graph_fingerprint) && Boolean(cmp.revision?.run_b_graph_fingerprint);
+  const revChanged =
+    (bothGraphFp && cmp.revision?.graph_same === false) ||
+    cmp.revision?.run_a_revision !== cmp.revision?.run_b_revision;
+  if (revChanged) {
+    rows.push({
+      key: 'revision',
+      label: '工作流修订 / 图指纹',
+      changed: true,
+      detail: `修订 ${cmp.revision?.run_a_revision ?? '—'} → ${cmp.revision?.run_b_revision ?? '—'}`,
+    });
+  }
+  const inputKeys = dictDiffKeys(cmp.inputs_changed);
+  if (inputKeys.length) {
+    rows.push({
+      key: 'inputs',
+      label: '输入参数',
+      changed: true,
+      detail: inputKeys.join(', '),
+    });
+  }
+  const dsKeys = dictDiffKeys(cmp.dataset_versions_changed);
+  if (dsKeys.length) {
+    rows.push({
+      key: 'datasets',
+      label: '数据集版本',
+      changed: true,
+      detail: dsKeys.join(', '),
+    });
+  }
+  const toolKeys = Object.keys(cmp.tool_versions_changed ?? {});
+  if (toolKeys.length) {
+    rows.push({
+      key: 'tools',
+      label: '工具版本',
+      changed: true,
+      detail: toolKeys.join(', '),
+    });
+  }
+  const paramKeys = Object.keys(cmp.params_changed ?? {});
+  if (paramKeys.length) {
+    rows.push({
+      key: 'params',
+      label: '步骤参数',
+      changed: true,
+      detail: paramKeys.join(', '),
+    });
+  }
+  const arts = cmp.output_artifacts_changed ?? {};
+  const artChanged =
+    arts.run_a_artifact_count !== arts.run_b_artifact_count ||
+    JSON.stringify(arts.run_a_fingerprints ?? []) !== JSON.stringify(arts.run_b_fingerprints ?? []);
+  if (artChanged) {
+    rows.push({
+      key: 'artifacts',
+      label: '产物',
+      changed: true,
+      detail: `${arts.run_a_artifact_count ?? 0} → ${arts.run_b_artifact_count ?? 0}`,
+    });
+  }
+  if (cmp.run_fingerprint && cmp.run_fingerprint.same !== true) {
+    rows.push({
+      key: 'fingerprint',
+      label: '运行指纹',
+      changed: true,
+      detail: '后端判定两次运行指纹不相同',
+    });
+  }
+  const warnings = cmp.warnings_changed ?? {};
+  if (warnings.run_a_error || warnings.run_b_error) {
+    rows.push({
+      key: 'warnings',
+      label: '警告 / 错误',
+      changed: true,
+      detail: `${String(warnings.run_a_error ?? '—')} → ${String(warnings.run_b_error ?? '—')}`,
+    });
+  }
+  const metrics = cmp.metrics_changed ?? {};
+  if (metrics.run_a_perf || metrics.run_b_perf) {
+    rows.push({
+      key: 'metrics',
+      label: '运行指标',
+      changed: true,
+      detail: '见后端 metrics_changed',
+    });
+  }
+  return rows;
+}
+
+export function isAbortError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const name = (err as { name?: string }).name;
+  return name === 'AbortError';
+}
+
+export function parseApiErrorDetail(err: unknown, fallback: string): string {
+  if (isAbortError(err)) return fallback;
+  if (err instanceof ApiError) {
+    const body = err.body;
+    if (typeof body === 'string' && body.trim()) return body;
+    if (body && typeof body === 'object') {
+      const detail = (body as { detail?: unknown }).detail;
+      if (typeof detail === 'string' && detail.trim()) return detail;
+      if (Array.isArray(detail)) {
+        const parts = detail
+          .map((item) => {
+            if (typeof item === 'string') return item;
+            if (item && typeof item === 'object' && 'msg' in item) {
+              return String((item as { msg: unknown }).msg);
+            }
+            return '';
+          })
+          .filter(Boolean);
+        if (parts.length) return parts.join('; ');
+      }
+    }
+    return err.message || fallback;
+  }
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+export function unwrapPage<T>(data: Page<T> | T[] | null | undefined): T[] {
+  if (!data) return [];
+  if (Array.isArray(data)) return data;
+  return Array.isArray(data.items) ? data.items : [];
+}
+
+export interface LineageRow {
+  key: string;
+  direction: 'upstream' | 'downstream';
+  depth: number;
+  nodeId: string;
+  relatedId: string | null;
+  tool: string;
+  toolVersion: string | null;
+  sourceDatasetId: string | null;
+  sourceDatasetFingerprint: string | null;
+}
+
+const LINEAGE_CAP = 48;
+
+export function lineageTruncated(graph: LineageGraph, maxRows = LINEAGE_CAP): boolean {
+  const total = (graph.parents?.length ?? 0) + (graph.consumers?.length ?? 0);
+  return total > maxRows;
+}
+
+export function buildLineageRows(graph: LineageGraph, maxRows = LINEAGE_CAP): LineageRow[] {
+  const rows: LineageRow[] = [];
+  for (const p of graph.parents ?? []) {
+    rows.push({
+      key: p.lineage_id || `up-${p.parent_artifact_id}-${p.depth}`,
+      direction: 'upstream',
+      depth: p.depth ?? 0,
+      nodeId: p.parent_artifact_id,
+      relatedId: p.artifact_id,
+      tool: p.producing_tool || '—',
+      toolVersion: p.tool_version ?? null,
+      sourceDatasetId: p.source_dataset_id ?? null,
+      sourceDatasetFingerprint: p.source_dataset_fingerprint ?? null,
+    });
+  }
+  for (const c of graph.consumers ?? []) {
+    rows.push({
+      key: c.lineage_id || `down-${c.consumer_artifact_id}-${c.depth}`,
+      direction: 'downstream',
+      depth: c.depth ?? 0,
+      nodeId: c.consumer_artifact_id,
+      relatedId: c.parent_artifact_id,
+      tool: c.producing_tool || '—',
+      toolVersion: c.tool_version ?? null,
+      sourceDatasetId: null,
+      sourceDatasetFingerprint: null,
+    });
+  }
+  return rows.slice(0, Math.max(0, maxRows));
+}
+
+export function isActiveRunStatus(status: string | undefined): boolean {
+  return status === 'pending' || status === 'running';
+}
+
+export function shortId(id: string | null | undefined, len = 8): string {
+  if (!id) return '—';
+  return id.length <= len ? id : id.slice(0, len);
+}
+
+export const REPLAY_MODE_COPY = {
+  exact: {
+    label: '精确回放',
+    description:
+      '使用该次运行冻结的修订、图快照与输入绑定。数据集指纹会按当前数据重新采集；是否复现需对比运行指纹，不能从这次结束状态推断。',
+  },
+  latest: {
+    label: '最新修订回放',
+    description: '使用工作流当前修订，沿用该次运行的输入绑定。图结构可能已与原运行不同。',
+  },
+} as const;


### PR DESCRIPTION
## Summary

Adds a Project-tab Workflow Run / Recovery inspector on top of the already-merged provenance backend. Users can follow **workflow → revision → runs → run detail**, inspect input dataset versions, steps/tools, artifacts (including truthful null CRS), lineage, and compare two runs, then invoke **exact** or **latest** replay or **resume** without inventing recoverability.

## BASE_SHA / FINAL_SHA

- **BASE_SHA:** `84c73fa85063957c81f80b877fbb0e3f9387f7ae`
- **FINAL_SHA:** `831d0bebcbb70deff94bb4f7997a0c09cb2b2486`

## Backend capabilities integrated

- `GET /api/v1/projects` / datasets / workflows as `Page` envelopes (unwrapped in the client)
- `GET /api/v1/projects/{id}/runs` (workflow-scoped, paginated) + `GET .../runs/{run_id}`
- `GET .../workflows/{wf}/revisions`
- `POST .../runs/{run_id}/replay` `{ mode: exact | latest }`
- `POST .../runs/{run_id}/resume` `{ allow_rerun: false }`
- `POST .../runs/compare?run_a_id=&run_b_id=`
- `GET /api/v1/projects/artifacts/{id}/lineage`
- Artifact / dataset `crs: string | null` — never defaulted to EPSG:4326 in TypeScript or UI

## Information architecture

Integrated into the existing **项目** context panel (280–420px). No new route, no nav-rail change, no second workflow system.

Stack: project list + datasets + workflows → workflow revisions + run list (+ load more) → run inspector (identity, inputs, steps, artifacts, metrics, recovery, compare, optional raw manifest).

## Replay / resume semantics

- Replay requires an explicit **精确回放** vs **最新修订回放** choice, then `ConfirmAction`.
- Exact copy states that dataset fingerprints are recaptured; reproduction is only known after compare.
- Resume is labeled **尝试续跑**, offered only when detail `status ∈ {failed, cancelled}` **and** `completed_steps.length > 0`. No `可续跑` badge. `allow_rerun` is always `false`.
- Toast chrome follows **returned run status**, not HTTP 2xx. Failed run → error toast. Copy is `结束，后端状态：…` (never “成功” on a non-completed run).
- 409 surfaces FastAPI `detail`. Timeout is not treated as abort; run caches are invalidated and the list is refreshed.
- Double POST is locked. A late success is **not** painted or toasted onto a run/project the user has left.

## Compare / lineage behavior

- Compare identity is **only** `run_fingerprint.same === true`.
- Changing the peer clears the previous verdict so a green “指纹相同” cannot stick to the wrong pair.
- Compare errors are separate from recovery errors.
- Lineage is a lazy, bounded accessible list (no graph library). Opening a run fetches **zero** lineage requests; one artifact click → one GET. Truncation is disclosed.

## Performance / request-count evidence

- Project open: list + datasets + workflows. **No runs/detail/lineage/compare** until the user drills in.
- Run detail uses `ttlMs: 0`. Lineage/compare are on demand.
- Abort + generation guards on project/workflow/run switch.
- Bounded poll (3s × 40) only while the selected run is `pending`/`running`.
- Tests lock: no runs until workflow open; no lineage until requested; one in-flight replay; stale project-detail discarded; late replay not painted; compare cleared on peer change.

## Accessibility / responsive

- Named back / replay / resume / compare controls; radios for replay mode; `role=alert` on errors; `sr-only` compare label.
- Status pulse is `motion-reduce:animate-none`.
- Compact inspector in the existing 280–420px panel; wrapping + `min-w-0` / truncate for 1024–1920 sidebar widths.

## Tests

New/updated frontend tests cover list/detail, loading/error/empty, replay exact/latest, resume 409, compare `same`, null CRS, lineage empty/lazy, stale project switch, session/run switch paint, double-action lock, timeout, keyboard back, ConfirmAction.

Local gates (frontend/):

- `npm test` — 103 files, **900 passed**, 3 skipped
- `npm run lint` — clean (`--max-warnings 0`)
- `npx tsc --noEmit` — clean
- `npx tsc -p tsconfig.test.json --noEmit` — clean
- `npm run build` — compiled successfully

## Adversarial review findings

Matt (plan + post-impl): **“Can this UI tell the user replay/resume/compare succeeded when the backend says otherwise?”**

- Plan-stage: yes (2xx-as-success). Fixed.
- Post-impl remaining P0/P1 (stale compare banner; success toast after run switch; wrong-workflow list refresh) — **fixed** before ship.
- 200+`failed` is an error toast. Fingerprint equality is only `.same`. Null CRS displays as `未知`.

Standards review: no hard violations. Spec leftovers deferred below.

## Compatibility

- Frontend-only. Does not redesign the workflow engine.
- Does not touch map/MVT (#344) or Data Fabric (#345).
- Existing Project tab loading/error/empty coverage kept; “重新运行” now two-step confirm and uses honest run-status toasts.

## Open-PR conflict boundaries

- **#344** `perf/large-map-data-plane-v3` — map/MVT/ref-descriptor. Not modified.
- **#345** `agent/data-fabric-v3-zcode2` — data-fabric reliability. Not modified.

## Deferred work

- No dedicated revision detail drill-in (revision id + fingerprint shown on the run).
- No pre-action “dataset drifted” probe (backend has no can_resume; 409 + compare remain authoritative).
- Dataset/workflow list `has_more` not paged (runs have load more).
- `execution_trace` is not a second timeline (manifest steps + raw manifest disclosure).

## Validation statement

Validation was **local only**. GitHub Actions / CI/CD was **not** used as completion evidence.