### PR TITLE
perf(llm): pool provider HTTP clients for keep-alive reuse

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -96,6 +96,17 @@ async def lifespan(app: FastAPI):
     from app.core.network import close_shared_client
     await close_shared_client()
 
+    # Close the pooled LLM provider HTTP clients (httpx). They are reused across
+    # LLM calls for keep-alive connection pooling and must be closed on shutdown
+    # so sockets are released (consistent with close_shared_client above).
+    # Idempotent; failure is best-effort and never blocks shutdown.
+    try:
+        from app.services.chat.llm_client import close_llm_http_clients
+
+        await close_llm_http_clients()
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"[lifespan] LLM HTTP client close failed: {e}")
+
     # 审计 BUG-03/AGENT-04：Pi bridge subprocess 之前从未在 shutdown 时关闭
     # → 每次重启泄漏一个 node 进程 + reader task。现在显式关闭。
     if USE_NEW_AGENT:

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -320,29 +320,27 @@ class ChatExecutionEngine:
 
     async def _generate_title(self, session_id: str, first_user_message: str):
         """异步生成对话标题"""
-        import httpx as _httpx
         title = None
         try:
-            payload = {
-                "model": self.model,
-                "messages": [
-                    {"role": "system", "content": "根据用户的首条消息，生成一个简短的对话主题标题。要求：1) 不超过12个字 2) 突出空间分析的核心对象（地名、分析类型等）3) 不要使用引号、书名号或多余的标点。只输出标题文本，不要任何额外内容。"},
-                    {"role": "user", "content": first_user_message[:500]},
-                ],
-                "max_tokens": 64,
-            }
-            async with _httpx.AsyncClient(timeout=30.0) as client:
-                resp = await client.post(
-                    f"{self.base_url}/chat/completions",
-                    headers={"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"},
-                    json=payload,
-                )
-                resp.raise_for_status()
-                choice = resp.json()["choices"][0]
-                msg = choice["message"]
-                title = msg.get("content") or msg.get("reasoning") or msg.get("reasoning_content")
-                if title:
-                    title = title.strip()
+            # Route through the pooled LLM client (call_llm) instead of opening a
+            # one-off httpx.AsyncClient, so title generation reuses the same
+            # keep-alive connection pool as every other LLM call to this provider.
+            cfg = LLMConfig(
+                base_url=self.base_url,
+                model=self.model,
+                api_key=self.api_key,
+                max_tokens=64,
+            )
+            messages = [
+                {"role": "system", "content": "根据用户的首条消息，生成一个简短的对话主题标题。要求：1) 不超过12个字 2) 突出空间分析的核心对象（地名、分析类型等）3) 不要使用引号、书名号或多余的标点。只输出标题文本，不要任何额外内容。"},
+                {"role": "user", "content": first_user_message[:500]},
+            ]
+            resp = await call_llm(cfg, messages)
+            choice = resp["choices"][0]
+            msg = choice["message"]
+            title = msg.get("content") or msg.get("reasoning") or msg.get("reasoning_content")
+            if title:
+                title = title.strip()
 
             if title:
                 title = title.strip('"\'""''《》')

--- a/app/services/chat/llm_client.py
+++ b/app/services/chat/llm_client.py
@@ -10,6 +10,7 @@
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -134,6 +135,214 @@ def _build_payload(cfg: LLMConfig, messages: list[dict], tools: Optional[list], 
     return payload
 
 
+# ─── Provider HTTP client lifecycle ──────────────────────────────────────────
+#
+# Before this block, ``call_llm`` / ``call_llm_stream`` opened a *fresh*
+# ``httpx.AsyncClient`` on every call (a new TCP/TLS handshake + connection pool
+# each time → zero keep-alive reuse across calls to the same provider).
+# ``LLMHttpClientRegistry`` replaces that with one pooled client per provider
+# base_url per running event loop, so repeated calls to the same provider reuse
+# the keep-alive connection pool instead of re-handshaking every turn.
+#
+# Design contract (see PR description):
+#   * Bounded — one client per distinct base_url; ``httpx.Limits`` bounds the pool.
+#   * Loop-aware — a client is bound to the event loop that created it; reusing it
+#     on a different loop raises "Future attached to a different loop". We key by
+#     (base_url, running loop); on loop change the stale entry is discarded. A
+#     client bound to an already-closed loop cannot be ``await``-closed (it raises
+#     ``RuntimeError``), so it is dropped for GC instead. This keeps the registry
+#     correct under pytest's per-function loop scope and on app restart.
+#   * Credentials-safe — NO Authorization or auth header is ever set on the pooled
+#     client. Every call passes ``Authorization`` per-request, so two configs that
+#     share a base_url but differ in api_key / prompt-caching share one client with
+#     zero header bleed (httpcore pools by origin scheme+host+port, never by
+#     Authorization). ASSUMPTION: OpenAI-compatible providers do not set cookies;
+#     if one ever did, keying would need to include that (see PR "deferred items").
+#   * Concurrency-safe — one registry-level ``asyncio.Lock`` (created lazily on
+#     first use, inside a running loop) guards the check-then-create path with a
+#     double check, so two concurrent first-of-provider calls don't make two
+#     clients. (Under single-threaded asyncio the critical section has no await,
+#     so the lock is belt-and-suspenders against a future await being added.)
+#   * Shutdown-safe — ``aclose_all`` is idempotent and closes every client on the
+#     live loop (a real socket close), dropping only foreign/closed-loop entries.
+#     Wired into the FastAPI lifespan shutdown alongside the existing aiohttp
+#     ``close_shared_client()``.
+#
+# No retry is performed at this layer. A mid-stream retry would duplicate tokens
+# and a post-send retry could double-execute tool calls; the only safe retry
+# boundary is connect/pool-phase only (ConnectError / ConnectTimeout /
+# PoolTimeout) and real resilience belongs at the orchestration layer after a
+# clean LLM error. That seam is intentionally left unimplemented here.
+
+# Bounded pool defaults, exposed for tests/ops. Pool sizing must be >= peak
+# concurrent in-flight LLM calls + headroom (streams dominate); the per-request
+# pool timeout stays short so self-inflicted exhaustion fails fast instead of
+# being mislabelled as upstream latency. keepalive_expiry is set above httpx's 5s
+# default so the pooled connection survives a short human pause between turns
+# (the headline reuse benefit) while still bounded — agentic multi-round bursts
+# (sub-second apart) reuse the pool regardless.
+_DEFAULT_MAX_CONNECTIONS = 100
+_DEFAULT_MAX_KEEPALIVE_CONNECTIONS = 20
+_DEFAULT_KEEPALIVE_EXPIRY = 30.0
+
+
+def _normalize_base_url(base_url: str) -> tuple[str, str]:
+    """Return ``(registry_key, url_prefix)`` for a provider base_url.
+
+    The key collapses trailing-slash / host-case variants so the same provider
+    reuses one pooled client. ``url_prefix`` is the canonical form (no trailing
+    slash) used to build request URLs, fixing a latent double slash when base_url
+    ended in ``/`` under the old ``f"{cfg.base_url}/chat/completions"`` build.
+    """
+    url = httpx.URL(base_url).copy_with(query=None, fragment=None)
+    canonical = str(url).rstrip("/")
+    return canonical.lower(), canonical
+
+
+class _PooledEntry:
+    """A pooled client bound to the event loop that created it."""
+
+    __slots__ = ("client", "loop")
+
+    def __init__(self, client: httpx.AsyncClient, loop: asyncio.AbstractEventLoop) -> None:
+        self.client = client
+        self.loop = loop
+
+
+async def _safe_aclose(client: httpx.AsyncClient) -> None:
+    """Close a pooled client, swallowing double-close / loop-gone failures.
+
+    On the live loop this is a real socket close. It is defensive by design: a
+    shutdown triggered twice, or a client already closed, must never raise.
+    """
+    try:
+        await client.aclose()
+    except Exception as e:  # noqa: BLE001 — best-effort teardown, never fatal
+        logger.debug("LLM HTTP client aclose failed (ignored): %s", e)
+
+
+class LLMHttpClientRegistry:
+    """Bounded, loop-aware, concurrency-safe pool of ``httpx.AsyncClient`` per base_url."""
+
+    def __init__(
+        self,
+        max_connections: int = _DEFAULT_MAX_CONNECTIONS,
+        max_keepalive_connections: int = _DEFAULT_MAX_KEEPALIVE_CONNECTIONS,
+        keepalive_expiry: float = _DEFAULT_KEEPALIVE_EXPIRY,
+    ) -> None:
+        self._limits = httpx.Limits(
+            max_connections=max_connections,
+            max_keepalive_connections=max_keepalive_connections,
+            keepalive_expiry=keepalive_expiry,
+        )
+        self._entries: dict[str, _PooledEntry] = {}
+        self._lock: asyncio.Lock | None = None
+        # Number of clients ever created — a deterministic "work-count" signal for
+        # the perf regression tests (before the fix this grew linearly with calls).
+        self.created_count = 0
+
+    def _ensure_lock(self) -> asyncio.Lock:
+        # Created lazily inside a running loop (``acquire`` is always awaited). On
+        # 3.10+ ``asyncio.Lock`` does not bind to a loop at construction, and any
+        # contended waiter is resolved/cancelled before its loop closes (asyncio is
+        # single-threaded per loop), so a single registry lock is safe across the
+        # per-test loop changes that ``function`` loop scope produces.
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        return self._lock
+
+    @staticmethod
+    def _is_live(entry: _PooledEntry, loop: asyncio.AbstractEventLoop) -> bool:
+        return entry.loop is loop and not entry.loop.is_closed()
+
+    async def acquire(self, base_url: str) -> httpx.AsyncClient:
+        """Return a pooled client for ``base_url``, bound to the running loop."""
+        key, _prefix = _normalize_base_url(base_url)
+        loop = asyncio.get_running_loop()
+
+        entry = self._entries.get(key)
+        if entry is not None and self._is_live(entry, loop):
+            return entry.client
+
+        stale: _PooledEntry | None = None
+        async with self._ensure_lock():
+            # Re-check inside the lock: another coroutine may have created it.
+            entry = self._entries.get(key)
+            if entry is not None and self._is_live(entry, loop):
+                return entry.client
+            stale = self._entries.pop(key, None)
+            client = httpx.AsyncClient(
+                limits=self._limits,
+                # Safety net only: both call sites pass an explicit per-request
+                # timeout (which overrides this), but a future caller of
+                # ``get_llm_http_client`` that forgets one still gets a sane bound
+                # instead of httpx's 5s default.
+                timeout=120.0,
+            )
+            self._entries[key] = _PooledEntry(client, loop)
+            self.created_count += 1
+
+        # Close the replaced entry *outside* the lock so creation isn't serialized.
+        # Only a same-live-loop entry can be closed; a foreign/closed-loop client
+        # cannot be await-closed (RuntimeError) and is dropped for GC.
+        if stale is not None:
+            if self._is_live(stale, loop):
+                await _safe_aclose(stale.client)
+            else:
+                logger.debug(
+                    "LLM HTTP client for %s was bound to a finished loop; dropped for GC",
+                    key,
+                )
+        # Return the local, NOT ``self._entries[key]``: a concurrent ``aclose_all``
+        # can clear ``_entries`` during the ``await _safe_aclose(stale)`` above,
+        # which would make a re-read raise ``KeyError``.
+        return client
+
+    def active_client_count(self) -> int:
+        """Pooled clients currently held (for tests/observability)."""
+        return len(self._entries)
+
+    async def aclose_all(self) -> None:
+        """Close every pooled client on the live loop. Idempotent; resets the registry."""
+        async with self._ensure_lock():
+            snapshot = list(self._entries.items())
+            self._entries.clear()
+        loop = asyncio.get_running_loop()
+        for _key, entry in snapshot:
+            if self._is_live(entry, loop):
+                await _safe_aclose(entry.client)
+            else:
+                logger.debug(
+                    "LLM HTTP client for %s was bound to a finished loop; dropped for GC",
+                    _key,
+                )
+
+    def _reset_for_tests(self) -> None:
+        """Synchronously clear pooled clients WITHOUT closing (tests own their loops).
+
+        Used by the lifecycle test autouse fixture so each test starts hermetic.
+        Safe because tests use ``httpx.MockTransport`` (no real sockets → no leak).
+        """
+        self._entries.clear()
+        self._lock = None
+        self.created_count = 0
+
+
+# Process-wide registry. Lazy: clients are created on first ``acquire`` inside a
+# running loop, so importing this module never opens connections.
+_registry = LLMHttpClientRegistry()
+
+
+async def get_llm_http_client(base_url: str) -> httpx.AsyncClient:
+    """Return the pooled HTTP client for a provider ``base_url`` (loop-bound)."""
+    return await _registry.acquire(base_url)
+
+
+async def close_llm_http_clients() -> None:
+    """Close every pooled LLM HTTP client. Called from the FastAPI lifespan shutdown."""
+    await _registry.aclose_all()
+
+
 async def call_llm(
     cfg: LLMConfig,
     messages: list[dict],
@@ -142,14 +351,19 @@ async def call_llm(
     """同步（非流式）调用 LLM API；返回完整响应 JSON。"""
     headers = _build_headers(cfg)
     payload = _build_payload(cfg, messages, tools, stream=False)
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        response = await client.post(
-            f"{cfg.base_url}/chat/completions",
-            headers=headers,
-            json=payload,
-        )
-        response.raise_for_status()
-        return response.json()
+    _key, prefix = _normalize_base_url(cfg.base_url)
+    # Pooled client: the connection/keep-alive pool is reused across calls to the
+    # same provider. Timeout is passed per-request to preserve the wire contract
+    # (flat 120s) exactly, independent of the shared client's own defaults.
+    client = await get_llm_http_client(cfg.base_url)
+    response = await client.post(
+        f"{prefix}/chat/completions",
+        headers=headers,
+        json=payload,
+        timeout=120.0,
+    )
+    response.raise_for_status()
+    return response.json()
 
 
 async def call_llm_stream(
@@ -174,102 +388,110 @@ async def call_llm_stream(
     finish_reason: Optional[str] = None
     in_think_block = False
 
-    timeout = httpx.Timeout(connect=10.0, read=180.0, write=10.0, pool=10.0)
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        async with client.stream(
-            "POST",
-            f"{cfg.base_url}/chat/completions",
-            headers=headers,
-            json=payload,
-        ) as response:
-            if response.status_code != 200:
-                error_text = await response.aread()
-                logger.error(f"LLM Stream Error {response.status_code}: {error_text.decode()}")
-            response.raise_for_status()
+    _key, prefix = _normalize_base_url(cfg.base_url)
+    # Pooled client reused across calls to the same provider. ``async with
+    # client.stream(...)`` releases the connection back to the pool on normal exit,
+    # exception, CancelledError and GeneratorExit, so a cancelled stream forfeits at
+    # most one connection and never poisons the pooled client. Pool timeout is
+    # shortened to 5s so self-inflicted pool exhaustion fails fast instead of being
+    # mislabelled as upstream latency; connect/read/write are unchanged.
+    timeout = httpx.Timeout(connect=10.0, read=180.0, write=10.0, pool=5.0)
+    client = await get_llm_http_client(cfg.base_url)
+    async with client.stream(
+        "POST",
+        f"{prefix}/chat/completions",
+        headers=headers,
+        json=payload,
+        timeout=timeout,
+    ) as response:
+        if response.status_code != 200:
+            error_text = await response.aread()
+            logger.error(f"LLM Stream Error {response.status_code}: {error_text.decode()}")
+        response.raise_for_status()
 
-            async for line in response.aiter_lines():
-                line = line.strip()
-                if not line or not line.startswith("data: "):
-                    continue
-                data_str = line[6:]
-                if data_str == "[DONE]":
-                    break
-                try:
-                    chunk = json.loads(data_str)
-                except json.JSONDecodeError:
-                    logger.warning(f"Failed to parse SSE chunk: {data_str[:200]}")
-                    continue
+        async for line in response.aiter_lines():
+            line = line.strip()
+            if not line or not line.startswith("data: "):
+                continue
+            data_str = line[6:]
+            if data_str == "[DONE]":
+                break
+            try:
+                chunk = json.loads(data_str)
+            except json.JSONDecodeError:
+                logger.warning(f"Failed to parse SSE chunk: {data_str[:200]}")
+                continue
 
-                choices = chunk.get("choices", [])
-                if not choices:
-                    continue
-                delta = choices[0].get("delta", {})
-                finish_reason = choices[0].get("finish_reason") or finish_reason
+            choices = chunk.get("choices", [])
+            if not choices:
+                continue
+            delta = choices[0].get("delta", {})
+            finish_reason = choices[0].get("finish_reason") or finish_reason
 
-                # reasoning delta（显式字段）
-                delta_reasoning = (
-                    delta.get("reasoning")
-                    or delta.get("reasoning_content")
-                    or delta.get("thinking_content")
-                    or delta.get("thinking")
-                )
-                if delta_reasoning:
-                    reasoning_parts.append(delta_reasoning)
-                    yield ("token", {"content": delta_reasoning, "is_reasoning": True})
+            # reasoning delta（显式字段）
+            delta_reasoning = (
+                delta.get("reasoning")
+                or delta.get("reasoning_content")
+                or delta.get("thinking_content")
+                or delta.get("thinking")
+            )
+            if delta_reasoning:
+                reasoning_parts.append(delta_reasoning)
+                yield ("token", {"content": delta_reasoning, "is_reasoning": True})
 
-                # content delta；可能含 <think> 内联标签
-                delta_content = delta.get("content")
-                if delta_content:
-                    remaining = delta_content
-                    while remaining:
-                        if not in_think_block:
-                            idx = remaining.find("<think>")
-                            if idx == -1:
-                                content_parts.append(remaining)
-                                yield ("token", {"content": remaining})
-                                remaining = ""
-                            else:
-                                pre = remaining[:idx]
-                                if pre:
-                                    content_parts.append(pre)
-                                    yield ("token", {"content": pre})
-                                in_think_block = True
-                                remaining = remaining[idx + 7:]
+            # content delta；可能含 <think> 内联标签
+            delta_content = delta.get("content")
+            if delta_content:
+                remaining = delta_content
+                while remaining:
+                    if not in_think_block:
+                        idx = remaining.find("<think>")
+                        if idx == -1:
+                            content_parts.append(remaining)
+                            yield ("token", {"content": remaining})
+                            remaining = ""
                         else:
-                            idx = remaining.find("</think>")
-                            if idx == -1:
-                                reasoning_parts.append(remaining)
-                                yield ("token", {"content": remaining, "is_reasoning": True})
-                                remaining = ""
-                            else:
-                                think_chunk = remaining[:idx]
-                                if think_chunk:
-                                    reasoning_parts.append(think_chunk)
-                                    yield ("token", {"content": think_chunk, "is_reasoning": True})
-                                in_think_block = False
-                                remaining = remaining[idx + 8:].lstrip()
+                            pre = remaining[:idx]
+                            if pre:
+                                content_parts.append(pre)
+                                yield ("token", {"content": pre})
+                            in_think_block = True
+                            remaining = remaining[idx + 7:]
+                    else:
+                        idx = remaining.find("</think>")
+                        if idx == -1:
+                            reasoning_parts.append(remaining)
+                            yield ("token", {"content": remaining, "is_reasoning": True})
+                            remaining = ""
+                        else:
+                            think_chunk = remaining[:idx]
+                            if think_chunk:
+                                reasoning_parts.append(think_chunk)
+                                yield ("token", {"content": think_chunk, "is_reasoning": True})
+                            in_think_block = False
+                            remaining = remaining[idx + 8:].lstrip()
 
-                # tool_call delta
-                delta_tool_calls = delta.get("tool_calls")
-                if delta_tool_calls:
-                    for tc_delta in delta_tool_calls:
-                        idx = tc_delta.get("index", 0)
-                        if idx not in tool_calls_accum:
-                            tool_calls_accum[idx] = {
-                                "id": "",
-                                "type": "function",
-                                "function": {"name": "", "arguments": ""},
-                            }
-                        tc_entry = tool_calls_accum[idx]
-                        if tc_delta.get("id"):
-                            tc_entry["id"] = tc_delta["id"]
-                        if tc_delta.get("type"):
-                            tc_entry["type"] = tc_delta["type"]
-                        fn_delta = tc_delta.get("function", {})
-                        if fn_delta.get("name"):
-                            tc_entry["function"]["name"] += fn_delta["name"]
-                        if fn_delta.get("arguments"):
-                            tc_entry["function"]["arguments"] += fn_delta["arguments"]
+            # tool_call delta
+            delta_tool_calls = delta.get("tool_calls")
+            if delta_tool_calls:
+                for tc_delta in delta_tool_calls:
+                    idx = tc_delta.get("index", 0)
+                    if idx not in tool_calls_accum:
+                        tool_calls_accum[idx] = {
+                            "id": "",
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""},
+                        }
+                    tc_entry = tool_calls_accum[idx]
+                    if tc_delta.get("id"):
+                        tc_entry["id"] = tc_delta["id"]
+                    if tc_delta.get("type"):
+                        tc_entry["type"] = tc_delta["type"]
+                    fn_delta = tc_delta.get("function", {})
+                    if fn_delta.get("name"):
+                        tc_entry["function"]["name"] += fn_delta["name"]
+                    if fn_delta.get("arguments"):
+                        tc_entry["function"]["arguments"] += fn_delta["arguments"]
 
     # Assemble final message
     assembled_content = "".join(content_parts)

--- a/tests/benchmarks/test_llm_http_pooling_perf.py
+++ b/tests/benchmarks/test_llm_http_pooling_perf.py
@@ -1,0 +1,193 @@
+"""Deterministic LLM HTTP client pooling performance evidence (no LLM, no mock).
+
+Two structural, fully deterministic proofs of the LLM Provider HTTP Runtime
+pooling goal — work-count metrics, not fragile wall-clock:
+
+  1. client_creation_count_constant_in_n
+     The cost this goal eliminates. Before the fix every LLM call constructed a
+     fresh ``httpx.AsyncClient`` (O(N) clients for N calls). After: O(1) — one
+     pooled client per provider regardless of N. Asserted by the registry's
+     ``created_count`` counter.
+
+  2. pooled_client_reuses_one_tcp_connection
+     ``httpx.MockTransport`` bypasses httpcore's connection pool, so it CANNOT
+     prove real keep-alive reuse — only "1 client". This workload stands up a
+     real localhost HTTP/1.1 keep-alive server and counts TCP ``accept()``s:
+     N pooled requests must reuse ONE socket (the provider no longer pays a
+     TCP/TLS handshake per turn). This is the only honest proof of reuse.
+
+Both are hard-assert structural gates (no baseline file needed) and run fast.
+Marked ``perf`` to group with the transport/compute perf harnesses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services.chat.llm_client import (
+    _registry,
+    close_llm_http_clients,
+    get_llm_http_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Hermetic reset for the module singleton under per-function loop scope."""
+    _registry._reset_for_tests()
+    yield
+    _registry._reset_for_tests()
+
+
+# ─── 1. client creation count is O(1), not O(N) ──────────────────────────────
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+async def test_client_creation_count_constant_in_n(monkeypatch):
+    """N calls to the same provider must create exactly ONE pooled client.
+
+    This is the deterministic work-count metric for the eliminated cost: before
+    the fix this counter grew linearly (one ``httpx.AsyncClient`` per call).
+    Uses ``httpx.MockTransport`` so no socket is touched.
+    """
+    import httpx
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]},
+        )
+
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(_handler)
+
+    def _factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+    base = "http://provider.example/v1"
+    n = 50
+    for i in range(n):
+        client = await get_llm_http_client(base)
+        # every call returns the SAME client instance
+        assert client is await get_llm_http_client(base)
+        resp = await client.post(
+            f"{base}/chat/completions",
+            json={"i": i},
+            headers={"Content-Type": "application/json"},
+            timeout=30.0,
+        )
+        assert resp.status_code == 200
+
+    assert _registry.created_count == 1, (
+        f"{n} calls must create exactly 1 pooled client, got {_registry.created_count}"
+    )
+    assert _registry.active_client_count() == 1
+    await close_llm_http_clients()
+
+
+# ─── 2. real-socket keep-alive: N requests reuse ONE TCP connection ──────────
+
+
+async def _start_keepalive_server(
+    accept_counter: list[int],
+) -> asyncio.base_events.Server:
+    """Minimal HTTP/1.1 keep-alive server that counts NEW TCP connections.
+
+    Speaks just enough HTTP/1.1: read request line + headers, drain the body by
+    Content-Length, reply with ``Connection: keep-alive`` so the client reuses
+    the socket. ``accept_counter`` counts new TCP accepts — the reuse metric.
+    """
+
+    async def _handle_one_conn(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        try:
+            while True:
+                request_line = await reader.readline()
+                if not request_line:
+                    break  # client closed the keep-alive socket
+                content_length = 0
+                while True:
+                    header = await reader.readline()
+                    if header in (b"\r\n", b"\n", b""):
+                        break
+                    if header.lower().startswith(b"content-length:"):
+                        content_length = int(header.split(b":", 1)[1].strip())
+                if content_length:
+                    await reader.readexactly(content_length)
+                body = (
+                    b'{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}'
+                )
+                response = (
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: application/json\r\n"
+                    b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                    b"Connection: keep-alive\r\n"
+                    b"\r\n" + body
+                )
+                writer.write(response)
+                await writer.drain()
+        except (asyncio.IncompleteReadError, ConnectionResetError):
+            pass
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:  # noqa: BLE001 — best-effort teardown
+                pass
+
+    async def _counted(reader, writer):
+        accept_counter[0] += 1
+        await _handle_one_conn(reader, writer)
+
+    return await asyncio.start_server(_counted, "127.0.0.1", 0)
+
+
+@pytest.mark.perf
+@pytest.mark.asyncio
+async def test_pooled_client_reuses_one_tcp_connection():
+    """The smoking gun: N pooled requests to a real keep-alive server reuse ONE
+    TCP connection (one ``accept``), proving the per-turn TCP/TLS handshake cost
+    is eliminated.
+
+    ``httpx.MockTransport`` cannot prove this — it replaces the transport and
+    bypasses httpcore's connection pool entirely, so only a real socket does.
+    """
+    accept_counter = [0]
+    server = await _start_keepalive_server(accept_counter)
+    port = server.sockets[0].getsockname()[1]
+    base = f"http://127.0.0.1:{port}"
+    try:
+        # The pooled client the registry hands out — the same instance every call.
+        client = await get_llm_http_client(base)
+        same_identity = 0
+        n = 20
+        for _ in range(n):
+            assert (await get_llm_http_client(base)) is client
+            same_identity += 1
+            resp = await client.post(
+                f"{base}/chat/completions",
+                json={"x": 1},
+                headers={"Content-Type": "application/json"},
+                timeout=30.0,
+            )
+            assert resp.status_code == 200
+            assert resp.json()["choices"][0]["message"]["content"] == "ok"
+
+        assert same_identity == n
+        assert _registry.created_count == 1, _registry.created_count
+        assert accept_counter[0] == 1, (
+            f"{n} pooled requests must reuse ONE TCP connection (got "
+            f"{accept_counter[0]} accepts); the per-turn handshake was not eliminated"
+        )
+        await close_llm_http_clients()
+        assert _registry.active_client_count() == 0
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tests/unit/test_llm_http_lifecycle.py
+++ b/tests/unit/test_llm_http_lifecycle.py
@@ -1,0 +1,537 @@
+"""LLM HTTP client lifecycle regression tests.
+
+Locks in the provider HTTP client pooling guarantees introduced for the
+LLM Provider HTTP Runtime reliability goal:
+
+  - N calls to the same provider reuse ONE pooled ``httpx.AsyncClient`` (no
+    per-call client/connection-pool recreation, so the keep-alive pool is
+    reused instead of re-handshaking every turn).
+  - different providers get separate clients; base_url variants collapse.
+  - ``Authorization`` is per-request → no header bleed across api_keys that
+    share a pooled client.
+  - concurrent first-of-provider calls share one client (the creation lock).
+  - ``aclose_all`` is idempotent, leaves no open clients, and the registry is
+    reusable afterwards.
+  - a cancelled stream forfeits at most one connection and never poisons the
+    pooled client (the next call succeeds on the same client).
+  - clients never cross event loops: under pytest's per-function loop scope a
+    new loop gets a new client and the stale one is discarded.
+
+All deterministic: ``httpx.MockTransport`` replaces the network — no real LLM,
+no subprocess, no sockets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from app.services.chat import llm_client
+from app.services.chat.llm_client import (
+    LLMConfig,
+    _normalize_base_url,
+    _registry,
+    call_llm,
+    call_llm_stream,
+    close_llm_http_clients,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Hermetic reset for the registry's own tests.
+
+    The registry is a module singleton, but ``asyncio_default_fixture_loop_scope
+    = function`` gives every test a fresh event loop. Without this reset, a
+    client created on a previous test's (now closed) loop lingers in the
+    registry until the next ``acquire`` detects the loop change — which makes
+    count assertions order-dependent and flaky. The reset is local to this
+    module: the rest of the suite mocks at the engine/planner boundary (above
+    the client) and never touches the registry.
+    """
+    _registry._reset_for_tests()
+    yield
+    _registry._reset_for_tests()
+
+
+def _install_mock_transport(monkeypatch, handler):
+    """Make registry-created clients use a MockTransport (no real network).
+
+    Patches the ``httpx.AsyncClient`` symbol the registry calls inside
+    ``acquire`` so the real creation path runs (``created_count`` increments,
+    entries are stored) but every client speaks to the mock transport.
+    """
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    def _factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.setdefault("transport", transport)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(llm_client.httpx, "AsyncClient", _factory)
+    return transport
+
+
+def _ok_response(request: httpx.Request) -> httpx.Response:
+    body = json.loads(request.content)
+    if body.get("stream"):
+        sse = (
+            "data: "
+            + json.dumps(
+                {"choices": [{"delta": {"content": "hi "}, "finish_reason": None}]}
+            )
+            + "\n\n"
+            + "data: "
+            + json.dumps({"choices": [{"delta": {}, "finish_reason": "stop"}]})
+            + "\n\n"
+            + "data: [DONE]\n\n"
+        )
+        return httpx.Response(
+            200, content=sse.encode(), headers={"content-type": "text/event-stream"}
+        )
+    return httpx.Response(
+        200, json={"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+    )
+
+
+def _cfg(
+    base_url: str = "http://provider.example/v1", api_key: str = "k1"
+) -> LLMConfig:
+    return LLMConfig(base_url=base_url, model="m", api_key=api_key)
+
+
+# ─── client reuse ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_n_calls_same_provider_create_one_client(monkeypatch):
+    _install_mock_transport(monkeypatch, _ok_response)
+    cfg = _cfg()
+    for _ in range(25):
+        resp = await call_llm(cfg, [{"role": "user", "content": "hi"}])
+        assert resp["choices"][0]["message"]["content"] == "ok"
+    assert _registry.created_count == 1, "25 calls must reuse one pooled client"
+    assert _registry.active_client_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_and_nonstream_share_one_client(monkeypatch):
+    _install_mock_transport(monkeypatch, _ok_response)
+    cfg = _cfg()
+    await call_llm(cfg, [{"role": "user", "content": "hi"}])
+    events = [
+        e async for e in call_llm_stream(cfg, [{"role": "user", "content": "hi"}])
+    ]
+    assert _registry.created_count == 1
+    assert any(t == "done" for t, _ in events)
+
+
+@pytest.mark.asyncio
+async def test_different_providers_get_separate_clients(monkeypatch):
+    _install_mock_transport(monkeypatch, _ok_response)
+    await call_llm(_cfg("http://a.example/v1"), [{"role": "user", "content": "x"}])
+    await call_llm(_cfg("http://b.example/v1"), [{"role": "user", "content": "x"}])
+    assert _registry.created_count == 2
+    assert _registry.active_client_count() == 2
+
+
+@pytest.mark.asyncio
+async def test_base_url_variants_collapse_into_one_client(monkeypatch):
+    _install_mock_transport(monkeypatch, _ok_response)
+    # trailing slash + scheme/host case must collapse to the same pooled client
+    await call_llm(
+        _cfg("http://provider.example/v1/"), [{"role": "user", "content": "x"}]
+    )
+    await call_llm(
+        _cfg("http://Provider.Example/V1"), [{"role": "user", "content": "x"}]
+    )
+    assert _registry.created_count == 1
+
+
+@pytest.mark.asyncio
+async def test_request_url_has_no_double_slash(monkeypatch):
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return _ok_response(request)
+
+    _install_mock_transport(monkeypatch, handler)
+    # base_url ends in '/' — the old f"{base_url}/chat/completions" produced a
+    # double slash; normalization must prevent that.
+    await call_llm(
+        _cfg("http://provider.example/v1/"), [{"role": "user", "content": "x"}]
+    )
+    assert seen, "no request observed"
+    assert seen[0].endswith("/v1/chat/completions"), seen
+    assert "//chat" not in seen[0], seen
+
+
+def test_normalize_base_url_key_and_prefix():
+    # httpx.URL lowercases the host (correct per HTTP — hosts are case-insensitive)
+    # while preserving path case; both feed the canonical key/prefix.
+    key_a, prefix_a = _normalize_base_url("https://api.x.com/v1/")
+    key_b, prefix_b = _normalize_base_url("https://API.x.com/v1")
+    assert key_a == key_b == "https://api.x.com/v1", (key_a, key_b)
+    assert prefix_a == prefix_b == "https://api.x.com/v1", (prefix_a, prefix_b)
+    assert not prefix_a.endswith("/"), "prefix must not keep a trailing slash"
+    # path case is preserved (paths may be case-sensitive on some origins)
+    _, prefix_path = _normalize_base_url("https://api.x.com/V1/Chat")
+    assert prefix_path == "https://api.x.com/V1/Chat", prefix_path
+
+
+# ─── header / credentials isolation ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_authorization_bleed_across_api_keys(monkeypatch):
+    seen_auth: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_auth.append(request.headers.get("authorization"))
+        return _ok_response(request)
+
+    _install_mock_transport(monkeypatch, handler)
+    # same provider, different keys → shared client, per-request Authorization
+    await call_llm(_cfg(api_key="key-A"), [{"role": "user", "content": "x"}])
+    await call_llm(_cfg(api_key="key-B"), [{"role": "user", "content": "x"}])
+    await call_llm(_cfg(api_key="key-A"), [{"role": "user", "content": "x"}])
+    assert _registry.created_count == 1, "same base_url shares one client"
+    assert seen_auth == ["Bearer key-A", "Bearer key-B", "Bearer key-A"], seen_auth
+
+
+@pytest.mark.asyncio
+async def test_authorization_not_set_on_pooled_client_headers(monkeypatch):
+    """The pooled client must carry NO Authorization header; it is per-request only.
+
+    Inspects the actual ``httpx.AsyncClient.headers`` on the stored entry — this
+    is the structural guarantee behind the header-isolation claim (httpcore pools
+    by origin, never by Authorization).
+    """
+    _install_mock_transport(monkeypatch, _ok_response)
+    await call_llm(_cfg(api_key="secret"), [{"role": "user", "content": "x"}])
+    assert _registry.active_client_count() == 1
+    entry = next(iter(_registry._entries.values()))
+    assert "authorization" not in entry.client.headers, dict(entry.client.headers)
+    assert "Authorization" not in entry.client.headers
+
+
+# ─── concurrency ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_share_one_client(monkeypatch):
+    _install_mock_transport(monkeypatch, _ok_response)
+    cfg = _cfg()
+    await asyncio.gather(
+        *(call_llm(cfg, [{"role": "user", "content": "x"}]) for _ in range(16))
+    )
+    assert _registry.created_count == 1, "concurrent first-calls must not race-create"
+    assert _registry.active_client_count() == 1
+
+
+# ─── shutdown ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aclose_all_closes_clients_and_is_idempotent(monkeypatch):
+    _install_mock_transport(monkeypatch, _ok_response)
+    await call_llm(_cfg(), [{"role": "user", "content": "x"}])
+    assert _registry.active_client_count() == 1
+    entry = next(iter(_registry._entries.values()))
+    assert not entry.client.is_closed
+
+    await close_llm_http_clients()
+    assert _registry.active_client_count() == 0
+    assert entry.client.is_closed, (
+        "aclose must really close the client on the live loop"
+    )
+
+    # idempotent
+    await close_llm_http_clients()
+    assert _registry.active_client_count() == 0
+
+    # reusable after shutdown: a new call lazily re-creates a client
+    await call_llm(_cfg(), [{"role": "user", "content": "x"}])
+    assert _registry.active_client_count() == 1
+    await close_llm_http_clients()
+
+
+# ─── streaming cancel/release ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stream_does_not_poison_pooled_client(monkeypatch):
+    release = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if not body.get("stream"):
+            # non-stream follow-up after the cancel (same pooled client)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]
+                },
+            )
+
+        async def gen():
+            yield (
+                b"data: "
+                + json.dumps(
+                    {"choices": [{"delta": {"content": "tok"}, "finish_reason": None}]}
+                ).encode()
+                + b"\n\n"
+            )
+            # simulated model latency: the body parks mid-stream
+            await asyncio.wait_for(release.wait(), timeout=10.0)
+            yield b"data: [DONE]\n\n"
+
+        return httpx.Response(
+            200, content=gen(), headers={"content-type": "text/event-stream"}
+        )
+
+    _install_mock_transport(monkeypatch, handler)
+    cfg = _cfg()
+    first_token_seen: list[bool] = []
+
+    async def consume():
+        # Fully iterate (do NOT break): after the first token the body parks at
+        # ``release.wait()``, so the consumer suspends mid-stream — exactly where
+        # a client disconnect delivers cancellation.
+        async for _event in call_llm_stream(cfg, [{"role": "user", "content": "x"}]):
+            first_token_seen.append(True)
+
+    task = asyncio.create_task(consume())
+    # Let the consumer read the first token and then park inside the blocked body.
+    await asyncio.sleep(0.2)
+    assert first_token_seen, "consumer should have read the first token before cancel"
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # MockTransport replaces httpcore's connection pool, so this can prove "the
+    # pooled client is not poisoned (next request succeeds)" but NOT "the
+    # connection was released" (there is no real connection). The real-socket
+    # release proof lives in
+    # ``test_cancelled_stream_releases_connection_over_real_socket`` below.
+    # The client's transport is fixed at creation, so this follow-up hits the
+    # SAME handler/client (no swap).
+    resp = await call_llm(cfg, [{"role": "user", "content": "again"}])
+    assert resp["choices"][0]["message"]["content"] == "ok"
+    assert _registry.created_count == 1, "cancelled stream must not create a new client"
+    release.set()
+
+
+# ─── streaming cancel: real-socket connection release proof ──────────────────
+
+
+async def _streaming_keepalive_server(
+    release: asyncio.Event, events: list[str]
+) -> asyncio.base_events.Server:
+    """Local HTTP/1.1 server proving connection lifecycle on a real socket.
+
+    Non-stream requests get a keep-alive JSON response. Stream requests get a
+    chunked SSE body that writes one token then parks at ``release`` (simulated
+    model latency). It appends ``"accept"`` per new TCP connection and
+    ``"client_closed"`` when the client closes the socket mid-stream — the
+    observable signal that httpx released the cancelled connection.
+    """
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        events.append("accept")
+        try:
+            while True:
+                request_line = await reader.readline()
+                if not request_line:
+                    break
+                content_length = 0
+                while True:
+                    header = await reader.readline()
+                    if header in (b"\r\n", b"\n", b""):
+                        break
+                    if header.lower().startswith(b"content-length:"):
+                        content_length = int(header.split(b":", 1)[1].strip())
+                raw = (
+                    await reader.readexactly(content_length) if content_length else b""
+                )
+                try:
+                    payload = json.loads(raw)
+                except (json.JSONDecodeError, ValueError):
+                    payload = {}
+
+                if not payload.get("stream"):
+                    body = b'{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}'
+                    response = (
+                        b"HTTP/1.1 200 OK\r\n"
+                        b"Content-Type: application/json\r\n"
+                        b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                        b"Connection: keep-alive\r\n\r\n" + body
+                    )
+                    writer.write(response)
+                    await writer.drain()
+                    continue
+
+                # Streaming branch: chunked SSE, one token, then park.
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: text/event-stream\r\n"
+                    b"Transfer-Encoding: chunked\r\n"
+                    b"Connection: keep-alive\r\n\r\n"
+                )
+                token = (
+                    b"data: "
+                    + json.dumps(
+                        {
+                            "choices": [
+                                {"delta": {"content": "tok"}, "finish_reason": None}
+                            ]
+                        }
+                    ).encode()
+                    + b"\n\n"
+                )
+                writer.write(b"%x\r\n" % len(token) + token + b"\r\n")
+                await writer.drain()
+
+                # Detect client-side close concurrently with the park. When httpx
+                # releases the cancelled connection it closes the socket → read EOF.
+                client_closed = asyncio.Event()
+
+                async def _watch_close():
+                    try:
+                        while True:
+                            data = await reader.read(1024)
+                            if not data:
+                                break
+                    except Exception:  # noqa: BLE001 — any read error means closed
+                        pass
+                    client_closed.set()
+
+                watch_task = asyncio.create_task(_watch_close())
+                close_wait = asyncio.create_task(client_closed.wait())
+                release_wait = asyncio.create_task(release.wait())
+                await asyncio.wait(
+                    {close_wait, release_wait},
+                    return_when=asyncio.FIRST_COMPLETED,
+                    timeout=10.0,
+                )
+                if client_closed.is_set():
+                    events.append("client_closed")
+                for pending in (watch_task, close_wait, release_wait):
+                    pending.cancel()
+                break  # the streaming connection ends here either way
+        except (asyncio.IncompleteReadError, ConnectionResetError):
+            pass
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:  # noqa: BLE001
+                pass
+
+    return await asyncio.start_server(_handle, "127.0.0.1", 0)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_stream_releases_connection_over_real_socket():
+    """A cancelled stream must RELEASE the connection (close the socket), not
+    hold it open or leak it onto the pool dirty.
+
+    MockTransport cannot prove this (it bypasses the connection pool). This
+    stands up a real HTTP/1.1 server whose streaming body parks mid-flight, then
+    cancels the consumer and asserts the server observes the socket close
+    (httpx released the connection) — plus the pooled client stays usable.
+    """
+    release = asyncio.Event()
+    events: list[str] = []
+    server = await _streaming_keepalive_server(release, events)
+    port = server.sockets[0].getsockname()[1]
+    base = f"http://127.0.0.1:{port}"
+    cfg = LLMConfig(base_url=base, model="m", api_key="k")
+    try:
+        # Wait for the streaming request to be accepted and the first token
+        # delivered, so the consumer is parked inside the blocked body.
+        first_token: list[bool] = []
+
+        async def consume():
+            async for _event in call_llm_stream(
+                cfg, [{"role": "user", "content": "x"}]
+            ):
+                first_token.append(True)
+
+        task = asyncio.create_task(consume())
+        await asyncio.sleep(0.3)
+        assert first_token, "consumer should have read the first token before cancel"
+        assert events.count("accept") == 1, events
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The server must observe the client closing the socket → connection
+        # released (not leaked / not held open by a dangling generator).
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + 2.0
+        while "client_closed" not in events and loop.time() < deadline:
+            await asyncio.sleep(0.05)
+        assert "client_closed" in events, (
+            f"cancelled stream did not release the connection (no socket close "
+            f"observed); events={events}"
+        )
+
+        # The pooled client is NOT poisoned: a follow-up request on the same
+        # client succeeds (created_count stays 1).
+        resp = await call_llm(cfg, [{"role": "user", "content": "again"}])
+        assert resp["choices"][0]["message"]["content"] == "ok"
+        assert _registry.created_count == 1, _registry.created_count
+
+        release.set()
+    finally:
+        release.set()
+        # Close the pooled client first: its keep-alive connections are held open
+        # by httpx's pool, so without this the server's keep-alive handlers never
+        # see EOF and ``server.wait_closed()`` would block. Guard wait_closed with
+        # a timeout so a parked handler can never hang the suite.
+        try:
+            await close_llm_http_clients()
+        except Exception:  # noqa: BLE001 — teardown
+            pass
+        server.close()
+        try:
+            await asyncio.wait_for(server.wait_closed(), timeout=5.0)
+        except asyncio.TimeoutError:
+            pass
+
+
+# ─── cross-loop safety ───────────────────────────────────────────────────────
+
+
+def test_clients_do_not_cross_event_loops(monkeypatch):
+    """Per-function loop scope invariant: a client bound to loop A must never be
+    reused on loop B (that raises "Future attached to a different loop"). Two
+    distinct ``asyncio.run`` loops acquire sequentially; the second must get a
+    fresh client bound to its own loop.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok_response(request)
+
+    def _run_once() -> None:
+        async def main() -> None:
+            await call_llm(_cfg(), [{"role": "user", "content": "x"}])
+
+        asyncio.run(main())
+
+    _install_mock_transport(monkeypatch, handler)
+    _run_once()  # loop A
+    created_after_a = _registry.created_count
+    assert created_after_a == 1
+
+    _run_once()  # loop B (new event loop); A is now closed
+    # A brand-new client was created for loop B; the stale A-entry was discarded
+    # (not await-closed — it is bound to the now-closed loop A).
+    assert _registry.created_count == created_after_a + 1


### PR DESCRIPTION
## Summary

Eliminates the per-call `httpx.AsyncClient` recreation in `app/services/chat/llm_client.py`. `call_llm` / `call_llm_stream` previously opened a **fresh** client on every call — a new TCP/TLS handshake + connection pool each turn, with **zero keep-alive reuse** across calls to the same provider. This introduces a bounded, loop-aware, concurrency-safe provider HTTP client lifecycle and hardens streaming timeout/cancel/release semantics, with deterministic performance evidence.

- **BASE_SHA:** `84c73fa85063957c81f80b877fbb0e3f9387f7ae` (origin/master)
- **FINAL_SHA:** `19bc493de51a0c1ba32dc0f9abeef38f8406cb41`
- Rebased onto latest origin/master (no movement since BASE).

## Confirmed bottleneck

`call_llm` (was `llm_client.py:145`) and `call_llm_stream` (was `:178`) both did `async with httpx.AsyncClient(...)` per call. Measured structurally: before this change, N calls ⇒ N clients (O(N)); after ⇒ 1 client (O(1)).

## Before / after architecture

**Before:** every LLM call constructs+tears down its own `httpx.AsyncClient`, connection pool, and (in production) TCP/TLS connection.

**After:** `LLMHttpClientRegistry` (in `llm_client.py`) holds **one pooled `httpx.AsyncClient` per provider `base_url` per running event loop**. `call_llm` / `call_llm_stream` acquire the pooled client via `get_llm_http_client(base_url)`; `Authorization` stays per-request; the FastAPI lifespan shutdown calls `close_llm_http_clients()`.

```
call_llm(cfg, ...) ──▶ get_llm_http_client(cfg.base_url) ──▶ registry.acquire()
                                                          │
                              reuse if (base_url, loop) live │ else create+store (locked)
```

Design contract:
- **Bounded** — one client per distinct `base_url`; `httpx.Limits(max_connections=100, max_keepalive_connections=20, keepalive_expiry=30s)` bounds the pool.
- **Loop-aware** — keyed by `(base_url, running_loop)`. On loop change the stale entry is discarded: a client bound to an already-closed loop cannot be `await`-closed (`RuntimeError`), so it is dropped for GC. This is what keeps the registry correct under pytest's per-function loop scope and on app restart.
- **Credentials-safe** — NO `Authorization` is ever set on the pooled client; it is passed per-request, so configs sharing a `base_url` but differing in `api_key`/prompt-caching share one client with zero header bleed (httpcore pools by origin scheme+host+port, never by `Authorization`). ASSUMPTION: OpenAI-compatible providers don't set cookies (see deferred).
- **Concurrency-safe** — lazy `asyncio.Lock` + double-checked create.
- **Shutdown-safe** — `aclose_all()` is idempotent, closes every client on the live loop, and is wired into lifespan shutdown.

## Performance evidence (deterministic — work-count, not wall-clock)

`tests/benchmarks/test_llm_http_pooling_perf.py` (`@pytest.mark.perf`):
- `client_creation_count_constant_in_n` — **50 calls ⇒ 1 client** (`created_count==1`). Before the fix this was 50.
- `pooled_client_reuses_one_tcp_connection` — **20 pooled requests to a real localhost HTTP/1.1 keep-alive server reuse ONE TCP `accept`**. This is the only honest proof of keep-alive reuse (`httpx.MockTransport` bypasses httpcore's connection pool, so it can only prove "1 client", not "1 connection").

`tests/unit/test_llm_http_lifecycle.py` (MockTransport, no sockets): client reuse, base_url normalization, header isolation, concurrency, shutdown idempotency, cross-loop safety, and a **real-socket** proof that a cancelled stream *releases* the connection (the server observes the socket close).

## Concurrency / cancellation semantics

- **Cancellation:** `call_llm_stream` keeps `async with client.stream(...)`, which runs `response.aclose()` on normal exit / exception / `CancelledError` / `GeneratorExit`. A cancelled stream forfeits at most one connection (httpcore closes the half-read one) and **never poisons the pooled client** — the next call succeeds on the same client (proven on a real socket).
- **No retry** is added: a mid-stream retry would duplicate tokens and a post-send retry could double-execute tool calls. The only safe boundary is connect/pool-phase (`ConnectError`/`ConnectTimeout`/`PoolTimeout`); that seam is documented but intentionally unimplemented.
- **Timeouts preserved per-request:** non-stream `120s`; stream `connect=10/read=180/write=10` (unchanged), `pool` shortened `10→5s` so self-inflicted pool exhaustion fails fast instead of being mislabelled as upstream latency.

## Review findings (adversarial: second-opinion pre-impl + diff review post-impl)

Two independent reviews (generalist + asyncio/httpx specialist). Verdict: **merge**. No P0. All P1/P2 addressed:
- **P1 fixed:** the MockTransport cancel test was a false-green (MockTransport has no real connection to release). Added a real-socket test proving the connection is released (server-side socket-close observation).
- **P2 fixed:** `acquire` now returns the local `client` (not `self._entries[key]`) — a concurrent `aclose_all` during the stale-close `await` could have raised `KeyError`.
- **P2 fixed:** pooled client gets an explicit default `timeout=120s` (per-request overrides still win) so a future caller of `get_llm_http_client` that forgets a timeout doesn't inherit httpx's 5s.
- **P2 fixed:** `keepalive_expiry` raised 5s→30s so the pooled connection survives a short human pause between turns.
- **P2 fixed:** `_generate_title` (`execution_engine.py`) was opening its own one-off client, bypassing the pool — now routed through `call_llm`.
- Documented (deferred, see below): `aclose_all` concurrent-acquirer during shutdown (acceptable hard-abort; process exit reclaims sockets); `_safe_aclose` broad `except` is intentional best-effort teardown; the registry `asyncio.Lock` is belt-and-suspenders (asyncio's single-threaded model already prevents the race).

## Tests

- New: `tests/unit/test_llm_http_lifecycle.py` (13 tests), `tests/benchmarks/test_llm_http_pooling_perf.py` (2 tests).
- Existing LLM-adjacent suite green: `test_llm_client`, `test_streaming_lifecycle`, `test_chat_engine*`, `test_planner`, `test_spatial_reasoning`, `test_main`, `test_self_healing`, `test_session_message_cap`, planner/runtime-concurrency — **118 passed**.
- `ruff check app/ tests/` — clean.

Pre-existing failures reproduced on BASE_SHA (not caused by this PR, not fixed here):
- `tests/benchmarks/test_transport_perf.py::concurrent_stream_p95_8` — load-dependent wall-clock flake on the Pi streaming path (this PR doesn't touch it). Reproduced flaking on the unmodified main tree.
- `tests/unit/test_harness_dispatch_hook.py::test_harness_disabled_by_default` — environmental subprocess test (ZCode AppImage), fails identically on BASE_SHA.

## Compatibility

- Function signatures unchanged: `call_llm(cfg, messages, tools=None)`, `call_llm_stream(cfg, messages, tools=None)`. All existing tests mock at the engine/planner boundary (above the client) and are unaffected.
- OpenAI-compatible wire contract preserved (same URL, headers, payload, timeouts).
- `_normalize_base_url` fixes a latent double-slash when `base_url` ended in `/`.

## Conflict boundary with #344 / #345

No overlap. #344 (large ref map data plane / MapSpec COW) and #345 (Data Fabric connectivity/reliability) are untouched. This PR only touches `app/services/chat/llm_client.py`, `app/services/chat/execution_engine.py` (`_generate_title` only), `app/main.py` (one shutdown hook), and the two new test files.

## Deferred items

- Cookie-jar isolation: the pooled client carries httpx's default empty `Cookies` jar; safe for cookie-less OpenAI-compatible providers, but if a provider ever sets a cookie the keying would need to include it.
- Graceful drain on shutdown: `aclose_all` is a hard abort (consistent with the existing aiohttp `close_shared_client`); a drain-with-deadline + in-flight counter is a possible follow-up.
- Connect-only retry seam: documented, intentionally not implemented.
- Cross-loop `ResourceWarning`: dropping a client bound to a closed loop (pytest) may emit an "unclosed socket" note; harmless (no `-W error`), and MockTransport tests have no sockets.

---

**Validation was performed locally; GitHub Actions/CI is not used as completion evidence.**