### PR TITLE
feat(ui): converge professional GIS visual system v4

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Visual regression screenshot output (see test/visual/capture.mjs)
+/.visual/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,14 +1,23 @@
-# WebGIS AI Agent 前端 (V2 重新设计)
+# WebGIS AI Agent 前端
 
-基于 **WebGIS AI Agent v2.html** 设计规范重新构建的新一代具身空间智能引擎前端。
+具身空间智能引擎前端。视觉体系当前为 **Visual System V4（专业 GIS 工作台）**，
+信息架构为 V3 的 NavRail + ContextPanel 工作区外壳。
 
-## 🎨 V2 新特性
+设计规范见下方 [🎨 设计规范 (Visual System V4)](#-设计规范-visual-system-v4)。
 
-### 全新视觉体系 - 玻璃拟态设计
-- **Light / Dark 双主题** - 完整的暗色/亮色主题切换
-- **玻璃拟态 (Glassmorphism)** - 半透明背景 + 毛玻璃模糊效果
-- **Agentic 配色** - 绿色为主色调的科技感配色方案
-- **动态光效** - 思考/执行状态的扫描线动画
+## 🎨 视觉体系沿革
+
+### V4 — 专业 GIS 工作台（当前）
+- **语义 token 体系** - 表面/描边/文字/状态/地图挂件一套变量，明暗各自定义
+- **地图优先** - 地图永远是视觉主体，抽屉不再盖满地图；底部挂件共用一条基线
+- **高信息密度** - 6 级密排字号、24/26/30 三档控件高度、图层行 ~30px
+- **去玻璃拟态** - 地图之上不再有 `backdrop-filter`，改用不透明面板 + 极平阴影
+- **明暗双一等公民** - `darkMode: 'class'`，对比度由测试直接解析 CSS 计算校验
+
+### V2 遗留
+- **玻璃拟态 (Glassmorphism)** - 已由 V4 移除（`.glass` 等类已删除）
+- **Agentic 配色** - 绿色主色调保留，但收敛为 `--accent` / `--accent-vivid` 两个角色
+- **动态光效** - 思考/执行状态的扫描线动画（受 `prefers-reduced-motion` 门控）
 
 ### 重构的组件架构
 ```
@@ -124,23 +133,78 @@ npm run build
 
 ### 新增组件
 所有新组件都应遵循：
-1. 支持 `isDark` 主题切换
-2. 使用 CSS 变量而非硬编码颜色
+1. 用语义 token 类（`bg-surface-panel` / `text-ink-muted` / `border-edge-subtle`），
+   **不要**读 `lib/theme.ts` 的 JS 颜色对象来做内联 `style`
+2. 明暗两套都要能看 —— token 已经在两个主题里各自定义，正常情况下不需要写 `dark:`
 3. 提供 TypeScript 类型定义
 4. 保持小而精，单一职责
 
 ### 状态更新
 在 `lib/store/useHudStore.ts` 中添加新的状态字段和方法。
+需要跨刷新保留的字段必须加进 `partialize`（未列入的字段会静默丢失）。
 
 ### 主题扩展
-在 `lib/theme.ts` 中添加新的颜色变量，并在 `app/globals.css` 中同步。
+在 `app/globals.css` 的 `:root` **和** `.dark` 两个块里同时定义新 token，
+再在 `tailwind.config.ts` 里绑成 `var(--token)` 形式的工具类。
+`test/design-system/tokens.contract.test.ts` 会强制这条双定义规则。
 
-## 🎨 设计规范
+## 🎨 设计规范 (Visual System V4)
 
-- **字体**: DM Sans (正文) + JetBrains Mono (代码/数值)
-- **圆角**: 12px (大组件), 8px (小组件), 6px (按钮)
-- **阴影**: 两层阴影（主阴影 + 细节阴影）
-- **过渡**: 0.2s cubic-bezier(0.4, 0, 0.2, 1)
+定位是**专业 GIS 工作台**：地图永远是视觉主体，工具 UI 克制、紧凑、信息密度高。
+不用大面积渐变、不堆玻璃拟态、不加无意义动画。
+
+### 语义 token（唯一色彩来源）
+
+全部定义在 `app/globals.css`，通过 `tailwind.config.ts` 暴露成工具类。
+旧的 `--theme-*`、`--agent-*`、shadcn HSL 三套变量现在都 `var()` 指回 V4 token，
+所以历史调用点不会漂移。
+
+| 组 | token | 工具类 |
+|---|---|---|
+| 表面 | `--surface-canvas/panel/raised/overlay/sunken/hover/selected/scrim` | `bg-surface-*` |
+| 描边 | `--border-subtle/default/strong` | `border-edge-*` |
+| 文字 | `--text-primary/secondary/muted/disabled/on-accent` | `text-ink-*` |
+| 状态 | `accent` `success` `info` `warning` `critical` `neutral`（各带 `-soft`/`-border`） | `text-status-*` `bg-status-*-soft` |
+| 地图挂件 | `--map-chrome-bg/border/text/…` | `bg-map-chrome` / `.map-chrome` |
+
+- **字体**: DM Sans (正文) + JetBrains Mono (代码/数值/坐标)
+- **字号**: 6 级密排刻度 —— `text-micro`(10) `caption`(11) `meta`(12) `body`(13) `title`(14) `heading`(15)
+- **圆角**: `rounded-xs`(3) `sm`(4) `md`(6) `lg`(8) `xl`(12) `pill`。刻意偏紧 —— 精密仪器感，不是消费级卡片
+- **控件/行高**: `h-control-sm`(24) `md`(26) `lg`(30)；`min-h-row-sm/md/lg`。24px 是 WCAG 2.2 SC 2.5.8 的下限，不要再往下压
+- **图标**: `size-icon-sm`(12) `md`(14) `lg`(16)
+- **阴影**: `shadow-raised/overlay/drawer/chrome`，刻意很平
+- **焦点环**: 靠全局 `*:focus-visible`，别在组件里写 `outline: none`
+
+### 两个 accent，别搞混
+
+- `--accent` —— 文字安全，也是 `--text-on-accent` 底下的填充色
+- `--accent-vivid` —— 只用于图例色块/指示点这类非文字标记
+
+用户自选强调色走 `--agent-accent-raw`（store 写入）→ `--agent-accent`（按主题校正后的可用值）。
+**读的时候一律读 `--agent-accent`。**
+
+### 地图挂件布局
+
+底部所有挂件从 `--map-chrome-bottom` 这一个基线往上排（HUD 开合时会变）。
+新增挂件请挂到这个基线上，不要再写死 `bottom-*`，否则会和图例/比例尺叠在一起。
+
+### 设计系统测试
+
+`test/design-system/` 下三个套件是硬约束，改 token 前先看它们：
+
+- `tokens.contract.test.ts` —— `darkMode: 'class'`、token 双主题定义、工具类必须绑 CSS 变量
+- `contrast.test.ts` —— 直接解析 CSS 算真实对比度，正文 4.5:1 / 非文字 3:1
+- `visual-system.contract.test.tsx` —— 无障碍与交互行为（可及名称、焦点、inert、键盘重排…）
+
+### 视觉回归
+
+```bash
+npm run dev                                    # 另开一个终端
+node test/visual/capture.mjs --out .visual/after
+```
+
+4 视口 × 明暗 × 14 个界面 = 112 张图，落到 `.visual/`（已 gitignore）。
+后端全部走内置 fixture，不需要真的起后端。
 
 ## 📚 相关文档
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -9,127 +9,346 @@
    ════════════════════════════════════════════ */
 
 :root {
-  /* Core palette (HSL for shadcn compat) */
-  --background: 210 33% 96%;          /* #dce8f2 */
-  --foreground: 222 47% 11%;          /* #0f172a */
+  /* Core palette (HSL for shadcn compat).
+     These mirror the V4 surface/text tokens defined further down, expressed as
+     bare HSL triples because shadcn utilities wrap them in `hsl(...)`. Keep the
+     two in step: `bg-card` and `bg-[var(--surface-panel)]` must land on the
+     same colour or the panel chrome splits in two. */
+  --background: 208 41% 90%;          /* --surface-canvas #dbe6f1 */
+  --foreground: 222 47% 11%;          /* --text-primary   #0f172a */
 
-  --card: 210 33% 98%;
+  --card: 207 55% 98%;                /* --surface-panel  #f7fafd */
   --card-foreground: 222 47% 11%;
 
-  --popover: 0 0% 100%;
+  --popover: 200 33% 99%;             /* --surface-overlay */
   --popover-foreground: 222 47% 11%;
 
-  --primary: 142 71% 45%;             /* #16a34a — Agent Green */
+  --primary: 142 72% 29%;             /* --accent #15803d — AA as label text */
   --primary-foreground: 0 0% 100%;
 
-  --secondary: 210 15% 90%;
+  --secondary: 210 30% 95%;
   --secondary-foreground: 222 47% 11%;
 
-  --muted: 210 15% 92%;
-  --muted-foreground: 215 16% 47%;
+  --muted: 210 33% 95%;               /* --surface-sunken */
+  --muted-foreground: 215 18% 43%;    /* --text-muted #5b6b82 */
 
-  --accent: 142 71% 45%;
-  --accent-foreground: 142 71% 35%;
+  --accent: 142 72% 29%;
+  --accent-foreground: 142 72% 25%;
 
-  --destructive: 0 72% 51%;
+  --destructive: 347 82% 41%;         /* --critical #be123c */
   --destructive-foreground: 0 0% 98%;
 
-  --border: 220 13% 91%;
-  --input: 220 13% 91%;
-  --ring: 142 71% 45%;
+  --border: 220 13% 88%;
+  --input: 220 13% 88%;
+  --ring: 142 72% 29%;
 
   --radius: 0.75rem;
 
-  /* Standardized Semantic Theme Design Tokens - Light Theme */
-  --theme-bg: #dce8f2;
-  --theme-bg-panel: rgba(252, 253, 254, 0.88);
-  --theme-bg-glass: rgba(255, 255, 255, 0.80);
-  --theme-bg-subtle: rgba(248, 250, 252, 0.80);
-  --theme-bg-muted: rgba(226, 232, 240, 0.60);
-  --theme-bg-input: rgba(255, 255, 255, 0.60);
-  --theme-bg-hover: rgba(226, 232, 240, 0.60);
+  /* ════════════════════════════════════════════
+     Visual System V4 — semantic tokens
+     ════════════════════════════════════════════
+     One vocabulary for the whole workbench. The three older systems
+     (shadcn HSL vars, --theme-*, --agent-*) stay as-is and are re-pointed at
+     these values below, so nothing that already consumes them changes meaning.
 
-  --theme-text-primary: #1e293b;
-  --theme-text-secondary: #475569;
-  --theme-text-muted: #94a3b8;
-  --theme-text-subtle: #cbd5e1;
+     Naming rule: `--<category>-<role>`. Components should reach for a role
+     ("this is a raised surface"), never a literal ("this is #f8fafc").
+  */
 
-  --theme-border: rgba(15, 23, 42, 0.08);
-  --theme-border-subtle: rgba(226, 232, 240, 0.80);
-  --theme-border-strong: rgba(15, 23, 42, 0.15);
+  /* ── Surfaces: canvas → panel → raised → overlay, plus interaction states ── */
+  --surface-canvas: #dbe6f1;          /* the map / page bed */
+  --surface-panel: #f7fafd;           /* nav rail, context panel, top bar */
+  --surface-raised: #ffffff;          /* cards and rows inside a panel */
+  --surface-overlay: #fafcfe;         /* drawers, modals, map chrome */
+  /* The input well has to read as a well; #eef3f8 was only 1.07:1 against the
+     panel, so inputs were carried entirely by their border. */
+  --surface-sunken: #e7eef6;          /* inputs, code blocks, wells */
+  --surface-hover: rgba(15, 23, 42, 0.05);
+  --surface-selected: rgba(22, 163, 74, 0.10);
+  --surface-scrim: rgba(15, 23, 42, 0.32);
 
-  --theme-shadow: 0 4px 20px rgba(15, 23, 42, 0.06);
+  /* ── Borders ── */
+  --border-subtle: rgba(15, 23, 42, 0.07);
+  --border-default: rgba(15, 23, 42, 0.13);
+  --border-strong: rgba(15, 23, 42, 0.24);
+
+  /* ── Text. Every value below clears WCAG AA on --surface-panel. ──
+     Audited before V4: --theme-text-muted #94a3b8 measured 2.45:1 and
+     --theme-text-subtle #cbd5e1 measured 1.42:1 in light mode. Both were used
+     for real label copy, so they are darkened here rather than left decorative. */
+  --text-primary: #0f172a;            /* 15.9:1 */
+  --text-secondary: #47556a;          /* 7.4:1  */
+  /* Measured against the *canvas* (#dbe6f1), not just the panel — muted copy
+     appears over the map bed too, and the canvas is the darkest light surface. */
+  --text-muted: #566579;              /* 5.7:1 on panel, 4.7:1 on canvas */
+  --text-disabled: #7a8798;           /* 3.5:1 — non-text / disabled only */
+  /* Pairs with `--accent` (the text-bearing accent fill), never with
+     `--accent-vivid`: white on the vivid green is 3.3:1 and fails AA. */
+  --text-on-accent: #ffffff;
+
+  /* ── Status. `soft`/`border` are the tint pair for chips and notices.
+        Two accents by design:
+          --accent       text-safe, and the fill under `--text-on-accent`
+          --accent-vivid brighter; marks, indicators, swatches — never text ── */
+  --accent: #15803d;                  /* 4.9:1 as label text; 5.0:1 under white */
+  --accent-vivid: #16a34a;
+  --accent-soft: rgba(22, 163, 74, 0.10);
+  --accent-border: rgba(22, 163, 74, 0.26);
+
+  --success: #15803d;
+  --success-soft: rgba(22, 163, 74, 0.10);
+  --success-border: rgba(22, 163, 74, 0.26);
+
+  --info: #1d4ed8;                    /* the one "in progress" hue */
+  --info-soft: rgba(37, 99, 235, 0.10);
+  --info-border: rgba(37, 99, 235, 0.26);
+
+  --warning: #b45309;
+  --warning-soft: rgba(234, 88, 12, 0.10);
+  --warning-border: rgba(234, 88, 12, 0.26);
+
+  --critical: #be123c;
+  --critical-soft: rgba(220, 38, 38, 0.10);
+  --critical-border: rgba(220, 38, 38, 0.26);
+
+  --neutral: #5b6b82;
+  --neutral-soft: rgba(100, 116, 139, 0.12);
+  --neutral-border: rgba(100, 116, 139, 0.26);
+
+  /* ── Elevation. Flat by design: this is a workbench, not a landing page. ── */
+  --elevation-flat: none;
+  --elevation-raised: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --elevation-overlay: 0 4px 16px rgba(15, 23, 42, 0.10), 0 1px 3px rgba(15, 23, 42, 0.06);
+  --elevation-drawer: 0 8px 32px rgba(15, 23, 42, 0.14), 0 2px 6px rgba(15, 23, 42, 0.07);
+
+  /* ── Radius. Tight corners read as precision instrumentation. ── */
+  --radius-xs: 3px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-pill: 999px;
+
+  /* ── Typography. A 6-step dense scale; the audit found 12 raw px values
+        (8, 9, 9.5, 10, 10.5, 11, 12, 12.5, 13, 13.5, 14, 15) in use. ── */
+  --font-micro: 10px;                 /* uppercase eyebrows, unit suffixes */
+  --font-caption: 11px;               /* counts, timestamps */
+  --font-meta: 12px;                  /* secondary rows, descriptions */
+  --font-body: 13px;                  /* default panel body */
+  --font-title: 14px;                 /* panel + card titles */
+  --font-heading: 15px;               /* the single largest workbench step */
+  --leading-tight: 1.25;
+  --leading-normal: 1.45;
+  --tracking-eyebrow: 0.06em;
+
+  /* ── Metrics: density comes from agreeing on these, not from ad-hoc padding.
+        QGIS-class layer trees run ~22–24px rows; `--row-sm` is that target. ── */
+  --control-sm: 24px;
+  --control-md: 26px;
+  --control-lg: 30px;
+  --row-sm: 24px;
+  --row-md: 30px;
+  --row-lg: 38px;
+  --icon-sm: 12px;
+  --icon-md: 14px;
+  --icon-lg: 16px;
+  --panel-pad: 10px;
+  --panel-gap: 6px;
+  /* Right-hand drawer width (settings, template gallery).
+     The constraint is "the map stays visible", not "the drawer gets what it
+     wants". 1024 is the minimum target: visible map = 1024 − 48 (rail) − 330
+     (panel) = 646px, so 46vw = 471px leaves a 175px strip. The 720px cap stops
+     the drawer widening pointlessly at 1440/1920; the 400px floor keeps it
+     usable on anything narrower than the target range. */
+  --drawer-w: min(720px, max(400px, 46vw));
+
+  /* ── Focus ring. Single source for the global *:focus-visible rule below. ── */
+  --focus-ring: #15803d;
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 1px;
+
+  /* ── Map chrome: legends, scale bar, readouts, popups. One container look. ── */
+  --map-chrome-bg: rgba(253, 254, 254, 0.94);
+  --map-chrome-border: rgba(15, 23, 42, 0.13);
+  --map-chrome-text: #0f172a;
+  --map-chrome-text-muted: #5b6b82;
+  --map-chrome-shadow: 0 4px 16px rgba(15, 23, 42, 0.10), 0 1px 3px rgba(15, 23, 42, 0.06);
+  --map-chrome-radius: var(--radius-md);
+
+  /* Standardized Semantic Theme Design Tokens - Light Theme
+     Retained for the ~475 existing `var(--theme-*)` call sites; each now
+     resolves through the V4 tokens above so both vocabularies stay in step. */
+  --theme-bg: var(--surface-canvas);
+  --theme-bg-panel: var(--surface-panel);
+  --theme-bg-glass: var(--surface-overlay);
+  --theme-bg-subtle: var(--surface-raised);
+  --theme-bg-muted: var(--surface-sunken);
+  --theme-bg-input: var(--surface-raised);
+  --theme-bg-hover: var(--surface-hover);
+
+  --theme-text-primary: var(--text-primary);
+  --theme-text-secondary: var(--text-secondary);
+  --theme-text-muted: var(--text-muted);
+  --theme-text-subtle: var(--text-disabled);
+
+  --theme-border: var(--border-subtle);
+  --theme-border-subtle: var(--border-subtle);
+  --theme-border-strong: var(--border-strong);
+
+  --theme-shadow: var(--elevation-overlay);
 
   /* Agent semantic tokens (legacy compat) */
-  --agent-bg: var(--theme-bg);
-  --agent-panel: var(--theme-bg-panel);
-  --agent-glass: var(--theme-bg-glass);
-  --agent-border: var(--theme-border);
-  --agent-accent: #16a34a;
+  --agent-bg: var(--surface-canvas);
+  --agent-panel: var(--surface-panel);
+  --agent-glass: var(--surface-overlay);
+  --agent-border: var(--border-subtle);
+  /* The user-chosen accent, as a pure CSS lever.
+     `--agent-accent-raw` is what the effect in app/page.tsx writes: the exact hex
+     from the store, theme-agnostic. `--agent-accent` is the *theme-corrected*
+     accent every consumer should use — fills, marks, indicators and label copy.
+     In light the presets already clear AA both as label text and under a white
+     label (5.02–7.10:1), so the light correction is the identity. */
+  --agent-accent-raw: var(--accent-vivid);
+  --agent-accent: var(--agent-accent-raw);
 
-  /* Layout */
+  /* Layout. The shell reads these through Tailwind's spacing scale
+     (h-topbar / top-topbar / w-rail …) so one edit moves every consumer. */
   --topH: 42px;
   --stH: 24px;
   --sw: 330px;
+  --railW: 48px;
 }
 
 .dark,
 [data-theme='dark'] {
   /* shadcn HSL vars — 暗色重定义（审计：之前只有 --theme-* 翻转，
-     使用 bg-card/text-foreground 等 shadcn token 的组件在暗色下保持浅色） */
-  --background: 222 47% 11%;            /* #0f172a */
-  --foreground: 210 40% 96%;            /* #f1f5f9 */
+     使用 bg-card/text-foreground 等 shadcn token 的组件在暗色下保持浅色）。
+     V4：数值与下方 --surface- / --text- 系列一一对应，两套词汇不再各走一路。 */
+  --background: 220 49% 8%;             /* --surface-canvas #0b1220 */
+  --foreground: 213 43% 95%;            /* --text-primary   #eef2f8 */
 
-  --card: 222 44% 13%;
-  --card-foreground: 210 40% 96%;
+  --card: 220 42% 13%;                  /* --surface-panel  #131c2e */
+  --card-foreground: 213 43% 95%;
 
-  --popover: 222 44% 11%;
-  --popover-foreground: 210 40% 96%;
+  --popover: 221 39% 18%;               /* --surface-overlay #1c2740 */
+  --popover-foreground: 213 43% 95%;
 
-  --primary: 142 71% 45%;
-  --primary-foreground: 0 0% 100%;
+  --primary: 142 69% 58%;               /* --accent #4ade80 */
+  --primary-foreground: 140 70% 5%;
 
-  --secondary: 217 33% 20%;
-  --secondary-foreground: 210 40% 96%;
+  --secondary: 220 33% 20%;
+  --secondary-foreground: 213 43% 95%;
 
-  --muted: 217 33% 18%;
-  --muted-foreground: 215 20% 65%;
+  --muted: 220 46% 10%;                 /* --surface-sunken */
+  --muted-foreground: 214 16% 64%;      /* --text-muted #93a1b5 */
 
-  --accent: 142 71% 45%;
+  --accent: 142 69% 58%;
   /* 深底上 accent 为绿色，前景用近黑保证对比（shadcn 约定：fg 为accent上的文字色） */
-  --accent-foreground: 222 47% 11%;
+  --accent-foreground: 140 70% 5%;
 
-  --destructive: 0 72% 51%;
-  --destructive-foreground: 0 0% 98%;
+  --destructive: 351 95% 71%;           /* --critical #fb7185 */
+  --destructive-foreground: 222 47% 8%;
 
-  --border: 217 33% 22%;
-  --input: 217 33% 22%;
-  --ring: 142 71% 45%;
+  --border: 217 25% 24%;
+  --input: 217 25% 24%;
+  --ring: 142 69% 58%;
 
-  /* Standardized Semantic Theme Design Tokens - Dark Theme */
-  --theme-bg: #0f172a;
-  --theme-bg-panel: rgba(15, 23, 42, 0.85);
-  --theme-bg-glass: rgba(9, 9, 11, 0.80);
-  --theme-bg-subtle: rgba(30, 41, 59, 0.80);
-  --theme-bg-muted: rgba(30, 41, 59, 0.60);
-  --theme-bg-input: rgba(15, 23, 42, 0.60);
-  --theme-bg-hover: rgba(148, 163, 184, 0.15);
+  /* ── V4 semantic tokens — dark is a first-class theme, not a filter over
+        light. Every surface is opaque so nothing bleeds the map through a
+        panel, and every text value is re-measured against its own surface. ── */
+  --surface-canvas: #0b1220;
+  --surface-panel: #131c2e;
+  --surface-raised: #1a2437;
+  --surface-overlay: #1c2740;
+  --surface-sunken: #0e1626;
+  --surface-hover: rgba(226, 232, 240, 0.07);
+  --surface-selected: rgba(34, 197, 94, 0.16);
+  --surface-scrim: rgba(2, 6, 16, 0.60);
 
-  --theme-text-primary: #e2e8f0;
-  --theme-text-secondary: #cbd5e1;
-  --theme-text-muted: #94a3b8;
-  --theme-text-subtle: #64748b;
+  --border-subtle: rgba(226, 232, 240, 0.09);
+  --border-default: rgba(226, 232, 240, 0.16);
+  --border-strong: rgba(226, 232, 240, 0.30);
 
-  --theme-border: rgba(255, 255, 255, 0.06);
-  --theme-border-subtle: rgba(148, 163, 184, 0.20);
-  --theme-border-strong: rgba(148, 163, 184, 0.30);
+  /* Contrast on --surface-panel (#131c2e): 14.2 / 9.2 / 6.0 / 3.3 */
+  --text-primary: #eef2f8;
+  --text-secondary: #b9c4d4;
+  --text-muted: #93a1b5;
+  --text-disabled: #6a788d;
+  --text-on-accent: #04140a;
 
-  --theme-shadow: 0 -8px 32px rgba(0, 0, 0, 0.5);
+  --accent: #4ade80;
+  --accent-vivid: #22c55e;
+  --accent-soft: rgba(34, 197, 94, 0.16);
+  --accent-border: rgba(34, 197, 94, 0.38);
 
-  --agent-bg: var(--theme-bg);
-  --agent-panel: var(--theme-bg-panel);
-  --agent-glass: var(--theme-bg-glass);
-  --agent-border: var(--theme-border);
+  --success: #4ade80;
+  --success-soft: rgba(34, 197, 94, 0.16);
+  --success-border: rgba(34, 197, 94, 0.38);
+
+  --info: #7aa5ff;
+  --info-soft: rgba(96, 145, 255, 0.18);
+  --info-border: rgba(96, 145, 255, 0.40);
+
+  --warning: #fbbf24;
+  --warning-soft: rgba(251, 191, 36, 0.16);
+  --warning-border: rgba(251, 191, 36, 0.38);
+
+  --critical: #fb7185;
+  --critical-soft: rgba(248, 113, 133, 0.16);
+  --critical-border: rgba(248, 113, 133, 0.38);
+
+  --neutral: #93a1b5;
+  --neutral-soft: rgba(148, 163, 184, 0.16);
+  --neutral-border: rgba(148, 163, 184, 0.32);
+
+  /* Dark elevation reads as a lift in surface value plus a soft ambient
+     shadow; a hard drop shadow on a dark bed just muddies the edge. */
+  --elevation-flat: none;
+  --elevation-raised: 0 1px 2px rgba(0, 0, 0, 0.40);
+  --elevation-overlay: 0 4px 16px rgba(0, 0, 0, 0.45), 0 1px 3px rgba(0, 0, 0, 0.35);
+  --elevation-drawer: 0 8px 32px rgba(0, 0, 0, 0.55), 0 2px 6px rgba(0, 0, 0, 0.40);
+
+  --focus-ring: #4ade80;
+
+  --map-chrome-bg: rgba(19, 28, 46, 0.94);
+  --map-chrome-border: rgba(226, 232, 240, 0.16);
+  --map-chrome-text: #eef2f8;
+  --map-chrome-text-muted: #93a1b5;
+  --map-chrome-shadow: 0 4px 16px rgba(0, 0, 0, 0.45), 0 1px 3px rgba(0, 0, 0, 0.35);
+
+  /* Standardized Semantic Theme Design Tokens - Dark Theme
+     (aliases only — the values live in the V4 block above) */
+  --theme-bg: var(--surface-canvas);
+  --theme-bg-panel: var(--surface-panel);
+  --theme-bg-glass: var(--surface-overlay);
+  --theme-bg-subtle: var(--surface-raised);
+  --theme-bg-muted: var(--surface-sunken);
+  --theme-bg-input: var(--surface-sunken);
+  --theme-bg-hover: var(--surface-hover);
+
+  --theme-text-primary: var(--text-primary);
+  --theme-text-secondary: var(--text-secondary);
+  --theme-text-muted: var(--text-muted);
+  --theme-text-subtle: var(--text-disabled);
+
+  --theme-border: var(--border-subtle);
+  --theme-border-subtle: var(--border-subtle);
+  --theme-border-strong: var(--border-strong);
+
+  --theme-shadow: var(--elevation-overlay);
+
+  --agent-bg: var(--surface-canvas);
+  --agent-panel: var(--surface-panel);
+  --agent-glass: var(--surface-overlay);
+  --agent-border: var(--border-subtle);
+  --agent-accent-raw: var(--accent-vivid);
+  /* The dark correction. The raw presets are chosen to carry a white label on a
+     light surface, which makes them far too dark to work on a dark one: as a
+     mark against --surface-overlay they measure 2.09:1, and under the near-black
+     --text-on-accent label only 2.66:1. Mixing 65% toward white clears both
+     floors for all five presets — worst case 4.28:1 as a mark and 5.46:1 under
+     the label — so one variable stays correct for fills, marks and text. */
+  --agent-accent: color-mix(in srgb, var(--agent-accent-raw) 65%, #ffffff);
 }
 
 /* ═══ Base Styles ═══ */
@@ -141,128 +360,111 @@
 html {
   scroll-behavior: smooth;
   overflow: hidden;
+  /* Opaque on the root as well as the body: the theme class lands here, so the
+     bed is already correct on the first paint after the no-flash script runs. */
+  background: var(--surface-canvas);
 }
 
 body {
-  background: var(--agent-bg);
-  color: var(--foreground);
+  background: var(--surface-canvas);
+  color: var(--text-primary);
   font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
   min-height: 100vh;
   overflow: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-size: 15px;
+  /* The workbench body step. Was 15px, which made every dense panel inherit a
+     size it then had to override with a raw `text-[13px]`. */
+  font-size: var(--font-body);
+  line-height: var(--leading-normal);
 }
 
-/* ═══ Glassmorphism Utilities ═══ */
+/* ═══ Workbench primitives ═══
+   Two container recipes and one eyebrow, so a panel or a piece of map chrome is
+   described once instead of re-derived from raw utilities in each component.
+   (The pre-V4 `.glass/.ib/.tb/.lc/.sq` block was removed: it had zero call
+   sites and hardcoded light-only colours, i.e. a dark-mode trap in waiting.) */
 
 @layer components {
-  .glass {
-    background: var(--agent-panel);
-    backdrop-filter: blur(24px) saturate(1.4);
-    -webkit-backdrop-filter: blur(24px) saturate(1.4);
-    border: 1px solid rgba(255, 255, 255, 0.9);
-    box-shadow: 0 4px 24px rgba(15, 23, 42, 0.09), 0 1px 4px rgba(15, 23, 42, 0.05);
+  /* Panel-level surface: nav rail, context panel, settings column. */
+  .surface-panel {
+    background: var(--surface-panel);
+    border-color: var(--border-subtle);
+    color: var(--text-primary);
   }
 
-  /* Icon button */
-  .ib {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border-radius: 6px;
-    background: transparent;
-    color: #475569;
-    border: none;
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .ib:hover {
-    background: rgba(15, 23, 42, 0.06);
-    color: #0f172a;
-  }
-  .ib.on {
-    background: rgba(22, 163, 74, 0.08);
-    color: #15803d;
+  /* Floating chrome over the map: legends, readouts, scale bar, popups.
+     Deliberately no backdrop-filter — the map must stay legible underneath and
+     a blur on a continuously repainting canvas is the expensive kind. */
+  .map-chrome {
+    background: var(--map-chrome-bg);
+    border: 1px solid var(--map-chrome-border);
+    border-radius: var(--map-chrome-radius);
+    box-shadow: var(--map-chrome-shadow);
+    color: var(--map-chrome-text);
   }
 
-  /* Tab button */
-  .tb {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 4px;
-    flex: 1;
-    padding: 5px 8px;
-    border-radius: 5px;
-    background: transparent;
-    color: #94a3b8;
-    font-size: 13.5px;
-    font-weight: 500;
-    font-family: inherit;
-    border: none;
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s;
-  }
-  .tb:hover {
-    background: rgba(15, 23, 42, 0.05);
-    color: #475569;
-  }
-  .tb.on {
-    background: rgba(15, 23, 42, 0.06);
-    color: #0f172a;
-  }
-
-  /* Layer card */
-  .lc {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 5px 10px;
-    border-radius: 6px;
-    transition: background 0.1s;
-    cursor: default;
-  }
-  .lc:hover {
-    background: rgba(15, 23, 42, 0.04);
-  }
-  .lc:hover .lca {
-    opacity: 1;
-  }
-  .lca {
-    opacity: 0;
-    transition: opacity 0.1s;
-    display: flex;
-    gap: 2px;
-  }
-
-  /* Suggested prompt */
-  .sq {
-    text-align: left;
-    background: rgba(255, 255, 255, 0.7);
-    border: 1px solid var(--agent-border);
-    border-radius: 6px;
-    padding: 6px 9px;
-    color: #475569;
-    font-size: 13.5px;
-    width: 100%;
-    transition: border-color 0.12s, color 0.12s, background 0.12s;
+  /*
+    Range input. `appearance-none` removes the native thumb, and nothing in the
+    app ever restyled it — the review found the layer-opacity slider rendering
+    as a bare 4px bar with an invisible handle. These rules give every
+    `appearance-none` range a real, grabbable thumb in both themes.
+  */
+  .slider-track {
+    -webkit-appearance: none;
+    appearance: none;
+    background: var(--border-strong);
+    border-radius: var(--radius-pill);
     cursor: pointer;
   }
-  .sq:hover {
-    border-color: rgba(22, 163, 74, 0.22);
-    color: #0f172a;
-    background: rgba(255, 255, 255, 0.95);
+  .slider-track::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: var(--radius-pill);
+    background: var(--accent-vivid);
+    border: 2px solid var(--surface-raised);
+    box-shadow: var(--elevation-raised);
+    cursor: grab;
+  }
+  .slider-track::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border-radius: var(--radius-pill);
+    background: var(--accent-vivid);
+    border: 2px solid var(--surface-raised);
+    box-shadow: var(--elevation-raised);
+    cursor: grab;
+  }
+  .slider-track:active::-webkit-slider-thumb,
+  .slider-track:active::-moz-range-thumb {
+    cursor: grabbing;
+  }
+  .slider-track:disabled {
+    cursor: not-allowed;
+  }
+  .slider-track:disabled::-webkit-slider-thumb,
+  .slider-track:disabled::-moz-range-thumb {
+    background: var(--text-disabled);
+  }
+
+  /* Uppercase eyebrow label — the one small-caps treatment in the system. */
+  .eyebrow {
+    font-size: var(--font-micro);
+    font-weight: 600;
+    line-height: var(--leading-tight);
+    letter-spacing: var(--tracking-eyebrow);
+    text-transform: uppercase;
+    color: var(--text-muted);
   }
 }
 
 /* ═══ Scrollbar ═══ */
 
 ::-webkit-scrollbar {
-  width: 4px;
-  height: 4px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
@@ -270,100 +472,128 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(15, 23, 42, 0.15);
-  border-radius: 4px;
+  background: var(--border-strong);
+  border-radius: var(--radius-pill);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(15, 23, 42, 0.25);
+  background: var(--text-disabled);
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
 }
 
 /* ═══ Selection ═══ */
 
 ::selection {
-  background: rgba(22, 163, 74, 0.18);
-  color: #0f172a;
+  background: var(--accent-soft);
+  color: var(--text-primary);
 }
 
-/* ═══ MapLibre Overrides (Light Theme) ═══ */
+/* ═══ MapLibre Overrides ═══
+   Themed through --map-chrome-*, so popups and controls follow the same
+   container recipe as the legends and the scale bar in both themes. Before V4
+   these were hardcoded light and turned into white blocks on the dark map. */
 
 .mapboxgl-popup-content,
 .maplibregl-popup-content {
-  background: rgba(252, 253, 254, 0.95) !important;
-  backdrop-filter: blur(20px) !important;
-  border: 1px solid rgba(15, 23, 42, 0.08) !important;
-  border-radius: 10px !important;
-  box-shadow: 0 4px 24px rgba(15, 23, 42, 0.09), 0 1px 4px rgba(15, 23, 42, 0.05) !important;
-  color: #0f172a !important;
+  background: var(--map-chrome-bg) !important;
+  border: 1px solid var(--map-chrome-border) !important;
+  border-radius: var(--map-chrome-radius) !important;
+  box-shadow: var(--map-chrome-shadow) !important;
+  color: var(--map-chrome-text) !important;
   font-family: 'DM Sans', sans-serif !important;
-  padding: 10px 14px !important;
-  font-size: 14px !important;
+  padding: 8px 12px !important;
+  font-size: var(--font-body) !important;
 }
 
 .mapboxgl-popup-tip,
 .maplibregl-popup-tip {
-  border-top-color: rgba(252, 253, 254, 0.95) !important;
+  border-top-color: var(--map-chrome-bg) !important;
 }
 
 .mapboxgl-popup-close-button,
 .maplibregl-popup-close-button {
-  color: #94a3b8 !important;
-  font-size: 18px !important;
+  color: var(--map-chrome-text-muted) !important;
+  font-size: var(--font-heading) !important;
 }
 
 .maplibregl-ctrl-group {
-  background: rgba(255, 255, 255, 0.85) !important;
-  backdrop-filter: blur(20px) !important;
-  border: 1px solid rgba(255, 255, 255, 0.9) !important;
-  border-radius: 9px !important;
-  box-shadow: 0 4px 24px rgba(15, 23, 42, 0.09), 0 1px 4px rgba(15, 23, 42, 0.05) !important;
+  background: var(--map-chrome-bg) !important;
+  border: 1px solid var(--map-chrome-border) !important;
+  border-radius: var(--map-chrome-radius) !important;
+  box-shadow: var(--map-chrome-shadow) !important;
   overflow: hidden;
 }
 
 .maplibregl-ctrl-group button {
   background: transparent !important;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.06) !important;
-  width: 36px !important;
-  height: 36px !important;
+  border-bottom: 1px solid var(--map-chrome-border) !important;
+  width: 30px !important;
+  height: 30px !important;
+  color: var(--map-chrome-text) !important;
 }
 
 .maplibregl-ctrl-group button:hover {
-  background: rgba(15, 23, 42, 0.05) !important;
+  background: var(--surface-hover) !important;
 }
 
 .maplibregl-ctrl-group button:last-child {
   border-bottom: none !important;
 }
 
-.maplibregl-ctrl-icon {
-  filter: none;
+/* MapLibre ships black glyphs; invert them once in dark rather than shipping a
+   second icon set. */
+.dark .maplibregl-ctrl-icon,
+[data-theme='dark'] .maplibregl-ctrl-icon {
+  filter: invert(1) brightness(1.6);
 }
 
-/* ═══ Prose / Markdown ═══ */
+.maplibregl-ctrl-attrib.maplibregl-compact,
+.maplibregl-ctrl-attrib-inner {
+  color: var(--map-chrome-text-muted) !important;
+  font-size: var(--font-micro) !important;
+}
+
+/* ═══ Prose / Markdown ═══
+   Token-driven so assistant answers stay readable in dark, which was the single
+   largest dark-mode hole found in the audit (every reply body used this). */
 
 .prose-agent {
-  --tw-prose-body: #475569;
-  --tw-prose-headings: #0f172a;
-  --tw-prose-links: #16a34a;
-  --tw-prose-code: #15803d;
-  --tw-prose-bold: #0f172a;
+  --tw-prose-body: var(--text-secondary);
+  --tw-prose-headings: var(--text-primary);
+  --tw-prose-links: var(--accent);
+  --tw-prose-code: var(--accent);
+  --tw-prose-bold: var(--text-primary);
+  --tw-prose-quotes: var(--text-muted);
+  --tw-prose-quote-borders: var(--border-default);
+  --tw-prose-hr: var(--border-subtle);
+  --tw-prose-bullets: var(--text-disabled);
+  --tw-prose-counters: var(--text-muted);
+  --tw-prose-th-borders: var(--border-default);
+  --tw-prose-td-borders: var(--border-subtle);
+  --tw-prose-captions: var(--text-muted);
+  --tw-prose-pre-bg: var(--surface-sunken);
+  --tw-prose-pre-code: var(--text-primary);
 }
 
 .prose-agent code {
-  background: rgba(22, 163, 74, 0.08);
-  border: 1px solid rgba(22, 163, 74, 0.12);
-  border-radius: 4px;
-  padding: 1px 6px;
-  font-size: 0.85em;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-xs);
+  padding: 1px 5px;
+  font-size: 0.9em;
 }
 
 .prose-agent a {
-  text-decoration-color: rgba(22, 163, 74, 0.3);
+  text-decoration-color: var(--accent-border);
   text-underline-offset: 3px;
 }
 
 .prose-agent a:hover {
-  text-decoration-color: #16a34a;
+  text-decoration-color: var(--accent);
 }
 
 /* ═══ Textarea ═══ */
@@ -428,14 +658,17 @@ textarea {
 /* ═══ Accessibility: focus-visible + reduced motion (UI V3) ═══ */
 
 /* 统一键盘焦点环 — 之前全仓 0 处 focus-visible。鼠标点击不触发。
-   不覆盖元素自身 border-radius（review P2：圆形控件聚焦时不应变形）。 */
+   不覆盖元素自身 border-radius（review P2：圆形控件聚焦时不应变形）。
+   V4：颜色/宽度改由 --focus-ring* token 驱动，两套主题各自达标；这条规则位于
+   unlayered（非 @layer）作用域，因此仍然压过 Tailwind 的 focus:outline-none。 */
 *:focus-visible {
-  outline: 2px solid var(--agent-accent, #16a34a);
-  outline-offset: 1px;
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
 }
 
 /* prefers-reduced-motion：全站 CSS 动画/过渡降级。
-   JS/rAF 动画由 usePrefersReducedMotion hook 单独门控。 */
+   JS/rAF 动画由 usePrefersReducedMotion hook 单独门控，
+   framer-motion 由 client-providers 的 MotionConfig reducedMotion="user" 门控。 */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { DM_Sans, JetBrains_Mono } from "next/font/google"
 import { ClientProviders } from "@/components/providers/client-providers"
+import { PERSIST_KEY } from "@/lib/store/useHudStore"
 import "./globals.css"
 
 const dmSans = DM_Sans({
@@ -20,13 +21,35 @@ export const metadata: Metadata = {
   description: "智能地理空间分析系统 — 地图即感知，图层即记忆，分析即行动",
 }
 
+/**
+ * Applies the persisted theme + accent before the first paint.
+ *
+ * The React path (`app/page.tsx`) only sets the `dark` class from an effect that
+ * runs after hydration, so without this a dark-mode user got a full light frame
+ * on every load. Reads the same `geoagent-settings` key the zustand `persist`
+ * middleware writes, and fails silently — a bad/absent value just leaves the
+ * light default in place.
+ */
+const themeBootstrap = `(function(){try{
+var s=localStorage.getItem(${JSON.stringify(PERSIST_KEY)});
+if(!s)return;
+var v=(JSON.parse(s)||{}).state||{};
+var r=document.documentElement;
+if(v.theme==='dark'){r.classList.add('dark');r.setAttribute('data-theme','dark');}
+else{r.setAttribute('data-theme','light');}
+if(typeof v.accentColor==='string')r.style.setProperty('--agent-accent-raw',v.accentColor);
+}catch(e){}})();`
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
   return (
-    <html lang="zh-CN">
+    <html lang="zh-CN" data-theme="light">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeBootstrap }} />
+      </head>
       <body className={`${dmSans.variable} ${jetbrainsMono.variable} font-sans antialiased`}>
         <ClientProviders>{children}</ClientProviders>
       </body>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,7 +3,6 @@
 import { memo, useCallback, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { useHudStore } from '@/lib/store/useHudStore';
-import { getThemeColors } from '@/lib/theme';
 import { useGeolocation } from '@/lib/hooks/use-geolocation';
 import { useMapAction } from '@/lib/contexts/map-action-context';
 
@@ -16,6 +15,7 @@ import TopBar from '@/components/layout/top-bar';
 import { NavRail } from '@/components/layout/nav-rail';
 import { ContextPanel } from '@/components/layout/context-panel';
 import FloatingLegend from '@/components/map/floating-legend';
+import { MapStatusReadout } from '@/components/map/map-status-readout';
 import { SpatialCrosshair } from '@/components/map/spatial-crosshair';
 import { MapErrorBoundary } from '@/components/map/map-error-boundary';
 import { EmbodiedHud } from '@/components/hud/embodied-hud';
@@ -33,8 +33,8 @@ const MapPanel = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className='flex-1 flex items-center justify-center bg-[#dce8f2]'>
-        <div className='animate-pulse text-slate-300 text-xs font-mono uppercase tracking-wider'>
+      <div className='flex-1 flex items-center justify-center bg-surface-canvas'>
+        <div className='animate-pulse text-ink-muted text-micro font-mono uppercase tracking-wider'>
           Loading Map...
         </div>
       </div>
@@ -51,6 +51,7 @@ const MemoMapPanel = memo(MapPanel);
 const MemoEmbodiedHud = memo(EmbodiedHud);
 const MemoSpatialCrosshair = memo(SpatialCrosshair);
 const MemoFloatingLegend = memo(FloatingLegend);
+const MemoMapStatusReadout = memo(MapStatusReadout);
 
 export default function Home() {
   const { getMapSnapshot, dispatchAction } = useMapAction();
@@ -109,6 +110,12 @@ export default function Home() {
     [selectSession, setMessages, setHistoryOpen]
   );
 
+  // 稳定引用：内联箭头会让 RagIndependentPanel 的 Escape 监听在 Home 每次
+  // 重渲染（即每个流式 token 批次）时反复解绑/重绑。
+  const handleCloseRagPanel = useCallback(() => setRagPanelOpen(false), [setRagPanelOpen]);
+  const handleCloseHistory = useCallback(() => setHistoryOpen(false), [setHistoryOpen]);
+  const handleCloseTemplates = useCallback(() => setTemplatesOpen(false), [setTemplatesOpen]);
+
   const handleNewSession = useCallback(() => {
     startNewSession(() => {
       setMessages([
@@ -123,11 +130,11 @@ export default function Home() {
     setHistoryOpen(false);
   }, [startNewSession, setMessages, setHistoryOpen]);
 
-  // Read theme colors and dimensions dynamically
+  // Theme + accent drive CSS custom properties (see the effects below); the
+  // shell itself styles from tokens rather than JS colour objects.
   const theme = useHudStore((s) => s.theme);
   const reactiveAccentColor = useHudStore((s) => s.accentColor);
   const fontSize = useHudStore((s) => s.fontSize);
-  const colors = getThemeColors(theme);
 
   useEffect(() => {
     if (theme === 'dark') {
@@ -139,21 +146,23 @@ export default function Home() {
     }
   }, [theme]);
 
+  // UI V4：把 store 的 accentColor 推给 --agent-accent-raw。
+  // 之前该变量只有 globals.css 里的静态默认值，nav-rail / context-panel 等
+  // 通过 var() 取色的位置永远是默认绿，与 JS 内联取色的组件不一致。
+  // 注意写入的是 *-raw：主题校正（暗色下向白色混合）由 globals.css 完成，
+  // 组件只需读 var(--agent-accent) 就能拿到当前主题下达标的 accent。
+  useEffect(() => {
+    document.documentElement.style.setProperty('--agent-accent-raw', reactiveAccentColor);
+  }, [reactiveAccentColor]);
+
   const currentSessionTitle = sessionId
     ? sessions.find((s) => s.id === sessionId)?.title || '新会话'
     : '新会话';
 
   return (
     <div
-      style={{
-        height: '100vh',
-        width: '100vw',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-        background: colors.bg,
-        fontSize: `${fontSize}px`,
-      }}
+      className='h-screen w-screen flex flex-col overflow-hidden bg-surface-canvas'
+      style={{ fontSize: `${fontSize}px` }}
     >
       <MemoTopBar
         sessionName={currentSessionTitle}
@@ -170,6 +179,11 @@ export default function Home() {
           // UI V3：地图 chrome（图例等）的水平避让偏移 —— nav rail(48) +
           // context panel(可选) 占据的左侧空间。
           ['--workspace-offset' as string]: `${leftPanelOpen ? 48 + sidebarWidth + 12 : 60}px`,
+          // UI V4：地图 chrome 的底部基线。workspace 已经预留 24px 状态条，
+          // HUD 展开到 210px 时需要再抬 186px。所有底部 chrome（读数条、比例尺、
+          // 热力图例、专题图例）都从这一个变量堆叠，因此不会互相压盖 ——
+          // 审计发现浮动图例与专题图例此前固定在同一 left/bottom 上必然重叠。
+          ['--map-chrome-bottom' as string]: hudOpen ? '196px' : '10px',
         }}
       >
         {/* Map Panel */}
@@ -186,16 +200,13 @@ export default function Home() {
           </MapErrorBoundary>
         </div>
 
-        {/* Floating Legend */}
+        {/* Floating heatmap legend — bottom-RIGHT, stacked above the scale bar.
+            It used to sit at the same left/bottom as the thematic legend stack,
+            where the higher-z thematic card hid it outright. */}
         {layers.find((l) => l.visible && l.type === 'heatmap') && (
           <div
-            style={{
-              position: 'absolute',
-              bottom: hudOpen ? 220 : 34,
-              left: 'var(--workspace-offset, 60px)',
-              transition: 'left 0.22s cubic-bezier(0.4,0,0.2,1), bottom 0.3s cubic-bezier(0.4,0,0.2,1)',
-              zIndex: 10,
-            }}
+            className='absolute right-3 z-10 transition-[bottom] duration-300'
+            style={{ bottom: 'calc(var(--map-chrome-bottom, 10px) + 66px)' }}
           >
             <MemoFloatingLegend />
           </div>
@@ -207,33 +218,21 @@ export default function Home() {
           messages={messages}
           aiStatus={aiStatus}
           onSend={handleSend}
-          accentColor={reactiveAccentColor}
           sessionId={sessionId}
           ownerToken={sessionTokenRef.current}
           onPlanAction={handlePlanAction}
         />
 
         {/* RAG Independent Panel */}
-        <RagIndependentPanel open={ragPanelOpen} onClose={() => setRagPanelOpen(false)} />
+        <RagIndependentPanel open={ragPanelOpen} onClose={handleCloseRagPanel} />
 
-        {/* Map attribution */}
+        {/* Map status readout: centre coordinate, zoom, CRS, attribution.
+            Anchors the bottom-right chrome column. */}
         <div
-          style={{
-            position: 'absolute',
-            bottom: 30,
-            right: 12,
-            fontSize: '11.5px',
-            color: theme === 'dark' ? 'rgba(148,163,184,0.6)' : 'rgba(15,23,42,0.35)',
-            fontFamily: "'JetBrains Mono', monospace",
-            background: theme === 'dark' ? 'rgba(30,41,59,0.72)' : 'rgba(255,255,255,0.72)',
-            padding: '2px 8px',
-            borderRadius: 4,
-            backdropFilter: 'blur(8px)',
-            WebkitBackdropFilter: 'blur(8px)',
-            zIndex: 10,
-          }}
+          className='absolute right-3 z-10 transition-[bottom] duration-300'
+          style={{ bottom: 'var(--map-chrome-bottom, 10px)' }}
         >
-          © OpenStreetMap contributors
+          <MemoMapStatusReadout />
         </div>
       </div>
 
@@ -241,7 +240,7 @@ export default function Home() {
 
       <HistoryDrawer
         open={historyOpen}
-        onClose={() => setHistoryOpen(false)}
+        onClose={handleCloseHistory}
         onSelect={(session) => {
           if (session && session.id) {
             handleSelectSession(session.id);
@@ -249,7 +248,6 @@ export default function Home() {
             handleNewSession();
           }
         }}
-        accentColor={reactiveAccentColor}
       />
 
       {settingsOpen && <SettingsPanel />}
@@ -257,7 +255,7 @@ export default function Home() {
       {/* Template Gallery V2 — nav rail「模板」入口（与 history/settings 互斥） */}
       <TemplateGalleryV2
         open={templatesOpen}
-        onClose={() => setTemplatesOpen(false)}
+        onClose={handleCloseTemplates}
         onApply={(t) => useToastStore.getState().addToast(`模板已应用：${t.name}`, 'success')}
       />
 

--- a/frontend/app/story/page.tsx
+++ b/frontend/app/story/page.tsx
@@ -5,7 +5,7 @@ import dynamic from "next/dynamic"
 
 const MapPanel = dynamic(
   () => import('@/components/map/map-panel').then((m) => ({ default: m.MapPanel })),
-  { ssr: false, loading: () => <div className="w-full h-full bg-slate-900 animate-pulse" /> }
+  { ssr: false, loading: () => <div className="w-full h-full bg-surface-canvas animate-pulse" /> }
 )
 
 const StoryMarkdown = dynamic(() => import('@/components/chat/story-markdown'), { ssr: false })
@@ -17,7 +17,7 @@ import { Play, SkipBack, Share2 } from "lucide-react"
 
 export default function StoryPage() {
   return (
-    <Suspense fallback={<div className="flex items-center justify-center h-screen text-white/50">Loading...</div>}>
+    <Suspense fallback={<div className="flex items-center justify-center h-screen text-ink-muted">Loading...</div>}>
       <StoryPageInner />
     </Suspense>
   )
@@ -72,31 +72,39 @@ function StoryPageInner() {
   }
 
   if (loading) {
-    return <div className="h-screen w-screen bg-ds-black flex items-center justify-center text-hud-cyan font-mono relative">
-      <div className="absolute inset-0 z-[1] opacity-[0.015] bg-grid-hud bg-[size:60px_60px]"></div>
+    /* E：bg-ds-black / text-hud-cyan / bg-grid-hud 从未在 tailwind.config 或
+       任何 CSS 中定义 —— 此前这个 loading 屏与整页都没有背景。改走 V4 语义
+       token（surface-canvas 是页面床色，status-info 是叙事 accent），网格
+       底纹用已定义的 bg-grid-agent。 */
+    return <div className="h-screen w-screen bg-surface-canvas flex items-center justify-center text-status-info font-mono relative">
+      <div className="absolute inset-0 z-[1] opacity-[0.015] bg-grid-agent bg-[size:60px_60px]"></div>
       <div className="animate-pulse">Loading StoryMap CNS...</div>
     </div>
   }
 
   return (
-    <div className="h-screen w-screen overflow-hidden bg-ds-black relative flex">
+    <div className="h-screen w-screen overflow-hidden bg-surface-canvas relative flex">
       {/* Grid overlay for depth */}
-      <div className="absolute inset-0 pointer-events-none z-[1] opacity-[0.015] bg-grid-hud bg-[size:60px_60px]" />
+      <div className="absolute inset-0 pointer-events-none z-[1] opacity-[0.015] bg-grid-agent bg-[size:60px_60px]" />
 
       {/* Narrative Panel (Left) */}
+      {/* E：glass-panel / glass-panel-dense 未定义 → 叙事面板此前完全没有背景。
+          改用不透明 surface-panel（面板配方）；backdrop-blur-xl 一并去掉 ——
+          blur 盖在持续重绘的地图画布上是最贵的那类合成。 */}
       <div 
         ref={containerRef}
         onScroll={handleScroll}
-        className="w-[400px] xl:w-[500px] h-full z-20 glass-panel border-r border-hud-cyan/20 overflow-y-auto overflow-x-hidden flex flex-col relative"
+        className="w-[400px] xl:w-[500px] h-full z-20 bg-surface-panel border-r border-edge-subtle overflow-y-auto overflow-x-hidden flex flex-col relative"
       >
-        <div className="sticky top-0 p-6 glass-panel-dense backdrop-blur-xl border-b border-white/5 z-10 flex justify-between items-center">
-          <h1 className="text-hud-cyan font-semibold tracking-widest text-lg flex items-center gap-2">
-            STORY<span className="text-white/50">MAP</span>
+        <div className="sticky top-0 p-6 bg-surface-panel border-b border-edge-subtle z-10 flex justify-between items-center">
+          <h1 className="text-status-info font-semibold tracking-widest text-heading flex items-center gap-2">
+            STORY<span className="text-ink-muted">MAP</span>
           </h1>
           <div className="flex gap-2">
-            <button aria-label="上一个" className="hud-btn p-2 rounded-lg text-white/50 hover:text-hud-cyan"><SkipBack className="h-4 w-4" /></button>
-            <button aria-label="播放" className="hud-btn p-2 rounded-lg text-white/50 hover:text-hud-cyan"><Play className="h-4 w-4" /></button>
-            <button aria-label="分享" className="hud-btn p-2 rounded-lg text-white/50 hover:text-hud-cyan"><Share2 className="h-4 w-4" /></button>
+            {/* E：hud-btn 未定义 → 按钮此前无任何样式；改为面板内图标按钮配方。 */}
+            <button aria-label="上一个" className="rounded-md p-2 text-ink-muted transition-colors hover:bg-surface-hover hover:text-status-info"><SkipBack className="h-4 w-4" /></button>
+            <button aria-label="播放" className="rounded-md p-2 text-ink-muted transition-colors hover:bg-surface-hover hover:text-status-info"><Play className="h-4 w-4" /></button>
+            <button aria-label="分享" className="rounded-md p-2 text-ink-muted transition-colors hover:bg-surface-hover hover:text-status-info"><Share2 className="h-4 w-4" /></button>
           </div>
         </div>
 
@@ -104,8 +112,8 @@ function StoryPageInner() {
           {messages.map((msg, idx) => (
             <div 
               key={idx} 
-              className={`prose prose-invert prose-p:text-white/70 prose-headings:text-hud-cyan prose-a:text-hud-cyan prose-strong:text-white max-w-none transition-opacity duration-700
-                ${msg.role === 'user' ? 'opacity-50 border-l-2 border-white/10 pl-4 italic text-sm' : 'opacity-100'}`}
+              className={`prose prose-agent prose-headings:text-status-info prose-a:text-status-info max-w-none transition-opacity duration-700
+                ${msg.role === 'user' ? 'opacity-50 border-l-2 border-edge-subtle pl-4 italic text-body' : 'opacity-100'}`}
             >
               {msg.role === 'user' ? (
                 <p className="m-0 font-mono">USER: {msg.content}</p>
@@ -120,7 +128,7 @@ function StoryPageInner() {
       {/* Map Panel (Right) */}
       <div className="flex-1 h-full relative z-0 relative shadow-[-20px_0_40px_rgba(0,0,0,0.8)]">
         {/* Adds Cinematic Gradient */}
-        <div className="absolute inset-y-0 left-0 w-32 bg-gradient-to-r from-ds-black to-transparent z-10 pointer-events-none" />
+        <div className="absolute inset-y-0 left-0 w-32 bg-gradient-to-r from-surface-canvas to-transparent z-10 pointer-events-none" />
         
         <MapPanel
           layers={layers}

--- a/frontend/components/chat/cartography-result-card.tsx
+++ b/frontend/components/chat/cartography-result-card.tsx
@@ -39,27 +39,27 @@ export function CartographyResultCard({ result, layerId, onFocus }: Props) {
   const title = result?.layer_meta?.title ?? '专题图';
   const colors = swatches(spec);
   return (
-    <div className="my-2 p-3 rounded-lg border border-border bg-card/70">
+    <div className="my-2 p-3 rounded-md border border-edge-subtle bg-surface-raised">
       <div className="flex items-center gap-2 mb-2">
-        <Palette className="h-4 w-4 text-primary" />
-        <span className="text-sm font-semibold text-foreground truncate">{title}</span>
+        <Palette className="h-4 w-4 text-status-accent" />
+        <span className="text-body font-semibold text-ink truncate">{title}</span>
       </div>
       <div className="flex items-center gap-1 mb-2">
         {colors.map((c, i) => (
           <div
             key={i}
             data-testid="card-swatch"
-            className="w-5 h-3 rounded-sm ring-1 ring-black/10"
+            className="w-5 h-3 rounded-sm ring-1 ring-edge-subtle"
             style={{ backgroundColor: c }}
           />
         ))}
       </div>
       <div className="flex items-center justify-between">
-        <span className="text-[15px] text-muted-foreground">{summarize(spec)}</span>
+        <span className="text-body text-ink-muted">{summarize(spec)}</span>
         <button
           type="button"
           onClick={() => onFocus?.(layerId)}
-          className="inline-flex items-center gap-1 text-[15px] font-medium text-primary hover:underline"
+          className="inline-flex items-center gap-1 text-body font-medium text-status-accent hover:underline"
         >
           <Target className="h-3 w-3" />
           高亮此图层

--- a/frontend/components/chat/chat-announcer.tsx
+++ b/frontend/components/chat/chat-announcer.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { AiStatus } from '@/lib/store/hud-types';
+
+/** Structural minimum: two message shapes exist in the app, both satisfy this. */
+interface AnnounceableMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface Props {
+  messages: readonly AnnounceableMessage[];
+  aiStatus: AiStatus;
+}
+
+/**
+ * Screen-reader announcer for the chat turn lifecycle.
+ *
+ * The first attempt at this put `aria-live` on the message list itself. That is
+ * wrong for this DOM shape: every token batch re-parses the streaming message's
+ * markdown and *replaces* its whole subtree, so the smallest changed container
+ * is the entire bubble and a screen reader re-reads the full accumulated answer
+ * on every batch — dozens of times per turn. `aria-atomic="false"` only gives
+ * you increments when the change is an append to a leaf node.
+ *
+ * So instead of narrating the stream, this announces the turn's *state* plus the
+ * finished answer once. That is what a screen-reader user actually needs: know
+ * that work started, know when it ended, then read the result at their own pace
+ * with normal browse-mode navigation.
+ */
+export function ChatAnnouncer({ messages, aiStatus }: Props) {
+  const [message, setMessage] = useState('');
+  const lastStatus = useRef<AiStatus | null>(null);
+
+  useEffect(() => {
+    if (aiStatus === lastStatus.current) return;
+    const previous = lastStatus.current;
+    lastStatus.current = aiStatus;
+
+    if (aiStatus === 'thinking') {
+      setMessage('正在分析指令');
+      return;
+    }
+    if (aiStatus === 'acting') {
+      setMessage('正在执行空间操作');
+      return;
+    }
+    if (aiStatus === 'error') {
+      setMessage('指令执行失败，请调整后重试');
+      return;
+    }
+    // Back to idle after work: announce the finished reply exactly once.
+    if (previous === 'thinking' || previous === 'acting') {
+      const last = messages[messages.length - 1];
+      const text = last?.role === 'assistant' ? (last.content ?? '').trim() : '';
+      setMessage(text ? `回复已完成：${text}` : '回复已完成');
+    }
+  }, [aiStatus, messages]);
+
+  return (
+    <div
+      // sr-only: this duplicates content that is already on screen.
+      className="sr-only"
+      role="status"
+      aria-live="polite"
+      // atomic: the whole sentence is one announcement, not an increment.
+      aria-atomic="true"
+    >
+      {message}
+    </div>
+  );
+}
+
+export default ChatAnnouncer;

--- a/frontend/components/chat/collapsible-think.tsx
+++ b/frontend/components/chat/collapsible-think.tsx
@@ -1,21 +1,21 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { ChevronDown, ChevronRight, Brain } from 'lucide-react';
 
 interface CollapsibleThinkProps {
   content: string;
-  isDark: boolean;
-  accentColor: string;
 }
 
-export function CollapsibleThink({ content, isDark, accentColor }: CollapsibleThinkProps) {
+export function CollapsibleThink({ content }: CollapsibleThinkProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  // 审计 findings.md a11y Low：toggle 缺 aria-expanded + aria-controls 关联。
+  // V4 修复：原先是常量 'think-content' —— 一屏多条消息时 id 重复，
+  // aria-controls 指向的是第一条，关联即失效。useId 保证每实例唯一。
+  // 必须在早返回之前调用（hooks 顺序规则）。
+  const panelId = useId();
 
   if (!content) return null;
-
-  // 审计 findings.md a11y Low：toggle 缺 aria-expanded + aria-controls 关联。
-  const panelId = 'think-content';
 
   return (
     <div className="mb-2">
@@ -23,23 +23,17 @@ export function CollapsibleThink({ content, isDark, accentColor }: CollapsibleTh
         onClick={() => setIsExpanded(!isExpanded)}
         aria-expanded={isExpanded}
         aria-controls={panelId}
-        className="flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors hover:bg-black/5"
-        style={{ color: isDark ? '#94a3b8' : '#64748b' }}
+        className="flex items-center gap-1.5 rounded-sm px-1.5 py-0.5 text-ink-muted transition-colors hover:bg-surface-hover hover:text-ink-secondary"
       >
-        {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-        <Brain size={14} style={{ color: accentColor }} />
-        <span className="text-[15px] font-medium uppercase tracking-wider">思考过程</span>
+        {isExpanded ? <ChevronDown size={12} aria-hidden /> : <ChevronRight size={12} aria-hidden />}
+        <Brain size={12} className="text-status-accent" aria-hidden />
+        <span className="eyebrow">思考过程</span>
       </button>
 
       {isExpanded && (
         <div
           id={panelId}
-          className="mt-1 px-3 py-2 rounded-lg text-[13.5px] leading-relaxed border-l-2 italic"
-          style={{
-            backgroundColor: isDark ? 'rgba(30,41,59,0.4)' : 'rgba(241,245,249,0.6)',
-            borderColor: accentColor,
-            color: isDark ? '#cbd5e1' : '#475569'
-          }}
+          className="mt-1 rounded-sm border-l-2 border-l-status-accent-border bg-surface-sunken px-2 py-1.5 text-meta italic text-ink-secondary"
         >
           <div className="whitespace-pre-wrap">{content}</div>
         </div>

--- a/frontend/components/chat/h3-lisa-result-card.tsx
+++ b/frontend/components/chat/h3-lisa-result-card.tsx
@@ -25,11 +25,14 @@ interface Props {
 }
 
 const CLUSTER_CONFIG: Record<string, { label: string; bg: string; text: string; desc: string }> = {
-  HH: { label: '高-高热点', bg: 'bg-red-500/15 border-red-500/30', text: 'text-red-600 dark:text-red-400', desc: '显著高值聚集区' },
-  LL: { label: '低-低冷点', bg: 'bg-blue-500/15 border-blue-500/30', text: 'text-blue-600 dark:text-blue-400', desc: '显著低值聚集区' },
-  HL: { label: '高-低异常', bg: 'bg-orange-500/15 border-orange-500/30', text: 'text-orange-600 dark:text-orange-400', desc: '高值包围低值' },
-  LH: { label: '低-高异常', bg: 'bg-cyan-500/15 border-cyan-500/30', text: 'text-cyan-600 dark:text-cyan-400', desc: '低值包围高值' },
-  NS: { label: '不显著', bg: 'bg-slate-500/10 border-slate-500/20', text: 'text-slate-500 dark:text-slate-400', desc: '无显著空间关联' },
+  /* C：聚类色板收敛到 V4 status 词汇（红=critical / 蓝=info / 橙=warning /
+     灰=neutral，均换 AA 达标值）。LH 的 cyan 在 V4 里没有对应 token，为保留
+     四类聚类的色相区分而保留原色相，浅色档加深一档（cyan-700）过 AA。 */
+  HH: { label: '高-高热点', bg: 'bg-status-critical-soft border-status-critical-border', text: 'text-status-critical', desc: '显著高值聚集区' },
+  LL: { label: '低-低冷点', bg: 'bg-status-info-soft border-status-info-border', text: 'text-status-info', desc: '显著低值聚集区' },
+  HL: { label: '高-低异常', bg: 'bg-status-warning-soft border-status-warning-border', text: 'text-status-warning', desc: '高值包围低值' },
+  LH: { label: '低-高异常', bg: 'bg-cyan-500/15 border-cyan-500/30', text: 'text-cyan-700 dark:text-cyan-400', desc: '低值包围高值' },
+  NS: { label: '不显著', bg: 'bg-status-neutral-soft border-status-neutral-border', text: 'text-status-neutral', desc: '无显著空间关联' },
 };
 
 export function H3LisaResultCard({ result, layerId, onFocus }: Props) {
@@ -48,14 +51,17 @@ export function H3LisaResultCard({ result, layerId, onFocus }: Props) {
     : 0;
 
   return (
-    <div className="my-2 p-3.5 rounded-xl border border-slate-200/80 bg-white/80 dark:border-slate-800 dark:bg-slate-900/80 backdrop-blur-md text-sm shadow-sm transition-all">
+    /* C：去掉 backdrop-blur-md，把 bg-white/80 dark:bg-slate-900/80 半透明对
+       收敛为单一语义 token —— 结果卡浮在聊天气泡上，半透明+blur 只增加合成
+       成本且让底下的正文透出来。 */
+    <div className="my-2 p-3.5 rounded-md border border-edge-subtle bg-surface-raised text-body shadow-raised transition-all">
       {/* Header */}
       <div className="flex items-center justify-between mb-2.5">
-        <div className="flex items-center gap-1.5 font-semibold text-slate-800 dark:text-slate-200">
-          <Hexagon className="h-4 w-4 text-indigo-500 shrink-0" />
+        <div className="flex items-center gap-1.5 font-semibold text-ink">
+          <Hexagon className="h-4 w-4 text-status-info shrink-0" />
           <span>H3 LISA 空间聚类分析</span>
         </div>
-        <span className="text-xs px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600 dark:bg-indigo-950/60 dark:text-indigo-300 font-mono font-medium">
+        <span className="text-meta px-2 py-0.5 rounded-pill bg-status-info-soft text-status-info font-mono font-medium">
           字段: {valueField}
         </span>
       </div>
@@ -70,13 +76,13 @@ export function H3LisaResultCard({ result, layerId, onFocus }: Props) {
               <div
                 key={type}
                 data-testid={`lisa-badge-${type}`}
-                className={`p-2 rounded-lg border ${cfg.bg} flex flex-col justify-between transition-all`}
+                className={`p-2 rounded-md border ${cfg.bg} flex flex-col justify-between transition-all`}
               >
                 <div className="flex items-center justify-between">
-                  <span className={`text-xs font-bold ${cfg.text}`}>{cfg.label}</span>
-                  <span className={`text-sm font-mono font-bold ${cfg.text}`}>{count}</span>
+                  <span className={`text-meta font-bold ${cfg.text}`}>{cfg.label}</span>
+                  <span className={`text-body font-mono font-bold ${cfg.text}`}>{count}</span>
                 </div>
-                <span className="text-xs text-slate-400 dark:text-slate-500 truncate mt-0.5">{cfg.desc}</span>
+                <span className="text-meta text-ink-muted truncate mt-0.5">{cfg.desc}</span>
               </div>
             );
           })}
@@ -85,22 +91,22 @@ export function H3LisaResultCard({ result, layerId, onFocus }: Props) {
 
       {/* Summary note */}
       {summaryText && (
-        <div className="flex items-start gap-2 mb-2.5 text-sm text-slate-600 dark:text-slate-300 leading-relaxed bg-slate-50/90 dark:bg-slate-800/50 p-2.5 rounded-lg border border-slate-100 dark:border-slate-800">
-          <Sparkles className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+        <div className="flex items-start gap-2 mb-2.5 text-body text-ink-secondary leading-relaxed bg-surface-sunken p-2.5 rounded-md border border-edge-subtle">
+          <Sparkles className="h-4 w-4 text-status-warning shrink-0 mt-0.5" />
           <span>{summaryText}</span>
         </div>
       )}
 
       {/* Action Footer */}
-      <div className="flex items-center justify-between pt-1.5 border-t border-slate-100 dark:border-slate-800 text-xs">
-        <span className="text-slate-400 dark:text-slate-500 font-mono">
+      <div className="flex items-center justify-between pt-1.5 border-t border-edge-subtle text-meta">
+        <span className="text-ink-muted font-mono">
           {totalSig > 0 ? `累计显著聚类: ${totalSig} 个网格` : '未发现显著聚集'}
         </span>
         {layerId && onFocus && (
           <button
             type="button"
             onClick={() => onFocus(layerId)}
-            className="inline-flex items-center gap-1 font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 hover:underline transition-colors"
+            className="inline-flex items-center gap-1 font-medium text-status-info hover:underline transition-colors"
           >
             <Target className="h-3.5 w-3.5" />
             高亮图层

--- a/frontend/components/chat/isochrone-result-card.tsx
+++ b/frontend/components/chat/isochrone-result-card.tsx
@@ -41,36 +41,39 @@ export function IsochroneResultCard({ result, layerId, onFocus }: Props) {
   const modeLabel = mode === 'driving' || mode === 'car' ? '驾车' : '步行';
 
   return (
-    <div className="my-2 p-3.5 rounded-xl border border-slate-200/80 bg-white/80 dark:border-slate-800 dark:bg-slate-900/80 backdrop-blur-md text-sm shadow-sm transition-all">
+    /* C：去掉 backdrop-blur-md，把 bg-white/80 dark:bg-slate-900/80 半透明对
+       收敛为单一语义 token —— 结果卡浮在聊天气泡上，半透明+blur 只增加合成
+       成本且让底下的正文透出来。 */
+    <div className="my-2 p-3.5 rounded-md border border-edge-subtle bg-surface-raised text-body shadow-raised transition-all">
       {/* Header */}
       <div className="flex items-center justify-between mb-2.5">
-        <div className="flex items-center gap-1.5 font-semibold text-slate-800 dark:text-slate-200">
-          <Clock className="h-4 w-4 text-emerald-500 shrink-0" />
+        <div className="flex items-center gap-1.5 font-semibold text-ink">
+          <Clock className="h-4 w-4 text-status-success shrink-0" />
           <span>等时圈网络分析 ({travelTime} 分钟)</span>
         </div>
-        <span className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-600 dark:bg-emerald-950/60 dark:text-emerald-300 font-medium">
+        <span className="flex items-center gap-1 text-meta px-2 py-0.5 rounded-pill bg-status-success-soft text-status-success font-medium">
           <ModeIcon className="h-3.5 w-3.5" />
           {modeLabel}模式
         </span>
       </div>
 
       {/* Metrics Row */}
-      <div className="grid grid-cols-2 gap-2 mb-2.5 p-2.5 rounded-lg bg-emerald-50/40 dark:bg-emerald-950/20 border border-emerald-100/50 dark:border-emerald-900/30">
+      <div className="grid grid-cols-2 gap-2 mb-2.5 p-2.5 rounded-md bg-status-success-soft border border-status-success-border">
         <div className="flex items-center gap-2">
-          <MapPin className="h-4 w-4 text-emerald-500 shrink-0" />
+          <MapPin className="h-4 w-4 text-status-success shrink-0" />
           <div>
-            <div className="text-xs text-slate-400 dark:text-slate-500 font-medium">设施点数量</div>
-            <div className="text-sm font-mono font-bold text-slate-700 dark:text-slate-200">
+            <div className="text-meta text-ink-muted font-medium">设施点数量</div>
+            <div className="text-body font-mono font-bold text-ink">
               {facilityCount} 个设施
             </div>
           </div>
         </div>
 
         <div className="flex items-center gap-2">
-          <Layers className="h-4 w-4 text-emerald-500 shrink-0" />
+          <Layers className="h-4 w-4 text-status-success shrink-0" />
           <div>
-            <div className="text-xs text-slate-400 dark:text-slate-500 font-medium">覆盖面积</div>
-            <div className="text-sm font-mono font-bold text-slate-700 dark:text-slate-200">
+            <div className="text-meta text-ink-muted font-medium">覆盖面积</div>
+            <div className="text-body font-mono font-bold text-ink">
               {areaKm2 !== null ? `${areaKm2.toFixed(2)} km²` : `${travelTime} 分钟圈`}
             </div>
           </div>
@@ -79,21 +82,21 @@ export function IsochroneResultCard({ result, layerId, onFocus }: Props) {
 
       {/* Summary Note */}
       {summaryText && (
-        <div className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed mb-2.5 bg-slate-50/90 dark:bg-slate-800/50 p-2.5 rounded-lg border border-slate-100 dark:border-slate-800">
+        <div className="text-body text-ink-secondary leading-relaxed mb-2.5 bg-surface-sunken p-2.5 rounded-md border border-edge-subtle">
           {summaryText}
         </div>
       )}
 
       {/* Action Footer */}
-      <div className="flex items-center justify-between pt-1.5 border-t border-slate-100 dark:border-slate-800 text-xs">
-        <span className="text-slate-400 dark:text-slate-500 font-mono">
+      <div className="flex items-center justify-between pt-1.5 border-t border-edge-subtle text-meta">
+        <span className="text-ink-muted font-mono">
           速度基准: {modeLabel === '驾车' ? '400m/min' : '80m/min'}
         </span>
         {layerId && onFocus && (
           <button
             type="button"
             onClick={() => onFocus(layerId)}
-            className="inline-flex items-center gap-1 font-medium text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300 hover:underline transition-colors"
+            className="inline-flex items-center gap-1 font-medium text-status-success hover:underline transition-colors"
           >
             <Target className="h-3.5 w-3.5" />
             高亮图层

--- a/frontend/components/chat/mini-md.tsx
+++ b/frontend/components/chat/mini-md.tsx
@@ -32,26 +32,28 @@ export const safeUrlTransform: UrlTransform = (url) => {
 
 export default function MiniMd({ text }: MiniMdProps) {
   return (
-    <div className="prose-agent text-[12.5px] leading-[1.7] text-slate-600 max-w-none break-words">
+    <div className="prose-agent text-body leading-[1.7] text-ink-secondary max-w-none break-words">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         urlTransform={safeUrlTransform}
         components={{
           p: ({ children }) => <p className="mb-2 last:mb-0 leading-relaxed">{children}</p>,
+          // 可访问性（V4）：聊天气泡里的 markdown 标题从 h4 起跳（h1→h4、h2→h5、h3→h6），
+          // 避免把 h1/h2 注入页面大纲 —— 应用自身的顶层标题就是 h2。视觉字号不变。
           h1: ({ children }) => (
-            <h1 className="text-[15px] font-bold text-slate-800 mt-3 mb-1.5 first:mt-0">{children}</h1>
+            <h4 className="text-heading font-bold text-ink mt-3 mb-1.5 first:mt-0">{children}</h4>
           ),
           h2: ({ children }) => (
-            <h2 className="text-[13.5px] font-semibold text-slate-800 mt-2.5 mb-1 first:mt-0">{children}</h2>
+            <h5 className="text-title font-semibold text-ink mt-2.5 mb-1 first:mt-0">{children}</h5>
           ),
           h3: ({ children }) => (
-            <h3 className="text-[12.5px] font-semibold text-slate-700 mt-2 mb-1 first:mt-0">{children}</h3>
+            <h6 className="text-body font-semibold text-ink-secondary mt-2 mb-1 first:mt-0">{children}</h6>
           ),
           ul: ({ children }) => <ul className="list-disc list-outside ml-4 mb-2 space-y-0.5">{children}</ul>,
           ol: ({ children }) => <ol className="list-decimal list-outside ml-4 mb-2 space-y-0.5">{children}</ol>,
           li: ({ children }) => <li className="leading-relaxed">{children}</li>,
           blockquote: ({ children }) => (
-            <blockquote className="border-l-2 border-green-300 pl-3 my-2 text-slate-500 italic">
+            <blockquote className="border-l-2 border-status-accent-border pl-3 my-2 text-ink-muted italic">
               {children}
             </blockquote>
           ),
@@ -59,13 +61,13 @@ export default function MiniMd({ text }: MiniMdProps) {
             const isBlock = className?.includes('language-');
             if (isBlock) {
               return (
-                <pre className="my-2 p-3 bg-slate-50 border border-slate-200/80 rounded-lg overflow-x-auto text-[13.5px] leading-relaxed">
+                <pre className="my-2 p-3 bg-surface-sunken border border-edge-subtle rounded-md overflow-x-auto text-body leading-relaxed">
                   <code>{children}</code>
                 </pre>
               );
             }
             return (
-              <code className="rounded bg-green-50 px-1 py-0.5 font-mono text-[13.5px] text-green-700">
+              <code className="rounded-sm bg-status-accent-soft px-1 py-0.5 font-mono text-body text-status-accent">
                 {children}
               </code>
             );
@@ -81,25 +83,25 @@ export default function MiniMd({ text }: MiniMdProps) {
               children: [],
             });
             return (
-              <a href={safeHref ?? undefined} target="_blank" rel="noopener noreferrer" className="text-green-600 underline hover:text-green-700">
+              <a href={safeHref ?? undefined} target="_blank" rel="noopener noreferrer" className="text-status-accent underline hover:text-status-accent">
                 {children}
               </a>
             );
           },
           table: ({ children }) => (
-            <div className="overflow-x-auto my-2 rounded-lg border border-slate-200/80">
-              <table className="w-full text-[14px]">{children}</table>
+            <div className="overflow-x-auto my-2 rounded-md border border-edge-subtle">
+              <table className="w-full text-body">{children}</table>
             </div>
           ),
           th: ({ children }) => (
-            <th className="px-2.5 py-1.5 bg-green-50/50 text-left font-semibold text-slate-700 border-b border-slate-200/80">
+            <th className="px-2.5 py-1.5 bg-status-accent-soft text-left font-semibold text-ink-secondary border-b border-edge-subtle">
               {children}
             </th>
           ),
           td: ({ children }) => (
-            <td className="px-2.5 py-1.5 border-b border-slate-100 text-slate-600">{children}</td>
+            <td className="px-2.5 py-1.5 border-b border-edge-subtle text-ink-secondary">{children}</td>
           ),
-          hr: () => <hr className="my-3 border-slate-200/60" />,
+          hr: () => <hr className="my-3 border-edge-subtle" />,
         }}
       >
         {text}

--- a/frontend/components/chat/plan-card.tsx
+++ b/frontend/components/chat/plan-card.tsx
@@ -9,9 +9,9 @@ interface Props {
 }
 
 const STATUS_ICON: Record<AgentPlanStepStatus, ReactElement> = {
-  done: <Check className="h-3 w-3 text-emerald-500" />,
-  pending: <Circle className="h-3 w-3 text-muted-foreground/50 animate-pulse" />,
-  skipped: <MinusCircle className="h-3 w-3 text-muted-foreground/40" />,
+  done: <Check className="h-3 w-3 text-status-success" />,
+  pending: <Circle className="h-3 w-3 text-ink-disabled animate-pulse" />,
+  skipped: <MinusCircle className="h-3 w-3 text-ink-disabled" />,
 };
 
 export function PlanCard({ plan }: Props) {
@@ -19,11 +19,11 @@ export function PlanCard({ plan }: Props) {
   if (total === 0) return null;
   const doneCount = plan.steps.filter(s => s.status === 'done').length;
   return (
-    <div className="my-2 p-3 rounded-lg border border-border bg-card/60">
+    <div className="my-2 p-3 rounded-md border border-edge-subtle bg-surface-raised">
       <div className="flex items-center gap-2 mb-2">
-        <ClipboardList className="h-4 w-4 text-primary" />
-        <span className="text-sm font-semibold text-foreground truncate">{plan.intent}</span>
-        <span className="text-[14px] ml-auto text-muted-foreground tabular-nums">
+        <ClipboardList className="h-4 w-4 text-status-accent" />
+        <span className="text-body font-semibold text-ink truncate">{plan.intent}</span>
+        <span className="text-body ml-auto text-ink-muted tabular-nums">
           {doneCount} / {total}
         </span>
       </div>
@@ -31,12 +31,12 @@ export function PlanCard({ plan }: Props) {
         {plan.steps.map(s => (
           <li
             key={s.n}
-            className={`flex items-center gap-2 text-[15px] ${
+            className={`flex items-center gap-2 text-body ${
               s.status === 'skipped' ? 'opacity-50' : ''
             }`}
           >
             <span className="shrink-0">{STATUS_ICON[s.status]}</span>
-            <span className={`flex-1 ${s.status === 'done' ? 'text-foreground' : 'text-muted-foreground'}`}>
+            <span className={`flex-1 ${s.status === 'done' ? 'text-ink' : 'text-ink-muted'}`}>
               {s.goal}
             </span>
           </li>

--- a/frontend/components/chat/plan-proposal-card.tsx
+++ b/frontend/components/chat/plan-proposal-card.tsx
@@ -29,8 +29,6 @@ export interface PlanProposalCardProps {
   destructiveSteps?: string[];
   stepsPreview?: PlanStepPreview[];
   status: 'pending' | 'approved' | 'rejected';
-  isDark?: boolean;
-  accentColor?: string;
   /** 执行确认 — 父组件应触发一条 chat 让 LLM 调 execute_plan(plan_id)。 */
   onApprove: (planId: string) => void;
   /** 让 LLM 修改计划 */
@@ -48,8 +46,6 @@ export function PlanProposalCard(props: PlanProposalCardProps) {
     destructiveSteps = [],
     stepsPreview = [],
     status,
-    isDark = true,
-    accentColor = '#10b981',
     onApprove,
     onRevise,
     onReject,
@@ -59,102 +55,54 @@ export function PlanProposalCard(props: PlanProposalCardProps) {
   const hasDestructive = destructiveSteps.length > 0;
   const locked = status !== 'pending';
 
-  const bg = isDark ? 'rgba(15,23,42,0.6)' : 'rgba(248,250,252,0.95)';
-  const border = isDark ? 'rgba(148,163,184,0.25)' : 'rgba(203,213,225,0.9)';
-  const subText = isDark ? '#94a3b8' : '#64748b';
-  const titleColor = isDark ? '#e2e8f0' : '#0f172a';
-
+  /* V4（D）：卡片表面/文字全部走语义 token（随主题翻转），不再按 isDark 手工
+     二选一 —— 原来暗色下的 subText #94a3b8 只有 2.45:1。accent 作文字一律用
+     text-safe 派生（--agent-accent 已含主题校正）。 */
   return (
     <div
       data-testid="plan-proposal-card"
-      style={{
-        marginTop: 8,
-        borderRadius: 12,
-        border: `1px solid ${border}`,
-        backgroundColor: bg,
-        padding: 12,
-        fontSize: 14,
-      }}
+      className="my-2 rounded-md border border-edge-subtle bg-surface-raised p-3 text-body"
     >
       {/* Header */}
       <div className="flex items-start gap-2">
         <div
-          className="w-7 h-7 rounded-md flex items-center justify-center shrink-0"
-          style={{ backgroundColor: `${accentColor}1f` }}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+          style={{ backgroundColor: 'color-mix(in srgb, var(--agent-accent) 12%, transparent)' }}
         >
-          <ListTodo size={14} style={{ color: accentColor }} />
+          <ListTodo size={14} style={{ color: 'var(--agent-accent)' }} />
         </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span style={{ color: titleColor, fontWeight: 600, fontSize: 15 }}>{title}</span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-title font-semibold text-ink">{title}</span>
             <span
+              className="rounded-pill px-2 py-px text-meta font-medium"
               style={{
-                padding: '1px 8px',
-                borderRadius: 999,
-                fontSize: 12,
-                fontWeight: 500,
-                color: accentColor,
-                backgroundColor: `${accentColor}1f`,
+                color: 'var(--agent-accent)',
+                backgroundColor: 'color-mix(in srgb, var(--agent-accent) 12%, transparent)',
               }}
             >
               计划 · {stepCount} 步
             </span>
             {status === 'approved' && (
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 4,
-                  padding: '1px 8px',
-                  borderRadius: 999,
-                  fontSize: 12,
-                  color: '#22c55e',
-                  backgroundColor: 'rgba(34,197,94,0.15)',
-                }}
-              >
+              <span className="inline-flex items-center gap-1 rounded-pill bg-status-success-soft px-2 py-px text-meta text-status-success">
                 <CheckCircle2 size={10} /> 已批准
               </span>
             )}
             {status === 'rejected' && (
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 4,
-                  padding: '1px 8px',
-                  borderRadius: 999,
-                  fontSize: 12,
-                  color: '#ef4444',
-                  backgroundColor: 'rgba(239,68,68,0.15)',
-                }}
-              >
+              <span className="inline-flex items-center gap-1 rounded-pill bg-status-critical-soft px-2 py-px text-meta text-status-critical">
                 <X size={10} /> 已取消
               </span>
             )}
           </div>
           {summary && (
-            <div style={{ color: subText, marginTop: 4, lineHeight: 1.5 }}>{summary}</div>
+            <div className="mt-1 text-body text-ink-muted">{summary}</div>
           )}
         </div>
       </div>
 
       {/* Destructive warning */}
       {hasDestructive && (
-        <div
-          style={{
-            marginTop: 8,
-            padding: '6px 10px',
-            borderRadius: 6,
-            backgroundColor: 'rgba(245,158,11,0.12)',
-            border: '1px solid rgba(245,158,11,0.3)',
-            color: '#f59e0b',
-            display: 'flex',
-            gap: 6,
-            alignItems: 'flex-start',
-            fontSize: 13,
-            lineHeight: 1.5,
-          }}
-        >
+        <div className="mt-2 flex items-start gap-1.5 rounded-md border border-status-warning-border bg-status-warning-soft p-2 text-body leading-relaxed text-status-warning">
           <AlertTriangle size={12} className="mt-[1px] shrink-0" />
           <span>
             本计划含 {destructiveSteps.length} 个破坏性步骤（{destructiveSteps.join('、')}），
@@ -165,61 +113,35 @@ export function PlanProposalCard(props: PlanProposalCardProps) {
 
       {/* Steps */}
       {stepsPreview.length > 0 && (
-        <div style={{ marginTop: 10 }}>
+        <div className="mt-2.5">
           <button
             type="button"
             onClick={() => setExpanded((v) => !v)}
-            style={{
-              color: subText,
-              fontSize: 12,
-              padding: 0,
-              background: 'transparent',
-              border: 'none',
-              cursor: 'pointer',
-            }}
+            className="cursor-pointer border-none bg-transparent p-0 text-meta text-ink-muted"
           >
             {expanded ? '▾' : '▸'} 步骤明细
           </button>
           {expanded && (
-            <ol
-              style={{
-                marginTop: 6,
-                paddingLeft: 0,
-                listStyle: 'none',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 4,
-              }}
-            >
+            <ol className="mt-1.5 flex list-none flex-col gap-1 p-0">
               {stepsPreview.map((step, i) => (
                 <li
                   key={step.id}
-                  style={{
-                    display: 'flex',
-                    gap: 8,
-                    padding: '4px 8px',
-                    borderRadius: 6,
-                    backgroundColor: step.destructive
-                      ? 'rgba(245,158,11,0.08)'
-                      : isDark
-                      ? 'rgba(30,41,59,0.4)'
-                      : 'rgba(241,245,249,0.6)',
-                    fontSize: 13,
-                    lineHeight: 1.5,
-                  }}
+                  className={`flex gap-2 rounded-md px-2 py-1 ${
+                    step.destructive ? 'bg-status-warning-soft' : 'bg-surface-sunken'
+                  }`}
                 >
-                  <span style={{ color: subText, fontWeight: 600, minWidth: 18 }}>{i + 1}.</span>
-                  <div className="flex-1 min-w-0">
-                    <div style={{ color: titleColor }}>
-                      <code style={{ fontSize: 12, color: accentColor }}>{step.tool}</code>
+                  <span className="min-w-[18px] font-semibold text-ink-muted">{i + 1}.</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-ink">
+                      <code className="text-meta text-agent-accent">{step.tool}</code>
                       {step.destructive && (
-                        <span style={{ marginLeft: 6, color: '#f59e0b', fontSize: 12 }}>
+                        <span className="ml-1.5 text-meta text-status-warning">
                           ⚠ 破坏性
                         </span>
                       )}
                     </div>
                     {step.purpose && (
-                      <div style={{ color: subText, fontSize: 12.5 }}>{step.purpose}</div>
+                      <div className="text-meta text-ink-muted">{step.purpose}</div>
                     )}
                   </div>
                 </li>
@@ -230,25 +152,17 @@ export function PlanProposalCard(props: PlanProposalCardProps) {
       )}
 
       {/* Action buttons */}
-      <div className="flex gap-2" style={{ marginTop: 12 }}>
+      <div className="mt-3 flex gap-2">
         <button
           type="button"
           disabled={locked}
           onClick={() => onApprove(planId)}
+          className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-2.5 py-1.5 text-body font-medium ${
+            locked ? 'cursor-not-allowed' : 'cursor-pointer'
+          }`}
           style={{
-            flex: 1,
-            padding: '6px 10px',
-            borderRadius: 8,
-            border: 'none',
-            backgroundColor: locked ? 'rgba(100,116,139,0.3)' : accentColor,
-            color: locked ? subText : '#fff',
-            fontSize: 14,
-            fontWeight: 500,
-            cursor: locked ? 'not-allowed' : 'pointer',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 6,
+            backgroundColor: locked ? 'color-mix(in srgb, var(--neutral) 30%, transparent)' : 'var(--agent-accent)',
+            color: locked ? 'var(--text-muted)' : 'var(--text-on-accent)',
           }}
         >
           {locked ? <Lock size={12} /> : <Play size={12} />}
@@ -258,17 +172,11 @@ export function PlanProposalCard(props: PlanProposalCardProps) {
           type="button"
           disabled={locked}
           onClick={() => onRevise(planId)}
+          className={`flex items-center gap-1.5 rounded-md border border-edge-subtle bg-transparent px-2.5 py-1.5 text-body ${
+            locked ? 'cursor-not-allowed' : 'cursor-pointer'
+          }`}
           style={{
-            padding: '6px 10px',
-            borderRadius: 8,
-            border: `1px solid ${border}`,
-            backgroundColor: 'transparent',
-            color: locked ? subText : titleColor,
-            fontSize: 14,
-            cursor: locked ? 'not-allowed' : 'pointer',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
+            color: locked ? 'var(--text-muted)' : 'var(--text-primary)',
           }}
         >
           <Edit3 size={12} /> 修改
@@ -277,17 +185,11 @@ export function PlanProposalCard(props: PlanProposalCardProps) {
           type="button"
           disabled={locked}
           onClick={() => onReject(planId)}
+          className={`flex items-center gap-1.5 rounded-md border border-edge-subtle bg-transparent px-2.5 py-1.5 text-body ${
+            locked ? 'cursor-not-allowed' : 'cursor-pointer'
+          }`}
           style={{
-            padding: '6px 10px',
-            borderRadius: 8,
-            border: `1px solid ${border}`,
-            backgroundColor: 'transparent',
-            color: locked ? subText : '#ef4444',
-            fontSize: 14,
-            cursor: locked ? 'not-allowed' : 'pointer',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
+            color: locked ? 'var(--text-muted)' : 'var(--text-critical)',
           }}
         >
           <X size={12} /> 取消

--- a/frontend/components/chat/tool-call-card.tsx
+++ b/frontend/components/chat/tool-call-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { ChevronRight, ChevronDown, CheckCircle2, AlertCircle, Loader2, Clock, Wrench } from 'lucide-react';
 import { CartographyResultCard } from './cartography-result-card';
 import { H3LisaResultCard } from './h3-lisa-result-card';
@@ -137,39 +137,42 @@ function ToolCallRow({ call, expanded }: { call: ToolCallEntry; expanded: boolea
 
   const statusIcon =
     call.status === 'running' ? (
-      <Loader2 size={11} className="animate-spin text-blue-500" />
+      <Loader2 size={11} className="animate-spin text-status-info" />
     ) : call.status === 'completed' ? (
-      <CheckCircle2 size={11} className="text-green-500" />
+      <CheckCircle2 size={11} className="text-status-success" />
     ) : (
-      <AlertCircle size={11} className="text-red-500" />
+      <AlertCircle size={11} className="text-status-critical" />
     );
 
   const panelId = `tool-row-panel-${call.id}`;
 
   return (
-    <div className={`rounded-md border text-[15px] overflow-hidden ${expanded ? 'border-slate-200/80 bg-white/50' : 'border-transparent'}`}>
+    <div className={`rounded-sm border text-body overflow-hidden ${expanded ? 'border-edge-subtle bg-surface-raised' : 'border-transparent'}`}>
       <button
         onClick={() => setOpen(!open)}
         aria-expanded={open}
         aria-controls={panelId}
-        className="w-full flex items-center gap-1.5 px-2 py-1 text-left hover:bg-slate-50/60 transition-colors focus:outline-none focus:ring-1 focus:ring-blue-400"
+        /* B: 删掉 focus:outline-none focus:ring-1 focus:ring-blue-400 —— 硬编码
+           blue 与全站焦点环词汇冲突；globals.css 的 unlayered *:focus-visible
+           已从 --focus-ring 提供统一焦点环。 */
+        className="w-full flex items-center gap-1.5 px-2 py-1 text-left hover:bg-surface-hover transition-colors"
       >
         <ChevronRight
           size={10}
-          className={`shrink-0 text-slate-400 transition-transform ${open ? 'rotate-90' : ''}`}
+          className={`shrink-0 text-ink-disabled transition-transform ${open ? 'rotate-90' : ''}`}
         />
         {statusIcon}
-        <span className="font-mono text-slate-600">
+        <span className="font-mono text-ink-secondary">
           <ToolName name={call.tool} />
         </span>
         {call.hasGeojson && (
-          <span className="px-1 py-0 rounded text-[8px] bg-green-50 text-green-600 font-medium">
+          <span className="px-1 py-0 rounded-sm text-micro bg-status-accent-soft text-status-accent font-medium">
             GeoJSON
           </span>
         )}
         <span className="flex-1" />
         {duration && (
-          <span className="flex items-center gap-0.5 text-[15px] text-slate-400">
+          <span className="flex items-center gap-0.5 text-body text-ink-disabled">
             <Clock size={9} />
             {duration}
           </span>
@@ -201,11 +204,11 @@ function ToolCallRow({ call, expanded }: { call: ToolCallEntry; expanded: boolea
       )}
 
       {open && (
-        <div id={panelId} role="region" aria-label={`${call.tool} 详细信息`} className="border-t border-slate-100 px-2.5 py-1.5 space-y-1.5 bg-slate-50/30">
+        <div id={panelId} role="region" aria-label={`${call.tool} 详细信息`} className="border-t border-edge-subtle px-2.5 py-1.5 space-y-1.5 bg-surface-sunken">
           {parsedArgs && (
             <div>
-              <p className="text-[15px] font-semibold text-slate-400 uppercase tracking-wider mb-0.5">参数</p>
-              <pre className="p-1.5 rounded bg-white/80 border border-slate-100 text-[14px] leading-relaxed text-slate-600 font-mono overflow-x-auto max-h-[100px] overflow-y-auto">
+              <p className="text-body font-semibold text-ink-muted uppercase tracking-wider mb-0.5">参数</p>
+              <pre className="p-1.5 rounded-sm bg-surface-raised border border-edge-subtle text-body leading-relaxed text-ink-secondary font-mono overflow-x-auto max-h-[100px] overflow-y-auto">
                 {Object.entries(parsedArgs)
                   .map(([k, v]) => {
                     const val = typeof v === 'string' ? `"${v}"` : JSON.stringify(v);
@@ -217,8 +220,8 @@ function ToolCallRow({ call, expanded }: { call: ToolCallEntry; expanded: boolea
           )}
           {call.result && (
             <div>
-              <p className="text-[15px] font-semibold text-slate-400 uppercase tracking-wider mb-0.5">结果</p>
-              <pre className="p-1.5 rounded bg-white/80 border border-slate-100 text-[14px] leading-relaxed text-slate-600 font-mono overflow-x-auto max-h-[150px] overflow-y-auto">
+              <p className="text-body font-semibold text-ink-muted uppercase tracking-wider mb-0.5">结果</p>
+              <pre className="p-1.5 rounded-sm bg-surface-raised border border-edge-subtle text-body leading-relaxed text-ink-secondary font-mono overflow-x-auto max-h-[150px] overflow-y-auto">
                 {formatJson(call.result).slice(0, 1500)}
                 {formatJson(call.result).length > 1500 ? '\n...' : ''}
               </pre>
@@ -226,8 +229,8 @@ function ToolCallRow({ call, expanded }: { call: ToolCallEntry; expanded: boolea
           )}
           {call.error && (
             <div>
-              <p className="text-[15px] font-semibold text-red-400 uppercase tracking-wider mb-0.5">错误</p>
-              <pre className="p-1.5 rounded bg-red-50/50 border border-red-100 text-[14px] text-red-600 font-mono">{call.error}</pre>
+              <p className="text-body font-semibold text-status-critical uppercase tracking-wider mb-0.5">错误</p>
+              <pre className="p-1.5 rounded-sm bg-status-critical-soft border border-status-critical-border text-body text-status-critical font-mono">{call.error}</pre>
             </div>
           )}
         </div>
@@ -251,38 +254,41 @@ export function ToolCallChain({ calls }: { calls: ToolCallEntry[] }) {
     ? `${completedCount} 个工具调用完成${failedCount > 0 ? `，${failedCount} 个失败` : ''}`
     : `正在执行 ${runningCount} 个工具...`;
 
-  const chainListId = 'tool-call-chain-list';
+  // Fix: a constant id collides when several tool-call chains are on screen,
+  // which breaks the aria-controls relationship; useId() keeps it unique per instance.
+  const chainListId = useId();
 
   return (
-    <div className="my-1.5 rounded-lg border border-slate-200/70 bg-white/40 overflow-hidden">
+    <div className="my-1.5 rounded-md border border-edge-subtle bg-surface-raised overflow-hidden">
       {/* Chain header — click to expand */}
       <button
         onClick={() => setExpanded(!expanded)}
         aria-expanded={expanded}
         aria-controls={chainListId}
-        className="w-full flex items-center gap-1.5 px-2.5 py-1.5 text-left hover:bg-slate-50/60 transition-colors text-[15px] focus:outline-none focus:ring-1 focus:ring-blue-400"
+        /* B: 同 ToolCallRow —— 删掉 focus:ring-blue-400，交给全局 *:focus-visible。 */
+        className="w-full flex items-center gap-1.5 px-2.5 py-1.5 text-left hover:bg-surface-hover transition-colors text-body"
       >
         {expanded ? (
-          <ChevronDown size={12} className="shrink-0 text-slate-400" />
+          <ChevronDown size={12} className="shrink-0 text-ink-disabled" />
         ) : (
-          <ChevronRight size={12} className="shrink-0 text-slate-400" />
+          <ChevronRight size={12} className="shrink-0 text-ink-disabled" />
         )}
-        <Wrench size={11} className="text-slate-400" />
-        <span className="text-slate-500">
+        <Wrench size={11} className="text-ink-disabled" />
+        <span className="text-ink-muted">
           {expanded ? '工具调用链' : statusText}
         </span>
         <span className="flex-1" />
         {allDone && !expanded && (
-          <CheckCircle2 size={11} className="text-green-500" />
+          <CheckCircle2 size={11} className="text-status-success" />
         )}
         {!allDone && (
-          <Loader2 size={11} className="animate-spin text-blue-500" />
+          <Loader2 size={11} className="animate-spin text-status-info" />
         )}
       </button>
 
       {/* Expanded: individual tool calls */}
       {expanded && (
-        <div id={chainListId} role="region" aria-label="工具调用链详情" className="border-t border-slate-100 px-2 py-1 space-y-0.5 bg-slate-50/20">
+        <div id={chainListId} role="region" aria-label="工具调用链详情" className="border-t border-edge-subtle px-2 py-1 space-y-0.5 bg-surface-sunken">
           {calls.map((tc) => (
             <ToolCallRow key={tc.id} call={tc} expanded={expanded} />
           ))}

--- a/frontend/components/drawers/history-drawer.test.tsx
+++ b/frontend/components/drawers/history-drawer.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { SessionSummary } from '@/lib/store/hud-types';
 
@@ -34,11 +34,11 @@ describe('HistoryDrawer keyboard focus trap', () => {
         open
         onClose={vi.fn()}
         onSelect={vi.fn()}
-        accentColor="#0ea5e9"
       />,
     );
 
     const panel = await screen.findByRole('dialog');
+    await waitForInitialFocus();
     const focusables = getTabbable(panel);
     expect(focusables.length).toBeGreaterThanOrEqual(2);
 
@@ -59,11 +59,11 @@ describe('HistoryDrawer keyboard focus trap', () => {
         open
         onClose={vi.fn()}
         onSelect={vi.fn()}
-        accentColor="#0ea5e9"
       />,
     );
 
     const panel = await screen.findByRole('dialog');
+    await waitForInitialFocus();
     const focusables = getTabbable(panel);
 
     focusables[0].focus();
@@ -85,12 +85,12 @@ describe('HistoryDrawer keyboard focus trap', () => {
           open
           onClose={vi.fn()}
           onSelect={vi.fn()}
-          accentColor="#0ea5e9"
         />
       </div>,
     );
 
     const panel = await screen.findByRole('dialog');
+    await waitForInitialFocus();
     const panelFocusables = getTabbable(panel);
     const backgroundButton = screen.getByText('背景按钮');
 
@@ -108,7 +108,7 @@ describe('HistoryDrawer keyboard focus trap', () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
     render(
-      <HistoryDrawer open onClose={onClose} onSelect={vi.fn()} accentColor="#0ea5e9" />,
+      <HistoryDrawer open onClose={onClose} onSelect={vi.fn()} />,
     );
 
     await screen.findByRole('dialog');
@@ -119,11 +119,13 @@ describe('HistoryDrawer keyboard focus trap', () => {
 
   it('moves focus into the search input when opened', async () => {
     render(
-      <HistoryDrawer open onClose={vi.fn()} onSelect={vi.fn()} accentColor="#0ea5e9" />,
+      <HistoryDrawer open onClose={vi.fn()} onSelect={vi.fn()} />,
     );
 
     const search = await screen.findByLabelText('搜索历史会话');
-    expect(document.activeElement).toBe(search);
+    // useDialogFocus（与全站其他 dialog 共用的 hook）初始聚焦带 50ms 延迟，
+    // 需等待焦点落位；断言本身不变。
+    await waitFor(() => expect(document.activeElement).toBe(search));
   });
 
   it('restores focus to the previously-focused element when closed', async () => {
@@ -136,7 +138,6 @@ describe('HistoryDrawer keyboard focus trap', () => {
             open={open}
             onClose={() => setOpen(false)}
             onSelect={vi.fn()}
-            accentColor="#0ea5e9"
           />
         </>
       );
@@ -154,7 +155,7 @@ describe('HistoryDrawer keyboard focus trap', () => {
   it('closes when the backdrop is clicked', async () => {
     const onClose = vi.fn();
     render(
-      <HistoryDrawer open onClose={onClose} onSelect={vi.fn()} accentColor="#0ea5e9" />,
+      <HistoryDrawer open onClose={onClose} onSelect={vi.fn()} />,
     );
 
     await screen.findByRole('dialog');
@@ -169,10 +170,18 @@ describe('HistoryDrawer keyboard focus trap', () => {
 // 工具：获取容器内 tab 顺序的可聚焦元素（与浏览器 Tab 行为一致）。
 // 注意：jsdom 不计算布局，getClientRects() 恒为空，故不能用可见性过滤 —— 这里只按
 // 选择器与 DOM 顺序返回，符合浏览器对可见元素的默认 Tab 顺序。
-// 选择器必须与生产代码 history-drawer.tsx::getTabbableIn 完全一致（含 input[type=hidden]
-// 排除），否则测试不会覆盖生产代码所做的过滤。
+// 选择器必须与生产代码 lib/utils/focus.ts 的 FOCUSABLE_SELECTOR 完全一致
+// （含 input[type=hidden] 排除），否则测试不会覆盖生产代码所做的过滤。
 function getTabbable(container: HTMLElement): HTMLElement[] {
   const selector =
     'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
   return Array.from(container.querySelectorAll<HTMLElement>(selector));
+}
+
+// 共用 hook（useDialogFocus）的初始聚焦带 50ms 延迟：测试手动接管焦点前先等
+// 自动聚焦落位，否则延迟聚焦会在测试执行中途触发、与焦点断言竞态
+// （全量跑测试时更慢，更容易触发）。
+async function waitForInitialFocus() {
+  const search = await screen.findByLabelText('搜索历史会话');
+  await waitFor(() => expect(document.activeElement).toBe(search));
 }

--- a/frontend/components/drawers/history-drawer.tsx
+++ b/frontend/components/drawers/history-drawer.tsx
@@ -1,26 +1,18 @@
 'use client';
 
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { History, X, Plus, Search } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
+import { useDialogFocus } from '@/lib/hooks/use-dialog-focus';
 import type { SessionSummary } from '@/lib/store/hud-types';
 
 interface HistoryDrawerProps {
   open: boolean;
   onClose: () => void;
   onSelect: (session: SessionSummary | null) => void;
-  accentColor: string;
 }
 
-// 面板内 tab 顺序的可聚焦元素，供焦点陷阱循环使用。
-// 排除 hidden input（不可聚焦但会被 input 选择器命中，导致循环目标落到空节点）。
-function getTabbableIn(container: HTMLElement): HTMLElement[] {
-  const selector =
-    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-  return Array.from(container.querySelectorAll<HTMLElement>(selector));
-}
-
-export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryDrawerProps) {
+export function HistoryDrawer({ open, onClose, onSelect }: HistoryDrawerProps) {
   const sessions = useHudStore((s) => s.sessions);
   const [search, setSearch] = useState('');
 
@@ -39,52 +31,17 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
     onClose();
   }
 
-  // 审计 a11y HIGH（findings.md F4 残留缺口）：drawer 已有 Escape 关闭、打开聚焦、
-  // 关闭回焦；缺 Tab 焦点陷阱 —— 键盘用户可 Tab 到背景元素。这里在已有 keydown 处理
-  // 里拦截 Tab/Shift+Tab，把焦点循环限制在面板内的可聚焦元素之间。
+  // 审计 a11y HIGH（findings.md F4 残留缺口）曾在这里手写焦点陷阱（本地
+  // getTabbableIn + Tab/Escape/回焦），与全站共用的 useDialogFocus 是两套平行
+  // 实现，逻辑容易漂移。统一改用共用 hook：搜索框初始聚焦、Tab/Shift+Tab 围栏、
+  // Escape 关闭、关闭回焦，行为与原来一致。
   const panelRef = useRef<HTMLDivElement>(null);
-  const previouslyFocused = useRef<HTMLElement | null>(null);
-  useEffect(() => {
-    if (!open) return;
-    previouslyFocused.current = document.activeElement as HTMLElement | null;
-    // 聚焦 drawer 面板（搜搜索框，便于键盘用户立刻操作）
-    const searchInput = panelRef.current?.querySelector<HTMLInputElement>('input[type="text"], input');
-    searchInput?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-        return;
-      }
-      if (e.key !== 'Tab') return;
-      const panel = panelRef.current;
-      if (!panel) return;
-      const focusables = getTabbableIn(panel);
-      if (focusables.length === 0) return;
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      const active = document.activeElement as HTMLElement | null;
-      if (e.shiftKey) {
-        // 在第一个（或面板本身）上 Shift+Tab → 跳到最后一个，阻止焦点回退到背景。
-        if (active === first || active === panel || !panel.contains(active)) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        // 在最后一个（或面板本身）上 Tab → 跳回第一个，阻止焦点前进到背景。
-        // 注意 panel 自身 tabIndex={-1} 不在 focusables 中，故需显式判断 active === panel。
-        if (active === last || active === panel || !panel.contains(active)) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('keydown', onKey);
-      previouslyFocused.current?.focus?.();
-    };
-  }, [open, onClose]);
+  useDialogFocus({
+    open,
+    containerRef: panelRef,
+    onEscape: onClose,
+    initialFocusSelector: 'input',
+  });
 
   if (!open) return null;
 
@@ -92,8 +49,7 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
     <div className="fixed inset-0 z-50 flex">
       {/* Backdrop (left side -- click to close) */}
       <div
-        className="flex-1 bg-slate-900/20"
-        style={{ backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)' }}
+        className="flex-1 bg-surface-scrim"
         onClick={onClose}
         aria-hidden="true"
       />
@@ -105,11 +61,11 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
         aria-modal="true"
         aria-labelledby="history-drawer-title"
         tabIndex={-1}
-        className="w-[340px] shrink-0 flex flex-col border-l border-slate-200/60 shadow-[-2px_0_24px_rgba(15,23,42,0.09)] outline-none"
+        className="w-[340px] shrink-0 flex flex-col border-l border-edge-subtle shadow-drawer outline-none"
         style={{
-          background: 'rgba(252,253,254,0.92)',
-          backdropFilter: 'blur(28px)',
-          WebkitBackdropFilter: 'blur(28px)',
+          // V4：overlay 表面不透明（--surface-overlay 双主题均不透明），
+          // 半透明白底 + backdrop blur 已无作用，去掉。
+          background: 'var(--surface-overlay)',
           animation: 'slide-from-right 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
         }}
       >
@@ -121,14 +77,14 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
         `}</style>
 
         {/* Header */}
-        <div className="shrink-0 flex items-center gap-2 px-4 py-3 border-b border-slate-200/60">
-          <History size={16} style={{ color: accentColor }} />
-          <h2 id="history-drawer-title" className="flex-1 text-[15px] font-semibold text-slate-800">历史会话</h2>
+        <div className="shrink-0 flex items-center gap-2 px-4 py-3 border-b border-edge-subtle">
+          <History size={16} style={{ color: 'var(--agent-accent)' }} />
+          <h2 id="history-drawer-title" className="flex-1 text-body font-semibold text-ink">历史会话</h2>
           <button
             onClick={() => { onSelect(null); onClose(); }}
             aria-label="新建会话"
-            className="flex items-center gap-1 px-2 py-1 rounded-md text-[10.5px] font-medium text-white transition-opacity hover:opacity-90"
-            style={{ backgroundColor: accentColor }}
+            className="flex items-center gap-1 px-2 py-1 rounded-sm text-caption font-medium text-ink-on-accent transition-opacity hover:opacity-90"
+            style={{ backgroundColor: 'var(--agent-accent)' }}
           >
             <Plus size={12} />
             新建会话
@@ -136,23 +92,23 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
           <button
             onClick={onClose}
             aria-label="关闭历史会话"
-            className="p-1.5 rounded-md text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors"
+            className="p-1.5 rounded-sm text-ink-disabled hover:text-ink-secondary hover:bg-surface-hover transition-colors"
           >
             <X size={15} />
           </button>
         </div>
 
         {/* Search input */}
-        <div className="shrink-0 px-3 py-2 border-b border-slate-100">
-          <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-slate-100/60 border border-slate-200/60">
-            <Search size={13} className="text-slate-300 shrink-0" />
+        <div className="shrink-0 px-3 py-2 border-b border-edge-subtle">
+          <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-surface-sunken border border-edge-subtle">
+            <Search size={13} className="text-ink-disabled shrink-0" />
             <input
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               aria-label="搜索历史会话"
               placeholder="搜索会话..."
-              className="flex-1 bg-transparent text-[14px] text-slate-700 placeholder:text-slate-300 outline-none"
+              className="flex-1 bg-transparent text-body text-ink-secondary placeholder:text-ink-disabled outline-none"
             />
           </div>
         </div>
@@ -165,8 +121,8 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
               role="status"
               aria-live="polite"
             >
-              <History size={20} className="text-slate-200 mb-2" />
-              <p className="text-[13.5px] text-slate-400">
+              <History size={20} className="text-ink-disabled mb-2" />
+              <p className="text-body text-ink-muted">
                 {search ? '没有匹配的会话' : '暂无历史会话'}
               </p>
             </div>
@@ -176,19 +132,19 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
                 <button
                   key={session.id}
                   onClick={() => handleSelect(session)}
-                  className="w-full text-left px-3 py-2.5 rounded-xl hover:bg-slate-50/80 transition-colors group"
+                  className="w-full text-left px-3 py-2.5 rounded-md hover:bg-surface-hover transition-colors group"
                   role="listitem"
                 >
                   {/* Title */}
-                  <p className="text-[12.5px] font-medium text-slate-700 truncate group-hover:text-slate-900">
+                  <p className="text-meta font-medium text-ink-secondary truncate group-hover:text-ink">
                     {session.title || '未命名会话'}
                   </p>
 
                   {/* Meta */}
                   <div className="flex items-center gap-2 mt-0.5">
-                    <span className="text-[9.5px] text-slate-300">{session.time}</span>
+                    <span className="text-micro text-ink-muted">{session.time}</span>
                     {session.msgs > 0 && (
-                      <span className="text-[9.5px] text-slate-300">
+                      <span className="text-micro text-ink-muted">
                         {session.msgs} 条消息
                       </span>
                     )}
@@ -200,10 +156,10 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
                       {session.tags.map((tag: string) => (
                         <span
                           key={tag}
-                          className="inline-flex px-1.5 py-0.5 rounded-full text-[15px] font-medium"
+                          className="inline-flex px-1.5 py-0.5 rounded-pill text-body font-medium"
                           style={{
-                            backgroundColor: `${accentColor}12`,
-                            color: accentColor,
+                            backgroundColor: 'color-mix(in srgb, var(--agent-accent) 7%, transparent)',
+                            color: 'var(--agent-accent)',
                           }}
                         >
                           {tag}
@@ -218,8 +174,8 @@ export function HistoryDrawer({ open, onClose, onSelect, accentColor }: HistoryD
         </div>
 
         {/* Footer */}
-        <div className="shrink-0 px-4 py-2.5 border-t border-slate-200/60 bg-white/30">
-          <span className="text-[14px] text-slate-400">
+        <div className="shrink-0 px-4 py-2.5 border-t border-edge-subtle bg-surface-raised">
+          <span className="text-body text-ink-muted">
             共 {filtered.length} 条历史会话
           </span>
         </div>

--- a/frontend/components/drawers/template-gallery-v2.tsx
+++ b/frontend/components/drawers/template-gallery-v2.tsx
@@ -233,8 +233,9 @@ export function TemplateGalleryV2({ open, onClose, onApply }: TemplateGalleryV2P
 
   return (
     <div
-      className="fixed inset-0 z-[90] flex justify-end"
-      style={{ background: 'rgba(15, 23, 42, 0.32)', backdropFilter: 'blur(4px)', WebkitBackdropFilter: 'blur(4px)' }}
+      /* V4：scrim 改语义 token（--surface-scrim 即原来的 rgba(15,23,42,0.32)）。
+         A：去掉 blur(4px) —— scrim 已经盖住地图，blur 只增加合成成本。 */
+      className="fixed inset-0 z-[90] flex justify-end bg-surface-scrim"
       onClick={onClose}
     >
       <div
@@ -243,8 +244,10 @@ export function TemplateGalleryV2({ open, onClose, onApply }: TemplateGalleryV2P
         aria-modal="true"
         aria-labelledby="template-gallery-title"
         tabIndex={-1}
-        className="flex h-full w-[560px] max-w-[92vw] flex-col border-l border-[var(--theme-border)] shadow-2xl"
-        style={{ background: 'var(--theme-bg-panel)', backdropFilter: 'blur(28px)', WebkitBackdropFilter: 'blur(28px)' }}
+        /* 宽度走 --drawer-w（见 globals.css）：约束是"地图仍然可见"，
+           两个右侧抽屉共用同一条规则。 */
+        className="flex h-full flex-col border-l border-edge-subtle bg-surface-overlay shadow-drawer animate-slide-from-right"
+        style={{ width: 'var(--drawer-w)' }}
         onClick={(e) => e.stopPropagation()}
       >
         <Header onClose={onClose} search={search} setSearch={setSearch} loading={loading} />
@@ -300,13 +303,13 @@ function Header({
   loading: boolean;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 border-b border-[var(--theme-border)] p-4">
+    <div className="flex items-center justify-between gap-3 border-b border-edge-subtle p-4">
       <div className="min-w-0">
-        <h2 id="template-gallery-title" className="flex items-center gap-2 text-[15px] font-semibold text-[var(--theme-text-primary)]">
-          <Sparkles className="h-4 w-4" style={{ color: 'var(--agent-accent, #16a34a)' }} aria-hidden />
+        <h2 id="template-gallery-title" className="flex items-center gap-2 text-title font-semibold text-ink">
+          <Sparkles className="h-4 w-4 text-agent-accent" aria-hidden />
           地图制图模板库
         </h2>
-        <p className="mt-0.5 text-[12px] text-[var(--theme-text-muted)]">模板 · 按分类/关键词搜索 · 快速应用</p>
+        <p className="mt-0.5 text-meta text-ink-muted">模板 · 按分类/关键词搜索 · 快速应用</p>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {/* 受控 + debounce=0：fetch 防抖由组件自身的 200ms debouncedSearch 承担；
@@ -318,7 +321,7 @@ function Header({
           aria-label="搜索模板"
           debounceMs={0}
         />
-        {loading && <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none text-[var(--theme-text-muted)]" aria-hidden />}
+        {loading && <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none text-ink-muted" aria-hidden />}
         <IconButton label="关闭模板库" icon={X} onClick={onClose} />
       </div>
     </div>
@@ -334,7 +337,7 @@ function KindTabs({
 }) {
   return (
     // 分类过滤是 toggle-button 组（不控制 tabpanel），不用 tablist 语义。
-    <div aria-label="模板分类" className="flex gap-1 overflow-x-auto border-b border-[var(--theme-border)] px-4 pt-2">
+    <div aria-label="模板分类" className="flex gap-1 overflow-x-auto border-b border-edge-subtle px-4 pt-2">
       {KIND_TABS.map(({ kind, label, Icon }) => {
         const selected = active === kind;
         return (
@@ -343,12 +346,14 @@ function KindTabs({
             type="button"
             aria-pressed={selected}
             onClick={() => onChange(kind)}
-            className={`flex items-center gap-1.5 whitespace-nowrap rounded-t-md px-3 py-2 text-[13px] transition-colors ${
-              selected ? '' : 'hover:bg-[var(--theme-bg-hover)]'
+            className={`flex items-center gap-1.5 whitespace-nowrap rounded-t-md px-3 py-2 text-body transition-colors ${
+              selected ? '' : 'hover:bg-surface-hover'
             }`}
             style={{
-              color: selected ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-secondary)',
-              boxShadow: selected ? 'inset 0 -2px 0 var(--agent-accent, #16a34a)' : undefined,
+              /* 选中项的文字是 accent 作文字 —— 暗色下原色 2.96–3.40:1，
+                 用 text-safe 派生；底部的指示条仍是 fill，用原色。 */
+              color: selected ? 'var(--agent-accent)' : 'var(--text-secondary)',
+              boxShadow: selected ? 'inset 0 -2px 0 var(--agent-accent)' : undefined,
             }}
           >
             <Icon className="h-3.5 w-3.5" aria-hidden />
@@ -380,11 +385,11 @@ const TemplateCard = React.memo(function TemplateCard({
   return (
     <div
       onClick={handleClick}
-      className="group cursor-pointer rounded-lg border p-3 transition-colors"
+      className="group cursor-pointer rounded-md border p-3 transition-colors"
       style={{
-        borderColor: selected ? 'var(--agent-accent, #16a34a)' : 'var(--theme-border)',
-        background: selected ? 'var(--theme-bg-subtle)' : 'var(--theme-bg-glass)',
-        boxShadow: selected ? '0 0 0 1px color-mix(in srgb, var(--agent-accent, #16a34a) 35%, transparent)' : undefined,
+        borderColor: selected ? 'var(--agent-accent)' : 'var(--border-subtle)',
+        background: selected ? 'var(--surface-selected)' : 'var(--surface-raised)',
+        boxShadow: selected ? '0 0 0 1px color-mix(in srgb, var(--agent-accent) 35%, transparent)' : undefined,
       }}
     >
       <div className="flex items-start gap-2">
@@ -396,11 +401,11 @@ const TemplateCard = React.memo(function TemplateCard({
           {template.kind === 'composite' ? '⧉' : template.kind[0]?.toUpperCase()}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-medium text-[var(--theme-text-primary)]">{template.name}</div>
-          <div className="mt-0.5 line-clamp-2 text-[12px] text-[var(--theme-text-muted)]">{template.description || '—'}</div>
+          <div className="truncate text-body font-medium text-ink">{template.name}</div>
+          <div className="mt-0.5 line-clamp-2 text-meta text-ink-muted">{template.description || '—'}</div>
           <div className="mt-1.5 flex flex-wrap gap-1">
             {(template.keywords || []).slice(0, 3).map((k) => (
-              <span key={k} className="rounded bg-[var(--theme-bg-muted)] px-1.5 py-0.5 text-[10px] text-[var(--theme-text-secondary)]">
+              <span key={k} className="rounded-sm bg-surface-sunken px-1.5 py-0.5 text-micro text-ink-secondary">
                 {k}
               </span>
             ))}
@@ -408,16 +413,15 @@ const TemplateCard = React.memo(function TemplateCard({
         </div>
       </div>
       <div className="mt-2 flex items-center justify-between">
-        <span className="font-mono text-[10px] text-[var(--theme-text-muted)]">{template.id}</span>
+        <span className="font-mono text-micro text-ink-muted">{template.id}</span>
         <button
           onClick={(e) => {
             e.stopPropagation();
             handleApplyClick();
           }}
-          className="rounded px-2 py-1 text-[11px] font-medium transition-opacity hover:opacity-80"
+          className="rounded-sm px-2 py-1 text-caption font-medium text-agent-accent transition-opacity hover:opacity-80"
           style={{
-            color: 'var(--agent-accent, #16a34a)',
-            background: 'color-mix(in srgb, var(--agent-accent, #16a34a) 12%, transparent)',
+            background: 'color-mix(in srgb, var(--agent-accent) 12%, transparent)',
           }}
         >
           应用
@@ -441,20 +445,20 @@ function Footer({
   onPage: (p: number) => void;
 }) {
   return (
-    <div className="flex items-center justify-between border-t border-[var(--theme-border)] p-3">
-      <span className="text-[12px] text-[var(--theme-text-muted)]">第 {page + 1} / {totalPages} 页</span>
+    <div className="flex items-center justify-between border-t border-edge-subtle p-3">
+      <span className="text-meta text-ink-muted">第 {page + 1} / {totalPages} 页</span>
       <div className="flex gap-2">
         <button
           onClick={() => onPage(page - 1)}
           disabled={isFirstPage}
-          className="flex items-center gap-1 rounded-md border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-2 py-1 text-[12px] text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-hover)] disabled:opacity-40"
+          className="flex items-center gap-1 rounded-md border border-edge-subtle bg-surface-raised px-2 py-1 text-meta text-ink-secondary hover:bg-surface-hover disabled:opacity-40"
         >
           <ChevronLeft className="h-3.5 w-3.5" aria-hidden /> 上一页
         </button>
         <button
           onClick={() => onPage(page + 1)}
           disabled={isLastPage}
-          className="flex items-center gap-1 rounded-md border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-2 py-1 text-[12px] text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-hover)] disabled:opacity-40"
+          className="flex items-center gap-1 rounded-md border border-edge-subtle bg-surface-raised px-2 py-1 text-meta text-ink-secondary hover:bg-surface-hover disabled:opacity-40"
         >
           下一页 <ChevronRight className="h-3.5 w-3.5" aria-hidden />
         </button>

--- a/frontend/components/hud/embodied-hud.tsx
+++ b/frontend/components/hud/embodied-hud.tsx
@@ -56,7 +56,6 @@ export function EmbodiedHud() {
   const theme = useHudStore((s) => s.theme);
   const setTheme = useHudStore((s) => s.setTheme);
   const aiStatus = useHudStore((s) => s.aiStatus);
-  const accentColor = useHudStore((s) => s.accentColor);
   const is3D = useHudStore((s) => s.is3D);
   const opsLog = useHudStore((s) => s.opsLog) || [];
   const causalChain = useHudStore((s) => s.causalChain) || [];
@@ -111,25 +110,15 @@ export function EmbodiedHud() {
   };
 
   return (
+    /* V4（B）：整条状态栏改不透明 surface-panel —— 它压在持续重绘的地图画布上，
+       backdrop-filter 是最贵的那类合成，半透明还会让地图细节透进正文。字体覆盖
+       (Inter) 去掉，改继承全站 DM Sans。静态样式全部落 class，只剩高度/过渡等
+       动态值留在 inline。 */
     <div
+      className="fixed bottom-0 left-0 right-0 z-50 flex flex-col overflow-hidden border-t border-edge-subtle bg-surface-panel text-ink shadow-overlay"
       style={{
-        position: 'fixed',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        zIndex: 50,
         height: hudOpen ? 210 : 24,
-        background: 'var(--theme-bg-panel)',
-        backdropFilter: 'blur(28px)',
-        WebkitBackdropFilter: 'blur(28px)',
-        borderTop: '1px solid var(--theme-border)',
-        boxShadow: 'var(--theme-shadow)',
-        color: 'var(--theme-text-primary)',
         transition: 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-        fontFamily: "'Inter', sans-serif"
       }}
     >
       <style jsx>{`
@@ -140,11 +129,11 @@ export function EmbodiedHud() {
           background: transparent;
         }
         .custom-scrollbar::-webkit-scrollbar-thumb {
-          background: rgba(148, 163, 184, 0.2);
+          background: var(--border-strong);
           border-radius: 99px;
         }
         .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-          background: rgba(148, 163, 184, 0.4);
+          background: var(--text-disabled);
         }
       `}</style>
 
@@ -153,20 +142,15 @@ export function EmbodiedHud() {
           （避免 button-in-button 的嵌套交互违规）。 */}
       <div
         onClick={() => setHudOpen(!hudOpen)}
+        className="flex cursor-pointer select-none items-center px-3"
         style={{
-          display: 'flex',
-          alignItems: 'center',
           height: 24,
           minHeight: 24,
-          paddingLeft: 12,
-          paddingRight: 12,
-          cursor: 'pointer',
-          userSelect: 'none',
-          borderBottom: hudOpen ? '1px solid var(--theme-border)' : 'none',
+          borderBottom: hudOpen ? '1px solid var(--border-subtle)' : 'none',
         }}
       >
         {/* Telemetry Stats */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+        <div className="flex items-center gap-4">
           {[
             { label: 'CRS', value: 'EPSG:4326' },
             { label: 'LNG', value: lng.toFixed(5) },
@@ -175,11 +159,9 @@ export function EmbodiedHud() {
             { label: '底图', value: BASE_LAYER_LABELS[baseLayer] ?? baseLayer },
             { label: '图层', value: `${visibleLayerCount}/${layers.length}` }
           ].map((item) => (
-            <div key={item.label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-              <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--theme-text-muted)', letterSpacing: '0.06em' }}>
-                {item.label}
-              </span>
-              <span style={{ fontSize: 12, fontFamily: "'JetBrains Mono', monospace", color: 'var(--theme-text-secondary)' }}>
+            <div key={item.label} className="flex items-center gap-1">
+              <span className="eyebrow">{item.label}</span>
+              <span className="font-mono text-meta text-ink-secondary">
                 {item.value}
               </span>
             </div>
@@ -188,48 +170,45 @@ export function EmbodiedHud() {
 
         {/* Neural Wave representation in Docked State */}
         {!hudOpen && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginLeft: 24, flex: 1, height: '100%', overflow: 'hidden' }}>
-            <span style={{ fontSize: 11, color: 'var(--theme-text-subtle)' }}>|</span>
-            <Activity size={10} style={{ color: isThinking ? accentColor : '#475569', animation: isThinking ? 'pulse 1s infinite' : 'none' }} />
-            <span style={{ fontSize: 11, color: 'var(--theme-text-muted)', fontFamily: "'JetBrains Mono', monospace", letterSpacing: '0.04em' }}>
+          <div className="flex h-full flex-1 items-center gap-2 overflow-hidden" style={{ marginLeft: 24 }}>
+            <span className="text-caption text-ink-disabled">|</span>
+            <Activity
+              size={10}
+              className={isThinking ? 'animate-pulse' : ''}
+              style={{ color: isThinking ? 'var(--agent-accent)' : 'var(--text-disabled)' }}
+            />
+            <span className="font-mono text-caption text-ink-muted" style={{ letterSpacing: '0.04em' }}>
               {isThinking ? 'AGENT NEURAL SIGNAL ACTIVE' : 'COGNITIVE CORE IDLE'}
             </span>
-            <svg width="60" height="12" style={{ opacity: 0.4, marginLeft: 4 }}>
+            <svg width="60" height="12" className="ml-1 opacity-40">
               <path
                 d={`M 0,6 Q 15,${6 + Math.sin(phase) * (isThinking ? 5 : 1.5)} 30,6 T 60,6`}
                 fill="none"
-                stroke={isThinking ? accentColor : '#64748b'}
+                stroke={isThinking ? 'var(--agent-accent)' : 'var(--text-disabled)'}
                 strokeWidth="1"
               />
             </svg>
           </div>
         )}
 
-        <div style={{ flex: 1 }} />
+        <div className="flex-1" />
 
         {/* Right Buttons */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }} onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
           {/* Theme Toggle */}
           <button
             type="button"
             onClick={handleToggleTheme}
             aria-label={isDark ? '切换到浅色主题' : '切换到深色主题'}
-            style={{
-              background: 'transparent',
-              border: 'none',
-              padding: 0,
-              cursor: 'pointer',
-              color: 'var(--theme-text-muted)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
             title="切换主题"
+            className={`flex cursor-pointer items-center justify-center border-none bg-transparent p-0 text-ink-muted transition-colors ${
+              isDark ? 'hover:text-status-warning' : 'hover:text-status-info'
+            }`}
           >
-            {isDark ? <Sun size={12} className="hover:text-amber-400 transition-colors" /> : <Moon size={12} className="hover:text-indigo-600 transition-colors" />}
+            {isDark ? <Sun size={12} /> : <Moon size={12} />}
           </button>
 
-          <span style={{ fontSize: 11, color: 'var(--theme-text-subtle)' }}>|</span>
+          <span className="text-caption text-ink-disabled">|</span>
 
           {/* Expand/Collapse Chevron — HUD 开合的键盘可达控制 */}
           <button
@@ -237,89 +216,63 @@ export function EmbodiedHud() {
             onClick={() => setHudOpen(!hudOpen)}
             aria-expanded={hudOpen}
             aria-label={hudOpen ? '收起状态栏' : '展开状态栏'}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: 'var(--theme-text-muted)',
-              cursor: 'pointer',
-              background: 'transparent',
-              border: 'none',
-              padding: 2,
-            }}
+            className="flex cursor-pointer items-center justify-center border-none bg-transparent p-0.5 text-ink-muted transition-colors hover:text-ink"
           >
-            {hudOpen ? <ChevronDown size={14} className="hover:text-slate-200 transition-colors" /> : <ChevronUp size={14} className="hover:text-slate-200 transition-colors" />}
+            {hudOpen ? <ChevronDown size={14} /> : <ChevronUp size={14} />}
           </button>
         </div>
       </div>
 
       {/* EXPANDED TELEMETRY BAY (3 columns) */}
       {hudOpen && (
-        <div 
-          style={{
-            flex: 1,
-            display: 'grid',
-            gridTemplateColumns: '1fr 1.1fr 1.2fr',
-            gap: 16,
-            padding: '12px 16px',
-            fontSize: '13px',
-            minHeight: 0
-          }}
-        >
+        <div className="grid min-h-0 flex-1 grid-cols-[1fr_1.1fr_1.2fr] gap-4 px-4 py-3 text-body">
           {/* COLUMN 1: SENSORY PERCEPTION (感知系统) */}
-          <div style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 8,
-            borderRight: '1px solid var(--theme-border)',
-            paddingRight: 12
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: 'var(--theme-text-secondary)', fontWeight: 600, letterSpacing: '0.04em' }}>
-              <Compass size={13} style={{ color: isThinking ? accentColor : '#64748b' }} />
+          <div className="flex min-h-0 flex-col gap-2 border-r border-edge-subtle pr-3">
+            <div className="flex items-center gap-1.5 font-semibold text-ink-secondary" style={{ letterSpacing: '0.04em' }}>
+              <Compass size={13} style={{ color: isThinking ? 'var(--agent-accent)' : 'var(--text-disabled)' }} />
               <span>感知系统 / SENSORY PERCEPTION</span>
             </div>
 
-            <div style={{ flex: 1, display: 'flex', gap: 12, alignItems: 'center', minHeight: 0 }}>
+            <div className="flex min-h-0 flex-1 items-center gap-3">
               {/* Sonar Vector Radar */}
-              <div style={{ position: 'relative', width: 70, height: 70, flexShrink: 0 }}>
+              <div className="relative shrink-0" style={{ width: 70, height: 70 }}>
                 <svg width="70" height="70" viewBox="0 0 100 100" style={{ transform: 'rotate(-90deg)' }}>
-                  <circle cx="50" cy="50" r="45" fill="none" stroke="var(--theme-border)" strokeWidth="1" />
-                  <circle cx="50" cy="50" r="30" fill="none" stroke="var(--theme-border)" strokeWidth="1" />
-                  <circle cx="50" cy="50" r="15" fill="none" stroke="var(--theme-border)" strokeWidth="1" />
-                  <line x1="50" y1="5" x2="50" y2="95" stroke="var(--theme-border)" strokeWidth="0.75" />
-                  <line x1="5" y1="50" x2="95" y2="50" stroke="var(--theme-border)" strokeWidth="0.75" />
+                  <circle cx="50" cy="50" r="45" fill="none" stroke="var(--border-subtle)" strokeWidth="1" />
+                  <circle cx="50" cy="50" r="30" fill="none" stroke="var(--border-subtle)" strokeWidth="1" />
+                  <circle cx="50" cy="50" r="15" fill="none" stroke="var(--border-subtle)" strokeWidth="1" />
+                  <line x1="50" y1="5" x2="50" y2="95" stroke="var(--border-subtle)" strokeWidth="0.75" />
+                  <line x1="5" y1="50" x2="95" y2="50" stroke="var(--border-subtle)" strokeWidth="0.75" />
                   {/* Radar sweep */}
                   <path
                     d="M 50,50 L 50,5 A 45,45 0 0,1 81.8,18.1 Z"
-                    fill={`linear-gradient(45deg, transparent, ${accentColor}15)`}
                     style={{
-                      fill: isThinking ? `${accentColor}15` : 'transparent',
+                      fill: isThinking ? 'color-mix(in srgb, var(--agent-accent) 8%, transparent)' : 'transparent',
                       transformOrigin: '50px 50px',
                       animation: isThinking ? 'spin-clockwise 3s linear infinite' : 'none'
                     }}
                   />
                   {/* Pulse active marker */}
-                  <circle cx="50" cy="20" r="2.5" fill={isThinking ? accentColor : '#64748b'} style={{ opacity: isThinking ? 0.8 : 0.2 }} />
+                  <circle cx="50" cy="20" r="2.5" fill={isThinking ? 'var(--agent-accent)' : 'var(--text-disabled)'} style={{ opacity: isThinking ? 0.8 : 0.2 }} />
                 </svg>
               </div>
 
               {/* Detailed perception reads */}
-              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 3, fontFamily: "'JetBrains Mono', monospace", fontSize: '12px' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                  <span style={{ color: '#64748b' }}>CENTER:</span>
-                  <span style={{ color: 'var(--theme-text-secondary)' }}>[{lng.toFixed(4)}, {lat.toFixed(4)}]</span>
+              <div className="flex flex-1 flex-col gap-3 font-mono text-meta">
+                <div className="flex justify-between">
+                  <span className="text-ink-muted">CENTER:</span>
+                  <span className="text-ink-secondary">[{lng.toFixed(4)}, {lat.toFixed(4)}]</span>
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                  <span style={{ color: '#64748b' }}>BEARING/PITCH:</span>
-                  <span style={{ color: 'var(--theme-text-secondary)' }}>{bearing.toFixed(0)}° / {pitch.toFixed(0)}°</span>
+                <div className="flex justify-between">
+                  <span className="text-ink-muted">BEARING/PITCH:</span>
+                  <span className="text-ink-secondary">{bearing.toFixed(0)}° / {pitch.toFixed(0)}°</span>
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                  <span style={{ color: '#64748b' }}>DIMENSION:</span>
-                  <span style={{ color: 'var(--theme-text-secondary)' }}>{is3D ? '3D TERRAIN (1.5x)' : '2D PERSPECTIVE'}</span>
+                <div className="flex justify-between">
+                  <span className="text-ink-muted">DIMENSION:</span>
+                  <span className="text-ink-secondary">{is3D ? '3D TERRAIN (1.5x)' : '2D PERSPECTIVE'}</span>
                 </div>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                  <span style={{ color: '#64748b' }}>BASEMAP:</span>
-                  <span style={{ color: 'var(--theme-text-secondary)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 95 }}>
+                <div className="flex justify-between">
+                  <span className="text-ink-muted">BASEMAP:</span>
+                  <span className="max-w-[95px] truncate text-ink-secondary">
                     {BASE_LAYER_LABELS[baseLayer] ?? baseLayer}
                   </span>
                 </div>
@@ -328,37 +281,31 @@ export function EmbodiedHud() {
           </div>
 
           {/* COLUMN 2: COGNITIVE CORE (认知中枢) */}
-          <div style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 8,
-            borderRight: '1px solid var(--theme-border)',
-            paddingRight: 12
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: 'var(--theme-text-secondary)', fontWeight: 600, letterSpacing: '0.04em' }}>
-              <Cpu size={13} style={{ color: isThinking ? accentColor : '#64748b' }} />
+          <div className="flex min-h-0 flex-col gap-2 border-r border-edge-subtle pr-3">
+            <div className="flex items-center gap-1.5 font-semibold text-ink-secondary" style={{ letterSpacing: '0.04em' }}>
+              <Cpu size={13} style={{ color: isThinking ? 'var(--agent-accent)' : 'var(--text-disabled)' }} />
               <span>认知中枢 / COGNITIVE CORE</span>
             </div>
 
             {/* AI Status Indicators */}
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, flex: 1, justifyItems: 'center', minHeight: 0 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div className="flex min-h-0 flex-1 flex-col gap-1.5">
+              <div className="flex items-center gap-2.5">
                 {/* Status indicator */}
-                <div style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 5,
-                  padding: '2px 8px',
-                  borderRadius: 6,
-                  background: isThinking ? `${accentColor}18` : 'var(--theme-bg-hover)',
-                  fontSize: '11.5px',
-                  fontWeight: 600,
-                  color: isThinking ? accentColor : 'var(--theme-text-secondary)',
-                  border: isThinking ? `1px solid ${accentColor}33` : '1px solid transparent'
-                }}>
+                <div
+                  className="flex items-center gap-1.5 rounded-md px-2 py-0.5 text-caption font-semibold"
+                  style={{
+                    background: isThinking
+                      ? 'color-mix(in srgb, var(--agent-accent) 10%, transparent)'
+                      : 'var(--surface-hover)',
+                    color: isThinking ? 'var(--agent-accent)' : 'var(--text-secondary)',
+                    border: isThinking
+                      ? '1px solid color-mix(in srgb, var(--agent-accent) 20%, transparent)'
+                      : '1px solid transparent'
+                  }}
+                >
                   {isThinking ? (
                     <>
-                      <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-ping" style={{ backgroundColor: accentColor }} />
+                      <span className="h-1.5 w-1.5 animate-ping rounded-full" style={{ backgroundColor: 'var(--agent-accent)' }} />
                       <span>{aiStatus === 'thinking' ? '感知中' : '执行中'}</span>
                     </>
                   ) : (
@@ -371,122 +318,98 @@ export function EmbodiedHud() {
 
                 {/* Cognitive Active Tools */}
                 {isThinking && opsLog.length > 0 && (
-                  <span style={{
-                    fontSize: '11.5px',
-                    fontFamily: "'JetBrains Mono', monospace",
-                    color: accentColor,
-                    letterSpacing: '0.04em',
-                    fontWeight: 500,
-                    textTransform: 'uppercase',
-                    animation: 'pulse 1.5s infinite'
-                  }}>
+                  <span
+                    className="animate-pulse font-mono text-caption font-medium uppercase text-agent-accent"
+                    style={{ letterSpacing: '0.04em' }}
+                  >
                     RUNNING: {opsLog[0].type}
                   </span>
                 )}
               </div>
 
               {/* Dynamic Waveform Graph & Memory count */}
-              <div style={{ display: 'flex', gap: 12, alignItems: 'center', flex: 1 }}>
-                <svg width="105" height="35" style={{ flexShrink: 0, overflow: 'visible', filter: isThinking ? `drop-shadow(0 0 2px ${accentColor}88)` : 'none' }}>
-                  <path d={renderWaveform()} fill="none" stroke={isThinking ? accentColor : '#475569'} strokeWidth="1.5" />
+              <div className="flex flex-1 items-center gap-3">
+                <svg width="105" height="35" className="shrink-0 overflow-visible" style={{ filter: isThinking ? 'drop-shadow(0 0 2px color-mix(in srgb, var(--agent-accent) 53%, transparent))' : 'none' }}>
+                  <path d={renderWaveform()} fill="none" stroke={isThinking ? 'var(--agent-accent)' : 'var(--text-disabled)'} strokeWidth="1.5" />
                 </svg>
 
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 3, fontSize: '11px', fontFamily: "'JetBrains Mono', monospace" }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                    <Database size={10} style={{ color: '#94a3b8' }} />
-                    <span style={{ color: '#64748b' }}>RAG MEM:</span>
-                    <span style={{ color: 'var(--theme-text-secondary)' }}>{ragResults.length} SLOTS</span>
+                <div className="flex flex-col gap-3 font-mono text-caption">
+                  <div className="flex items-center gap-1">
+                    <Database size={10} className="text-ink-disabled" />
+                    <span className="text-ink-muted">RAG MEM:</span>
+                    <span className="text-ink-secondary">{ragResults.length} SLOTS</span>
                   </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                    <Layers size={10} style={{ color: '#94a3b8' }} />
-                    <span style={{ color: '#64748b' }}>SPATIAL REF:</span>
-                    <span style={{ color: 'var(--theme-text-secondary)' }}>{layers.length} ACTIVE</span>
+                  <div className="flex items-center gap-1">
+                    <Layers size={10} className="text-ink-disabled" />
+                    <span className="text-ink-muted">SPATIAL REF:</span>
+                    <span className="text-ink-secondary">{layers.length} ACTIVE</span>
                   </div>
                 </div>
               </div>
 
               {/* 3-Step AI Stepper */}
-              <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                marginTop: 'auto',
-                paddingTop: 8,
-                borderTop: '1px dashed var(--theme-border)',
-                width: '100%'
-              }}>
+              <div className="mt-auto flex w-full items-center justify-between border-t border-dashed border-edge-subtle pt-2">
                 {STEPS.map((step, i) => {
                   const state = getStepState(i, aiStatus);
                   const isLast = i === STEPS.length - 1;
-                  
+
                   // Color computation
-                  let dotColor = '#64748b';
-                  let textColor = '#64748b';
+                  let dotColor = 'var(--text-disabled)';
+                  let textColor = 'var(--text-muted)';
                   let glowStyle = {};
-                  
+
                   if (state === 'done') {
-                    dotColor = '#10b981';
-                    textColor = 'var(--theme-text-primary)';
+                    dotColor = 'var(--success)';
+                    textColor = 'var(--text-primary)';
                   } else if (state === 'active') {
-                    dotColor = accentColor;
-                    textColor = accentColor;
+                    dotColor = 'var(--agent-accent)';
+                    // accent 作文字在暗色下只有 2.96–3.40:1 —— 步骤名是正文，
+                    // 用 text-safe 派生；发光/圆点是 mark，仍用原色。
+                    textColor = 'var(--agent-accent)';
                     glowStyle = {
-                      boxShadow: `0 0 8px ${accentColor}`,
+                      boxShadow: '0 0 8px var(--agent-accent)',
                       animation: 'pulse 1.5s infinite'
                     };
-                  } else {
-                    dotColor = 'var(--theme-text-subtle)';
-                    textColor = 'var(--theme-text-muted)';
                   }
 
                   return (
-                    <div key={step.label} style={{ display: 'flex', alignItems: 'center', flex: isLast ? '0 0 auto' : '1 1 auto', minWidth: 0 }}>
+                    <div key={step.label} className="flex min-w-0 items-center" style={{ flex: isLast ? '0 0 auto' : '1 1 auto' }}>
                       {/* Step item */}
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 5, minWidth: 0 }}>
+                      <div className="flex min-w-0 items-center gap-1.5">
                         {/* Glowing dot */}
-                        <div style={{
-                          width: 6,
-                          height: 6,
-                          borderRadius: '50%',
-                          backgroundColor: dotColor,
-                          flexShrink: 0,
-                          transition: 'all 0.3s ease',
-                          ...glowStyle
-                        }} />
-                        
+                        <div
+                          className="h-1.5 w-1.5 shrink-0 rounded-full"
+                          style={{
+                            backgroundColor: dotColor,
+                            transition: 'all 0.3s ease',
+                            ...glowStyle
+                          }}
+                        />
+
                         {/* Label & Subtext */}
-                        <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-                          <span style={{
-                            fontSize: '11px',
-                            fontWeight: 600,
-                            fontFamily: "'JetBrains Mono', monospace",
-                            color: textColor,
-                            transition: 'color 0.3s ease',
-                            whiteSpace: 'nowrap'
-                          }}>{step.label}</span>
-                          <span style={{
-                            fontSize: '9.5px',
-                            color: 'var(--theme-text-muted)',
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis'
-                          }}>{step.sub}</span>
+                        <div className="flex min-w-0 flex-col">
+                          <span
+                            className="whitespace-nowrap font-mono text-caption font-semibold"
+                            style={{
+                              color: textColor,
+                              transition: 'color 0.3s ease'
+                            }}
+                          >{step.label}</span>
+                          <span className="truncate whitespace-nowrap text-micro text-ink-muted">{step.sub}</span>
                         </div>
                       </div>
 
                       {/* Horizontal Connector Track */}
                       {!isLast && (
-                        <div style={{
-                          flex: 1,
-                          height: 1,
-                          marginLeft: 6,
-                          marginRight: 6,
-                          background: state === 'done' 
-                            ? `linear-gradient(to right, #10b981, ${getStepState(i+1, aiStatus) === 'active' ? accentColor : 'var(--theme-text-subtle)'})`
-                            : 'var(--theme-border)',
-                          transition: 'background 0.3s ease',
-                          minWidth: 8
-                        }} />
+                        <div
+                          className="mx-1.5 h-px min-w-2 flex-1"
+                          style={{
+                            background: state === 'done'
+                              ? `linear-gradient(to right, var(--success), ${getStepState(i+1, aiStatus) === 'active' ? 'var(--agent-accent)' : 'var(--text-disabled)'})`
+                              : 'var(--border-subtle)',
+                            transition: 'background 0.3s ease'
+                          }}
+                        />
                       )}
                     </div>
                   );
@@ -496,60 +419,49 @@ export function EmbodiedHud() {
           </div>
 
           {/* COLUMN 3: ACTION STREAM (执行通道) */}
-          <div style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 8,
-            minHeight: 0
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: 'var(--theme-text-secondary)', fontWeight: 600, letterSpacing: '0.04em' }}>
-              <Terminal size={13} style={{ color: isThinking ? accentColor : '#64748b' }} />
+          <div className="flex min-h-0 flex-col gap-2">
+            <div className="flex items-center gap-1.5 font-semibold text-ink-secondary" style={{ letterSpacing: '0.04em' }}>
+              <Terminal size={13} style={{ color: isThinking ? 'var(--agent-accent)' : 'var(--text-disabled)' }} />
               <span>执行通道 / ACTION LOG & CAUSAL CHAIN</span>
             </div>
 
             {/* scrolling log window */}
-            <div 
-              className="custom-scrollbar"
-              style={{
-                flex: 1,
-                overflowY: 'auto',
-                background: 'var(--theme-bg-input)',
-                border: '1px solid var(--theme-border)',
-                borderRadius: 8,
-                padding: '6px 8px',
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: '11px',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 5,
-                minHeight: 0
-              }}
+            <div
+              className="custom-scrollbar flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto rounded-md border border-edge-subtle bg-surface-sunken p-1.5 px-2 font-mono text-caption"
             >
               {/* Combine opsLog and causalChain */}
               {causalChain.length === 0 && opsLog.length === 0 ? (
-                <div style={{ color: '#475569', fontStyle: 'italic', textAlign: 'center', margin: 'auto' }}>
+                <div className="m-auto text-center italic text-ink-muted">
                   AWAITING SPATIAL AI COMMANDS...
                 </div>
               ) : (
                 <>
                   {causalChain.map((entry) => (
-                    <div key={entry.id} style={{ display: 'flex', flexDirection: 'column', gap: 1, borderLeft: `1.5px solid ${accentColor}bb`, paddingLeft: 6, marginBottom: 2 }}>
-                      <div style={{ display: 'flex', justifyContent: 'space-between', color: accentColor, fontWeight: 600 }}>
+                    <div
+                      key={entry.id}
+                      className="mb-0.5 flex flex-col gap-0.5 pl-1.5"
+                      style={{ borderLeft: '1.5px solid color-mix(in srgb, var(--agent-accent) 73%, transparent)' }}
+                    >
+                      <div className="flex justify-between font-semibold text-agent-accent">
                         <span>[CAUSAL] {entry.tool}</span>
-                        <span style={{ color: '#475569', fontSize: '10px' }}>{entry.time}</span>
+                        <span className="text-micro text-ink-muted">{entry.time}</span>
                       </div>
-                      {entry.toolInput && <div style={{ color: 'var(--theme-text-secondary)' }}>IN: {entry.toolInput}</div>}
-                      {entry.mapEffect && <div style={{ color: '#94a3b8' }}>OUT: {entry.mapEffect}</div>}
+                      {entry.toolInput && <div className="text-ink-secondary">IN: {entry.toolInput}</div>}
+                      {entry.mapEffect && <div className="text-ink-muted">OUT: {entry.mapEffect}</div>}
                     </div>
                   ))}
 
                   {opsLog.map((entry) => (
-                    <div key={entry.id} style={{ display: 'flex', flexDirection: 'column', gap: 1, borderLeft: '1.5px solid #475569', paddingLeft: 6, marginBottom: 2 }}>
-                      <div style={{ display: 'flex', justifyContent: 'space-between', color: 'var(--theme-text-secondary)', fontWeight: 500 }}>
+                    <div
+                      key={entry.id}
+                      className="mb-0.5 flex flex-col gap-0.5 pl-1.5"
+                      style={{ borderLeft: '1.5px solid var(--border-strong)' }}
+                    >
+                      <div className="flex justify-between font-medium text-ink-secondary">
                         <span>[OP] {entry.label}</span>
-                        <span style={{ color: '#475569', fontSize: '10px' }}>{entry.time}</span>
+                        <span className="text-micro text-ink-muted">{entry.time}</span>
                       </div>
-                      <div style={{ color: '#64748b' }}>{entry.detail}</div>
+                      <div className="text-ink-muted">{entry.detail}</div>
                     </div>
                   ))}
                 </>

--- a/frontend/components/layout/context-panel.tsx
+++ b/frontend/components/layout/context-panel.tsx
@@ -42,7 +42,6 @@ export interface ContextPanelProps {
   }>;
   aiStatus: AiStatus;
   onSend: (text: string) => void;
-  accentColor?: string;
   sessionId?: string | null;
   ownerToken?: string | null;
   onPlanAction?: (planId: string, action: 'approve' | 'revise' | 'reject') => void;
@@ -74,7 +73,6 @@ export function ContextPanel({
   messages,
   aiStatus,
   onSend,
-  accentColor = '#16a34a',
   sessionId,
   ownerToken,
   onPlanAction,
@@ -149,21 +147,19 @@ export function ContextPanel({
   }, [toggleLeftPanel, metaKey]);
 
   return (
+    // V4：壳层度量改用 token（left-rail / top-topbar），背景改为不透明
+    // surface-panel 并移除 backdrop-blur —— 面板压在持续重绘的地图画布上，
+    // blur 是最贵的那一类滤镜，且半透明会让地图细节透进密集文本。
     <aside
       role="tabpanel"
       id="workspace-panel"
       aria-labelledby={`rail-tab-${metaKey}`}
       aria-hidden={!leftPanelOpen}
-      className="fixed left-12 top-[42px] z-40 flex flex-col"
+      className="fixed left-rail top-topbar z-40 flex flex-col border-r border-edge-subtle bg-surface-panel shadow-overlay"
       style={{
         bottom: hudOpen ? 234 : 24,
         width: sidebarWidth,
-        maxWidth: 'calc(100vw - 48px)',
-        background: 'var(--theme-bg-panel)',
-        backdropFilter: 'blur(28px)',
-        WebkitBackdropFilter: 'blur(28px)',
-        borderRight: '1px solid var(--theme-border)',
-        boxShadow: 'var(--theme-shadow)',
+        maxWidth: 'calc(100vw - var(--railW))',
         transform: leftPanelOpen ? 'translateX(0)' : 'translateX(-110%)',
         visibility: leftPanelOpen ? 'visible' : 'hidden',
         transition: dragging
@@ -186,7 +182,6 @@ export function ContextPanel({
             messages={messages}
             aiStatus={aiStatus}
             onSend={onSend}
-            accentColor={accentColor}
             onPlanAction={onPlanAction}
           />
         )}
@@ -196,7 +191,7 @@ export function ContextPanel({
         {activeTab === 'data_sources' && <DataSourcesTab />}
         {(activeTab === 'export_layout' || activeTab === 'exports') && <MapStudioTab />}
         {activeTab === 'tasks' && (
-          <TasksTab sessionId={sessionId} ownerToken={ownerToken} accentColor={accentColor} />
+          <TasksTab sessionId={sessionId} ownerToken={ownerToken} />
         )}
       </div>
 

--- a/frontend/components/layout/nav-rail.tsx
+++ b/frontend/components/layout/nav-rail.tsx
@@ -110,14 +110,13 @@ export function NavRail() {
   return (
     <nav
       aria-label="主导航"
-      className="fixed left-0 top-[42px] z-40 flex w-12 flex-col items-center"
+      // V4：宽度/顶距改用 --railW / --topH token；背景改为不透明 surface-panel，
+      // 去掉 blur(28px) —— 面板压在持续重绘的地图画布上，backdrop-filter 是最贵
+      // 的那一类，而且半透明面板会让底下的地图干扰图标可读性。
+      className="fixed left-0 top-topbar z-40 flex w-rail flex-col items-center border-r border-edge-subtle bg-surface-panel"
       style={{
         bottom: hudOpen ? 234 : 24,
         transition: 'bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-        background: 'var(--theme-bg-panel)',
-        backdropFilter: 'blur(28px)',
-        WebkitBackdropFilter: 'blur(28px)',
-        borderRight: '1px solid var(--theme-border)',
       }}
     >
       <div
@@ -129,7 +128,7 @@ export function NavRail() {
       >
         {RAIL_GROUPS.map((group, gi) => (
           <div key={gi} className="flex w-full flex-col items-center gap-1">
-            {gi > 0 && <div aria-hidden className="my-1 w-6 border-t border-[var(--theme-border-subtle)]" />}
+            {gi > 0 && <div aria-hidden className="my-1 w-6 border-t border-edge-subtle" />}
             {group.map(({ key, icon: Icon, label }) => {
               const active = isTabActive(key);
               const badge = badges[key];
@@ -150,27 +149,30 @@ export function NavRail() {
                   title={label}
                   tabIndex={active ? 0 : -1}
                   onClick={() => activateTab(key)}
+                  // 审计修复：active 用的底色类与 hover 完全相同，于是
+                  // hover 当前 tab 时毫无反馈，"已选中" 与 "指针在上面" 视觉同源。
+                  // 现在 selected = accent 软底 + accent 图标 + 左侧指示条，
+                  // hover 只是中性底色，两者不再混淆。
                   className={clsx(
-                    'relative flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
-                    active ? 'bg-[var(--theme-bg-hover)]' : 'hover:bg-[var(--theme-bg-hover)]'
+                    'relative flex h-9 w-9 items-center justify-center rounded-md transition-colors',
+                    active
+                      ? 'bg-status-accent-soft text-status-accent'
+                      : 'text-ink-secondary hover:bg-surface-hover hover:text-ink'
                   )}
-                  style={{
-                    color: active ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-secondary)',
-                  }}
                 >
                   {active && leftPanelOpen && (
                     <span
                       aria-hidden
-                      className="absolute left-[-4px] top-1/2 h-5 w-[2.5px] -translate-y-1/2 rounded-full"
-                      style={{ background: 'var(--agent-accent, #16a34a)' }}
+                      className="absolute left-[-5px] top-1/2 h-5 w-[2.5px] -translate-y-1/2 rounded-pill bg-status-accent-vivid"
                     />
                   )}
                   <Icon size={17} strokeWidth={active ? 2.1 : 1.6} aria-hidden />
                   {badge !== undefined && (
                     <span
                       aria-hidden
-                      className="absolute right-0 top-0 inline-flex h-3.5 min-w-[14px] items-center justify-center rounded-full px-0.5 text-[9px] font-semibold text-white"
-                      style={{ background: 'var(--agent-accent, #16a34a)' }}
+                      // 计数徽标是中性信息，不是交互重点 —— 之前用满饱和品牌绿，
+                      // 与 active 指示条抢同一个视觉权重。
+                      className="absolute right-0 top-0 inline-flex h-3.5 min-w-[14px] items-center justify-center rounded-pill bg-surface-sunken px-0.5 text-micro font-semibold tabular-nums text-ink-secondary ring-1 ring-edge-subtle"
                     >
                       {badge}
                     </span>
@@ -183,13 +185,13 @@ export function NavRail() {
       </div>
 
       {/* 工具区：模板库（drawer）+ 面板折叠 */}
-      <div className="flex w-full flex-col items-center gap-1 border-t border-[var(--theme-border-subtle)] py-2">
+      <div className="flex w-full flex-col items-center gap-1 border-t border-edge-subtle py-2">
         <button
           type="button"
           aria-label="模板库"
           title="模板库"
           onClick={() => setTemplatesOpen(true)}
-          className="flex h-10 w-10 items-center justify-center rounded-lg text-[var(--theme-text-secondary)] transition-colors hover:bg-[var(--theme-bg-hover)]"
+          className="flex h-9 w-9 items-center justify-center rounded-md text-ink-secondary transition-colors hover:bg-surface-hover hover:text-ink"
         >
           <LayoutTemplate size={17} strokeWidth={1.6} aria-hidden />
         </button>
@@ -200,7 +202,7 @@ export function NavRail() {
           aria-controls="workspace-panel"
           title={leftPanelOpen ? '折叠面板' : '展开面板'}
           onClick={toggleLeftPanel}
-          className="flex h-10 w-10 items-center justify-center rounded-lg text-[var(--theme-text-secondary)] transition-colors hover:bg-[var(--theme-bg-hover)]"
+          className="flex h-9 w-9 items-center justify-center rounded-md text-ink-secondary transition-colors hover:bg-surface-hover hover:text-ink"
         >
           {leftPanelOpen ? (
             <PanelLeftClose size={17} strokeWidth={1.6} aria-hidden />

--- a/frontend/components/layout/top-bar.tsx
+++ b/frontend/components/layout/top-bar.tsx
@@ -24,21 +24,20 @@ export default function TopBar({ sessionName = '未命名', onNewSession }: TopB
   const aiStatus = useHudStore((s) => s.aiStatus);
   const setSettingsOpen = useHudStore((s) => s.setSettingsOpen);
   const setHistoryOpen = useHudStore((s) => s.setHistoryOpen);
-  const theme = useHudStore((s) => s.theme);
-  const accentColor = useHudStore((s) => s.accentColor);
   const is3D = useHudStore((s) => s.is3D);
   const setIs3D = useHudStore((s) => s.setIs3D);
-  const isDark = theme === 'dark';
 
   const isActive = aiStatus === 'thinking' || aiStatus === 'acting';
 
   const getStatusConfig = (status: string) => {
     switch (status) {
-      case 'idle': return { label: '就绪', color: 'var(--theme-text-muted)', bg: 'var(--theme-bg-muted)' };
-      case 'thinking': case 'acting': return { label: status === 'thinking' ? '感知中' : '执行中', color: accentColor, bg: isDark ? `${accentColor}15` : `${accentColor}10` };
-      case 'done': return { label: '完成', color: isDark ? '#4ade80' : '#16a34a', bg: isDark ? 'rgba(74,222,128,0.15)' : 'rgba(16,185,129,0.10)' };
-      case 'error': return { label: '异常', color: isDark ? '#fca5a5' : '#ef4444', bg: isDark ? 'rgba(248,113,113,0.15)' : 'rgba(254,226,226,0.6)' };
-      default: return { label: '就绪', color: 'var(--theme-text-muted)', bg: 'var(--theme-bg-muted)' };
+      case 'idle': return { label: '就绪', color: 'var(--text-muted)', bg: 'var(--surface-sunken)' };
+      case 'thinking': case 'acting': return { label: status === 'thinking' ? '感知中' : '执行中', color: 'var(--agent-accent)', bg: 'color-mix(in srgb, var(--agent-accent) 8%, transparent)' };
+      // V4：走与 StatusBadge / InlineNotice / toast 同一套语义 token，
+      // 不再各写一对明暗 hex（原先是 #4ade80/#16a34a 与 #fca5a5/#ef4444）。
+      case 'done': return { label: '完成', color: 'var(--success)', bg: 'var(--success-soft)' };
+      case 'error': return { label: '异常', color: 'var(--critical)', bg: 'var(--critical-soft)' };
+      default: return { label: '就绪', color: 'var(--text-muted)', bg: 'var(--surface-sunken)' };
     }
   };
 
@@ -63,15 +62,15 @@ export default function TopBar({ sessionName = '未命名', onNewSession }: TopB
   }, [isActive, reducedMotion]);
 
   return (
+    // V4：壳层度量改用 token（h-topbar），背景改为不透明 surface-panel 并
+    // 移除 backdrop-blur —— 顶栏压在持续重绘的地图画布上，blur 是最贵的
+    // 那一类滤镜，半透明又会让地图细节透进密集文本。
     <div
+      className="fixed inset-x-0 top-0 z-50 flex h-topbar items-center gap-2.5 bg-surface-panel px-3"
       style={{
-        position: 'fixed', top: 0, left: 0, right: 0, zIndex: 50,
-        display: 'flex', alignItems: 'center', height: 42, paddingLeft: 12, paddingRight: 12, gap: 10,
-        backgroundColor: 'var(--theme-bg-glass)',
-        backdropFilter: 'blur(28px)', WebkitBackdropFilter: 'blur(28px)',
         borderBottomWidth: isActive ? 2 : 1,
         borderBottomStyle: 'solid',
-        borderBottomColor: isActive ? `${accentColor}55` : 'var(--theme-border)'
+        borderBottomColor: isActive ? 'color-mix(in srgb, var(--agent-accent) 33%, transparent)' : 'var(--border-subtle)'
       }}
     >
       {/* heartbeat scan line */}
@@ -79,7 +78,7 @@ export default function TopBar({ sessionName = '未命名', onNewSession }: TopB
         <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 2, overflow: 'hidden', pointerEvents: 'none' }}>
           <div
             style={{
-              background: `linear-gradient(90deg, transparent 0%, ${accentColor}99 50%, transparent 100%)`,
+              background: 'linear-gradient(90deg, transparent 0%, color-mix(in srgb, var(--agent-accent) 60%, transparent) 50%, transparent 100%)',
               width: '40%',
               transform: `translateX(${scanX * 2.5}%)`,
               height: '100%'
@@ -92,102 +91,73 @@ export default function TopBar({ sessionName = '未命名', onNewSession }: TopB
       <button
         onClick={toggleLeftPanel}
         aria-label={leftPanelOpen ? '收起侧栏' : '展开侧栏'}
-        style={{
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          width: 28, height: 28, borderRadius: 6, cursor: 'pointer',
-          color: 'var(--theme-text-primary)', backgroundColor: 'transparent'
-        }}
-        onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--theme-bg-hover)'; }}
-        onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
         title={leftPanelOpen ? '收起侧栏' : '展开侧栏'}
+        className="flex h-control-md w-control-md items-center justify-center rounded-sm text-ink transition-colors hover:bg-surface-hover"
       >
-        {leftPanelOpen ? <PanelLeftClose size={15} /> : <Menu size={15} />}
+        {leftPanelOpen ? <PanelLeftClose size={14} aria-hidden /> : <Menu size={14} aria-hidden />}
       </button>
 
       {/* logo */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, userSelect: 'none' }}>
+      <div className="flex select-none items-center gap-1.5">
         <span
+          aria-hidden
+          className="flex h-6 w-6 items-center justify-center rounded-sm"
           style={{
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            width: 24, height: 24, borderRadius: 6,
-            background: `linear-gradient(135deg, ${accentColor}, ${accentColor}dd)`
+            background: 'linear-gradient(135deg, var(--agent-accent), color-mix(in srgb, var(--agent-accent) 87%, transparent))'
           }}
         >
-          <Compass size={13} style={{ color: '#fff' }} />
+          <Compass size={13} className="text-ink-on-accent" />
         </span>
-        <div style={{ lineHeight: 1 }}>
-          <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--theme-text-primary)' }}>
+        <div className="leading-tight">
+          <span className="text-heading font-semibold text-ink">
             GeoAgent
           </span>
-          <span style={{ fontSize: 11, marginLeft: 4, color: 'var(--theme-text-muted)' }}>All is Agent</span>
+          <span className="ml-1 text-caption text-ink-muted">All is Agent</span>
         </div>
       </div>
 
       {/* session name pill */}
-      <span
-        style={{
-          marginLeft: 4, padding: '2px 8px', borderRadius: 999,
-          backgroundColor: 'var(--theme-bg-muted)',
-          fontSize: 12, color: 'var(--theme-text-secondary)',
-          borderWidth: 1, borderStyle: 'solid',
-          borderColor: 'var(--theme-border-subtle)',
-          maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'
-        }}
-      >
+      <span className="ml-1 max-w-[180px] truncate rounded-pill border border-edge-subtle bg-surface-sunken px-2 py-0.5 text-meta text-ink-secondary">
         会话 / {sessionName}
       </span>
 
       {/* spacer */}
-      <div style={{ flex: 1 }} />
+      <div className="flex-1" />
 
       {/* agent status badge */}
       <span
-        style={{
-          display: 'flex', alignItems: 'center', gap: 4, padding: '2px 8px',
-          borderRadius: 999, backgroundColor: status.bg, fontSize: 12, fontWeight: 500
-        }}
+        className="flex items-center gap-1 rounded-pill px-2 py-0.5 text-meta font-medium"
+        style={{ backgroundColor: status.bg }}
       >
         <span
-          style={{
-            width: 6, height: 6, borderRadius: '50%', backgroundColor: status.color
-          }}
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-pill"
+          style={{ backgroundColor: status.color }}
         />
-        <span style={{ color: 'var(--theme-text-primary)' }}>{status.label}</span>
+        <span className="text-ink">{status.label}</span>
       </span>
 
       {/* right actions */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      <div className="flex items-center gap-0.5">
         <button
           onClick={onNewSession}
           aria-label="新建会话"
-          style={{
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            width: 28, height: 28, borderRadius: 6, cursor: 'pointer',
-            color: 'var(--theme-text-secondary)', backgroundColor: 'transparent'
-          }}
-          onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--theme-bg-hover)'; e.currentTarget.style.color = 'var(--theme-text-primary)'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--theme-text-secondary)'; }}
           title="新建会话"
+          className="flex h-control-md w-control-md items-center justify-center rounded-sm text-ink-secondary transition-colors hover:bg-surface-hover hover:text-ink"
         >
-          <Plus size={15} />
+          <Plus size={14} aria-hidden />
         </button>
 
         <button
           onClick={() => setHistoryOpen(true)}
           aria-label="历史记录"
-          style={{
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            width: 28, height: 28, borderRadius: 6, cursor: 'pointer',
-            color: 'var(--theme-text-secondary)', backgroundColor: 'transparent'
-          }}
-          onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--theme-bg-hover)'; e.currentTarget.style.color = 'var(--theme-text-primary)'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--theme-text-secondary)'; }}
           title="历史记录"
+          className="flex h-control-md w-control-md items-center justify-center rounded-sm text-ink-secondary transition-colors hover:bg-surface-hover hover:text-ink"
         >
-          <History size={15} />
+          <History size={14} aria-hidden />
         </button>
 
-        <span style={{ marginLeft: 4, marginRight: 4, width: 1, height: 16, backgroundColor: 'var(--theme-border-subtle)' }} />
+        <span aria-hidden className="mx-1 h-4 w-px bg-edge-subtle" />
 
         <BaselayerSwitcher />
 
@@ -196,57 +166,32 @@ export default function TopBar({ sessionName = '未命名', onNewSession }: TopB
           onClick={() => setIs3D(!is3D)}
           aria-label={is3D ? '切换至 2D 视图' : '切换至 3D 视角'}
           title={is3D ? '视角: 3D (点击切换 2D)' : '视角: 2D (点击切换 3D)'}
-          style={{
-            padding: '5px 10px',
-            borderRadius: 8,
-            background: 'var(--theme-bg-glass)',
-            backdropFilter: 'blur(12px)',
-            WebkitBackdropFilter: 'blur(12px)',
-            border: '1px solid var(--theme-border)',
-            boxShadow: 'var(--theme-shadow)',
-            fontSize: '12.5px',
-            color: 'var(--theme-text-secondary)',
-            cursor: 'pointer',
-            fontFamily: "'JetBrains Mono', monospace",
-            display: 'flex',
-            alignItems: 'center',
-            gap: 5,
-            transition: 'all 0.2s ease',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = 'var(--theme-bg-hover)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = 'var(--theme-bg-glass)';
-          }}
+          className="flex items-center gap-1 rounded-md border border-edge-subtle bg-surface-overlay px-2.5 py-1 font-mono text-body text-ink-secondary shadow-overlay transition-colors hover:bg-surface-hover"
         >
           <svg width='11' height='11' viewBox='0 0 11 11' fill='none' style={{ display: 'block' }}>
             {is3D ? (
-              <path d='M5.5 1.5L2 3.5l3.5 2L9 3.5 5.5 1.5z M2 6l3.5 2L9 6 M2 8.5l3.5 2 3.5-2' stroke={isDark ? '#4ade80' : '#16a34a'} strokeWidth='1' strokeLinecap='round' strokeLinejoin='round'/>
+              <path d='M5.5 1.5L2 3.5l3.5 2L9 3.5 5.5 1.5z M2 6l3.5 2L9 6 M2 8.5l3.5 2 3.5-2' stroke='var(--success)' strokeWidth='1' strokeLinecap='round' strokeLinejoin='round'/>
             ) : (
-              <path d='M5.5 2.5L2 4.5l3.5 2 3.5-2-3.5-2z' stroke='var(--theme-text-secondary)' strokeWidth='1' strokeLinecap='round' strokeLinejoin='round'/>
+              <path d='M5.5 2.5L2 4.5l3.5 2 3.5-2-3.5-2z' stroke='var(--text-secondary)' strokeWidth='1' strokeLinecap='round' strokeLinejoin='round'/>
             )}
           </svg>
-          <span style={{ color: is3D ? (isDark ? '#4ade80' : '#16a34a') : 'var(--theme-text-secondary)', fontWeight: is3D ? 600 : 400 }}>
+          <span
+            className={is3D ? 'font-semibold' : undefined}
+            style={{ color: is3D ? 'var(--success)' : undefined }}
+          >
             {is3D ? '3D' : '2D'}
           </span>
         </button>
 
-        <span style={{ marginLeft: 4, marginRight: 4, width: 1, height: 16, backgroundColor: 'var(--theme-border-subtle)' }} />
+        <span aria-hidden className="mx-1 h-4 w-px bg-edge-subtle" />
 
         <button
           onClick={() => setSettingsOpen(true)}
           aria-label="设置"
-          style={{
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            width: 28, height: 28, borderRadius: 6, cursor: 'pointer',
-            color: 'var(--theme-text-secondary)', backgroundColor: 'transparent'
-          }}
-          onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--theme-bg-hover)'; e.currentTarget.style.color = 'var(--theme-text-primary)'; }}
-          onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--theme-text-secondary)'; }}
           title="设置"
+          className="flex h-control-md w-control-md items-center justify-center rounded-sm text-ink-secondary transition-colors hover:bg-surface-hover hover:text-ink"
         >
-          <Settings size={15} />
+          <Settings size={14} aria-hidden />
         </button>
       </div>
     </div>

--- a/frontend/components/map/baselayer-switcher.tsx
+++ b/frontend/components/map/baselayer-switcher.tsx
@@ -22,8 +22,6 @@ export function BaselayerSwitcher({ className }: BaselayerSwitcherProps) {
   const baseLayer = useHudStore((s) => s.baseLayer);
   const setBaseLayer = useHudStore((s) => s.setBaseLayer);
   const { selectedBaseLayer, setSelectedBaseLayer } = useMapAction();
-  const theme = useHudStore((s) => s.theme);
-  const isDark = theme === 'dark';
   const rootRef = useRef<HTMLDivElement>(null);
 
   const currentLabel = TILE_PROVIDERS[selectedBaseLayer]?.name || baseLayer || 'Carto 浅色';
@@ -58,36 +56,24 @@ export function BaselayerSwitcher({ className }: BaselayerSwitcherProps) {
 
   return (
     <div ref={rootRef} style={{ position: 'relative' }} className={className}>
+      {/* C: 下拉浮在地图上 —— 之前用 backdrop-filter: blur(12px)，对持续重绘的
+          画布是最贵的那类合成；改走 .map-chrome 不透明容器配方（主题色由
+          --map-chrome-* 提供，不再按 isDark 手写两套 hex）。 */}
       <button
         type='button'
         aria-haspopup='listbox'
         aria-expanded={open}
         aria-label={`Base layer: ${currentLabel}`}
         onClick={() => setOpen(!open)}
-        style={{
-          padding: '5px 10px',
-          borderRadius: 8,
-          background: isDark ? 'rgba(15, 23, 42, 0.72)' : 'rgba(255,255,255,0.88)',
-          backdropFilter: 'blur(12px)',
-          WebkitBackdropFilter: 'blur(12px)',
-          border: isDark ? '1px solid rgba(255,255,255,0.08)' : '1px solid rgba(255,255,255,0.92)',
-          boxShadow: isDark ? '0 2px 12px rgba(0,0,0,0.3)' : '0 2px 12px rgba(15,23,42,0.08)',
-          fontSize: '12.5px',
-          color: isDark ? '#cbd5e1' : '#475569',
-          cursor: 'pointer',
-          fontFamily: "'JetBrains Mono', monospace",
-          display: 'flex',
-          alignItems: 'center',
-          gap: 5,
-        }}
+        className='map-chrome flex cursor-pointer items-center gap-1.5 px-2.5 py-1 text-body font-mono text-map-chrome-ink'
       >
-        <svg width='11' height='11' viewBox='0 0 11 11' fill='none' style={{ display: 'block' }}>
-          <path d='M5.5 1L1 4l4.5 2.5L10 4 5.5 1z' stroke={isDark ? '#475569' : '#94a3b8'} strokeWidth='1'/>
-          <path d='M1 7l4.5 2.5L10 7' stroke={isDark ? '#475569' : '#94a3b8'} strokeWidth='1' strokeLinecap='round'/>
+        <svg width='11' height='11' viewBox='0 0 11 11' fill='none' stroke='currentColor' strokeWidth='1' className='text-map-chrome-ink-muted' style={{ display: 'block' }}>
+          <path d='M5.5 1L1 4l4.5 2.5L10 4 5.5 1z' />
+          <path d='M1 7l4.5 2.5L10 7' strokeLinecap='round'/>
         </svg>
         {currentLabel}
-        <svg width='8' height='8' viewBox='0 0 8 8' fill='none' style={{ display: 'block', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>
-          <path d='M1 2.5l3 3 3-3' stroke={isDark ? '#475569' : '#94a3b8'} strokeWidth='1.2' strokeLinecap='round'/>
+        <svg width='8' height='8' viewBox='0 0 8 8' fill='none' stroke='currentColor' strokeWidth='1.2' strokeLinecap='round' className='text-map-chrome-ink-muted' style={{ display: 'block', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s' }}>
+          <path d='M1 2.5l3 3 3-3' />
         </svg>
       </button>
 
@@ -95,22 +81,7 @@ export function BaselayerSwitcher({ className }: BaselayerSwitcherProps) {
         <div
           role='listbox'
           aria-label='Base layer options'
-          style={{
-            position: 'absolute',
-            top: '100%',
-            right: 0,
-            marginTop: 4,
-            background: isDark ? 'rgba(15, 23, 42, 0.95)' : 'rgba(252,253,254,0.96)',
-            backdropFilter: 'blur(20px)',
-            WebkitBackdropFilter: 'blur(20px)',
-            border: isDark ? '1px solid rgba(255,255,255,0.08)' : '1px solid rgba(255,255,255,0.92)',
-            boxShadow: isDark ? '0 4px 24px rgba(0,0,0,0.5)' : '0 4px 24px rgba(15,23,42,0.09)',
-            borderRadius: 10,
-            overflow: 'hidden',
-            minWidth: 160,
-            maxHeight: 340,
-            overflowY: 'auto',
-          }}
+          className='map-chrome absolute right-0 top-full z-30 mt-1 max-h-[340px] min-w-[160px] overflow-y-auto py-1'
         >
           {TILE_PROVIDERS.map((provider, idx) => {
             const isActive = idx === selectedBaseLayer;
@@ -132,8 +103,9 @@ export function BaselayerSwitcher({ className }: BaselayerSwitcherProps) {
                   width: '100%',
                   padding: '7px 12px',
                   border: 'none',
-                  background: isActive ? (isDark ? 'rgba(22,163,74,0.15)' : 'rgba(22,163,74,0.07)') : 'transparent',
-                  color: isActive ? (isDark ? '#4ade80' : '#15803d') : (isDark ? '#94a3b8' : '#475569'),
+                  background: isActive ? 'var(--accent-soft)' : 'transparent',
+                  /* 选中项文字是 accent 作文字 —— 用 text-safe 的 --agent-accent-text。 */
+                  color: isActive ? 'var(--agent-accent)' : 'var(--map-chrome-text)',
                   fontSize: 13,
                   cursor: 'pointer',
                   textAlign: 'left',
@@ -142,7 +114,7 @@ export function BaselayerSwitcher({ className }: BaselayerSwitcherProps) {
                 }}
                 onMouseEnter={(e) => {
                   if (!isActive) {
-                    e.currentTarget.style.background = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(15,23,42,0.04)';
+                    e.currentTarget.style.background = 'var(--surface-hover)';
                   }
                 }}
                 onMouseLeave={(e) => {

--- a/frontend/components/map/floating-legend.tsx
+++ b/frontend/components/map/floating-legend.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useHudStore } from '@/lib/store/useHudStore';
+import { LegendCard } from './legends/legend-card';
 
 interface FloatingLegendProps {
   className?: string;
@@ -9,45 +10,41 @@ interface FloatingLegendProps {
 const COLORS = ['#0ff0ff', '#00ff41', '#ffff00', '#ff5f00', '#ff2d55'];
 const LABELS = ['极低', '低', '中', '高', '极高'];
 
+/**
+ * 热力图图例。
+ *
+ * UI V4：改用与四种专题图例相同的 LegendCard 容器 —— 之前它是地图 chrome 里
+ * 唯一一套独立视觉系统（硬编码 rgba、blur(20px)、12.5px JetBrains Mono 标题），
+ * 其标题色在浅色下只有约 2.4:1，而它就贴在三个已收敛的图例旁边。
+ * 色带本身是热力图渲染器的固定配色，属于数据编码，保持原样。
+ */
 export function FloatingLegend({ className }: FloatingLegendProps) {
   const layers = useHudStore((s) => s.layers);
-  const theme = useHudStore((s) => s.theme);
-  const isDark = theme === 'dark';
   const visibleHeatLayer = layers.find((l) => l.visible && l.type === 'heatmap');
 
   return (
     <div
+      className={className}
       style={{
-        background: isDark ? 'rgba(15, 23, 42, 0.85)' : 'rgba(252,253,254,0.92)',
-        backdropFilter: 'blur(20px)',
-        WebkitBackdropFilter: 'blur(20px)',
-        border: isDark ? '1px solid rgba(255, 255, 255, 0.06)' : '1px solid rgba(255,255,255,0.92)',
-        boxShadow: isDark ? '0 4px 24px rgba(0,0,0,0.4)' : '0 4px 24px rgba(15,23,42,0.09)',
-        borderRadius: 10,
-        padding: '8px 12px',
-        fontSize: '12.5px',
-        fontFamily: "'DM Sans', system-ui, sans-serif",
-        minWidth: 140,
         transform: visibleHeatLayer ? 'translateY(0)' : 'translateY(20px)',
         opacity: visibleHeatLayer ? 1 : 0,
         transition: 'transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
         pointerEvents: visibleHeatLayer ? 'auto' : 'none',
       }}
-      className={className}
+      aria-hidden={!visibleHeatLayer}
     >
-      <div style={{ fontSize: 12, color: isDark ? '#64748b' : '#94a3b8', fontFamily: "'JetBrains Mono', monospace", textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 6 }}>
-        {visibleHeatLayer?.name || ''}
-      </div>
-      <div style={{ display: 'flex', height: 8, borderRadius: 4, overflow: 'hidden', marginBottom: 5 }}>
-        {COLORS.map((color, idx) => (
-          <div key={idx} style={{ flex: 1, backgroundColor: color }} />
-        ))}
-      </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', color: isDark ? '#94a3b8' : '#64748b', fontSize: 11 }}>
-        {LABELS.map((label, idx) => (
-          <span key={idx}>{label}</span>
-        ))}
-      </div>
+      <LegendCard field={visibleHeatLayer?.name} kind="热力密度渲染">
+        <div aria-hidden className="mb-1 flex h-2 overflow-hidden rounded-xs ring-1 ring-inset ring-map-chrome-border">
+          {COLORS.map((color) => (
+            <div key={color} className="flex-1" style={{ backgroundColor: color }} />
+          ))}
+        </div>
+        <div className="flex justify-between text-micro text-map-chrome-ink">
+          {LABELS.map((label) => (
+            <span key={label}>{label}</span>
+          ))}
+        </div>
+      </LegendCard>
     </div>
   );
 }

--- a/frontend/components/map/legends/categorical-legend.tsx
+++ b/frontend/components/map/legends/categorical-legend.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Info } from 'lucide-react';
 import type { CategoricalLegendSpec } from '@/lib/map-kit/types';
+import { LegendCard } from './legend-card';
 
 interface Props {
   spec: CategoricalLegendSpec;
@@ -10,33 +10,21 @@ interface Props {
 export function CategoricalLegend({ spec }: Props) {
   const { field, categories } = spec;
   return (
-    <div className="bg-card/90 backdrop-blur-md border border-border p-4 rounded-xl shadow-2xl min-w-[200px] animate-in slide-in-from-right-4 duration-500">
-      <div className="flex items-center gap-2 mb-3 border-b border-border pb-2">
-        <div className="p-1 bg-primary/10 rounded-md">
-          <Info className="h-3.5 w-3.5 text-primary" />
-        </div>
-        <div className="flex flex-col">
-          <span className="text-[14px] uppercase font-bold tracking-widest text-muted-foreground/80">图例说明</span>
-          <span className="text-xs font-semibold text-foreground truncate max-w-[140px]" title={field}>
-            字段: {field}
-          </span>
-        </div>
-      </div>
-      <div className="space-y-2">
+    <LegendCard field={field} kind="分类专题">
+      <div className="space-y-1">
         {categories.map((c) => (
-          <div key={c.key} className="flex items-center gap-3 p-1">
+          <div key={c.key} className="flex items-center gap-2">
             <div
               data-testid="cat-swatch"
-              className="w-3.5 h-3.5 rounded-sm shadow-sm ring-1 ring-black/10"
+              className="h-icon-sm w-icon-sm shrink-0 rounded-xs ring-1 ring-inset ring-map-chrome-border"
               style={{ backgroundColor: c.color }}
             />
-            <span className="text-[15px] font-medium text-muted-foreground">{c.label}</span>
+            <span className="truncate text-meta text-map-chrome-ink" title={c.label}>
+              {c.label}
+            </span>
           </div>
         ))}
       </div>
-      <div className="mt-4 pt-2 border-t border-border/40 text-[15px] text-muted-foreground/60 italic text-center">
-        分类专题
-      </div>
-    </div>
+    </LegendCard>
   );
 }

--- a/frontend/components/map/legends/continuous-legend.test.tsx
+++ b/frontend/components/map/legends/continuous-legend.test.tsx
@@ -12,10 +12,13 @@ const spec = {
 };
 
 describe('ContinuousLegend', () => {
+  // UI V4：数值格式统一到 formatLegendValue —— 之前 continuous 用 1 位小数
+  // （0.0 / 100.0）而 graduated 用整数，同一份数据在两种图例里长得不一样。
+  // 现在整数就是整数。
   it('renders min and max labels', () => {
     render(<ContinuousLegend spec={spec} />);
-    expect(screen.getByText('0.0')).toBeInTheDocument();
-    expect(screen.getByText('100.0')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
   });
 
   it('renders the field name', () => {
@@ -25,6 +28,18 @@ describe('ContinuousLegend', () => {
 
   it('omits field row when no field given', () => {
     render(<ContinuousLegend spec={{ ...spec, field: undefined }} />);
-    expect(screen.queryByText(/字段:/)).toBeNull();
+    expect(screen.queryByText(/density/)).toBeNull();
+  });
+
+  // 默认脚注是「连续密度渲染」；divergent 复用本渲染器时必须能改写它，
+  // 否则发散配色的图例会自称连续密度（V4 之前就是这个 bug）。
+  it('renders the default renderer label, and honours an override', () => {
+    const { unmount } = render(<ContinuousLegend spec={spec} />);
+    expect(screen.getByText('连续密度渲染')).toBeInTheDocument();
+    unmount();
+
+    render(<ContinuousLegend spec={spec} kind="发散渐变渲染" />);
+    expect(screen.getByText('发散渐变渲染')).toBeInTheDocument();
+    expect(screen.queryByText('连续密度渲染')).toBeNull();
   });
 });

--- a/frontend/components/map/legends/continuous-legend.tsx
+++ b/frontend/components/map/legends/continuous-legend.tsx
@@ -1,46 +1,30 @@
 'use client';
 
-import { Info } from 'lucide-react';
 import type { ContinuousLegendSpec } from '@/lib/map-kit/types';
+import { LegendCard, formatLegendValue } from './legend-card';
 
 interface Props {
   spec: ContinuousLegendSpec;
+  /** Renderer description for the footer. Divergent passes its own. */
+  kind?: string;
 }
 
-const fmt = (n: number) => {
-  if (Math.abs(n) >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
-  if (Math.abs(n) >= 1_000) return (n / 1_000).toFixed(1) + 'k';
-  return n.toFixed(1);
-};
-
-export function ContinuousLegend({ spec }: Props) {
+export function ContinuousLegend({ spec, kind = '连续密度渲染' }: Props) {
   const { field, min, max, palette_colors } = spec;
   const gradient = `linear-gradient(to right, ${palette_colors.join(', ')})`;
   return (
-    <div className="bg-card/90 backdrop-blur-md border border-border p-4 rounded-xl shadow-2xl min-w-[200px] animate-in slide-in-from-right-4 duration-500">
-      <div className="flex items-center gap-2 mb-3 border-b border-border pb-2">
-        <div className="p-1 bg-primary/10 rounded-md">
-          <Info className="h-3.5 w-3.5 text-primary" />
-        </div>
-        <div className="flex flex-col">
-          <span className="text-[14px] uppercase font-bold tracking-widest text-muted-foreground/80">图例说明</span>
-          {field && (
-            <span className="text-xs font-semibold text-foreground truncate max-w-[140px]" title={field}>
-              字段: {field}
-            </span>
-          )}
+    <LegendCard field={field} kind={kind}>
+      <div className="space-y-1">
+        <div
+          aria-hidden
+          className="h-2.5 rounded-xs ring-1 ring-inset ring-map-chrome-border"
+          style={{ background: gradient }}
+        />
+        <div className="flex justify-between text-meta tabular-nums text-map-chrome-ink">
+          <span>{formatLegendValue(min)}</span>
+          <span>{formatLegendValue(max)}</span>
         </div>
       </div>
-      <div className="space-y-2">
-        <div className="h-3 rounded-sm shadow-inner" style={{ background: gradient }} />
-        <div className="flex justify-between text-[15px] text-muted-foreground">
-          <span>{fmt(min)}</span>
-          <span>{fmt(max)}</span>
-        </div>
-      </div>
-      <div className="mt-4 pt-2 border-t border-border/40 text-[15px] text-muted-foreground/60 italic text-center">
-        连续密度渲染
-      </div>
-    </div>
+    </LegendCard>
   );
 }

--- a/frontend/components/map/legends/divergent-legend.tsx
+++ b/frontend/components/map/legends/divergent-legend.tsx
@@ -17,5 +17,7 @@ export function DivergentLegend({ spec }: Props) {
     palette: spec.palette,
     palette_colors: spec.palette_colors,
   };
-  return <ContinuousLegend spec={asContinuous} />;
+  // Pass the divergent label through: sharing the continuous renderer is fine,
+  // silently inheriting its 「连续密度渲染」 footer was mislabelling the map.
+  return <ContinuousLegend spec={asContinuous} kind="发散渐变渲染" />;
 }

--- a/frontend/components/map/legends/graduated-legend.tsx
+++ b/frontend/components/map/legends/graduated-legend.tsx
@@ -1,19 +1,14 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Info, Eye, EyeOff } from 'lucide-react';
+import { Eye, EyeOff } from 'lucide-react';
 import type { GraduatedLegendSpec } from '@/lib/map-kit/types';
+import { LegendCard, formatLegendValue } from './legend-card';
 
 interface Props {
   spec: GraduatedLegendSpec;
   onFilterChange?: (visibleBreaks: number[][]) => void;
 }
-
-const formatNum = (n: number) => {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(0) + 'M';
-  if (n >= 1_000) return (n / 1_000).toFixed(0) + 'k';
-  return String(Math.round(n));
-};
 
 export function GraduatedLegend({ spec, onFilterChange }: Props) {
   const { field, breaks, palette_colors } = spec;
@@ -39,59 +34,55 @@ export function GraduatedLegend({ spec, onFilterChange }: Props) {
   };
 
   return (
-    <div className="bg-card/90 backdrop-blur-md border border-border p-4 rounded-xl shadow-2xl min-w-[200px] animate-in slide-in-from-right-4 duration-500">
-      <div className="flex items-center gap-2 mb-3 border-b border-border pb-2">
-        <div className="p-1 bg-primary/10 rounded-md">
-          <Info className="h-3.5 w-3.5 text-primary" />
-        </div>
-        <div className="flex flex-col">
-          <span className="text-[14px] uppercase font-bold tracking-widest text-muted-foreground/80">图例说明</span>
-          <span className="text-xs font-semibold text-foreground truncate max-w-[140px]" title={field}>
-            字段: {field}
-          </span>
-        </div>
+    <LegendCard field={field} kind="数据驱动专题渲染">
+      <div className="mb-1 flex justify-between text-micro tabular-nums text-map-chrome-ink-muted">
+        <span>{formatLegendValue(breaks[0])}</span>
+        <span>{formatLegendValue(breaks[breaks.length - 1])}</span>
       </div>
-      <div className="flex justify-between text-[15px] text-muted-foreground/70 mb-1 px-1">
-        <span>{formatNum(breaks[0])}</span>
-        <span>{formatNum(breaks[breaks.length - 1])}</span>
-      </div>
-      <div className="space-y-2">
+      <div className="space-y-0.5">
         {breaks.slice(0, -1).map((val, idx) => {
           const nextVal = breaks[idx + 1];
           const colorIdx = Math.min(idx, palette_colors.length - 1);
           const isVisible = visible[idx];
-          const rangeLabel = `${formatNum(val)} — ${formatNum(nextVal)}`;
+          const rangeLabel = `${formatLegendValue(val)} — ${formatLegendValue(nextVal)}`;
           return (
             <div
               key={idx}
               role="button"
               tabIndex={0}
+              // aria-pressed carries the class's visibility, which the eye icon
+              // showed visually but never announced.
+              aria-pressed={isVisible}
               aria-label={rangeLabel}
-              className={`flex items-center justify-between group transition-all cursor-pointer hover:bg-muted/30 p-1 rounded-md ${!isVisible ? 'opacity-50' : ''}`}
+              className={`group flex min-h-row-sm cursor-pointer items-center justify-between gap-2 rounded-sm px-1 transition-colors hover:bg-surface-hover ${!isVisible ? 'opacity-50' : ''}`}
               onClick={() => toggle(idx)}
-              onKeyDown={(e) => { if (e.key === 'Enter') toggle(idx); }}
+              onKeyDown={(e) => {
+                // Space as well as Enter: role="button" must honour both.
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  toggle(idx);
+                }
+              }}
             >
-              <div className="flex items-center gap-3">
+              <div className="flex min-w-0 items-center gap-2">
                 <div
-                  className="w-3.5 h-3.5 rounded-sm shadow-sm ring-1 ring-black/10 group-hover:scale-110 transition-transform"
+                  aria-hidden
+                  className="h-icon-sm w-icon-sm shrink-0 rounded-xs ring-1 ring-inset ring-map-chrome-border"
                   style={{ backgroundColor: palette_colors[colorIdx] }}
                 />
-                <span className="text-[15px] font-medium text-muted-foreground group-hover:text-foreground transition-colors">
+                <span className="truncate text-meta tabular-nums text-map-chrome-ink">
                   {rangeLabel}
                 </span>
               </div>
-              <div className="flex items-center">
-                {isVisible
-                  ? <Eye className="h-3 w-3 text-primary/70" />
-                  : <EyeOff className="h-3 w-3 text-muted-foreground/50" />}
-              </div>
+              {isVisible ? (
+                <Eye aria-hidden className="h-icon-sm w-icon-sm shrink-0 text-status-accent" />
+              ) : (
+                <EyeOff aria-hidden className="h-icon-sm w-icon-sm shrink-0 text-ink-disabled" />
+              )}
             </div>
           );
         })}
       </div>
-      <div className="mt-4 pt-2 border-t border-border/40 text-[15px] text-muted-foreground/60 italic text-center">
-        数据驱动专题渲染
-      </div>
-    </div>
+    </LegendCard>
   );
 }

--- a/frontend/components/map/legends/legend-card.tsx
+++ b/frontend/components/map/legends/legend-card.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Info } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+/**
+ * The one legend container.
+ *
+ * All four legend types previously repeated the same container/​header string by
+ * hand and drifted apart anyway: two different number formatters, two different
+ * title treatments, no height cap on any of them (a 30-class categorical legend
+ * or a 9-break graduated legend simply grew until it reached the top bar), and a
+ * divergent legend that printed the continuous legend's footer.
+ */
+
+interface LegendCardProps {
+  /** The attribute being symbolised; omitted for legends without one. */
+  field?: string | null;
+  /** Short renderer description shown in the footer, e.g. 「分类专题」. */
+  kind: string;
+  children: ReactNode;
+}
+
+export function LegendCard({ field, kind, children }: LegendCardProps) {
+  return (
+    <div className="map-chrome flex min-h-0 min-w-[188px] max-w-[260px] flex-col animate-in slide-in-from-right-4 duration-500">
+      <div className="flex items-center gap-2 border-b border-map-chrome-border px-panel py-1.5">
+        <Info aria-hidden className="h-icon-sm w-icon-sm shrink-0 text-status-accent" />
+        <div className="flex min-w-0 flex-col">
+          <span className="eyebrow">图例</span>
+          {field && (
+            <span
+              className="truncate text-meta font-semibold text-map-chrome-ink"
+              title={field}
+            >
+              {field}
+            </span>
+          )}
+        </div>
+      </div>
+      {/* Scrolls instead of growing. The height budget is owned by the stack
+          (see the container in map-panel.tsx), not by the card: capping each
+          card individually let two legends still overflow the workspace. */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-panel py-1.5">{children}</div>
+      <div className="border-t border-map-chrome-border px-panel py-1 text-center text-micro text-map-chrome-ink-muted">
+        {kind}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Shared legend number format: compact for large magnitudes, thousands-grouped
+ * otherwise, and stable across legend types (continuous used 1 decimal + M/k
+ * while graduated used 0 decimals + M/k for the same data).
+ *
+ * Fractions keep enough significant digits to stay distinguishable — a fixed
+ * single decimal collapsed 0.04 to "0" and -0.04 to "-0", which is exactly the
+ * range NDVI, per-capita rates and densities live in.
+ */
+export function formatLegendValue(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `${significant(n / 1_000_000)}M`;
+  if (abs >= 10_000) return `${significant(n / 1_000)}k`;
+  if (Number.isInteger(n)) return n.toLocaleString('zh-CN');
+  return significant(n);
+}
+
+/** Up to 3 significant digits, trailing zeros dropped, never rounded to zero. */
+function significant(n: number): string {
+  const abs = Math.abs(n);
+  const decimals = abs >= 100 ? 0 : abs >= 10 ? 1 : abs >= 1 ? 2 : 3;
+  const out = Number(n.toFixed(decimals));
+  // A non-zero input must never print as zero: fall back to exponential.
+  if (out === 0 && n !== 0) return n.toExponential(1);
+  return String(out);
+}

--- a/frontend/components/map/map-decorations.tsx
+++ b/frontend/components/map/map-decorations.tsx
@@ -37,28 +37,38 @@ export const MapDecorations = React.memo(function MapDecorations({ show, title, 
       {title && (
         <div
           data-testid="map-title"
-          className="absolute top-3 left-1/2 -translate-x-1/2 z-30 px-4 py-1.5 rounded-full bg-card/90 backdrop-blur-md border border-border shadow-lg text-sm font-semibold text-foreground"
+          className="map-chrome absolute top-3 left-1/2 -translate-x-1/2 z-30 max-w-[min(46ch,50%)] truncate px-3 py-1 text-title font-semibold"
         >
           {title}
         </div>
       )}
+      {/* North arrow with an explicit N label — a bare compass glyph is not the
+          GIS convention, and the rotation makes "which way is north" the whole
+          point of the control. */}
       <div
         data-testid="north-arrow"
-        className="absolute top-3 right-3 z-30 p-2 rounded-full bg-card/90 backdrop-blur-md border border-border shadow-lg"
+        className="map-chrome absolute top-3 right-3 z-30 flex h-control-lg w-control-lg flex-col items-center justify-center gap-px rounded-chrome"
         style={{ transform: `rotate(${-bearing}deg)` }}
-        aria-label="指北针"
+        aria-label={`指北针，当前方位角 ${Math.round(bearing)}°`}
       >
-        <Compass className="h-4 w-4 text-foreground" />
+        <Compass aria-hidden className="h-icon-md w-icon-md text-map-chrome-ink" />
+        <span aria-hidden className="text-micro font-semibold leading-none text-map-chrome-ink-muted">N</span>
       </div>
+      {/* Scale bar sits in the bottom-right chrome column, one step above the
+          status readout. Before V4 it was a fixed `bottom-14` that left a 6px
+          gap to the attribution pill and collided as soon as either grew. */}
       <div
         data-testid="scale-bar"
-        className="absolute bottom-14 right-3 z-30 px-2 py-1 rounded-md bg-card/90 backdrop-blur-md border border-border shadow-lg text-[15px] font-medium text-foreground flex items-center gap-2"
+        className="map-chrome absolute right-3 z-30 flex items-center gap-2 px-2 py-1 text-caption font-medium tabular-nums transition-[bottom] duration-300"
+        style={{ bottom: 'calc(var(--map-chrome-bottom, 10px) + 30px)' }}
+        aria-label={`比例尺 ${formatMeters(meters)}`}
       >
         <div
-          className="border-b-2 border-l-2 border-r-2 border-foreground"
-          style={{ width: `${Math.round(pixels)}px`, height: '6px' }}
+          aria-hidden
+          className="border-b-2 border-l-2 border-r-2 border-map-chrome-ink"
+          style={{ width: `${Math.round(pixels)}px`, height: '5px' }}
         />
-        <span>{formatMeters(meters)}</span>
+        <span className="text-map-chrome-ink">{formatMeters(meters)}</span>
       </div>
     </>
   );

--- a/frontend/components/map/map-error-boundary.tsx
+++ b/frontend/components/map/map-error-boundary.tsx
@@ -39,23 +39,26 @@ export class MapErrorBoundary extends Component<{ children: ReactNode }, MapErro
     // loading". Name the network cause so the user doesn't read it as data loss.
     const isStyleLoadError = /style is not done loading|failed to fetch|networkerror/i.test(message);
 
+    // Tokenized (bg-surface-canvas / text-ink-*): the fallback used hardcoded
+    // light colours and would render as a white block over the map under the
+    // dark theme.
     return (
-      <div className='absolute inset-0 flex items-center justify-center bg-[#dce8f2]'>
+      <div className='absolute inset-0 flex items-center justify-center bg-surface-canvas'>
         <div className='max-w-sm space-y-3 px-6 text-center'>
-          <div className='font-mono text-xs uppercase tracking-widest text-slate-500'>
+          <div className='font-mono text-xs uppercase tracking-widest text-ink-muted'>
             Map Unavailable
           </div>
-          <p className='text-sm text-slate-600'>
+          <p className='text-body text-ink-secondary'>
             {isStyleLoadError
               ? 'The basemap tiles could not be loaded. Check your network connection or tile provider.'
               : message}
           </p>
-          <p className='text-xs text-slate-400'>
+          <p className='text-meta text-ink-muted'>
             Chat and analysis still work. Layers will render once the map recovers.
           </p>
           <button
             onClick={this.handleRetry}
-            className='rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-600 transition-colors hover:bg-slate-200/60'
+            className='rounded-md border border-edge px-4 py-2 text-body text-ink-secondary transition-colors hover:bg-surface-hover'
           >
             Retry Map
           </button>

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -601,7 +601,9 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
   const showPerceptionRings = aiStatus === 'thinking' || aiStatus === 'acting'
 
   return (
-    <div className="absolute inset-0">
+    /* bg-surface-canvas 作为地图底衬：瓦片未到位（首帧、离线、瓦片报错）时
+       暗色主题下会露出一整屏白色画布 —— 地图是主视觉，这里不该闪白。 */
+    <div className="absolute inset-0 bg-surface-canvas">
       {/* Map Canvas — Full Viewport */}
       <Map
         id="default"
@@ -625,8 +627,8 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
             onClose={() => setOverlapFeatures(null)}
             closeOnClick={false}
           >
-            <div className="text-xs p-1 font-sans min-w-[160px]">
-              <div className="font-semibold border-b pb-1 mb-1 border-white/20 text-primary">选择要素</div>
+            <div className="min-w-[160px] p-1 font-sans text-meta">
+              <div className="mb-1 border-b border-map-chrome-border pb-1 font-semibold text-map-chrome-ink">选择要素</div>
               {overlapFeatures.features.map((f, i) => {
                 const sublayerId = (f.layer?.id as string | undefined)
                 const parentId = sublayerId ? resolveParentLayerId(sublayerId, layersRef.current.map((l) => l.id)) : undefined
@@ -637,10 +639,10 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
                   <button
                     key={i}
                     type="button"
-                    className="block w-full text-left px-1 py-0.5 hover:bg-white/10 rounded"
+                    className="block w-full rounded-xs px-1 py-0.5 text-left hover:bg-surface-hover"
                     onClick={() => pickOverlapFeature(f, overlapFeatures.point)}
                   >
-                    <span className="text-gray-400 font-mono">{name}</span>
+                    <span className="font-mono text-map-chrome-ink-muted">{name}</span>
                     {firstProp && <span className="ml-2 font-mono break-all">{String(firstProp[1])}</span>}
                   </button>
                 )
@@ -656,19 +658,19 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
             onClose={() => setSelectedFeature(null)}
             closeOnClick={false}
           >
-            <div className="text-xs p-1 font-sans">
-              <div className="font-semibold border-b pb-1 mb-1 border-white/20 text-primary">
+            <div className="p-1 font-sans text-meta">
+              <div className="mb-1 truncate border-b border-map-chrome-border pb-1 font-semibold text-map-chrome-ink" title={selectedFeature.layerName || '未命名图层'}>
                 {selectedFeature.layerName || '未命名图层'}
               </div>
-              <div className="max-h-32 overflow-y-auto space-y-0.5 min-w-[150px]">
+              <div className="max-h-32 min-w-[150px] space-y-0.5 overflow-y-auto">
                 {Object.entries(selectedFeature.properties).slice(0, 5).map(([k, v]) => (
                   <div key={k} className="flex justify-between gap-4">
-                    <span className="text-gray-400 font-mono">{k}:</span>
-                    <span className="font-mono break-all">{String(v)}</span>
+                    <span className="font-mono text-map-chrome-ink-muted">{k}:</span>
+                    <span className="break-all font-mono text-map-chrome-ink">{String(v)}</span>
                   </div>
                 ))}
                 {Object.keys(selectedFeature.properties).length > 5 && (
-                  <div className="text-gray-500 text-[10px] italic">
+                  <div className="text-micro italic text-map-chrome-ink-muted">
                     ...以及其他 {Object.keys(selectedFeature.properties).length - 5} 个属性
                   </div>
                 )}
@@ -684,13 +686,15 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
             closeOnClick={false}
             closeButton={false}
           >
-            <div className="text-xs p-1 font-sans">
-              <div className="font-semibold border-b pb-1 mb-1 border-white/20">{hoverInfo.layerName}</div>
-              <div className="space-y-0.5 min-w-[120px]">
+            <div className="p-1 font-sans text-meta">
+              <div className="mb-1 truncate border-b border-map-chrome-border pb-1 font-semibold text-map-chrome-ink" title={hoverInfo.layerName}>
+                {hoverInfo.layerName}
+              </div>
+              <div className="min-w-[120px] space-y-0.5">
                 {Object.entries(hoverInfo.props).map(([k, v]) => (
                   <div key={k} className="flex justify-between gap-4">
-                    <span className="text-gray-400 font-mono">{k}:</span>
-                    <span className="font-mono break-all">{String(v)}</span>
+                    <span className="font-mono text-map-chrome-ink-muted">{k}:</span>
+                    <span className="break-all font-mono text-map-chrome-ink">{String(v)}</span>
                   </div>
                 ))}
               </div>
@@ -702,15 +706,28 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
       {/* Live cartography overlays — driven by layer.legend_spec */}
       {thematicLayers.length > 0 && (
         <>
-          <div className="absolute bottom-4 z-30 space-y-3" style={{ left: 'var(--workspace-offset, 16px)' }}>
+          {/* The stack owns the vertical budget: `top` pins it below the map
+              title so it can never grow past the top bar, and it scrolls once
+              several thematic legends are loaded. */}
+          <div
+            className="absolute z-30 flex max-w-[268px] flex-col gap-2 overflow-y-auto pr-1 transition-[bottom,left] duration-300"
+            style={{
+              left: 'var(--workspace-offset, 16px)',
+              bottom: 'var(--map-chrome-bottom, 10px)',
+              top: '48px',
+              justifyContent: 'flex-end',
+            }}
+          >
             {thematicLayers.map((l) => {
               const flashing = focusLayerId === l.id;
               return (
                 <div
                   key={l.id}
-                  className={`rounded-xl transition-all ${flashing ? "ring-2 ring-primary/80 ring-offset-2 ring-offset-background animate-pulse" : ""}`}
+                  className={`rounded-chrome ${flashing ? 'ring-2 ring-status-accent-vivid' : ''}`}
                 >
-                  <div className="text-[14px] uppercase tracking-widest text-muted-foreground/60 mb-1 px-1">{l.name}</div>
+                  <div className="eyebrow mb-1 max-w-[240px] truncate px-1" title={l.name}>
+                    {l.name}
+                  </div>
                   <ThematicLegend spec={l.legend_spec!} onFilterChange={legendFilterHandlers[l.id]} />
                 </div>
               );
@@ -730,9 +747,11 @@ export function MapPanel({ layers, onRemoveLayer: _onRemoveLayer, onToggleLayer:
       {showPerceptionRings && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-20">
           <svg width="120" height="120" viewBox="0 0 120 120" className="opacity-60">
-            <circle cx="60" cy="60" r="20" fill="none" stroke="#16a34a" strokeWidth="1.5" className="animate-ring-pulse" />
-            <circle cx="60" cy="60" r="35" fill="none" stroke="#16a34a" strokeWidth="1" className="animate-ring-pulse-delay" />
-            <circle cx="60" cy="60" r="50" fill="none" stroke="#16a34a" strokeWidth="0.75" className="animate-ring-pulse-delay2" />
+            {/* stroke 走 --agent-accent（页面已把 store 的 accentColor 同步到
+                该变量），此前硬编码 #16a34a：用户换主题色后感知环还是默认绿。 */}
+            <circle cx="60" cy="60" r="20" fill="none" stroke="var(--agent-accent)" strokeWidth="1.5" className="animate-ring-pulse" />
+            <circle cx="60" cy="60" r="35" fill="none" stroke="var(--agent-accent)" strokeWidth="1" className="animate-ring-pulse-delay" />
+            <circle cx="60" cy="60" r="50" fill="none" stroke="var(--agent-accent)" strokeWidth="0.75" className="animate-ring-pulse-delay2" />
           </svg>
         </div>
       )}

--- a/frontend/components/map/map-status-readout.tsx
+++ b/frontend/components/map/map-status-readout.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useHudStore } from '@/lib/store/useHudStore';
+
+/**
+ * Bottom-right map readout: cursor-independent centre coordinate, zoom level,
+ * CRS and attribution.
+ *
+ * A desktop GIS always tells you *where* and *how far in* you are. Before V4 the
+ * app showed only "© OpenStreetMap contributors" in a hardcoded light pill, so a
+ * user had no zoom or CRS reference at all and the pill turned into a bright
+ * block on the dark map.
+ *
+ * It subscribes to `viewport` itself rather than taking it as a prop, which
+ * keeps the map-pan render path out of the page component (`app/page.tsx`
+ * re-renders on every streamed token batch, and its siblings are memoised to
+ * stay off that path).
+ */
+export function MapStatusReadout() {
+  const viewport = useHudStore((s) => s.viewport);
+
+  const [lng, lat] = viewport?.center ?? [0, 0];
+  const zoom = viewport?.zoom ?? 0;
+
+  return (
+    <div
+      className='map-chrome flex items-center gap-2 px-2 py-1 font-mono text-micro tabular-nums'
+      // Not a live region: the values change on every pan frame and would flood
+      // a screen reader. The static label carries the meaning instead.
+      aria-label='地图视图状态'
+    >
+      <span className='text-map-chrome-ink'>
+        {Number.isFinite(lat) ? lat.toFixed(4) : '—'}, {Number.isFinite(lng) ? lng.toFixed(4) : '—'}
+      </span>
+      <span aria-hidden className='text-map-chrome-border'>│</span>
+      <span className='text-map-chrome-ink'>Z{Number.isFinite(zoom) ? zoom.toFixed(1) : '—'}</span>
+      <span aria-hidden className='text-map-chrome-border'>│</span>
+      <span className='text-map-chrome-ink-muted'>EPSG:4326</span>
+      <span aria-hidden className='text-map-chrome-border'>│</span>
+      <span className='text-map-chrome-ink-muted'>© OpenStreetMap</span>
+    </div>
+  );
+}
+
+export default MapStatusReadout;

--- a/frontend/components/map/spatial-crosshair.test.tsx
+++ b/frontend/components/map/spatial-crosshair.test.tsx
@@ -9,7 +9,6 @@ describe('SpatialCrosshair', () => {
     useHudStore.setState({
       viewport: { center: [116.4074, 39.9042], zoom: 10, bearing: 0, pitch: 0 },
       aiStatus: 'idle',
-      accentColor: '#16a34a',
       is3D: false,
     });
     // Mock navigator.clipboard

--- a/frontend/components/map/spatial-crosshair.tsx
+++ b/frontend/components/map/spatial-crosshair.tsx
@@ -6,7 +6,6 @@ import { useHudStore } from '@/lib/store/useHudStore';
 export function SpatialCrosshair() {
   const viewport = useHudStore((s) => s.viewport);
   const aiStatus = useHudStore((s) => s.aiStatus);
-  const accentColor = useHudStore((s) => s.accentColor);
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -86,7 +85,7 @@ export function SpatialCrosshair() {
           height: 140,
           border: '1px dashed rgba(22, 163, 74, 0.25)',
           borderRadius: '50%',
-          borderColor: isThinking ? `${accentColor}77` : 'rgba(148, 163, 184, 0.2)',
+          borderColor: isThinking ? 'color-mix(in srgb, var(--agent-accent) 47%, transparent)' : 'rgba(148, 163, 184, 0.2)',
           animation: isThinking ? 'spin-clockwise 15s linear infinite' : 'spin-clockwise 45s linear infinite',
           transition: 'border-color 0.3s ease',
         }}>
@@ -98,7 +97,7 @@ export function SpatialCrosshair() {
               left: '50%',
               width: 1,
               height: 6,
-              background: isThinking ? accentColor : '#64748b',
+              background: isThinking ? 'var(--agent-accent)' : '#64748b',
               transform: `translate(-50%, -50%) rotate(${deg}deg) translateY(-67px)`,
               transition: 'background-color 0.3s ease',
             }} />
@@ -112,7 +111,7 @@ export function SpatialCrosshair() {
           height: 80,
           border: '1px solid rgba(22, 163, 74, 0.15)',
           borderRadius: '30%',
-          borderColor: isThinking ? `${accentColor}55` : 'rgba(148, 163, 184, 0.15)',
+          borderColor: isThinking ? 'color-mix(in srgb, var(--agent-accent) 33%, transparent)' : 'rgba(148, 163, 184, 0.15)',
           animation: 'spin-counterclockwise 12s linear infinite',
           transition: 'border-color 0.3s ease',
         }} />
@@ -123,7 +122,7 @@ export function SpatialCrosshair() {
             position: 'absolute',
             width: 110,
             height: 110,
-            border: `2px solid ${accentColor}`,
+            border: '2px solid var(--agent-accent)',
             borderRadius: '50%',
             opacity: 0.4,
             animation: 'radar-pulse 2s ease-in-out infinite',
@@ -150,15 +149,19 @@ export function SpatialCrosshair() {
           style={{
             position: 'absolute',
             zIndex: 10,
-            filter: copied ? `drop-shadow(0 0 6px ${accentColor})` : (isThinking ? `drop-shadow(0 0 4px ${accentColor})` : 'none'),
+            filter: copied
+              ? 'drop-shadow(0 0 6px var(--agent-accent))'
+              : (isThinking ? 'drop-shadow(0 0 4px var(--agent-accent))' : 'none'),
             transition: 'filter 0.3s ease',
             cursor: 'pointer',
-            pointerEvents: 'auto',
+            // 审计：这里恒为 'auto'，于是地图正中央始终有一个 24px 的点击陷阱，
+            // 空闲时也会吞掉要素拾取。只有真正可复制时才接收指针事件。
+            pointerEvents: copied || isThinking ? 'auto' : 'none',
           }}
         >
           <title>{copied ? "已复制！" : "点击复制当前中心坐标"}</title>
-          <circle cx="12" cy="12" r="3" fill={copied ? accentColor : (isThinking ? accentColor : '#cbd5e1')} style={{ transition: 'fill 0.3s ease' }} />
-          <path d="M12 2v6M12 16v6M2 12h6M16 12h6" stroke={copied ? accentColor : (isThinking ? accentColor : '#64748b')} strokeWidth="1.5" strokeLinecap="round" style={{ transition: 'stroke 0.3s ease' }} />
+          <circle cx="12" cy="12" r="3" fill={copied || isThinking ? 'var(--agent-accent)' : 'var(--text-disabled)'} style={{ transition: 'fill 0.3s ease' }} />
+          <path d="M12 2v6M12 16v6M2 12h6M16 12h6" stroke={copied || isThinking ? 'var(--agent-accent)' : 'var(--text-muted)'} strokeWidth="1.5" strokeLinecap="round" style={{ transition: 'stroke 0.3s ease' }} />
         </svg>
 
         {/* Laser Scanning Line Overlay */}
@@ -167,8 +170,8 @@ export function SpatialCrosshair() {
             position: 'absolute',
             width: 120,
             height: 2,
-            background: `linear-gradient(90deg, transparent, ${accentColor}, transparent)`,
-            boxShadow: `0 0 8px ${accentColor}`,
+            background: 'linear-gradient(90deg, transparent, var(--agent-accent), transparent)',
+            boxShadow: '0 0 8px var(--agent-accent)',
             animation: 'laser-sweep 1.8s ease-in-out infinite',
             zIndex: 5,
           }} />

--- a/frontend/components/map/thematic-legend.test.tsx
+++ b/frontend/components/map/thematic-legend.test.tsx
@@ -19,8 +19,9 @@ describe('ThematicLegend (router)', () => {
       min: 0, max: 1, palette: 'Viridis',
       palette_colors: ['#440154', '#fde725'],
     }} />);
-    expect(screen.getByText('0.0')).toBeInTheDocument();
-    expect(screen.getByText('1.0')).toBeInTheDocument();
+    // UI V4：图例数值统一走 formatLegendValue（整数不再补 .0）。
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 
   it('routes categorical spec to CategoricalLegend', () => {

--- a/frontend/components/panel/rag-independent-panel.tsx
+++ b/frontend/components/panel/rag-independent-panel.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { X } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
+import { useInertWhenClosed } from '@/lib/hooks/use-inert';
 
 interface RagIndependentPanelProps {
   open: boolean;
@@ -10,9 +12,32 @@ interface RagIndependentPanelProps {
 
 export function RagIndependentPanel({ open, onClose }: RagIndependentPanelProps) {
   const ragResults = useHudStore((s) => s.ragResults);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // 该面板始终挂载、仅靠 transform+opacity 视觉隐藏，读屏仍会读到其中的内容；
+  // role="dialog" + aria-modal="false" 给出轻量对话框语义。
+  // 关闭时同时打 aria-hidden 与 inert：只写 aria-hidden 反而是 ARIA 违规 ——
+  // 容器里仍有可聚焦控件，键盘会 Tab 进一个看不见、也不会被播报的面板。
+  // inert 一并移除命中测试、焦点与 a11y 树（见 use-inert.ts）。
+  useInertWhenClosed(panelRef, open);
+
+  // Escape 只在 open 时注册监听、卸载时清理。
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
 
   return (
     <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="rag-panel-title"
+      aria-hidden={!open}
       style={{
         position: 'absolute',
         right: 10,
@@ -20,11 +45,11 @@ export function RagIndependentPanel({ open, onClose }: RagIndependentPanelProps)
         zIndex: 40,
         width: 380,
         maxHeight: 320,
-        background: 'rgba(252,253,254,0.96)',
-        backdropFilter: 'blur(20px)',
-        WebkitBackdropFilter: 'blur(20px)',
-        border: '1px solid rgba(255,255,255,0.95)',
-        boxShadow: '0 8px 32px rgba(15,23,42,0.12)',
+        // V4：overlay 表面不透明（--surface-overlay 双主题均不透明），
+        // 半透明白底 + backdrop blur 已无作用，去掉。
+        background: 'var(--surface-overlay)',
+        border: '1px solid var(--border-subtle)',
+        boxShadow: 'var(--elevation-overlay)',
         borderRadius: 16,
         overflow: 'hidden',
         transform: open ? 'translateY(0)' : 'translateY(105%)',
@@ -34,23 +59,23 @@ export function RagIndependentPanel({ open, onClose }: RagIndependentPanelProps)
       }}
     >
       {/* Header */}
-      <div className='flex items-center justify-between px-4 py-3 border-b border-slate-200/60 bg-white/40'>
+      <div className='flex items-center justify-between px-4 py-3 border-b border-edge-subtle bg-surface-raised'>
         <div className='flex items-center gap-2'>
-          <div className='w-6 h-6 rounded-lg bg-green-100 flex items-center justify-center'>
+          <div className='w-6 h-6 rounded-md bg-status-accent-soft flex items-center justify-center'>
             <svg width='14' height='14' viewBox='0 0 14 14' fill='none'>
-              <path d='M3 7h8M7 3v8' stroke='#16a34a' strokeWidth='1.5' strokeLinecap='round'/>
-              <circle cx='7' cy='7' r='5' stroke='#16a34a' strokeWidth='1'/>
+              <path d='M3 7h8M7 3v8' stroke='var(--accent)' strokeWidth='1.5' strokeLinecap='round'/>
+              <circle cx='7' cy='7' r='5' stroke='var(--accent)' strokeWidth='1'/>
             </svg>
           </div>
           <div>
-            <div className='text-xs font-semibold text-slate-800'>RAG 检索</div>
-            <div className='text-[14px] text-slate-400'>{ragResults.length} 个结果</div>
+            <div id="rag-panel-title" className='text-meta font-semibold text-ink'>RAG 检索</div>
+            <div className='text-body text-ink-muted'>{ragResults.length} 个结果</div>
           </div>
         </div>
         <button
           onClick={onClose}
           aria-label="关闭"
-          className='w-6 h-6 flex items-center justify-center rounded hover:bg-slate-100 text-slate-400 hover:text-slate-600'
+          className='w-6 h-6 flex items-center justify-center rounded-sm hover:bg-surface-hover text-ink-disabled hover:text-ink-secondary'
         >
           <X size={14} />
         </button>
@@ -59,7 +84,7 @@ export function RagIndependentPanel({ open, onClose }: RagIndependentPanelProps)
       {/* Content */}
       <div className='overflow-y-auto max-h-[240px] p-3'>
         {ragResults.length === 0 ? (
-          <div className='text-center py-8 text-xs text-slate-400'>
+          <div className='text-center py-8 text-meta text-ink-muted'>
             暂无检索结果
           </div>
         ) : (
@@ -67,18 +92,18 @@ export function RagIndependentPanel({ open, onClose }: RagIndependentPanelProps)
             {ragResults.map((result) => (
               <div
                 key={result.id}
-                className='p-3 rounded-xl border border-slate-200/60 bg-white/60'
+                className='p-3 rounded-md border border-edge-subtle bg-surface-raised'
               >
                 {/* Source header */}
                 <div className='flex items-center justify-between mb-2'>
-                  <div className='text-xs font-medium text-slate-700 truncate flex-1'>
+                  <div className='text-meta font-medium text-ink-secondary truncate flex-1'>
                     {result.source}
                   </div>
                   <div className='flex items-center gap-2 ml-2'>
-                    <span className='text-[14px] px-1.5 py-0.5 rounded-full bg-green-100 text-green-700 font-mono font-semibold'>
+                    <span className='text-body px-1.5 py-0.5 rounded-pill bg-status-accent-soft text-status-accent font-mono font-semibold'>
                       {result.score}
                     </span>
-                    <span className='text-[14px] text-slate-400 font-mono'>
+                    <span className='text-body text-ink-muted font-mono'>
                       {result.chunks} 块
                     </span>
                   </div>
@@ -89,7 +114,7 @@ export function RagIndependentPanel({ open, onClose }: RagIndependentPanelProps)
                   {result.excerpts.map((excerpt, idx) => (
                     <div
                       key={idx}
-                      className='text-[15px] text-slate-500 leading-relaxed'
+                      className='text-body text-ink-muted leading-relaxed'
                     >
                       &quot;{excerpt}&quot;
                     </div>

--- a/frontend/components/providers/client-providers.tsx
+++ b/frontend/components/providers/client-providers.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React, { Component } from "react"
+import { MotionConfig } from "framer-motion"
 import { MapProvider } from "react-map-gl/maplibre"
 import { MapActionProvider } from "@/lib/contexts/map-action-context"
 import { ToastContainer } from "@/components/ui/toast"
@@ -20,16 +21,18 @@ class ErrorBoundary extends Component<{ children: React.ReactNode }, ErrorBounda
 
   render() {
     if (this.state.hasError) {
+      // 全屏错误页走语义 token（bg-surface-canvas / text-ink-* / status-*）：
+      // 硬编码浅色在暗色主题下会渲染成一块白屏。
       return (
-        <div className="h-screen w-screen bg-[#dce8f2] flex items-center justify-center text-slate-800">
+        <div className="h-screen w-screen bg-surface-canvas flex items-center justify-center text-ink">
           <div className="text-center space-y-4">
-            <div className="text-[#16a34a] text-sm font-mono uppercase tracking-widest">System Error</div>
-            <p className="text-slate-500 text-sm max-w-md">
+            <div className="text-status-accent text-sm font-mono uppercase tracking-widest">System Error</div>
+            <p className="text-ink-muted text-sm max-w-md">
               {this.state.error?.message || "An unexpected error occurred"}
             </p>
             <button
               onClick={() => { this.setState({ hasError: false, error: null }); window.location.reload() }}
-              className="px-4 py-2 rounded-lg border border-[#16a34a]/30 text-[#16a34a] text-sm hover:bg-[#16a34a]/10 transition-colors"
+              className="px-4 py-2 rounded-md border border-status-accent-border text-status-accent text-sm hover:bg-status-accent-soft transition-colors"
             >
               Reload
             </button>
@@ -43,14 +46,19 @@ class ErrorBoundary extends Component<{ children: React.ReactNode }, ErrorBounda
 
 export function ClientProviders({ children }: { children: React.ReactNode }) {
   return (
-    <ErrorBoundary>
-      <MapProvider>
-        <MapActionProvider>
-          {children}
-          <SystemMessageBridge />  {/* FE-01: 消费 pendingSystemMessage 队列 */}
-          <ToastContainer />
-        </MapActionProvider>
-      </MapProvider>
-    </ErrorBoundary>
+    // MotionConfig reducedMotion="user"：globals.css 的 reduced-motion 全局样式
+    // 只能关掉 CSS 动画，触不到 framer-motion 用 JS 内联样式驱动的弹簧动画；
+    // 这里让 framer-motion 自行读取 prefers-reduced-motion 并降级。
+    <MotionConfig reducedMotion="user">
+      <ErrorBoundary>
+        <MapProvider>
+          <MapActionProvider>
+            {children}
+            <SystemMessageBridge />  {/* FE-01: 消费 pendingSystemMessage 队列 */}
+            <ToastContainer />
+          </MapActionProvider>
+        </MapProvider>
+      </ErrorBoundary>
+    </MotionConfig>
   )
 }

--- a/frontend/components/settings/layer-management.tsx
+++ b/frontend/components/settings/layer-management.tsx
@@ -186,6 +186,7 @@ export function LayerManagement() {
 
                 {/* Visibility toggle */}
                 <ToggleSwitch
+                  label={`显示图层：${layer.name}`}
                   checked={layer.visible}
                   onChange={() => toggleLayer(layer.id)}
                 />

--- a/frontend/components/settings/llm-config.tsx
+++ b/frontend/components/settings/llm-config.tsx
@@ -86,14 +86,12 @@ export function LlmConfig() {
       {/* Caching toggle */}
       <div className="flex items-center justify-between py-1">
         <div>
-          <div className="text-[14px] font-medium text-[var(--theme-text-primary)]">
-            Prompt Caching
-          </div>
-          <div className="text-[15px] text-[var(--theme-text-muted)]">
+          <div className="text-title font-medium text-ink">Prompt Caching</div>
+          <div className="text-body text-ink-muted">
             Cache repeated prompts to reduce latency and token usage
           </div>
         </div>
-        <ToggleSwitch checked={caching} onChange={() => setCaching(!caching)} />
+        <ToggleSwitch label="Prompt Caching" checked={caching} onChange={() => setCaching(!caching)} />
       </div>
 
       {/* Connectivity test */}
@@ -101,7 +99,7 @@ export function LlmConfig() {
         <button
           onClick={handleTest}
           disabled={testing}
-          className="inline-flex items-center gap-1.5 rounded px-3 py-1 text-[15px] font-medium border border-[var(--theme-border)] bg-[var(--theme-bg-input)] text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-hover)] transition-all disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded-sm border border-edge-subtle bg-surface-sunken px-3 py-1 text-body font-medium text-ink-secondary transition-all hover:bg-surface-hover disabled:opacity-50"
         >
           {testing ? (
             <>
@@ -129,12 +127,12 @@ export function LlmConfig() {
           )}
         </button>
         {testResult === 'success' && (
-          <span className="text-[15px] font-medium text-emerald-600 dark:text-emerald-300">
+          <span className="text-body font-medium text-status-success">
             Connection OK
           </span>
         )}
         {testResult === 'error' && (
-          <span className="text-[15px] font-medium text-red-600 dark:text-red-400">
+          <span className="text-body font-medium text-status-critical">
             Connection Failed
           </span>
         )}

--- a/frontend/components/settings/map-config.tsx
+++ b/frontend/components/settings/map-config.tsx
@@ -46,7 +46,7 @@ export function MapConfig() {
 
       {/* Basemap style cards */}
       <div>
-        <div className="text-[15px] uppercase tracking-wider text-[var(--theme-text-muted)] font-semibold mb-3">
+        <div className="text-heading uppercase tracking-wider text-ink-muted font-semibold mb-3">
           Basemap Style
         </div>
         <div className="grid grid-cols-3 gap-2">
@@ -56,43 +56,44 @@ export function MapConfig() {
               <button
                 key={style.id}
                 onClick={() => setBaseLayer(style.name)}
-                className="flex flex-col items-center justify-center gap-1.5 rounded-xl border-2 py-3 px-2 transition-all"
+                className="flex flex-col items-center justify-center gap-1.5 rounded-md border-2 px-2 py-3 transition-all"
                 style={{
                   borderColor: isActive
                     ? 'var(--agent-accent, #16a34a)'
-                    : 'var(--theme-border)',
+                    : 'var(--border-subtle)',
                   backgroundColor: isActive
                     ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 4%, transparent)'
-                    : 'var(--theme-bg-subtle)',
+                    : 'var(--surface-raised)',
                 }}
               >
                 {/* Mini preview */}
                 <div
-                  className="rounded-lg flex items-center justify-center"
+                  className="flex items-center justify-center rounded-md"
                   style={{
                     width: 48,
                     height: 32,
                     background: isActive
                       ? 'linear-gradient(135deg, color-mix(in srgb, var(--agent-accent, #16a34a) 15%, transparent), color-mix(in srgb, var(--agent-accent, #16a34a) 5%, transparent))'
-                      : 'linear-gradient(135deg, var(--theme-bg-muted), var(--theme-bg-subtle))',
+                      : 'linear-gradient(135deg, var(--surface-sunken), var(--surface-raised))',
                     border: isActive
                       ? '1px solid color-mix(in srgb, var(--agent-accent, #16a34a) 20%, transparent)'
-                      : '1px solid var(--theme-border)',
+                      : '1px solid var(--border-subtle)',
                   }}
                 >
                   {isActive && (
-                    <Check size={16} style={{ color: 'var(--agent-accent, #16a34a)' }} />
+                    /* 选中勾是状态图标，accent 作文字 —— 用 text-safe 变体。 */
+                    <Check size={16} className="text-agent-accent" />
                   )}
                 </div>
                 <span
-                  className="text-[15px] font-medium leading-tight"
+                  className="text-title font-medium leading-tight"
                   style={{
-                    color: isActive ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-secondary)',
+                    color: isActive ? 'var(--agent-accent)' : 'var(--text-secondary)',
                   }}
                 >
                   {style.name}
                 </span>
-                <span className="text-[14px] text-[var(--theme-text-muted)] leading-tight">
+                <span className="text-body leading-tight text-ink-muted">
                   {style.desc}
                 </span>
               </button>
@@ -103,10 +104,10 @@ export function MapConfig() {
 
       {/* Add custom basemap */}
       <div>
-        <div className="text-[15px] uppercase tracking-wider text-[var(--theme-text-muted)] font-semibold mb-3">
+        <div className="text-heading uppercase tracking-wider text-ink-muted font-semibold mb-3">
           Add Custom Basemap
         </div>
-        <div className="flex flex-col gap-2.5 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-4 py-3">
+        <div className="flex flex-col gap-2.5 rounded-md border border-edge-subtle bg-surface-raised px-4 py-3">
           <SField
             label="Name"
             value={newName}
@@ -135,7 +136,7 @@ export function MapConfig() {
 
       {/* CRS selection */}
       <div>
-        <div className="text-[15px] uppercase tracking-wider text-[var(--theme-text-muted)] font-semibold mb-3">
+        <div className="text-heading uppercase tracking-wider text-ink-muted font-semibold mb-3">
           Coordinate Reference System
         </div>
         <div className="flex gap-2">
@@ -145,28 +146,28 @@ export function MapConfig() {
               <button
                 key={opt.code}
                 onClick={() => setCrs(opt.code)}
-                className="flex-1 flex flex-col items-center gap-0.5 rounded-lg border-2 py-2 px-2 transition-all"
+                className="flex flex-1 flex-col items-center gap-0.5 rounded-md border-2 px-2 py-2 transition-all"
                 style={{
                   borderColor: isActive
                     ? 'var(--agent-accent, #16a34a)'
-                    : 'var(--theme-border)',
+                    : 'var(--border-subtle)',
                   backgroundColor: isActive
                     ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 4%, transparent)'
-                    : 'var(--theme-bg-subtle)',
+                    : 'var(--surface-raised)',
                 }}
               >
                 <span
-                  className="text-[14px] font-mono font-semibold"
+                  className="text-title font-mono font-semibold"
                   style={{
-                    color: isActive ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-secondary)',
+                    color: isActive ? 'var(--agent-accent)' : 'var(--text-secondary)',
                   }}
                 >
                   {opt.code}
                 </span>
                 <span
-                  className="text-[14px]"
+                  className="text-body"
                   style={{
-                    color: isActive ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-muted)',
+                    color: isActive ? 'var(--agent-accent)' : 'var(--text-muted)',
                   }}
                 >
                   {opt.label}

--- a/frontend/components/settings/rag-config.tsx
+++ b/frontend/components/settings/rag-config.tsx
@@ -60,11 +60,11 @@ export function RagConfig() {
 
       {/* Spatial index section */}
       <div>
-        <div className="text-[15px] uppercase tracking-wider text-[var(--theme-text-muted)] font-semibold mb-2">
+        <div className="text-heading uppercase tracking-wider text-ink-muted font-semibold mb-2">
           Spatial Index
         </div>
         {ragSpatial.length === 0 ? (
-          <div className="text-[15px] text-[var(--theme-text-subtle)] italic py-2">
+          <div className="text-body text-ink-muted italic py-2">
             No spatial documents indexed yet
           </div>
         ) : (
@@ -72,30 +72,30 @@ export function RagConfig() {
             {ragSpatial.map((doc) => (
               <div
                 key={doc.id}
-                className="flex items-center gap-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-3 py-2"
+                className="flex items-center gap-3 rounded-md border border-edge-subtle bg-surface-raised px-3 py-2"
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <span className="text-[14px] font-medium text-[var(--theme-text-primary)]">
+                    <span className="text-body font-medium text-ink">
                       {doc.name}
                     </span>
-                    <span className="text-[14px] text-[var(--theme-text-muted)] bg-[var(--theme-bg-muted)] rounded px-1.5 py-0.5">
+                    <span className="rounded-sm bg-surface-sunken px-1.5 py-0.5 text-body text-ink-muted">
                       {doc.type}
                     </span>
                   </div>
-                  <div className="text-[14px] text-[var(--theme-text-muted)] mt-0.5">
+                  <div className="text-body text-ink-muted mt-0.5">
                     {doc.features !== null && `${doc.features} features`}
                     {doc.features !== null && ' · '}
                     {doc.size}
                   </div>
                 </div>
                 <span
-                  className="text-[14px] font-medium rounded-full px-1.5 py-0.5"
+                  className="rounded-pill px-1.5 py-0.5 text-body font-medium"
                   style={{
                     backgroundColor: doc.indexed
                       ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 10%, transparent)'
-                      : 'var(--theme-bg-muted)',
-                    color: doc.indexed ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-muted)',
+                      : 'var(--surface-sunken)',
+                    color: doc.indexed ? 'var(--agent-accent)' : 'var(--text-muted)',
                   }}
                 >
                   {doc.indexed ? 'Indexed' : 'Pending'}
@@ -108,11 +108,11 @@ export function RagConfig() {
 
       {/* Semantic index section */}
       <div>
-        <div className="text-[15px] uppercase tracking-wider text-[var(--theme-text-muted)] font-semibold mb-2">
+        <div className="text-heading uppercase tracking-wider text-ink-muted font-semibold mb-2">
           Semantic Index
         </div>
         {ragSemantic.length === 0 ? (
-          <div className="text-[15px] text-[var(--theme-text-subtle)] italic py-2">
+          <div className="text-body text-ink-muted italic py-2">
             No semantic documents indexed yet
           </div>
         ) : (
@@ -120,28 +120,28 @@ export function RagConfig() {
             {ragSemantic.map((doc) => (
               <div
                 key={doc.id}
-                className="flex items-center gap-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-3 py-2"
+                className="flex items-center gap-3 rounded-md border border-edge-subtle bg-surface-raised px-3 py-2"
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <span className="text-[14px] font-medium text-[var(--theme-text-primary)]">
+                    <span className="text-body font-medium text-ink">
                       {doc.name}
                     </span>
-                    <span className="text-[14px] text-[var(--theme-text-muted)]">
+                    <span className="text-body text-ink-muted">
                       {doc.chunks} chunks
                     </span>
                   </div>
-                  <div className="text-[14px] text-[var(--theme-text-muted)] mt-0.5">
+                  <div className="text-body text-ink-muted mt-0.5">
                     {doc.size}
                   </div>
                 </div>
                 <span
-                  className="text-[14px] font-medium rounded-full px-1.5 py-0.5"
+                  className="rounded-pill px-1.5 py-0.5 text-body font-medium"
                   style={{
                     backgroundColor: doc.indexed
                       ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 10%, transparent)'
-                      : 'var(--theme-bg-muted)',
-                    color: doc.indexed ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-muted)',
+                      : 'var(--surface-sunken)',
+                    color: doc.indexed ? 'var(--agent-accent)' : 'var(--text-muted)',
                   }}
                 >
                   {doc.indexed ? 'Indexed' : 'Pending'}
@@ -154,18 +154,18 @@ export function RagConfig() {
 
       {/* Retrieval config */}
       <div>
-        <div className="text-[15px] uppercase tracking-wider text-[var(--theme-text-muted)] font-semibold mb-3">
+        <div className="text-heading uppercase tracking-wider text-ink-muted font-semibold mb-3">
           Retrieval Config
         </div>
 
-        <div className="flex flex-col gap-4 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-4 py-3">
+        <div className="flex flex-col gap-4 rounded-md border border-edge-subtle bg-surface-raised px-4 py-3">
           {/* Spatial weight slider */}
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <span className="text-[15px] text-[var(--theme-text-secondary)]">
+              <span className="text-body text-ink-secondary">
                 Spatial Weight
               </span>
-              <span className="text-[15px] font-mono text-[var(--theme-text-secondary)]">
+              <span className="text-body font-mono text-ink-secondary">
                 {ragConfig.spatialWeight}%
               </span>
             </div>
@@ -177,9 +177,9 @@ export function RagConfig() {
               onChange={(e) =>
                 setRagConfig({ spatialWeight: Number(e.target.value) })
               }
-              className="w-full h-1.5 rounded-full appearance-none cursor-pointer"
+              className="slider-track h-1.5 w-full"
               style={{
-                background: `linear-gradient(to right, var(--agent-accent, #16a34a) ${ragConfig.spatialWeight}%, var(--theme-border-subtle) ${ragConfig.spatialWeight}%)`,
+                background: `linear-gradient(to right, var(--agent-accent, #16a34a) ${ragConfig.spatialWeight}%, var(--border-subtle) ${ragConfig.spatialWeight}%)`,
               }}
             />
           </div>
@@ -187,7 +187,7 @@ export function RagConfig() {
           {/* Top K */}
           <div>
             <div className="flex items-center justify-between mb-1">
-              <span className="text-[15px] text-[var(--theme-text-secondary)]">Top K</span>
+              <span className="text-body text-ink-secondary">Top K</span>
             </div>
             <input
               type="number"
@@ -197,19 +197,20 @@ export function RagConfig() {
               onChange={(e) =>
                 setRagConfig({ topK: Number(e.target.value) })
               }
-              className="w-20 rounded bg-[var(--theme-bg-input)] border border-[var(--theme-border)] px-2 py-1 text-[14px] font-mono text-[var(--theme-text-primary)] focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
+              className="w-20 rounded-sm border border-edge-subtle bg-surface-sunken px-2 py-1 text-body font-mono text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
             />
           </div>
 
           {/* Rerank toggle */}
           <div className="flex items-center justify-between">
             <div>
-              <span className="text-[15px] text-[var(--theme-text-secondary)]">Rerank</span>
-              <span className="text-[14px] text-[var(--theme-text-muted)] ml-1">
+              <span className="text-body text-ink-secondary">Rerank</span>
+              <span className="text-body text-ink-muted ml-1">
                 Cross-encoder reranking
               </span>
             </div>
             <ToggleSwitch
+              label="Rerank（交叉编码器重排序）"
               checked={ragConfig.rerank}
               onChange={() =>
                 setRagConfig({ rerank: !ragConfig.rerank })
@@ -221,10 +222,10 @@ export function RagConfig() {
 
       {/* Vector DB connection */}
       <div>
-        <div className="text-[15px] uppercase tracking-wider text-[var(--theme-text-muted)] font-semibold mb-3">
+        <div className="text-heading uppercase tracking-wider text-ink-muted font-semibold mb-3">
           Vector DB Connection
         </div>
-        <div className="flex flex-col gap-3 rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-4 py-3">
+        <div className="flex flex-col gap-3 rounded-md border border-edge-subtle bg-surface-raised px-4 py-3">
           <SField
             label="Address"
             value={vectorDb}
@@ -241,17 +242,17 @@ export function RagConfig() {
             <button
               onClick={handleTestConnection}
               disabled={testing}
-              className="inline-flex items-center gap-1.5 rounded px-3 py-1 text-[15px] font-medium border border-[var(--theme-border)] bg-[var(--theme-bg-input)] text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-hover)] transition-all disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-sm border border-edge-subtle bg-surface-sunken px-3 py-1 text-body font-medium text-ink-secondary transition-all hover:bg-surface-hover disabled:opacity-50"
             >
               {testing ? 'Testing...' : 'Test Connection'}
             </button>
             {testResult === 'success' && (
-              <span className="text-[15px] font-medium text-emerald-600 dark:text-emerald-300">
+              <span className="text-body font-medium text-status-success">
                 Connected
               </span>
             )}
             {testResult === 'error' && (
-              <span className="text-[15px] font-medium text-red-600 dark:text-red-400">
+              <span className="text-body font-medium text-status-critical">
                 Failed
               </span>
             )}

--- a/frontend/components/settings/settings-panel.tsx
+++ b/frontend/components/settings/settings-panel.tsx
@@ -117,7 +117,7 @@ export function SettingsPanel() {
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 z-[100] bg-slate-900/20 backdrop-blur-sm"
+        className="fixed inset-0 z-[100] bg-surface-scrim"
         onClick={() => setSettingsOpen(false)}
       />
 
@@ -128,29 +128,28 @@ export function SettingsPanel() {
         aria-modal="true"
         aria-labelledby="settings-panel-title"
         tabIndex={-1}
+        /* 宽度走 --drawer-w（见 globals.css）：约束是"地图仍然可见"，
+           两个右侧抽屉共用同一条规则。 */
         className="fixed inset-y-0 right-0 z-[101] flex animate-slide-from-right"
-        style={{ width: 'min(720px, 92vw)' }}
+        style={{ width: 'var(--drawer-w)' }}
       >
+        {/* E: 抽屉本体之前有两处 backdrop-filter: blur(32px)（左栏 + 内容区）。
+            backdrop 压在持续重绘的地图画布上是最贵的那类合成，而且 scrim 已经
+            盖住地图 —— 全部移除，改不透明 surface-panel + shadow-drawer。 */}
         {/* Left nav rail */}
         <nav
           aria-label="设置分类"
-          className="flex flex-col border-r py-4"
+          className="flex flex-col border-r border-edge-subtle bg-surface-panel py-4"
           style={{
             width: 136,
             flexShrink: 0,
-            borderColor: 'var(--theme-border)',
-            background: 'var(--theme-bg-panel)',
-            backdropFilter: 'blur(32px)',
-            WebkitBackdropFilter: 'blur(32px)',
           }}
         >
           {/* Header mini */}
           <div className="px-4 mb-4">
             <div className="flex items-center gap-1.5">
-              <ShieldCheck size={14} style={{ color: 'var(--agent-accent, #16a34a)' }} />
-              <span className="text-[14px] font-semibold" style={{ color: 'var(--theme-text-primary)' }}>
-                控制中心
-              </span>
+              <ShieldCheck size={14} className="text-agent-accent" />
+              <span className="text-title font-semibold text-ink">控制中心</span>
             </div>
           </div>
 
@@ -166,112 +165,92 @@ export function SettingsPanel() {
               const Icon = item.icon;
               const isActive = settingsTab === item.key;
               return (
+                /* 选中项的 label/icon 是 accent 作文字，暗色下 2.96–3.40:1 ——
+                   改用主题校正后的 --agent-accent；底色同源，
+                   --agent-accent。 */
                 <button
-                  key={item.key}
-                  ref={(el) => {
-                    if (el) tabRefs.current.set(item.key, el);
-                    else tabRefs.current.delete(item.key);
-                  }}
-                  role="tab"
-                  id={`settings-tab-${item.key}`}
-                  aria-selected={isActive}
-                  aria-controls="settings-tabpanel"
-                  tabIndex={isActive ? 0 : -1}
-                  onClick={() => setSettingsTab(item.key)}
-                  className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-all duration-150"
-                  style={{
-                    backgroundColor: isActive
-                      ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 10%, transparent)'
-                      : 'transparent',
-                    color: isActive ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-secondary)',
-                  }}
-                >
-                  <Icon
-                    size={16}
-                    style={{
-                      color: isActive ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-muted)',
+                    key={item.key}
+                    ref={(el) => {
+                      if (el) tabRefs.current.set(item.key, el);
+                      else tabRefs.current.delete(item.key);
                     }}
-                  />
-                  <span
-                    className="text-[13px] font-medium truncate flex-1"
-                    style={{ color: isActive ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-secondary)' }}
+                    role="tab"
+                    id={`settings-tab-${item.key}`}
+                    aria-selected={isActive}
+                    aria-controls="settings-tabpanel"
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => setSettingsTab(item.key)}
+                    className="flex items-center gap-2 rounded-md px-2.5 py-2 text-left transition-all duration-150"
+                    style={{
+                      backgroundColor: isActive
+                        ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 10%, transparent)'
+                        : 'transparent',
+                      color: isActive ? 'var(--agent-accent)' : 'var(--text-secondary)',
+                    }}
                   >
-                    {item.label}
-                  </span>
-                  {item.count !== undefined && item.count > 0 && (
-                    <span
-                      className="text-[11px] font-bold rounded-full px-1.5 leading-tight"
+                    <Icon
+                      size={16}
                       style={{
-                        backgroundColor: isActive
-                          ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 14%, transparent)'
-                          : 'var(--theme-bg-muted)',
-                        color: isActive ? 'var(--agent-accent, #16a34a)' : 'var(--theme-text-muted)',
-                        minWidth: 18,
-                        textAlign: 'center',
+                        color: isActive ? 'var(--agent-accent)' : 'var(--text-muted)',
                       }}
+                    />
+                    <span
+                      className="text-body font-medium truncate flex-1"
+                      style={{ color: isActive ? 'var(--agent-accent)' : 'var(--text-secondary)' }}
                     >
-                      {item.count}
+                      {item.label}
                     </span>
-                  )}
-                </button>
+                    {item.count !== undefined && item.count > 0 && (
+                      <span
+                        className="text-caption font-bold rounded-pill px-1.5 leading-tight"
+                        style={{
+                          backgroundColor: isActive
+                            ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 14%, transparent)'
+                            : 'var(--surface-sunken)',
+                          color: isActive ? 'var(--agent-accent)' : 'var(--text-muted)',
+                          minWidth: 18,
+                          textAlign: 'center',
+                        }}
+                      >
+                        {item.count}
+                      </span>
+                    )}
+                  </button>
               );
             })}
           </div>
         </nav>
 
         {/* Right content area */}
-        <div
-          className="flex flex-col flex-1"
-          style={{
-            background: 'var(--theme-bg-panel)',
-            backdropFilter: 'blur(32px)',
-            WebkitBackdropFilter: 'blur(32px)',
-            boxShadow: '-8px 0 48px rgba(15,23,42,0.12)',
-          }}
-        >
+        <div className="flex flex-1 flex-col bg-surface-panel shadow-drawer">
           {/* Header */}
-          <div
-            className="flex items-center justify-between px-6 py-4 border-b"
-            style={{ borderColor: 'var(--theme-border)' }}
-          >
+          <div className="flex items-center justify-between border-b border-edge-subtle px-6 py-4">
             <div className="flex items-center gap-3">
               <div
-                className="flex items-center justify-center rounded-xl"
+                className="flex h-9 w-9 items-center justify-center rounded-md"
                 style={{
-                  width: 36,
-                  height: 36,
                   background:
                     'linear-gradient(135deg, var(--agent-accent, #16a34a) 0%, color-mix(in srgb, var(--agent-accent, #16a34a) 72%, #ffffff) 100%)',
                 }}
               >
-                <Settings size={18} className="text-white" />
+                <Settings size={18} className="text-ink-on-accent" />
               </div>
               <div>
-                <div
-                  id="settings-panel-title"
-                  className="text-[14px] font-bold leading-tight"
-                  style={{ color: 'var(--theme-text-primary)' }}
-                >
+                <div id="settings-panel-title" className="text-title font-bold leading-tight text-ink">
                   Agent 控制中心
                 </div>
-                <div className="text-[12px] leading-tight" style={{ color: 'var(--theme-text-muted)' }}>
-                  Agent Command Center
-                </div>
+                <div className="text-meta leading-tight text-ink-muted">Agent Command Center</div>
               </div>
               <span
-                className="ml-2 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[12px] font-medium"
+                className="ml-2 inline-flex items-center gap-1 rounded-pill px-2 py-0.5 text-meta font-medium"
                 style={{
                   backgroundColor: 'color-mix(in srgb, var(--agent-accent, #16a34a) 10%, transparent)',
-                  color: 'var(--agent-accent, #16a34a)',
+                  color: 'var(--agent-accent)',
                 }}
               >
                 <span
-                  className="inline-block rounded-full"
-                  style={{
-                    width: 6,
-                    height: 6,
-                    backgroundColor: 'var(--agent-accent, #16a34a)',
-                  }}
+                  className="inline-block h-1.5 w-1.5 rounded-full"
+                  style={{ backgroundColor: 'var(--agent-accent, #16a34a)' }}
                 />
                 系统在线
               </span>
@@ -280,8 +259,7 @@ export function SettingsPanel() {
             <button
               onClick={() => setSettingsOpen(false)}
               aria-label="关闭设置"
-              className="flex items-center justify-center rounded-lg w-8 h-8 transition-colors hover:bg-[var(--theme-bg-hover)]"
-              style={{ color: 'var(--theme-text-muted)' }}
+              className="flex h-8 w-8 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-surface-hover"
             >
               <X size={18} />
             </button>

--- a/frontend/components/settings/skills-hub.tsx
+++ b/frontend/components/settings/skills-hub.tsx
@@ -70,29 +70,30 @@ export function SkillsHub() {
 
       {sortedCategories.map((category) => (
         <div key={category}>
-          <div className="text-[15px] uppercase tracking-wider text-[var(--theme-text-muted)] font-semibold mb-2">
+          <div className="text-heading uppercase tracking-wider text-ink-muted font-semibold mb-2">
             {category}
           </div>
           <div className="flex flex-col gap-1.5">
             {grouped[category].map((sk) => (
               <div
                 key={sk.id}
-                className="flex items-center gap-3 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-3 py-2.5 transition-all"
+                className="flex items-center gap-3 rounded-md border border-edge-subtle bg-surface-raised px-3 py-2.5 transition-all"
                 style={{
                   opacity: sk.enabled ? 1 : 0.55,
                 }}
               >
                 {/* Name + badge */}
                 <div className="flex items-center gap-2 min-w-0 flex-1">
-                  <span className="text-[14px] font-medium text-[var(--theme-text-primary)] truncate">
+                  <span className="text-body font-medium text-ink truncate">
                     {sk.name}
                   </span>
                   {sk.calls > 0 && (
                     <span
-                      className="text-[14px] font-bold rounded-full px-1.5 py-0.5 leading-none"
+                      className="rounded-pill px-1.5 py-0.5 text-body font-bold leading-none"
                       style={{
                         backgroundColor: 'color-mix(in srgb, var(--agent-accent, #16a34a) 8%, transparent)',
-                        color: 'var(--agent-accent, #16a34a)',
+                        /* 计数是 accent 作文字（状态数字）—— 用 text-safe 变体。 */
+                        color: 'var(--agent-accent)',
                       }}
                     >
                       {sk.calls}
@@ -101,12 +102,13 @@ export function SkillsHub() {
                 </div>
 
                 {/* Description */}
-                <div className="text-[15px] text-[var(--theme-text-muted)] truncate flex-1">
+                <div className="text-body text-ink-muted truncate flex-1">
                   {sk.desc}
                 </div>
 
                 {/* Toggle */}
                 <ToggleSwitch
+                  label={`启用技能：${sk.name}`}
                   checked={sk.enabled}
                   onChange={() => toggleSkill(sk.id)}
                 />
@@ -117,7 +119,7 @@ export function SkillsHub() {
       ))}
 
       {/* Upload custom skill */}
-      <button className="flex items-center justify-center gap-2 rounded-xl border-2 border-dashed border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] py-3 text-[14px] font-medium text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)] hover:border-[var(--theme-border-strong)] transition-all">
+      <button className="flex items-center justify-center gap-2 rounded-md border-2 border-dashed border-edge-subtle bg-surface-raised py-3 text-body font-medium text-ink-muted transition-all hover:border-edge-strong hover:text-ink-secondary">
         <svg
           width="14"
           height="14"

--- a/frontend/components/settings/system-settings.tsx
+++ b/frontend/components/settings/system-settings.tsx
@@ -23,28 +23,28 @@ export function SystemSettings() {
 
       {/* Backend API URL — read-only, determined at build time */}
       <div>
-        <div className="text-[14px] uppercase tracking-wide text-[var(--theme-text-muted)] font-medium mb-2">
+        <div className="text-title uppercase tracking-wide text-ink-muted font-medium mb-2">
           Backend API URL
         </div>
         <div
-          className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-input)] px-3 py-2 text-[14px] font-mono text-[var(--theme-text-secondary)]"
+          className="rounded-md border border-edge-subtle bg-surface-sunken px-3 py-2 text-body font-mono text-ink-secondary"
           aria-label="后端 API 地址（只读，由构建时环境变量决定）"
         >
           {API_BASE}
         </div>
-        <div className="text-[15px] text-[var(--theme-text-muted)] mt-1">
-          由 <code className="text-[15px] text-[var(--theme-text-secondary)]">NEXT_PUBLIC_API_URL</code> 环境变量在构建时确定，运行时不可修改。
+        <div className="text-body text-ink-muted mt-1">
+          由 <code className="text-body text-ink-secondary">NEXT_PUBLIC_API_URL</code> 环境变量在构建时确定，运行时不可修改。
         </div>
       </div>
 
       {/* Language selection — disabled, i18n not yet implemented */}
       <div>
         <div className="flex items-center gap-2 mb-2">
-          <span className="text-[14px] uppercase tracking-wide text-[var(--theme-text-muted)] font-medium">
+          <span className="text-title uppercase tracking-wide text-ink-muted font-medium">
             Language / 语言
           </span>
           <span
-            className="text-[14px] rounded-full px-1.5 py-0.5 bg-[var(--theme-bg-muted)] text-[var(--theme-text-muted)] font-medium"
+            className="rounded-pill bg-surface-sunken px-1.5 py-0.5 text-body font-medium text-ink-muted"
             title="国际化系统尚未实现"
           >
             规划中
@@ -53,23 +53,18 @@ export function SystemSettings() {
         <div className="flex gap-2 opacity-50" aria-disabled="true">
           <button
             disabled
-            className="flex-1 rounded-lg border-2 py-2 text-[14px] font-medium cursor-not-allowed"
+            className="flex-1 cursor-not-allowed rounded-md border-2 py-2 text-body font-medium"
             style={{
               borderColor: 'var(--agent-accent, #16a34a)',
               backgroundColor: 'color-mix(in srgb, var(--agent-accent, #16a34a) 4%, transparent)',
-              color: 'var(--agent-accent, #16a34a)',
+              color: 'var(--agent-accent)',
             }}
           >
             中文
           </button>
           <button
             disabled
-            className="flex-1 rounded-lg border-2 py-2 text-[14px] font-medium cursor-not-allowed"
-            style={{
-              borderColor: 'var(--theme-border)',
-              backgroundColor: 'var(--theme-bg-subtle)',
-              color: 'var(--theme-text-secondary)',
-            }}
+            className="flex-1 cursor-not-allowed rounded-md border-2 border-edge-subtle bg-surface-raised py-2 text-body font-medium text-ink-secondary"
           >
             English
           </button>
@@ -77,13 +72,11 @@ export function SystemSettings() {
       </div>
 
       {/* About section — version from build-time injection */}
-      <div className="rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-4 py-3">
+      <div className="rounded-md border border-edge-subtle bg-surface-raised px-4 py-3">
         <div className="flex items-center gap-2.5 mb-2">
           <div
-            className="flex items-center justify-center rounded-lg"
+            className="flex h-7 w-7 items-center justify-center rounded-md"
             style={{
-              width: 28,
-              height: 28,
               background:
                 'linear-gradient(135deg, var(--agent-accent, #16a34a) 0%, color-mix(in srgb, var(--agent-accent, #16a34a) 72%, #ffffff) 100%)',
             }}
@@ -93,7 +86,7 @@ export function SystemSettings() {
               height="14"
               viewBox="0 0 24 24"
               fill="none"
-              stroke="white"
+              stroke="var(--text-on-accent)"
               strokeWidth="2.5"
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -103,15 +96,15 @@ export function SystemSettings() {
             </svg>
           </div>
           <div>
-            <div className="text-[15px] font-bold text-[var(--theme-text-primary)]">
+            <div className="text-heading font-bold text-ink">
               GeoAgent
             </div>
-            <div className="text-[14px] text-[var(--theme-text-muted)] font-mono">
+            <div className="text-body font-mono text-ink-muted">
               v{process.env.NEXT_PUBLIC_APP_VERSION || '0.1.2'}
             </div>
           </div>
         </div>
-        <div className="text-[15px] text-[var(--theme-text-muted)] italic">
+        <div className="text-body text-ink-muted italic">
           &quot;All is Agent&quot;
         </div>
       </div>

--- a/frontend/components/shared/confirm-action.tsx
+++ b/frontend/components/shared/confirm-action.tsx
@@ -6,6 +6,9 @@
  * 把 map-studio 的 2-step confirm + 3s 自动还原 + blur 取消泛化，
  * 替代原生 confirm()（project/data-sources）与无确认删除（ops-log）。
  * 危险操作默认红色语义。
+ *
+ * UI V4：配色改用 --critical token，与 StatusBadge / InlineNotice 的
+ * critical 语义同源。
  */
 import { useEffect, useRef, useState, type ButtonHTMLAttributes } from 'react';
 import clsx from 'clsx';
@@ -48,10 +51,10 @@ export function ConfirmAction({
       type="button"
       aria-label={confirming ? confirmLabel : label}
       className={clsx(
-        'rounded-md px-2 py-1 text-[11px] font-medium transition-colors',
+        'rounded-sm px-2 py-0.5 text-caption font-medium transition-colors',
         confirming
-          ? 'bg-red-500/15 text-red-600 hover:bg-red-500/25 dark:text-red-300'
-          : 'text-[var(--theme-text-muted)] hover:bg-red-500/10 hover:text-red-500',
+          ? 'bg-status-critical-soft text-status-critical hover:brightness-110'
+          : 'text-ink-muted hover:bg-status-critical-soft hover:text-status-critical',
         className
       )}
       onClick={(e) => {

--- a/frontend/components/shared/empty-state.tsx
+++ b/frontend/components/shared/empty-state.tsx
@@ -5,8 +5,11 @@
  *
  * 收敛审计发现的 4+ 种发散空状态（hero / 裸文本行 / 斜体盒）。
  * 可选 action 用于跨面板引导（如 图层空 → 前往数据源）。
+ *
+ * UI V4：icon tile 与 PanelHeader/LoadingState 共用同一配方，文字落到 token 刻度。
  */
 import type { LucideIcon } from 'lucide-react';
+import { ACCENT_TILE_CLASS } from './panel-header';
 
 export interface EmptyStateProps {
   icon: LucideIcon;
@@ -18,21 +21,16 @@ export interface EmptyStateProps {
 export function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center px-6 py-10 text-center">
-      <span
-        aria-hidden
-        className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl"
-        style={{ background: 'color-mix(in srgb, var(--agent-accent, #16a34a) 10%, transparent)' }}
-      >
-        <Icon size={18} style={{ color: 'var(--agent-accent, #16a34a)' }} />
+      <span aria-hidden className={`${ACCENT_TILE_CLASS} mb-3 h-control-lg w-control-lg`}>
+        <Icon size={16} className="text-status-accent" />
       </span>
-      <p className="text-[13px] font-medium text-[var(--theme-text-secondary)]">{title}</p>
-      {description && <p className="mt-1 text-[12px] leading-relaxed text-[var(--theme-text-muted)]">{description}</p>}
+      <p className="text-body font-medium text-ink-secondary">{title}</p>
+      {description && <p className="mt-1 text-meta text-ink-muted">{description}</p>}
       {action && (
         <button
           type="button"
           onClick={action.onClick}
-          className="mt-3 rounded-md px-3 py-1.5 text-[12px] font-medium text-white transition-opacity hover:opacity-85"
-          style={{ background: 'var(--agent-accent, #16a34a)' }}
+          className="mt-3 rounded-sm bg-status-accent px-3 py-1 text-meta font-medium text-ink-on-accent transition-opacity hover:opacity-85"
         >
           {action.label}
         </button>

--- a/frontend/components/shared/icon-button.tsx
+++ b/frontend/components/shared/icon-button.tsx
@@ -4,24 +4,41 @@
  * IconButton — 统一图标按钮（UI V3 shared primitive）。
  *
  * - `label` 必填：同时作为 aria-label 与 title（tooltip），杜绝无名字图标按钮。
- * - 28×28、主题变量着色、hover 有底色；`active` 时用 accent 色。
+ * - 主题变量着色、hover 有底色；`active` 时用 accent 色。
+ *
+ * UI V4 三处收敛：
+ * 1. `size` 取代逐处手写的 h-6/h-7/h-8。dense 列表用 `sm`：审计发现图层行的
+ *    59px 行高其实是被两颗 28px 操作按钮撑起来的（图标本身只有 12px）。
+ * 2. 补上 disabled 视觉 —— 之前 disabled 与 enabled 完全同貌。
+ * 3. 图标尺寸落到 --icon-* 三档，替代原先 12 个散落的 px 值。
  */
 import { forwardRef, type ButtonHTMLAttributes } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
 
+export type IconButtonSize = 'sm' | 'md' | 'lg';
+
 export interface IconButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
   label: string;
   icon: LucideIcon;
-  /** 图标 px 尺寸，默认 15 */
+  /** 图标 px 尺寸；默认跟随 size */
   iconSize?: number;
+  size?: IconButtonSize;
   active?: boolean;
   /** danger：hover 呈红色（删除类操作） */
   variant?: 'ghost' | 'danger';
 }
 
+const SIZE_CLASS: Record<IconButtonSize, string> = {
+  sm: 'h-control-sm w-control-sm',
+  md: 'h-control-md w-control-md',
+  lg: 'h-control-lg w-control-lg',
+};
+
+const DEFAULT_ICON_PX: Record<IconButtonSize, number> = { sm: 12, md: 14, lg: 16 };
+
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(function IconButton(
-  { label, icon: Icon, iconSize = 15, active = false, variant = 'ghost', className, style, type, ...rest },
+  { label, icon: Icon, iconSize, size = 'md', active = false, variant = 'ghost', className, type, disabled, ...rest },
   ref
 ) {
   return (
@@ -31,22 +48,20 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(functio
       aria-label={label}
       title={label}
       aria-pressed={active || undefined}
+      disabled={disabled}
       className={clsx(
-        'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors',
-        variant === 'danger' ? 'hover:bg-red-500/10 hover:text-red-500' : 'hover:bg-[var(--theme-bg-hover)]',
+        'inline-flex shrink-0 items-center justify-center rounded-sm transition-colors',
+        SIZE_CLASS[size],
+        active ? 'bg-status-accent-soft text-status-accent' : 'text-ink-secondary',
+        variant === 'danger' && !active && 'text-ink-muted',
+        !disabled && variant === 'danger' && 'hover:bg-status-critical-soft hover:text-status-critical',
+        !disabled && variant !== 'danger' && !active && 'hover:bg-surface-hover hover:text-ink',
+        disabled && 'cursor-not-allowed text-ink-disabled hover:bg-transparent',
         className
       )}
-      style={{
-        color: active
-          ? 'var(--agent-accent, #16a34a)'
-          : variant === 'danger'
-            ? 'var(--theme-text-muted)'
-            : 'var(--theme-text-secondary)',
-        ...style,
-      }}
       {...rest}
     >
-      <Icon size={iconSize} strokeWidth={active ? 2.2 : 1.7} aria-hidden />
+      <Icon size={iconSize ?? DEFAULT_ICON_PX[size]} strokeWidth={active ? 2.2 : 1.7} aria-hidden />
     </button>
   );
 });

--- a/frontend/components/shared/inline-notice.tsx
+++ b/frontend/components/shared/inline-notice.tsx
@@ -4,31 +4,22 @@
  * InlineNotice — 统一内联提示条（UI V3 shared primitive）。
  *
  * error 使用 role=alert（断言式），其余 role=status（礼貌播报）。
- * 颜色全部 dark-safe（Tailwind dark: 变体）。
+ *
+ * UI V4：配色改为复用 StatusBadge 的同一批语义 token，因此提示条与徽标在同屏
+ * 出现时是同一套颜色语言（此前两者各写一套 Tailwind 调色板 + dark: 变体）。
  */
 import type { ReactNode } from 'react';
 import { AlertCircle, AlertTriangle, CheckCircle2, Info } from 'lucide-react';
 import clsx from 'clsx';
+import { STATUS_TONE, type StatusTone } from './status-badge';
 
 export type InlineNoticeVariant = 'error' | 'warning' | 'info' | 'success';
 
-const VARIANT_STYLE: Record<InlineNoticeVariant, { className: string; Icon: typeof Info }> = {
-  error: {
-    className: 'border-red-500/25 bg-red-500/10 text-red-600 dark:text-red-300',
-    Icon: AlertCircle,
-  },
-  warning: {
-    className: 'border-amber-500/25 bg-amber-500/10 text-amber-600 dark:text-amber-300',
-    Icon: AlertTriangle,
-  },
-  info: {
-    className: 'border-sky-500/25 bg-sky-500/10 text-sky-600 dark:text-sky-300',
-    Icon: Info,
-  },
-  success: {
-    className: 'border-emerald-500/25 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
-    Icon: CheckCircle2,
-  },
+const VARIANT: Record<InlineNoticeVariant, { tone: StatusTone; Icon: typeof Info }> = {
+  error: { tone: 'critical', Icon: AlertCircle },
+  warning: { tone: 'warning', Icon: AlertTriangle },
+  info: { tone: 'info', Icon: Info },
+  success: { tone: 'success', Icon: CheckCircle2 },
 };
 
 export function InlineNotice({
@@ -40,13 +31,17 @@ export function InlineNotice({
   children: ReactNode;
   className?: string;
 }) {
-  const { className: variantClass, Icon } = VARIANT_STYLE[variant];
+  const { tone, Icon } = VARIANT[variant];
   return (
     <div
       role={variant === 'error' ? 'alert' : 'status'}
-      className={clsx('flex items-start gap-2 rounded-md border px-2.5 py-2 text-[12px] leading-relaxed', variantClass, className)}
+      className={clsx(
+        'flex items-start gap-2 rounded-sm border px-2 py-1.5 text-meta',
+        STATUS_TONE[tone],
+        className
+      )}
     >
-      <Icon size={14} className="mt-0.5 shrink-0" aria-hidden />
+      <Icon size={14} className="mt-px shrink-0" aria-hidden />
       <div className="min-w-0 flex-1">{children}</div>
     </div>
   );

--- a/frontend/components/shared/loading-state.tsx
+++ b/frontend/components/shared/loading-state.tsx
@@ -3,14 +3,23 @@
 /**
  * LoadingState — 统一加载占位（UI V3 shared primitive）。
  * 替代各处发散的“正在加载…”裸文本。
+ *
+ * UI V4：垂直节奏与图标尺寸对齐 EmptyState（审计：两者曾是 py-10/py-10 但
+ * 图标 18px vs 14px、文字 13px vs 12px，并排出现时明显不成套）。
  */
 import { Loader2 } from 'lucide-react';
+import { ACCENT_TILE_CLASS } from './panel-header';
 
 export function LoadingState({ label = '正在加载…' }: { label?: string }) {
   return (
-    <div role="status" className="flex items-center justify-center gap-2 px-4 py-10 text-[12px] text-[var(--theme-text-muted)]">
-      <Loader2 size={14} className="animate-spin motion-reduce:animate-none" aria-hidden />
-      <span>{label}</span>
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center px-6 py-10 text-center"
+    >
+      <span aria-hidden className={`${ACCENT_TILE_CLASS} mb-3 h-control-lg w-control-lg`}>
+        <Loader2 size={16} className="animate-spin text-status-accent motion-reduce:animate-none" />
+      </span>
+      <p className="text-body font-medium text-ink-secondary">{label}</p>
     </div>
   );
 }

--- a/frontend/components/shared/panel-header.tsx
+++ b/frontend/components/shared/panel-header.tsx
@@ -5,6 +5,10 @@
  *
  * 替代各 tab 自建的三套发散 header（审计：p-3 大写 / px-3 py-2 / 英文自有样式）。
  * 组成：icon tile + title/description + badge + 右侧 contextual actions + close。
+ *
+ * UI V4：全部改用语义 token（text-title / text-meta / surface-*），并与
+ * EmptyState 共用同一个 accent icon tile 配方 —— 审计发现两处 tile 的 accent
+ * 透明度分别是 12% 与 10%，肉眼可辨的不一致。
  */
 import type { ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
@@ -24,36 +28,31 @@ export interface PanelHeaderProps {
   id?: string;
 }
 
+/** accent 图标底座 —— PanelHeader 与 EmptyState 共用，保证同一视觉配方。 */
+export const ACCENT_TILE_CLASS =
+  'flex shrink-0 items-center justify-center rounded-md bg-status-accent-soft';
+
 export function PanelHeader({ icon: Icon, title, description, badge, actions, onClose, id }: PanelHeaderProps) {
   const showBadge = badge !== undefined && badge !== 0 && badge !== '';
   return (
-    <div
-      className="flex shrink-0 items-center gap-2.5 border-b border-[var(--theme-border)] px-3 py-2.5"
-      style={{ background: 'var(--theme-bg-glass)' }}
-    >
+    <div className="flex shrink-0 items-center gap-2 border-b border-edge-subtle bg-surface-panel px-panel py-2">
       {Icon && (
-        <span
-          aria-hidden
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
-          style={{ background: 'color-mix(in srgb, var(--agent-accent, #16a34a) 12%, transparent)' }}
-        >
-          <Icon size={15} style={{ color: 'var(--agent-accent, #16a34a)' }} />
+        <span aria-hidden className={`${ACCENT_TILE_CLASS} h-control-md w-control-md`}>
+          <Icon size={14} className="text-status-accent" />
         </span>
       )}
       <div className="min-w-0 flex-1 leading-tight">
         <div className="flex items-center gap-1.5">
-          <h2 id={id} className="truncate text-[14px] font-semibold text-[var(--theme-text-primary)]">
+          <h2 id={id} className="truncate text-title font-semibold text-ink">
             {title}
           </h2>
           {showBadge && (
-            <span className="inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-[var(--theme-bg-muted)] px-1 text-[10px] font-semibold text-[var(--theme-text-secondary)]">
+            <span className="inline-flex h-4 min-w-[16px] items-center justify-center rounded-pill bg-surface-sunken px-1 text-micro font-semibold tabular-nums text-ink-secondary">
               {badge}
             </span>
           )}
         </div>
-        {description && (
-          <p className="mt-0.5 truncate text-[12px] text-[var(--theme-text-muted)]">{description}</p>
-        )}
+        {description && <p className="mt-0.5 truncate text-meta text-ink-muted">{description}</p>}
       </div>
       {actions && <div className="flex shrink-0 items-center gap-0.5">{actions}</div>}
       {onClose && <IconButton label="收起面板" icon={X} onClick={onClose} />}

--- a/frontend/components/shared/search-field.tsx
+++ b/frontend/components/shared/search-field.tsx
@@ -5,6 +5,8 @@
  *
  * 收敛审计发现的 3 种发散实现（data-sources 300ms debounce / history 即席 /
  * template-v2 200ms）。受控值 + 可选 debounce；Escape 清空；带清除按钮。
+ *
+ * UI V4：高度/圆角/配色改用 token，与 SField 同一控件刻度。
  */
 import { useEffect, useState } from 'react';
 import { Search, X } from 'lucide-react';
@@ -38,7 +40,7 @@ export function SearchField({ value, onChange, placeholder, debounceMs = 0, 'ari
       <Search
         size={13}
         aria-hidden
-        className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--theme-text-muted)]"
+        className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-ink-muted"
       />
       <input
         type="search"
@@ -56,7 +58,7 @@ export function SearchField({ value, onChange, placeholder, debounceMs = 0, 'ari
             e.stopPropagation();
           }
         }}
-        className="w-full rounded-md border border-[var(--theme-border)] bg-[var(--theme-bg-input)] py-1.5 pl-7 pr-7 text-[13px] text-[var(--theme-text-primary)] placeholder:text-[var(--theme-text-muted)]"
+        className="h-control-lg w-full rounded-sm border border-edge-subtle bg-surface-sunken pl-7 pr-7 text-body text-ink placeholder:text-ink-disabled focus:border-status-accent-border focus:outline-none"
       />
       {draft && (
         <button
@@ -66,7 +68,7 @@ export function SearchField({ value, onChange, placeholder, debounceMs = 0, 'ari
             setDraft('');
             onChange('');
           }}
-          className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded text-[var(--theme-text-muted)] hover:bg-[var(--theme-bg-hover)]"
+          className="absolute right-1.5 top-1/2 flex h-control-sm w-control-sm -translate-y-1/2 items-center justify-center rounded-sm text-ink-muted transition-colors hover:bg-surface-hover hover:text-ink"
         >
           <X size={12} aria-hidden />
         </button>

--- a/frontend/components/shared/section-title.tsx
+++ b/frontend/components/shared/section-title.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useId } from 'react';
 
 /* ------------------------------------------------------------------ */
 /*  STitle — section heading with optional subtitle                    */
@@ -14,10 +14,10 @@ interface STitleProps {
 export function STitle({ title, sub }: STitleProps) {
   return (
     <div className="mb-2">
-      <div className="text-[14px] font-semibold text-[var(--theme-text-primary)] leading-tight">{title}</div>
-      {sub && (
-        <div className="text-[15px] text-[var(--theme-text-muted)] mt-0.5 leading-tight">{sub}</div>
-      )}
+      <div className="text-title font-semibold leading-tight text-ink">{title}</div>
+      {/* 审计修复：sub 之前是 15px 而 title 是 14px —— 副标题比标题还大，
+          层级是倒的。现在 sub 明确落在 title 下面一档。 */}
+      {sub && <div className="mt-0.5 text-meta leading-tight text-ink-muted">{sub}</div>}
     </div>
   );
 }
@@ -32,6 +32,8 @@ interface SFieldProps {
   onChange: (v: string) => void;
   type?: 'text' | 'number' | 'password';
   placeholder?: string;
+  /** 补充说明，渲染为 aria-describedby 关联的提示行 */
+  hint?: string;
 }
 
 export function SField({
@@ -40,19 +42,31 @@ export function SField({
   onChange,
   type = 'text',
   placeholder,
+  hint,
 }: SFieldProps) {
+  // a11y 修复（P0）：label 之前只是 input 的兄弟节点，既没有 htmlFor 也没有包裹，
+  // 于是 LLM / RAG / 地图配置里全部 8 个设置项对辅助技术都是「无名输入框」。
+  const inputId = useId();
+  const hintId = `${inputId}-hint`;
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-[14px] uppercase tracking-wide text-[var(--theme-text-muted)] font-medium">
+      <label htmlFor={inputId} className="eyebrow">
         {label}
       </label>
       <input
+        id={inputId}
         type={type}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full rounded bg-[var(--theme-bg-input)] border border-[var(--theme-border)] px-2 py-1 text-[14px] font-mono text-[var(--theme-text-primary)] placeholder:text-[var(--theme-text-subtle)] focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)] transition-shadow"
+        aria-describedby={hint ? hintId : undefined}
+        className="h-control-lg w-full rounded-sm border border-edge-subtle bg-surface-sunken px-2 font-mono text-body text-ink placeholder:text-ink-disabled focus:border-status-accent-border focus:outline-none"
       />
+      {hint && (
+        <p id={hintId} className="text-caption text-ink-muted">
+          {hint}
+        </p>
+      )}
     </div>
   );
 }
@@ -62,53 +76,34 @@ export function SField({
 /* ------------------------------------------------------------------ */
 
 interface SButtonProps {
-  accentColor?: string;
   saved?: boolean;
   onClick: () => void;
   children?: React.ReactNode;
 }
 
-export function SButton({
-  accentColor = '#16a34a',
-  saved = false,
-  onClick,
-  children,
-}: SButtonProps) {
+export function SButton({ saved = false, onClick, children }: SButtonProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center justify-center gap-1.5 rounded px-3 py-1 text-[15px] font-medium text-white transition-all duration-150 hover:brightness-110 active:scale-[0.97]"
-      style={{ backgroundColor: accentColor }}
+      // 文字色用 --text-on-accent 而非白色：白字压在 accent 绿上只有 3.3:1，
+      // 达不到正文 4.5:1。
+      className="inline-flex h-control-lg items-center justify-center gap-1.5 rounded-sm bg-status-accent px-3 text-meta font-medium text-ink-on-accent transition-[filter] duration-150 hover:brightness-110 active:brightness-95"
     >
-      {saved ? (
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="3,8 6.5,11.5 13,4.5" />
-        </svg>
-      ) : (
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 16 16"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M8 2v10M4 8l4 4 4-4" />
-        </svg>
-      )}
-      {children ?? (saved ? 'Saved' : 'Save')}
+      <svg
+        aria-hidden
+        width="12"
+        height="12"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={saved ? 2.5 : 2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {saved ? <polyline points="3,8 6.5,11.5 13,4.5" /> : <path d="M8 2v10M4 8l4 4 4-4" />}
+      </svg>
+      {children ?? (saved ? '已保存' : '保存')}
     </button>
   );
 }

--- a/frontend/components/shared/status-badge.tsx
+++ b/frontend/components/shared/status-badge.tsx
@@ -5,6 +5,13 @@
  *
  * 覆盖任务中心 8 种 JobStatus（ADR-0052）与通用 active/done/error 语义；
  * dark-safe；running/cancelling 带克制的 pulse 点（reduced-motion 下自动关闭）。
+ *
+ * UI V4 —— 这里是整个状态色词汇的唯一出处。审计发现三处矛盾：
+ *   · `active` 在本文件是 sky，在 source-item-card 却映射到 emerald；
+ *   · 「进行中」在 job 语境是蓝色，在 top-bar 的 agent 语境却是绿色；
+ *   · 「成功绿」同时存在 #16a34a / emerald-600 / teal-500 三个值。
+ * 现在四个语义槽（neutral / info / success / warning / critical）各自只有一个
+ * token 三元组，且 in-progress 一律是 info（蓝），成功一律是 success（绿）。
  */
 import clsx from 'clsx';
 
@@ -14,33 +21,44 @@ export interface StatusBadgeProps {
   label?: string;
 }
 
-const STATUS_MAP: Record<string, { label: string; className: string; pulse?: boolean }> = {
-  pending: { label: '等待中', className: 'border-slate-400/30 bg-slate-400/10 text-slate-500 dark:text-slate-300' },
-  queued: { label: '排队中', className: 'border-slate-400/30 bg-slate-400/10 text-slate-500 dark:text-slate-300' },
-  running: { label: '运行中', className: 'border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-300', pulse: true },
-  cancelling: { label: '取消中', className: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-300', pulse: true },
-  completed: { label: '已完成', className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300' },
-  failed: { label: '失败', className: 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-300' },
-  cancelled: { label: '已取消', className: 'border-slate-400/30 bg-slate-400/10 text-slate-500 dark:text-slate-400' },
-  stale: { label: '已过期', className: 'border-orange-500/30 bg-orange-500/10 text-orange-600 dark:text-orange-300' },
+/** 语义槽 → token 类名。徽标是唯一允许成对使用 soft/border 的地方。 */
+export const STATUS_TONE = {
+  neutral: 'border-status-neutral-border bg-status-neutral-soft text-status-neutral',
+  info: 'border-status-info-border bg-status-info-soft text-status-info',
+  success: 'border-status-success-border bg-status-success-soft text-status-success',
+  warning: 'border-status-warning-border bg-status-warning-soft text-status-warning',
+  critical: 'border-status-critical-border bg-status-critical-soft text-status-critical',
+} as const;
+
+export type StatusTone = keyof typeof STATUS_TONE;
+
+const STATUS_MAP: Record<string, { label: string; tone: StatusTone; pulse?: boolean }> = {
+  pending: { label: '等待中', tone: 'neutral' },
+  queued: { label: '排队中', tone: 'neutral' },
+  running: { label: '运行中', tone: 'info', pulse: true },
+  cancelling: { label: '取消中', tone: 'warning', pulse: true },
+  completed: { label: '已完成', tone: 'success' },
+  failed: { label: '失败', tone: 'critical' },
+  cancelled: { label: '已取消', tone: 'neutral' },
+  stale: { label: '已过期', tone: 'warning' },
   // 通用语义（图层 / 数据源同步状态等）
-  active: { label: '活跃', className: 'border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-300', pulse: true },
-  ok: { label: '正常', className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300' },
-  error: { label: '异常', className: 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-300' },
-  unknown: { label: '未知', className: 'border-slate-400/30 bg-slate-400/10 text-slate-500 dark:text-slate-400' },
+  active: { label: '活跃', tone: 'info', pulse: true },
+  ok: { label: '正常', tone: 'success' },
+  error: { label: '异常', tone: 'critical' },
+  unknown: { label: '未知', tone: 'neutral' },
 };
 
 export function StatusBadge({ status, label }: StatusBadgeProps) {
-  const conf = STATUS_MAP[status] ?? { label: label ?? status, className: STATUS_MAP.unknown.className };
+  const conf = STATUS_MAP[status] ?? { label: label ?? status, tone: 'neutral' as StatusTone };
   return (
     <span
       className={clsx(
-        'inline-flex items-center gap-1 whitespace-nowrap rounded-full border px-1.5 py-0.5 text-[10px] font-medium',
-        conf.className
+        'inline-flex items-center gap-1 whitespace-nowrap rounded-pill border px-1.5 py-0.5 text-micro font-medium',
+        STATUS_TONE[conf.tone]
       )}
     >
       {conf.pulse && (
-        <span aria-hidden className="h-1 w-1 animate-pulse rounded-full bg-current motion-reduce:animate-none" />
+        <span aria-hidden className="h-1 w-1 animate-pulse rounded-pill bg-current motion-reduce:animate-none" />
       )}
       {label ?? conf.label}
     </span>

--- a/frontend/components/shared/toggle-switch.tsx
+++ b/frontend/components/shared/toggle-switch.tsx
@@ -5,41 +5,37 @@ import React from 'react';
 interface ToggleSwitchProps {
   checked: boolean;
   onChange: () => void;
-  accentColor?: string;
+  /**
+   * 可访问名称。a11y 修复：此前 role="switch" 有 aria-checked 但完全没有名字，
+   * 于是 LLM / RAG 设置以及技能中心里每一个开关对读屏都是「无名开关」。
+   */
+  label: string;
 }
 
-export default function ToggleSwitch({
-  checked,
-  onChange,
-  accentColor = '#16a34a',
-}: ToggleSwitchProps) {
+export default function ToggleSwitch({ checked, onChange, label }: ToggleSwitchProps) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={checked}
+      aria-label={label}
+      title={label}
       onClick={onChange}
-      className="relative inline-flex flex-shrink-0 cursor-pointer border-0 p-0 focus:outline-none"
-      style={{ width: 34, height: 19 }}
+      // 只保留 relative 定位；焦点环由 globals.css 的 *:focus-visible 统一提供，
+      // 不再手写 focus:outline-none（那会把键盘可见性交给一条兜底规则去救）。
+      className="relative inline-flex h-[18px] w-[32px] shrink-0 cursor-pointer border-0 p-0"
     >
-      {/* Track */}
       <span
-        className="block rounded-full transition-colors duration-200"
-        style={{
-          width: 34,
-          height: 19,
-          backgroundColor: checked ? accentColor : 'var(--theme-border-strong, rgba(15,23,42,0.15))',
-        }}
+        aria-hidden
+        className={`block h-[18px] w-[32px] rounded-pill transition-colors duration-200 ${
+          checked ? 'bg-status-accent-vivid' : 'bg-edge-strong'
+        }`}
       />
-      {/* Knob */}
       <span
-        className="absolute top-[2px] rounded-full bg-white transition-all duration-200"
-        style={{
-          width: 15,
-          height: 15,
-          left: checked ? 16 : 2,
-          boxShadow: '0 1px 3px rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.1)',
-        }}
+        aria-hidden
+        className={`absolute top-[2px] h-[14px] w-[14px] rounded-pill bg-surface-raised shadow-raised transition-[left] duration-200 ${
+          checked ? 'left-[16px]' : 'left-[2px]'
+        }`}
       />
     </button>
   );

--- a/frontend/components/sidebar/analysis-tab.tsx
+++ b/frontend/components/sidebar/analysis-tab.tsx
@@ -40,12 +40,7 @@ function LayerSelect({ id, layers, value, onChange, placeholder }: {
       id={id}
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      style={{
-        backgroundColor: 'var(--theme-bg-input)',
-        borderColor: 'var(--theme-border)',
-        color: 'var(--theme-text-primary)',
-      }}
-      className="w-full text-xs border rounded-lg px-2 py-1.5"
+      className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-2 py-1.5 text-meta text-ink"
     >
       <option value="">{placeholder}</option>
       {layers.map((l) => (
@@ -58,7 +53,7 @@ function LayerSelect({ id, layers, value, onChange, placeholder }: {
 function Field({ id, label, children }: { id: string; label: string; children: React.ReactNode }) {
   return (
     <div>
-      <label htmlFor={id} className="block text-[12px] font-semibold mb-1" style={{ color: 'var(--theme-text-secondary)' }}>
+      <label htmlFor={id} className="mb-1 block text-meta font-semibold text-ink-secondary">
         {label}
       </label>
       {children}
@@ -70,7 +65,6 @@ export function AnalysisTab({ onSend }: AnalysisTabProps) {
   const uid = useId();
   const [activeTool, setActiveTool] = useState<ToolKey>('buffer');
   const layers = useHudStore((s) => s.layers);
-  const accentColor = useHudStore((s) => s.accentColor);
 
   // Buffer state
   const [bufferLayer, setBufferLayer] = useState('');
@@ -139,17 +133,17 @@ export function AnalysisTab({ onSend }: AnalysisTabProps) {
               aria-checked={activeTool === key}
               tabIndex={activeTool === key ? 0 : -1}
               onClick={() => setActiveTool(key)}
-              className="flex flex-col items-center gap-1 py-2 rounded-lg text-xs font-medium transition-all border"
+              className="flex flex-col items-center gap-1 rounded-md border py-2 text-meta font-medium transition-all"
               style={{
                 backgroundColor: activeTool === key
-                  ? 'var(--theme-bg-subtle)'
+                  ? 'var(--surface-raised)'
                   : 'transparent',
                 borderColor: activeTool === key
-                  ? `${accentColor}55`
-                  : 'var(--theme-border)',
+                  ? 'color-mix(in srgb, var(--agent-accent) 33%, transparent)'
+                  : 'var(--border-subtle)',
                 color: activeTool === key
-                  ? 'var(--theme-text-primary)'
-                  : 'var(--theme-text-muted)',
+                  ? 'var(--text-primary)'
+                  : 'var(--text-muted)',
               }}
             >
               <Icon size={16} aria-hidden />
@@ -158,7 +152,7 @@ export function AnalysisTab({ onSend }: AnalysisTabProps) {
           ))}
         </div>
         {/* 当前工具目标与产出（UI V3：强调任务目标而不是工具堆积） */}
-        <p className="text-[12px] leading-relaxed" style={{ color: 'var(--theme-text-muted)' }}>
+        <p className="text-meta leading-relaxed text-ink-muted">
           {activeDef.desc} · 输出：{activeDef.output}
         </p>
       </div>
@@ -183,12 +177,7 @@ export function AnalysisTab({ onSend }: AnalysisTabProps) {
                 value={bufferDistance}
                 onChange={(e) => setBufferDistance(e.target.value)}
                 placeholder="输入缓冲距离，如 500"
-                style={{
-                  backgroundColor: 'var(--theme-bg-input)',
-                  borderColor: 'var(--theme-border)',
-                  color: 'var(--theme-text-primary)',
-                }}
-                className="w-full text-xs border rounded-lg px-3 py-2"
+                className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-3 py-2 text-meta text-ink"
               />
             </Field>
           </>
@@ -207,12 +196,7 @@ export function AnalysisTab({ onSend }: AnalysisTabProps) {
                 id={`${uid}-overlay-op`}
                 value={overlayOp}
                 onChange={(e) => setOverlayOp(e.target.value)}
-                style={{
-                  backgroundColor: 'var(--theme-bg-input)',
-                  borderColor: 'var(--theme-border)',
-                  color: 'var(--theme-text-primary)',
-                }}
-                className="w-full text-xs border rounded-lg px-2 py-1.5"
+                className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-2 py-1.5 text-meta text-ink"
               >
                 <option value="intersection">相交 (Intersection)</option>
                 <option value="union">合并 (Union)</option>
@@ -238,13 +222,13 @@ export function AnalysisTab({ onSend }: AnalysisTabProps) {
       {/* Submit */}
       <div
         className="p-3 border-t shrink-0"
-        style={{ borderColor: 'var(--theme-border)' }}
+        style={{ borderColor: 'var(--border-subtle)' }}
       >
         <button
-          className="w-full text-white font-bold py-2 rounded-lg shadow-md transition-all text-xs disabled:opacity-40"
+          className="w-full rounded-md py-1.5 text-meta font-semibold text-ink-on-accent transition-opacity hover:opacity-90 disabled:opacity-40"
           style={{
-            background: `linear-gradient(135deg, ${accentColor}, ${accentColor}dd)`,
-            boxShadow: `0 4px 12px ${accentColor}25`,
+            background: 'linear-gradient(135deg, var(--agent-accent), color-mix(in srgb, var(--agent-accent) 87%, transparent))',
+            boxShadow: '0 4px 12px color-mix(in srgb, var(--agent-accent) 15%, transparent)',
           }}
           disabled={!canSubmit}
           onClick={handleSubmit}
@@ -254,7 +238,8 @@ export function AnalysisTab({ onSend }: AnalysisTabProps) {
           {activeTool === 'clip' && '执行裁剪'}
         </button>
         {!canSubmit && (
-          <p className="mt-1.5 text-[11px]" style={{ color: 'var(--theme-text-subtle)' }}>
+          /* 提示是真实正文，--text-disabled 只该用于禁用/装饰 —— 用 ink-muted。 */
+          <p className="mt-1.5 text-caption text-ink-muted">
             请选择所需图层{activeTool === 'buffer' ? '并输入有效距离' : ''}后执行
           </p>
         )}

--- a/frontend/components/sidebar/chat-tab.render-scope.test.tsx
+++ b/frontend/components/sidebar/chat-tab.render-scope.test.tsx
@@ -103,7 +103,6 @@ describe('ChatTab render scope (D-F8)', () => {
           messages={messages}
           aiStatus="thinking"
           onSend={() => {}}
-          accentColor="#16a34a"
         />
       </Profiler>
     );
@@ -130,7 +129,6 @@ describe('ChatTab render scope (D-F8)', () => {
             messages={messages}
             aiStatus="thinking"
             onSend={() => {}}
-            accentColor="#16a34a"
           />
         </Profiler>
       );

--- a/frontend/components/sidebar/chat-tab.tsx
+++ b/frontend/components/sidebar/chat-tab.tsx
@@ -3,13 +3,13 @@
 import { memo, useState, useRef, useEffect, useCallback, type KeyboardEvent } from 'react';
 import dynamic from 'next/dynamic';
 import { Send, Sparkles, CheckCircle2 } from 'lucide-react';
-import { useHudStore } from '@/lib/store/useHudStore';
 import type { AiStatus } from '@/lib/store/hud-types';
 import { ToolCallChain } from '@/components/chat/tool-call-card';
 import { CollapsibleThink } from '@/components/chat/collapsible-think';
 import { PlanProposalCard } from '@/components/chat/plan-proposal-card';
 import { PlanCard } from '@/components/chat/plan-card';
 import { InlineNotice } from '@/components/shared/inline-notice';
+import { ChatAnnouncer } from '@/components/chat/chat-announcer';
 import { adaptChartData } from "@/lib/chart-adapter";
 
 // Bundle-slimming: react-markdown (MiniMd) and recharts (ChartRenderer) load on
@@ -24,7 +24,7 @@ const ChartRenderer = dynamic(
 /* ─── Thinking dots animation ─── */
 const DOT_ANIMS = ['animate-dot-1', 'animate-dot-2', 'animate-dot-3'];
 
-function ThinkingDots({ text, accentColor }: { text: string; accentColor: string; isDark?: boolean }) {
+function ThinkingDots({ text }: { text: string }) {
   return (
     <div className="flex items-center gap-2 py-1.5 px-1">
       <div className="flex gap-[3px]">
@@ -33,13 +33,13 @@ function ThinkingDots({ text, accentColor }: { text: string; accentColor: string
             key={anim}
             style={{
               display: 'block', width: 5, height: 5, borderRadius: '50%',
-              backgroundColor: accentColor
+              backgroundColor: 'var(--agent-accent)'
             }}
             className={anim}
           />
         ))}
       </div>
-      <span className="text-[15px]" style={{ color: 'var(--theme-text-muted)' }}>{text}</span>
+      <span className="text-body text-ink-muted">{text}</span>
     </div>
   );
 }
@@ -52,25 +52,21 @@ const SUGGESTED_PROMPTS = [
   '叠加分析两个图层',
 ];
 
-function SuggestedPromptButtons({ onSend, accentColor }: { onSend: (text: string) => void; accentColor: string; isDark?: boolean }) {
+function SuggestedPromptButtons({ onSend }: { onSend: (text: string) => void }) {
   return (
     <div className="px-3 pt-3 pb-2">
-      <p className="text-[14px] uppercase tracking-wider mb-2" style={{ color: 'var(--theme-text-muted)' }}>快捷指令</p>
+      {/* A: 快捷指令头是 14px uppercase 标签 —— 走 V4 的 title 档 + ink-muted，
+          不再用裸 text-[14px] 与 --theme-* 双轨。 */}
+      <p className="text-title uppercase tracking-wider text-ink-muted mb-2">快捷指令</p>
       <div className="flex flex-wrap gap-1.5">
         {SUGGESTED_PROMPTS.map((prompt) => (
           <button
             key={prompt}
             onClick={() => onSend(prompt)}
-            style={{
-              padding: '6px 10px', borderRadius: 8, fontSize: 13,
-              color: 'var(--theme-text-primary)',
-              borderWidth: 1, borderStyle: 'solid',
-              borderColor: `${accentColor}22`,
-              backgroundColor: 'var(--theme-bg-subtle)',
-              cursor: 'pointer', transition: 'background-color 0.15s'
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--theme-bg-hover)'; }}
-            onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--theme-bg-subtle)'; }}
+            className="cursor-pointer rounded-md border bg-surface-raised px-2.5 py-1.5 text-body text-ink transition-colors"
+            style={{ borderColor: 'var(--accent-border)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--surface-hover)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--surface-raised)'; }}
           >
             {prompt}
           </button>
@@ -99,7 +95,6 @@ interface ChatTabProps {
   messages: ChatMessage[];
   aiStatus: AiStatus;
   onSend: (text: string) => void;
-  accentColor: string;
   /** Plan Mode: 用户在卡片上点按钮时回调，由父组件发送对应 chat 消息并更新 plan.status */
   onPlanAction?: (planId: string, action: 'approve' | 'revise' | 'reject') => void;
 }
@@ -114,15 +109,11 @@ interface ChatTabProps {
  */
 const ChatMessageItem = memo(function ChatMessageItem({
   message: msg,
-  accentColor,
-  isDark,
   mounted,
   thinkingText,
   onPlanAction,
 }: {
   message: ChatMessage;
-  accentColor: string;
-  isDark: boolean;
   mounted: boolean;
   thinkingText: string;
   onPlanAction?: (planId: string, action: 'approve' | 'revise' | 'reject') => void;
@@ -140,15 +131,19 @@ const ChatMessageItem = memo(function ChatMessageItem({
     <div className="flex justify-end">
       <div className="max-w-[85%]">
         <div className="flex items-center justify-end gap-1.5 mb-0.5">
-          {time && <span className="text-[15px]" style={{ color: 'var(--theme-text-subtle)' }}>{time}</span>}
-          <span className="text-[14px] font-semibold" style={{ color: accentColor }}>You</span>
+          {/* A: 时间戳是真实正文，--theme-text-subtle（= --text-disabled, 3.5:1）
+             只该用于禁用/装饰 —— 改 ink-muted。 */}
+          {time && <span className="text-body text-ink-muted">{time}</span>}
+          {/* 运行时 accent 直接作文字在暗色下只有 2.96–3.40:1 —— 角色标签改用
+              主题校正后的 --agent-accent。 */}
+          <span className="text-title font-semibold text-agent-accent">You</span>
         </div>
         <div
           style={{
             borderTopRightRadius: 4, borderTopLeftRadius: 16,
             borderBottomLeftRadius: 16, borderBottomRightRadius: 16,
-            padding: '8px 12px', fontSize: 14.5, lineHeight: 1.6, color: '#fff',
-            backgroundColor: accentColor
+            padding: '8px 12px', fontSize: 14.5, lineHeight: 1.6, color: 'var(--text-on-accent)',
+            backgroundColor: 'var(--agent-accent)'
           }}
         >
           <div className="whitespace-pre-wrap">{msg.content}</div>
@@ -161,24 +156,24 @@ const ChatMessageItem = memo(function ChatMessageItem({
       <div className="shrink-0 mt-0.5">
         <div
           className="w-6 h-6 rounded-full flex items-center justify-center"
-          style={{ backgroundColor: `${accentColor}15` }}
+          style={{ backgroundColor: 'color-mix(in srgb, var(--agent-accent) 8%, transparent)' }}
         >
-          <Sparkles size={11} style={{ color: accentColor }} />
+          <Sparkles size={11} style={{ color: 'var(--agent-accent)' }} />
         </div>
       </div>
 
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-0.5">
-          <span className="text-[14px] font-semibold" style={{ color: accentColor }}>GeoAgent</span>
-          {time && <span className="text-[15px]" style={{ color: 'var(--theme-text-subtle)' }}>{time}</span>}
+          <span className="text-title font-semibold text-agent-accent">GeoAgent</span>
+          {time && <span className="text-body text-ink-muted">{time}</span>}
         </div>
 
         {msg.layerAdded && (
           <div
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 8px',
-              borderRadius: 999, fontSize: 12, fontWeight: 500, color: '#fff',
-              backgroundColor: accentColor, marginBottom: 6
+              borderRadius: 999, fontSize: 12, fontWeight: 500, color: 'var(--text-on-accent)',
+              backgroundColor: 'var(--agent-accent)', marginBottom: 6
             }}
           >
             <CheckCircle2 size={10} />
@@ -187,22 +182,18 @@ const ChatMessageItem = memo(function ChatMessageItem({
         )}
 
         {msg.isThinking ? (
-          <ThinkingDots text={thinkingText} accentColor={accentColor} isDark={isDark} />
+          <ThinkingDots text={thinkingText} />
         ) : msg.content || msg.think || msg.toolCalls?.length ? (
           <div style={{
             borderTopLeftRadius: 4, borderTopRightRadius: 16,
             borderBottomLeftRadius: 16, borderBottomRightRadius: 16,
-            backgroundColor: 'var(--theme-bg-subtle)',
+            backgroundColor: 'var(--surface-raised)',
             borderWidth: 1, borderStyle: 'solid',
-            borderColor: 'var(--theme-border-subtle)',
+            borderColor: 'var(--border-subtle)',
             padding: '8px 12px'
           }}>
             {msg.think && (
-              <CollapsibleThink
-                content={msg.think}
-                isDark={isDark}
-                accentColor={accentColor}
-              />
+              <CollapsibleThink content={msg.think} />
             )}
             {msg.agentPlan && (
               <PlanCard plan={msg.agentPlan} />
@@ -220,8 +211,6 @@ const ChatMessageItem = memo(function ChatMessageItem({
                 destructiveSteps={msg.plan.destructive_steps}
                 stepsPreview={msg.plan.steps_preview}
                 status={msg.plan.status}
-                isDark={isDark}
-                accentColor={accentColor}
                 onApprove={(pid) => onPlanAction?.(pid, 'approve')}
                 onRevise={(pid) => onPlanAction?.(pid, 'revise')}
                 onReject={(pid) => onPlanAction?.(pid, 'reject')}
@@ -231,7 +220,7 @@ const ChatMessageItem = memo(function ChatMessageItem({
               const chart = adaptChartData(raw);
               if (!chart) return null;
               return (
-                <div key={`chart-${idx}`} style={{ marginTop: 8, borderRadius: 8, overflow: 'hidden', border: `1px solid ${accentColor}22`, backgroundColor: 'var(--theme-bg-input)' }}>
+                <div key={`chart-${idx}`} className="mt-2 overflow-hidden rounded-md border bg-surface-sunken" style={{ borderColor: 'var(--accent-border)' }}>
                   <ChartRenderer chart={chart} />
                 </div>
               );
@@ -243,9 +232,7 @@ const ChatMessageItem = memo(function ChatMessageItem({
   );
 });
 
-export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction }: ChatTabProps) {
-  const theme = useHudStore((s) => s.theme);
-  const isDark = theme === 'dark';
+export function ChatTab({ messages, aiStatus, onSend, onPlanAction }: ChatTabProps) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
@@ -303,28 +290,27 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction 
       {/* Messages scroll area */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto">
         {messages.length === 0 && !isBusy && (
-          <div className="flex flex-col items-center justify-center h-full px-6 text-center">
-            <div
-              className="w-12 h-12 rounded-2xl flex items-center justify-center mb-3"
-              style={{ backgroundColor: `${accentColor}15` }}
-            >
-              <Sparkles size={22} style={{ color: accentColor }} />
-            </div>
-            <h3 className="text-[15px] font-semibold mb-1" style={{ color: 'var(--theme-text-primary)' }}>GeoAgent</h3>
-            <p className="text-[13.5px] leading-relaxed" style={{ color: 'var(--theme-text-secondary)' }}>
-              输入空间分析指令，开始智能 GIS 分析
-            </p>
+          <div className="flex h-full flex-col items-center justify-center px-6 text-center">
+            <span aria-hidden className="mb-3 flex h-control-lg w-control-lg items-center justify-center rounded-md bg-status-accent-soft">
+              <Sparkles size={16} className="text-status-accent" />
+            </span>
+            <h3 className="mb-1 text-title font-semibold text-ink">GeoAgent</h3>
+            <p className="text-meta text-ink-muted">输入空间分析指令，开始智能 GIS 分析</p>
           </div>
         )}
 
-        {/* Message list */}
-        <div className="px-3 py-3 space-y-3">
+        {/*
+          a11y：流式回复此前完全没有播报 —— 助手 token、工具调用状态、
+          「正在分析指令…」全都只是视觉变化，读屏用户感知不到产品的主反馈回路。
+          播报交给 <ChatAnnouncer/>（下方 composer 区）：把 aria-live 直接放在
+          消息列表上会在每个 token 批次重读整段回答（MiniMd 每批重新解析、整个
+          气泡子树被替换，aria-atomic=false 只有在追加叶子节点时才是增量）。
+        */}
+        <div className="space-y-2 px-panel py-2">
           {messages.map((msg, idx) => (
             <ChatMessageItem
               key={msg.id ?? `msg-${idx}`}
               message={msg}
-              accentColor={accentColor}
-              isDark={isDark}
               mounted={mounted}
               thinkingText={thinkingText}
               onPlanAction={onPlanAction}
@@ -334,31 +320,30 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction 
 
           {/* Thinking indicator at end of messages */}
           {isBusy && messages.length > 0 && !messages[messages.length - 1]?.isThinking && (
-            <ThinkingDots text={thinkingText} accentColor={accentColor} isDark={isDark} />
+            <ThinkingDots text={thinkingText} />
           )}
         </div>
 
         {/* Suggested prompts when not busy and few messages */}
         {!isBusy && messages.length <= 1 && (
-          <SuggestedPromptButtons onSend={onSend} accentColor={accentColor} isDark={isDark} />
+          <SuggestedPromptButtons onSend={onSend} />
         )}
       </div>
 
       {/* Input area */}
-      <div style={{
-        borderTopWidth: 1, borderTopStyle: 'solid',
-        borderTopColor: 'var(--theme-border-subtle)',
-        backgroundColor: 'var(--theme-bg-input)',
-        backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)'
-      }} className="shrink-0">
+      <ChatAnnouncer messages={messages} aiStatus={aiStatus} />
+
+      {/* 不透明底 + 去掉 blur(12px)：composer 压在地图上，半透明会让输入文字
+          与底图细节互相干扰，而 backdrop-filter 又是最贵的那类合成。 */}
+      <div className="shrink-0 border-t border-edge-subtle bg-surface-panel">
         {/* UI V3：AI 错误在 chat 内可见（之前仅 top-bar/HUD 有指示，
             composer 静默恢复可用，用户无法感知失败） */}
         {aiStatus === 'error' && (
-          <div className="px-3 pt-2">
+          <div className="px-panel pt-2">
             <InlineNotice variant="error">上一条指令执行失败，请调整后重试。</InlineNotice>
           </div>
         )}
-        <div className="flex items-end gap-2 px-3 pt-2.5 pb-1.5">
+        <div className="flex items-end gap-2 px-panel pb-1 pt-2">
           {/* Textarea */}
           <textarea
             ref={textareaRef}
@@ -368,11 +353,11 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction 
             aria-label="输入空间分析指令"
             placeholder="输入空间分析指令..."
             rows={1}
-            style={{
-              flex: 1, resize: 'none', backgroundColor: 'transparent',
-              fontSize: 14.5, color: 'var(--theme-text-primary)',
-              outline: 'none', lineHeight: 1.5, maxHeight: 80, paddingTop: 4, paddingBottom: 4
-            }}
+            /* a11y 修复：这里原本是内联 `outline: 'none'`。内联样式压过
+               globals.css 里那条 unlayered 的 *:focus-visible 规则，于是产品最
+               核心的输入框是全站唯一没有键盘焦点环的控件。改成 focus-visible
+               时用 ring 表达，鼠标点击不显示。 */
+            className="max-h-20 flex-1 resize-none bg-transparent py-1 text-body leading-normal text-ink placeholder:text-ink-disabled focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-status-accent-border"
           />
 
           {/* Send button */}
@@ -380,24 +365,19 @@ export function ChatTab({ messages, aiStatus, onSend, accentColor, onPlanAction 
             onClick={handleSend}
             disabled={!input.trim() || isBusy}
             aria-label="发送消息"
-            style={{
-              flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
-              width: 26, height: 26, borderRadius: 8, transition: 'opacity 0.15s',
-              opacity: !input.trim() || isBusy ? 0.4 : 1,
-              backgroundColor: input.trim() ? accentColor : 'var(--theme-bg-muted)',
-              color: input.trim() ? '#fff' : 'var(--theme-text-muted)',
-              cursor: 'pointer'
-            }}
+            className={`flex h-control-md w-control-md shrink-0 items-center justify-center rounded-sm transition-colors ${
+              input.trim() && !isBusy
+                ? 'bg-status-accent text-ink-on-accent'
+                : 'cursor-not-allowed bg-surface-sunken text-ink-disabled'
+            }`}
           >
-            <Send size={13} />
+            <Send size={13} aria-hidden />
           </button>
         </div>
 
         {/* Hint */}
-        <div className="px-3 pb-2">
-          <span className="text-[9.5px]" style={{ color: 'var(--theme-text-subtle)' }}>
-            Enter 发送 · Shift+Enter 换行
-          </span>
+        <div className="px-panel pb-1.5">
+          <span className="text-micro text-ink-muted">Enter 发送 · Shift+Enter 换行</span>
         </div>
       </div>
     </div>

--- a/frontend/components/sidebar/data-sources-tab.tsx
+++ b/frontend/components/sidebar/data-sources-tab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Database, Inbox, Layers, SearchX } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import { useToastStore } from '@/components/ui/toast';
@@ -21,9 +21,33 @@ import { PreviewModal } from './data-sources/preview-modal';
 // the tab entry point (constant itself lives with the catalog hook).
 export { CATALOG_SEARCH_DEBOUNCE_MS } from './data-sources/use-spatial-catalog';
 
+/** 子页签顺序即渲染顺序（V4 tablist 键盘导航用）。 */
+const SUBTABS: Array<'catalog' | 'sources'> = ['catalog', 'sources'];
+
 export function DataSourcesTab() {
   const [activeSubTab, setActiveSubTab] = useState<'catalog' | 'sources'>('catalog');
   const [showAddForm, setShowAddForm] = useState(false);
+
+  // V4 子页签：补齐 WAI-APG tablist 语义（roving tabindex + 方向键/Home/End
+  // 键盘导航，activation-on-focus），与 nav-rail / map-studio 的 tablist 一致。
+  const subTabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  const onSubTabKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const idx = SUBTABS.indexOf(activeSubTab);
+      let next: 'catalog' | 'sources' | null = null;
+      if (e.key === 'ArrowRight') next = SUBTABS[(idx + 1) % SUBTABS.length];
+      else if (e.key === 'ArrowLeft') next = SUBTABS[(idx - 1 + SUBTABS.length) % SUBTABS.length];
+      else if (e.key === 'Home') next = SUBTABS[0];
+      else if (e.key === 'End') next = SUBTABS[SUBTABS.length - 1];
+      if (!next) return;
+      e.preventDefault();
+      // activation-on-focus（APG）：移动焦点即激活对应子页签。
+      setActiveSubTab(next);
+      subTabRefs.current.get(next)?.focus();
+    },
+    [activeSubTab]
+  );
 
   // Modal / Drawer state
   const [activeDescriptor, setActiveDescriptor] = useState<DatasetDescriptor | null>(null);
@@ -134,16 +158,33 @@ export function DataSourcesTab() {
   };
 
   return (
-    <div className="flex h-full flex-col overflow-hidden text-[13px]">
-      {/* Subtab navigation */}
-      <div className="flex shrink-0 gap-2 border-b border-[var(--theme-border)] bg-[var(--theme-bg-glass)] px-2.5 pt-2">
+    <div className="flex h-full flex-col overflow-hidden text-body">
+      {/* Subtab navigation —— 完整 WAI-APG tablist（role/aria-selected/
+          aria-controls/roving tabindex + 方向键与 Home/End 键盘导航）。
+          V4 之前是裸 button，无任何 tab 语义，键盘用户只能 Tab 到按钮后回车。 */}
+      <div
+        role="tablist"
+        aria-label="数据子页签"
+        onKeyDown={onSubTabKeyDown}
+        className="flex shrink-0 gap-2 border-b border-edge-subtle bg-surface-overlay px-2.5 pt-2"
+      >
         <button
           type="button"
+          role="tab"
+          id="data-subtab-catalog"
+          aria-selected={activeSubTab === 'catalog'}
+          // 仅当前激活 tab 指向实际渲染的 panel（另一 panel 未挂载）
+          aria-controls={activeSubTab === 'catalog' ? 'data-subtab-panel-catalog' : undefined}
+          tabIndex={activeSubTab === 'catalog' ? 0 : -1}
+          ref={(el) => {
+            if (el) subTabRefs.current.set('catalog', el);
+            else subTabRefs.current.delete('catalog');
+          }}
           onClick={() => setActiveSubTab('catalog')}
-          className={`flex items-center gap-1.5 border-b-2 px-2 pb-2 text-[12px] font-medium transition-colors ${
+          className={`flex items-center gap-1.5 border-b-2 px-2 pb-2 text-meta font-medium transition-colors ${
             activeSubTab === 'catalog'
-              ? 'border-[var(--agent-accent,#16a34a)] text-[var(--agent-accent,#16a34a)]'
-              : 'border-transparent text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)]'
+              ? 'border-status-accent-vivid text-status-accent'
+              : 'border-transparent text-ink-muted hover:text-ink-secondary'
           }`}
         >
           <Layers size={14} aria-hidden />
@@ -151,11 +192,20 @@ export function DataSourcesTab() {
         </button>
         <button
           type="button"
+          role="tab"
+          id="data-subtab-sources"
+          aria-selected={activeSubTab === 'sources'}
+          aria-controls={activeSubTab === 'sources' ? 'data-subtab-panel-sources' : undefined}
+          tabIndex={activeSubTab === 'sources' ? 0 : -1}
+          ref={(el) => {
+            if (el) subTabRefs.current.set('sources', el);
+            else subTabRefs.current.delete('sources');
+          }}
           onClick={() => setActiveSubTab('sources')}
-          className={`flex items-center gap-1.5 border-b-2 px-2 pb-2 text-[12px] font-medium transition-colors ${
+          className={`flex items-center gap-1.5 border-b-2 px-2 pb-2 text-meta font-medium transition-colors ${
             activeSubTab === 'sources'
-              ? 'border-[var(--agent-accent,#16a34a)] text-[var(--agent-accent,#16a34a)]'
-              : 'border-transparent text-[var(--theme-text-muted)] hover:text-[var(--theme-text-secondary)]'
+              ? 'border-status-accent-vivid text-status-accent'
+              : 'border-transparent text-ink-muted hover:text-ink-secondary'
           }`}
         >
           <Database size={14} aria-hidden />
@@ -165,7 +215,12 @@ export function DataSourcesTab() {
 
       {/* Catalog View */}
       {activeSubTab === 'catalog' && (
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div
+          role="tabpanel"
+          id="data-subtab-panel-catalog"
+          aria-labelledby="data-subtab-catalog"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
           <CatalogToolbar
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
@@ -198,7 +253,12 @@ export function DataSourcesTab() {
 
       {/* Sources View */}
       {activeSubTab === 'sources' && (
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div
+          role="tabpanel"
+          id="data-subtab-panel-sources"
+          aria-labelledby="data-subtab-sources"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
           <SourcesToolbar showAddForm={showAddForm} onToggleAddForm={() => setShowAddForm(!showAddForm)} />
 
           {showAddForm && <AddSourceForm onCreated={handleSourceCreated} />}

--- a/frontend/components/sidebar/data-sources/add-source-form.tsx
+++ b/frontend/components/sidebar/data-sources/add-source-form.tsx
@@ -62,15 +62,15 @@ export function AddSourceForm({ onCreated }: AddSourceFormProps) {
   };
 
   const inputClass =
-    'w-full rounded border border-[var(--theme-border)] bg-[var(--theme-bg-input)] px-2 py-1 text-[11px] text-[var(--theme-text-primary)]';
-  const labelClass = 'text-[11px] text-[var(--theme-text-muted)]';
+    'w-full rounded-sm border border-edge-subtle bg-surface-sunken px-2 py-1 text-caption text-ink';
+  const labelClass = 'text-caption text-ink-muted';
 
   return (
     <form
       onSubmit={handleSubmit}
-      className="shrink-0 space-y-2 border-b border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-3"
+      className="shrink-0 space-y-2 border-b border-edge-subtle bg-surface-raised p-3"
     >
-      <h5 className="text-[12px] font-semibold text-[var(--theme-text-primary)]">注册新数据源</h5>
+      <h5 className="text-meta font-semibold text-ink">注册新数据源</h5>
       <div>
         <label htmlFor={nameId} className={labelClass}>
           数据源名称
@@ -103,13 +103,13 @@ export function AddSourceForm({ onCreated }: AddSourceFormProps) {
           </select>
         </div>
         <div className="flex w-1/2 items-center pt-4">
-          <label htmlFor={privateId} className="flex cursor-pointer items-center gap-1.5 text-[11px] text-[var(--theme-text-secondary)]">
+          <label htmlFor={privateId} className="flex cursor-pointer items-center gap-1.5 text-caption text-ink-secondary">
             <input
               id={privateId}
               type="checkbox"
               checked={newAllowPrivate}
               onChange={(e) => setNewAllowPrivate(e.target.checked)}
-              className="rounded border-[var(--theme-border-strong)]"
+              className="rounded-sm border-edge-strong"
               style={{ accentColor: 'var(--agent-accent, #16a34a)' }}
             />
             <span>允许内网 (SSRF)</span>
@@ -132,7 +132,7 @@ export function AddSourceForm({ onCreated }: AddSourceFormProps) {
       <button
         type="submit"
         disabled={submittingSource}
-        className="w-full rounded py-1.5 text-[12px] font-medium text-white transition-opacity hover:opacity-85 disabled:opacity-50"
+        className="w-full rounded py-1.5 text-meta font-medium text-ink-on-accent transition-opacity hover:opacity-85 disabled:opacity-50"
         style={{ background: 'var(--agent-accent, #16a34a)' }}
       >
         {submittingSource ? '提交中...' : '提交注册并同步'}

--- a/frontend/components/sidebar/data-sources/catalog-item-card.tsx
+++ b/frontend/components/sidebar/data-sources/catalog-item-card.tsx
@@ -21,26 +21,28 @@ export function CatalogItemCard({
   onMaterialize,
 }: CatalogItemCardProps) {
   return (
-    <div className="rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-glass)] p-2.5 transition-all hover:shadow-sm">
+    /* 与 layers-tab 行同款交互配方：hover 底色 + 左侧 accent 指示条位
+       （border-l-2 border-l-transparent）；垂直内边距收一步更密。 */
+    <div className="rounded-md border border-l-2 border-edge-subtle border-l-transparent bg-surface-overlay px-panel py-2 transition-colors hover:bg-surface-hover">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
-          <h4 className="truncate text-[13px] font-semibold text-[var(--theme-text-primary)]">
+          <h4 className="truncate text-body font-semibold text-ink">
             {item.title || item.name}
           </h4>
-          <p className="mt-0.5 line-clamp-1 text-[11px] text-[var(--theme-text-muted)]">
+          <p className="mt-0.5 line-clamp-1 text-caption text-ink-muted">
             {item.description || item.name}
           </p>
         </div>
-        <span className="shrink-0 rounded bg-[var(--theme-bg-muted)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--theme-text-secondary)]">
+        <span className="shrink-0 rounded-sm bg-surface-sunken px-1.5 py-0.5 font-mono text-micro text-ink-secondary">
           {item.geometry_type || 'Vector'}
         </span>
       </div>
 
-      <div className="mt-2 flex items-center gap-2 border-t border-[var(--theme-border-subtle)] pt-2 text-[11px]">
+      <div className="mt-2 flex items-center gap-2 border-t border-edge-subtle pt-2 text-caption">
         <button
           type="button"
           onClick={() => onShowDescriptor(item.id)}
-          className="flex items-center gap-1 rounded bg-[var(--theme-bg-muted)] px-2 py-1 text-[var(--theme-text-secondary)] transition hover:bg-[var(--theme-bg-hover)]"
+          className="flex items-center gap-1 rounded-sm bg-surface-sunken px-2 py-1 text-ink-secondary transition-colors hover:bg-surface-hover"
         >
           <Info size={12} aria-hidden />
           <span>契约</span>
@@ -48,7 +50,7 @@ export function CatalogItemCard({
         <button
           type="button"
           onClick={() => onPreview(item.id)}
-          className="flex items-center gap-1 rounded bg-[var(--theme-bg-muted)] px-2 py-1 text-[var(--theme-text-secondary)] transition hover:bg-[var(--theme-bg-hover)]"
+          className="flex items-center gap-1 rounded-sm bg-surface-sunken px-2 py-1 text-ink-secondary transition-colors hover:bg-surface-hover"
         >
           <Eye size={12} aria-hidden />
           <span>预览</span>
@@ -57,8 +59,7 @@ export function CatalogItemCard({
           type="button"
           onClick={() => onMaterialize(item)}
           disabled={materializing}
-          className="ml-auto flex items-center gap-1 rounded px-2.5 py-1 font-medium text-white transition-opacity hover:opacity-85 disabled:opacity-50"
-          style={{ background: 'var(--agent-accent, #16a34a)' }}
+          className="ml-auto flex items-center gap-1 rounded-sm bg-status-accent px-2.5 py-1 font-medium text-ink-on-accent transition-opacity hover:opacity-85 disabled:opacity-50"
         >
           <Download size={12} aria-hidden />
           <span>{materializing ? '实例化中...' : '加载至地图'}</span>

--- a/frontend/components/sidebar/data-sources/catalog-toolbar.tsx
+++ b/frontend/components/sidebar/data-sources/catalog-toolbar.tsx
@@ -24,7 +24,7 @@ export function CatalogToolbar({
   onSourceFilterChange,
 }: CatalogToolbarProps) {
   return (
-    <div className="shrink-0 space-y-2 border-b border-[var(--theme-border)] p-2.5">
+    <div className="shrink-0 space-y-2 border-b border-edge-subtle px-panel py-2">
       <SearchField
         value={searchQuery}
         onChange={onSearchChange}
@@ -37,7 +37,7 @@ export function CatalogToolbar({
           value={selectedSourceFilter}
           onChange={(e) => onSourceFilterChange(e.target.value)}
           aria-label="按数据源筛选空间目录"
-          className="w-full rounded border border-[var(--theme-border)] bg-[var(--theme-bg-input)] px-2 py-1 text-[11px] text-[var(--theme-text-secondary)]"
+          className="w-full rounded-sm border border-edge-subtle bg-surface-sunken px-2 py-1 text-caption text-ink-secondary"
         >
           <option value="">全部数据源</option>
           {sources.map((s) => (

--- a/frontend/components/sidebar/data-sources/dataset-descriptor-modal.tsx
+++ b/frontend/components/sidebar/data-sources/dataset-descriptor-modal.tsx
@@ -17,50 +17,53 @@ export function DatasetDescriptorModal({ descriptor, onClose }: DatasetDescripto
   useDialogFocus({ open: true, containerRef: dialogRef, onEscape: onClose });
 
   return (
+    /* D: 去掉 backdrop-blur —— 弹窗盖在地图上，blur 是持续重绘画布上
+       最贵的那类合成；scrim（bg-surface-scrim）已承担压暗职责。 */
     <div
       ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label="DatasetDescriptor 契约"
       tabIndex={-1}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-surface-scrim p-4"
     >
-      <div className="max-h-[80vh] w-full max-w-md space-y-3 overflow-y-auto rounded-2xl bg-[var(--theme-bg-panel)] p-4 shadow-xl">
-        <div className="flex items-center justify-between border-b border-[var(--theme-border)] pb-2">
-          <h3 className="text-[14px] font-bold text-[var(--theme-text-primary)]">DatasetDescriptor 契约</h3>
-          <IconButton label="关闭" icon={X} onClick={onClose} />
-        </div>
-        <div className="space-y-2 text-[12px] text-[var(--theme-text-secondary)]">
-          <div>
-            <span className="font-semibold text-[var(--theme-text-primary)]">ID:</span> {descriptor.id}
+        <div className="max-h-[80vh] w-full max-w-md space-y-3 overflow-y-auto rounded-md bg-surface-panel p-4 shadow-overlay">
+          <div className="flex items-center justify-between border-b border-edge-subtle pb-2">
+            <h3 className="text-title font-bold text-ink">DatasetDescriptor 契约</h3>
+            <IconButton label="关闭" icon={X} onClick={onClose} />
           </div>
-          <div>
-            <span className="font-semibold text-[var(--theme-text-primary)]">标题:</span> {descriptor.title}
-          </div>
-          <div>
-            <span className="font-semibold text-[var(--theme-text-primary)]">几何类型:</span> {descriptor.geometry_type}
-          </div>
-          <div>
-            <span className="font-semibold text-[var(--theme-text-primary)]">SRS 坐标系:</span> {descriptor.srs}
-          </div>
-          <div>
-            <span className="font-semibold text-[var(--theme-text-primary)]">Bounding Box:</span>{' '}
-            {JSON.stringify(descriptor.bbox)}
-          </div>
-          <div>
-            <span className="font-semibold text-[var(--theme-text-primary)]">
-              字段 Schema ({descriptor.fields?.length || 0}):
-            </span>
-            <div className="mt-1 max-h-40 overflow-y-auto rounded bg-[var(--theme-bg-muted)] p-2 font-mono text-[11px]">
-              {descriptor.fields?.map((f, i) => (
-                <div key={i}>
-                  {f.name}: <span style={{ color: 'var(--agent-accent, #16a34a)' }}>{f.type}</span>
-                </div>
-              ))}
+          <div className="space-y-2 text-meta text-ink-secondary">
+            <div>
+              <span className="font-semibold text-ink">ID:</span> {descriptor.id}
+            </div>
+            <div>
+              <span className="font-semibold text-ink">标题:</span> {descriptor.title}
+            </div>
+            <div>
+              <span className="font-semibold text-ink">几何类型:</span> {descriptor.geometry_type}
+            </div>
+            <div>
+              <span className="font-semibold text-ink">SRS 坐标系:</span> {descriptor.srs}
+            </div>
+            <div>
+              <span className="font-semibold text-ink">Bounding Box:</span>{' '}
+              {JSON.stringify(descriptor.bbox)}
+            </div>
+            <div>
+              <span className="font-semibold text-ink">
+                字段 Schema ({descriptor.fields?.length || 0}):
+              </span>
+              <div className="mt-1 max-h-40 overflow-y-auto rounded-sm bg-surface-sunken p-2 font-mono text-caption">
+                {descriptor.fields?.map((f, i) => (
+                  <div key={i}>
+                    {f.name}: {/* 字段类型是 accent 作文字 —— 用 text-safe 变体。 */}
+                    <span className="text-agent-accent">{f.type}</span>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
   );
 }

--- a/frontend/components/sidebar/data-sources/preview-modal.tsx
+++ b/frontend/components/sidebar/data-sources/preview-modal.tsx
@@ -17,26 +17,29 @@ export function PreviewModal({ result, onClose }: PreviewModalProps) {
   useDialogFocus({ open: true, containerRef: dialogRef, onEscape: onClose });
 
   return (
+    /* D: 去掉 backdrop-blur —— 弹窗盖在地图上，blur 是持续重绘画布上
+       最贵的那类合成；scrim（bg-surface-scrim）已承担压暗职责。 */
     <div
       ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label="数据样例预览"
       tabIndex={-1}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-surface-scrim p-4"
     >
-      <div className="max-h-[80vh] w-full max-w-lg space-y-3 overflow-y-auto rounded-2xl bg-[var(--theme-bg-panel)] p-4 shadow-xl">
-        <div className="flex items-center justify-between border-b border-[var(--theme-border)] pb-2">
-          <h3 className="text-[14px] font-bold text-[var(--theme-text-primary)]">
-            数据样例预览 ({result.features.length} 要素)
-          </h3>
-          <IconButton label="关闭" icon={X} onClick={onClose} />
-        </div>
-        {/* 主题令牌化（review P2）：bg-slate-900 在暗色下与面板底色融为一体 */}
-        <div className="max-h-60 overflow-x-auto rounded-xl border border-[var(--theme-border)] bg-[var(--theme-bg-input)] p-3 font-mono text-[11px] text-[var(--agent-accent,#16a34a)]">
-          <pre>{JSON.stringify(result.features.slice(0, 3), null, 2)}</pre>
+        <div className="max-h-[80vh] w-full max-w-lg space-y-3 overflow-y-auto rounded-md bg-surface-panel p-4 shadow-overlay">
+          <div className="flex items-center justify-between border-b border-edge-subtle pb-2">
+            <h3 className="text-title font-bold text-ink">
+              数据样例预览 ({result.features.length} 要素)
+            </h3>
+            <IconButton label="关闭" icon={X} onClick={onClose} />
+          </div>
+          {/* 主题令牌化（review P2）：bg-slate-900 在暗色下与面板底色融为一体 */}
+          {/* JSON 是 accent 作正文 —— 用主题校正后的 --agent-accent。 */}
+          <div className="max-h-60 overflow-x-auto rounded-md border border-edge-subtle bg-surface-sunken p-3 font-mono text-caption text-agent-accent">
+            <pre>{JSON.stringify(result.features.slice(0, 3), null, 2)}</pre>
+          </div>
         </div>
       </div>
-    </div>
   );
 }

--- a/frontend/components/sidebar/data-sources/source-item-card.tsx
+++ b/frontend/components/sidebar/data-sources/source-item-card.tsx
@@ -7,7 +7,13 @@ import { ConfirmAction } from '@/components/shared/confirm-action';
 
 /**
  * 数据源状态 → 共享 StatusBadge 映射（原 light-only 手写徽标收敛）。
- * healthy/active=正常(ok)，degraded=降级(stale/amber)，其余=离线(error)。
+ *
+ * 这里只做后端词 → 徽标词的翻译，绝不定义第二套状态色。审计发现的冲突是
+ * 「active」这个词被两处赋予了不同颜色：徽标里 active 表示"进行中"（info 蓝
+ * + pulse），而数据源的 active 表示"已启用且可用"，本质是 success。
+ * 解决方式是让卡片放弃复用这个撞名的键 —— healthy 与 active 都翻译成
+ * ok（success 绿），degraded → stale（amber），其余 → error。
+ * 这样 pulse 蓝始终只代表"有事情正在跑"。
  */
 function toStatusBadgeProps(status: string): { status: string; label: string } {
   if (status === 'healthy' || status === 'active') return { status: 'ok', label: '正常' };
@@ -26,19 +32,21 @@ export interface SourceItemCardProps {
 export function SourceItemCard({ source, onProbe, onSync, onDelete }: SourceItemCardProps) {
   const badge = toStatusBadgeProps(source.status);
   return (
-    <div className="rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-glass)] p-2.5">
+    /* 与 layers-tab 行同款交互配方：hover 底色 + 左侧 accent 指示条位
+       （border-l-2 border-l-transparent）；垂直内边距收一步更密。 */
+    <div className="rounded-md border border-l-2 border-edge-subtle border-l-transparent bg-surface-overlay px-panel py-2 transition-colors hover:bg-surface-hover">
       <div className="flex items-center justify-between">
-        <span className="font-semibold text-[var(--theme-text-primary)]">{source.name}</span>
+        <span className="font-semibold text-ink">{source.name}</span>
         <StatusBadge status={badge.status} label={badge.label} />
       </div>
-      <div className="mt-1 truncate font-mono text-[11px] text-[var(--theme-text-muted)]">
+      <div className="mt-1 truncate font-mono text-caption text-ink-muted">
         {source.endpoint_url}
       </div>
-      <div className="mt-2 flex items-center gap-2 border-t border-[var(--theme-border-subtle)] pt-2 text-[11px]">
+      <div className="mt-2 flex items-center gap-2 border-t border-edge-subtle pt-2 text-caption">
         <button
           type="button"
           onClick={() => onProbe(source.id)}
-          className="flex items-center gap-1 text-[var(--theme-text-secondary)] transition hover:text-[var(--theme-text-primary)]"
+          className="flex items-center gap-1 rounded-sm text-ink-secondary transition-colors hover:text-ink"
         >
           <Activity size={12} aria-hidden />
           <span>探查</span>
@@ -46,7 +54,7 @@ export function SourceItemCard({ source, onProbe, onSync, onDelete }: SourceItem
         <button
           type="button"
           onClick={() => onSync(source.id)}
-          className="flex items-center gap-1 text-[var(--theme-text-secondary)] transition hover:text-[var(--theme-text-primary)]"
+          className="flex items-center gap-1 rounded-sm text-ink-secondary transition-colors hover:text-ink"
         >
           <RefreshCw size={12} aria-hidden />
           <span>同步</span>

--- a/frontend/components/sidebar/data-sources/sources-toolbar.tsx
+++ b/frontend/components/sidebar/data-sources/sources-toolbar.tsx
@@ -10,15 +10,14 @@ export interface SourcesToolbarProps {
 /** 数据源工具条：面板标题 + 添加/取消按钮。 */
 export function SourcesToolbar({ showAddForm, onToggleAddForm }: SourcesToolbarProps) {
   return (
-    <div className="flex shrink-0 items-center justify-between border-b border-[var(--theme-border)] p-2.5">
-      <span className="text-[11px] font-medium text-[var(--theme-text-muted)]">已注册数据源</span>
+    <div className="flex shrink-0 items-center justify-between border-b border-edge-subtle px-panel py-2">
+      <span className="text-caption font-medium text-ink-muted">已注册数据源</span>
       <button
         type="button"
         onClick={onToggleAddForm}
-        className="flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium text-white transition-opacity hover:opacity-85"
-        style={{ background: 'var(--agent-accent, #16a34a)' }}
+        className="flex items-center gap-1 rounded-sm bg-status-accent px-2 py-1 text-caption font-medium text-ink-on-accent transition-opacity hover:opacity-85"
       >
-        <Plus size={13} aria-hidden />
+        <Plus size={12} aria-hidden />
         <span>{showAddForm ? '取消' : '添加数据源'}</span>
       </button>
     </div>

--- a/frontend/components/sidebar/layers-tab.tsx
+++ b/frontend/components/sidebar/layers-tab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState, useCallback } from 'react';
+import clsx from 'clsx';
 import { Eye, EyeOff, GripVertical, Layers as LayersIcon } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import type { Layer } from '@/lib/types/layer';
@@ -35,8 +36,6 @@ export function LayersTab() {
   const updateLayer = useHudStore((s) => s.updateLayer);
   const reorderLayers = useHudStore((s) => s.reorderLayers);
   const setActiveLeftTab = useHudStore((s) => s.setActiveLeftTab);
-  const theme = useHudStore((s) => s.theme);
-  const isDark = theme === 'dark';
 
   const [dragId, setDragId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
@@ -154,22 +153,39 @@ export function LayersTab() {
     setOverId(null);
   }, []);
 
+  /**
+   * a11y：键盘重排。此前排序只有 draggable，鼠标独占 —— 键盘用户无法改变图层
+   * 叠放次序，而叠放次序是图层面板的核心功能。Alt+↑/↓ 沿用桌面 GIS 的习惯键。
+   */
+  const moveLayer = useCallback(
+    (id: string, delta: -1 | 1) => {
+      const current = [...layers];
+      const fromIdx = current.findIndex((l) => l.id === id);
+      const toIdx = fromIdx + delta;
+      if (fromIdx === -1 || toIdx < 0 || toIdx >= current.length) return;
+      const [moved] = current.splice(fromIdx, 1);
+      current.splice(toIdx, 0, moved);
+      reorderLayers(current);
+    },
+    [layers, reorderLayers]
+  );
+
   return (
     <div className="flex flex-col h-full">
-      {/* Stats header */}
-      <div className="shrink-0 grid grid-cols-3 gap-px" style={{ backgroundColor: 'var(--theme-border-subtle)', borderBottomColor: 'var(--theme-border-subtle)' }}>
-        <div className="px-2.5 py-2 text-center" style={{ backgroundColor: 'var(--theme-bg-subtle)' }}>
-          <div className="text-[14px] font-semibold" style={{ color: 'var(--theme-text-primary)' }}>{layers.length}</div>
-          <div className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--theme-text-muted)' }}>总图层</div>
-        </div>
-        <div className="px-2.5 py-2 text-center" style={{ backgroundColor: 'var(--theme-bg-subtle)' }}>
-          <div className="text-[14px] font-semibold" style={{ color: 'var(--agent-accent, #16a34a)' }}>{visibleCount}</div>
-          <div className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--theme-text-muted)' }}>可见</div>
-        </div>
-        <div className="px-2.5 py-2 text-center" style={{ backgroundColor: 'var(--theme-bg-subtle)' }}>
-          <div className="text-[14px] font-semibold" style={{ color: 'var(--theme-text-primary)' }}>{totalFeatures}</div>
-          <div className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--theme-text-muted)' }}>要素</div>
-        </div>
+      {/* Stats header — 单行、三段。V4 之前是 53px 高的三栏卡片，在 650px 的
+          面板里等于吃掉两行图层；同时「可见」数字被涂成 accent 绿，把一个中性
+          计数伪装成状态。accent 现在只留给交互重点。 */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-edge-subtle bg-surface-panel px-panel py-1">
+        {[
+          { label: '总图层', value: layers.length },
+          { label: '可见', value: visibleCount },
+          { label: '要素', value: totalFeatures },
+        ].map((stat) => (
+          <div key={stat.label} className="flex items-baseline gap-1">
+            <span className="text-body font-semibold tabular-nums text-ink">{stat.value}</span>
+            <span className="text-micro text-ink-muted">{stat.label}</span>
+          </div>
+        ))}
       </div>
 
       {/* Layer list */}
@@ -184,38 +200,36 @@ export function LayersTab() {
             />
           </div>
         ) : (
-          <div className="px-2 py-2 space-y-3">
+          <div className="py-1">
             {groups.map((group) => (
-              <div key={group.name}>
-                <div className="flex items-center gap-1.5 px-2 py-1">
-                  <span className="w-1.5 h-1.5 rounded-full" style={{ background: 'var(--agent-accent, #16a34a)' }} />
-                  <span className="text-[10px] font-medium uppercase tracking-wider" style={{ color: 'var(--theme-text-muted)' }}>
-                    {GROUP_NAMES[group.name] || group.name}
+              <div key={group.name} className="mb-1">
+                {/* 分组抬头：去掉装饰性 accent 圆点（accent 只表交互），
+                    统一走 .eyebrow —— 审计里 10px 一档曾有 5 种写法。 */}
+                <div className="flex items-center gap-1.5 px-panel py-1">
+                  <span className="eyebrow">{GROUP_NAMES[group.name] || group.name}</span>
+                  <span className="text-micro tabular-nums text-ink-disabled">
+                    {group.layers.length}
                   </span>
-                  <span className="text-[11px]" style={{ color: 'var(--theme-text-subtle)' }}>({group.layers.length})</span>
                 </div>
 
-                <div className="space-y-1">
+                <div>
                   {group.layers.map((layer) => {
                     const featureCount = getFeatureCount(layer);
-
-                    const color = layer.style?.color || '#16a34a';
+                    const color = layer.style?.color || 'var(--accent-vivid)';
                     const isHeatmap = layer.type === 'heatmap';
                     const isRaster = layer.type === 'raster';
                     const isDragging = dragId === layer.id;
                     const isDragOver = overId === layer.id;
-
-                    let borderColor = 'transparent';
-                    let bgColor = 'transparent';
-                    if (isDragging) {
-                      borderColor = isDark ? 'rgba(74,222,128,0.4)' : 'rgba(52,211,153,0.5)';
-                      bgColor = 'transparent';
-                    } else if (isDragOver) {
-                      borderColor = isDark ? 'rgba(74,222,128,0.6)' : 'rgba(16,185,129,0.7)';
-                      bgColor = isDark ? 'rgba(74,222,128,0.15)' : 'rgba(16,185,129,0.12)';
-                    }
+                    const globalIdx = layers.findIndex((l) => l.id === layer.id);
 
                     return (
+                      /* 单行图层项。V4 之前每项 59–63px（两行 + 两颗 28px 操作
+                         按钮撑高，图标本身只有 12px），650px 面板只放得下 8–9
+                         行；QGIS 图层树是 22–24px。现在收进一行 ~26px，可见行数
+                         提升到 20+ —— 密集数据面板优先可读的行数。 */
+                      /* 行本身不是 tab stop：role="group" 加 tabIndex 既是角色
+                         误用，也会让 20 个图层产生 20 个多余的停靠点。重排键改挂
+                         在把手按钮上 —— 它本来就是"抓着移动"的那个控件。 */
                       <div
                         key={layer.id}
                         draggable
@@ -223,94 +237,80 @@ export function LayersTab() {
                         onDragOver={(e) => handleDragOver(e, layer.id)}
                         onDrop={(e) => handleDrop(e, layer.id)}
                         onDragEnd={handleDragEnd}
-                        style={{
-                          borderRadius: 8,
-                          borderWidth: 1,
-                          borderStyle: 'solid',
-                          borderColor,
-                          backgroundColor: bgColor,
-                          padding: '6px 8px',
-                          transition: 'all 0.15s ease',
-                          opacity: !layer.visible ? 0.6 : isDragging ? 0.4 : 1,
-                          cursor: isDragging ? 'grabbing' : 'default'
-                        }}
-                        onMouseEnter={(e) => {
-                          if (!isDragging && !isDragOver) {
-                            e.currentTarget.style.backgroundColor = 'var(--theme-bg-hover)';
-                          }
-                        }}
-                        onMouseLeave={(e) => {
-                          if (!isDragging && !isDragOver) {
-                            e.currentTarget.style.backgroundColor = bgColor;
-                          }
-                        }}
+                        className={clsx(
+                          'group flex min-h-row-md items-center gap-1.5 border-l-2 px-panel py-0.5 transition-colors',
+                          isDragOver
+                            ? 'border-l-status-accent-vivid bg-surface-selected'
+                            : isDragging
+                              ? 'border-l-status-accent-border opacity-40'
+                              : 'border-l-transparent hover:bg-surface-hover',
+                          !layer.visible && 'opacity-60'
+                        )}
                       >
-                        {/* Row 1: drag handle + name + actions */}
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                          {/* Drag handle */}
-                          <div style={{ cursor: 'grab', color: 'var(--theme-text-subtle)', flexShrink: 0 }}
-                            onMouseDown={(e) => (e.currentTarget.style.cursor = 'grabbing')}
-                            onMouseUp={(e) => (e.currentTarget.style.cursor = 'grab')}
-                          >
-                            <GripVertical size={12} />
-                          </div>
-
-                          {/* Color dot */}
-                          {isRaster ? (
-                            <div style={{ width: 8, height: 8, borderRadius: 2, backgroundColor: color, flexShrink: 0 }} />
-                          ) : isHeatmap ? (
-                            <div style={{ width: 8, height: 8, borderRadius: '50%', background: `radial-gradient(circle, ${color} 0%, transparent 70%)`, flexShrink: 0 }} />
-                          ) : (
-                            <div style={{ width: 7, height: 7, borderRadius: '50%', backgroundColor: color, flexShrink: 0 }} />
-                          )}
-
-                          {/* Layer name */}
-                          <span style={{ flex: 1, fontSize: 13, color: 'var(--theme-text-primary)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 }}>
-                            {layer.name}
-                          </span>
-
-                          {/* Feature count */}
-                          {featureCount > 0 && (
-                            <span style={{ flexShrink: 0, fontSize: 11, color: 'var(--theme-text-subtle)' }}>
-                              {featureCount}
-                            </span>
-                          )}
-
-                          {/* Action buttons — always visible */}
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0 }}>
-                            <IconButton
-                              label={layer.visible ? '隐藏图层' : '显示图层'}
-                              icon={layer.visible ? Eye : EyeOff}
-                              iconSize={12}
-                              onClick={() => toggleLayer(layer.id)}
-                            />
-                            <DeleteLayerButton onDelete={() => removeLayer(layer.id)} />
-                          </div>
-                        </div>
-
-                        {/* Row 2: Opacity slider */}
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4, paddingLeft: 20 }}>
-                          <input
-                            type="range"
-                            min={0}
-                            max={100}
-                            aria-label={`${layer.name} 不透明度`}
-                            value={sliderPercent(layer)}
-                            onChange={(e) =>
-                              handleOpacityChange(layer, parseInt(e.target.value, 10))
+                        <button
+                          type="button"
+                          aria-label={`重新排序 ${layer.name}（第 ${globalIdx + 1} / ${layers.length} 层，Alt+↑/↓ 移动）`}
+                          title="拖拽移动，或 Alt+↑/↓"
+                          className="flex h-control-sm w-icon-md shrink-0 cursor-grab items-center justify-center rounded-xs text-ink-disabled transition-colors hover:text-ink-secondary active:cursor-grabbing"
+                          onKeyDown={(e) => {
+                            if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                              e.preventDefault();
+                              moveLayer(layer.id, e.key === 'ArrowUp' ? -1 : 1);
                             }
-                            onPointerUp={() => commitOpacity(layer)}
-                            onBlur={() => commitOpacity(layer)}
-                            style={{
-                              flex: 1, height: 4,
-                              appearance: 'none',
-                              backgroundColor: 'var(--theme-border-subtle)',
-                              borderRadius: 999, cursor: 'pointer',
-                            }}
+                          }}
+                        >
+                          <GripVertical aria-hidden size={12} />
+                        </button>
+
+                        {/* Layer symbol swatch */}
+                        {isRaster ? (
+                          <span aria-hidden className="h-2 w-2 shrink-0 rounded-xs" style={{ backgroundColor: color }} />
+                        ) : isHeatmap ? (
+                          <span
+                            aria-hidden
+                            className="h-2 w-2 shrink-0 rounded-pill"
+                            style={{ background: `radial-gradient(circle, ${color} 0%, transparent 70%)` }}
                           />
-                          <span style={{ fontSize: 11, color: 'var(--theme-text-muted)', width: 28, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
-                            {sliderPercent(layer)}%
+                        ) : (
+                          <span aria-hidden className="h-2 w-2 shrink-0 rounded-pill" style={{ backgroundColor: color }} />
+                        )}
+
+                        <span className="min-w-0 flex-1 truncate text-body text-ink" title={layer.name}>
+                          {layer.name}
+                        </span>
+
+                        {featureCount > 0 && (
+                          <span className="shrink-0 text-micro tabular-nums text-ink-muted">
+                            {featureCount}
                           </span>
+                        )}
+
+                        {/* 不透明度滑杆内联进同一行 —— 功能不变，不再多占一行。 */}
+                        <input
+                          type="range"
+                          min={0}
+                          max={100}
+                          aria-label={`${layer.name} 不透明度`}
+                          value={sliderPercent(layer)}
+                          onChange={(e) => handleOpacityChange(layer, parseInt(e.target.value, 10))}
+                          onPointerUp={() => commitOpacity(layer)}
+                          onBlur={() => commitOpacity(layer)}
+                          title={`不透明度 ${sliderPercent(layer)}%`}
+                          /* w-16 + .slider-track：w-9(36px) 配上被 appearance-none
+                             抹掉的原生 thumb，等于一条看不见把手的 4px 细杠，
+                             36px 上分 100 档也无法瞄准。 */
+                          className="slider-track h-1 w-16 shrink-0"
+                        />
+
+                        <div className="flex shrink-0 items-center">
+                          <IconButton
+                            size="sm"
+                            label={layer.visible ? '隐藏图层' : '显示图层'}
+                            icon={layer.visible ? Eye : EyeOff}
+                            active={layer.visible}
+                            onClick={() => toggleLayer(layer.id)}
+                          />
+                          <DeleteLayerButton onDelete={() => removeLayer(layer.id)} />
                         </div>
                       </div>
                     );

--- a/frontend/components/sidebar/map-studio-tab.test.tsx
+++ b/frontend/components/sidebar/map-studio-tab.test.tsx
@@ -37,7 +37,6 @@ const mockState: Record<string, any> = {
   updateExportSettings,
   exports: [] as ExportItem[],
   setExports,
-  accentColor: '#16a34a',
   leftPanelOpen: true,
 };
 

--- a/frontend/components/sidebar/map-studio-tab.tsx
+++ b/frontend/components/sidebar/map-studio-tab.tsx
@@ -61,8 +61,7 @@ function StudioSection({
   const sectionId = useId();
   return (
     <section
-      className="overflow-hidden rounded-lg border"
-      style={{ borderColor: 'var(--theme-border)', backgroundColor: 'var(--theme-bg-glass)' }}
+      className="overflow-hidden rounded-md border border-edge-subtle bg-surface-overlay"
     >
       <button
         id={sectionId}
@@ -70,19 +69,20 @@ function StudioSection({
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         aria-controls={`${sectionId}-content`}
-        className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-[var(--theme-bg-hover)]"
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition-colors hover:bg-surface-hover"
       >
         <ChevronDown
           size={14}
           aria-hidden
-          className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
-          style={{ color: 'var(--theme-text-muted)' }}
+          className={`shrink-0 text-ink-muted transition-transform ${open ? 'rotate-180' : ''}`}
         />
         <span className="min-w-0 flex-1">
-          <span className="block text-[13px] font-semibold" style={{ color: 'var(--theme-text-primary)' }}>
+          {/* 长制图标题会折行撑高整行，而下方摘要却在截断 —— 标题同样
+              truncate，并给 title 提示补回被截断的全文。 */}
+          <span className="block truncate text-body font-semibold text-ink" title={title}>
             {title}
           </span>
-          <span className="mt-0.5 block truncate text-[11px]" style={{ color: 'var(--theme-text-muted)' }}>
+          <span className="mt-0.5 block truncate text-caption text-ink-muted">
             {summary}
           </span>
         </span>
@@ -92,8 +92,7 @@ function StudioSection({
           id={`${sectionId}-content`}
           role="region"
           aria-labelledby={sectionId}
-          className="border-t px-3 pb-3 pt-3"
-          style={{ borderColor: 'var(--theme-border-subtle)' }}
+          className="border-t border-edge-subtle px-3 pb-3 pt-3"
         >
           {children}
         </div>
@@ -109,7 +108,6 @@ export function MapStudioTab() {
   const leftPanelOpen = useHudStore((s) => s.leftPanelOpen);
   const exports = useHudStore((s) => s.exports);
   const setExports = useHudStore((s) => s.setExports);
-  const accentColor = useHudStore((s) => s.accentColor);
   const { dispatchAction } = useMapAction();
 
   // Helper to update specific fields
@@ -176,21 +174,11 @@ export function MapStudioTab() {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Segmented subtab switcher（制图排版 / 导出历史）—— PanelHeader 已提供面板标题 */}
-      <div
-        className="p-3 pb-2.5 border-b shrink-0"
-        style={{
-          borderBottomColor: 'var(--theme-border)',
-          backgroundColor: 'var(--theme-bg-glass)'
-        }}
-      >
+      <div className="shrink-0 border-b border-edge-subtle bg-surface-overlay p-3 pb-2.5">
         <div
           role="tablist"
           aria-label="制图工坊子页签"
-          className="flex p-0.5 rounded-lg text-[12px]"
-          style={{
-            backgroundColor: 'var(--theme-bg-muted)',
-            border: '1px solid var(--theme-border)'
-          }}
+          className="flex rounded-md border border-edge-subtle bg-surface-sunken p-0.5 text-meta"
           onKeyDown={(e) => {
             if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
             e.preventDefault();
@@ -211,16 +199,16 @@ export function MapStudioTab() {
             aria-controls={activeSubTab === 'layout' ? 'map-studio-panel-layout' : undefined}
             tabIndex={activeSubTab === 'layout' ? 0 : -1}
             onClick={() => setActiveSubTab('layout')}
-            className="flex-1 py-1.5 rounded-md flex items-center justify-center gap-1.5 font-medium transition-all"
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-md py-1.5 font-medium transition-all"
             style={{
               backgroundColor: activeSubTab === 'layout'
-                ? 'var(--theme-bg-subtle)'
+                ? 'var(--surface-raised)'
                 : 'transparent',
               color: activeSubTab === 'layout'
-                ? 'var(--theme-text-primary)'
-                : 'var(--theme-text-muted)',
+                ? 'var(--text-primary)'
+                : 'var(--text-muted)',
               boxShadow: activeSubTab === 'layout'
-                ? '0 1px 2px var(--theme-border-strong)'
+                ? '0 1px 2px var(--border-strong)'
                 : 'none',
             }}
           >
@@ -234,16 +222,16 @@ export function MapStudioTab() {
             aria-controls={activeSubTab === 'history' ? 'map-studio-panel-history' : undefined}
             tabIndex={activeSubTab === 'history' ? 0 : -1}
             onClick={() => setActiveSubTab('history')}
-            className="flex-1 py-1.5 rounded-md flex items-center justify-center gap-1.5 font-medium transition-all"
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-md py-1.5 font-medium transition-all"
             style={{
               backgroundColor: activeSubTab === 'history'
-                ? 'var(--theme-bg-subtle)'
+                ? 'var(--surface-raised)'
                 : 'transparent',
               color: activeSubTab === 'history'
-                ? 'var(--theme-text-primary)'
-                : 'var(--theme-text-muted)',
+                ? 'var(--text-primary)'
+                : 'var(--text-muted)',
               boxShadow: activeSubTab === 'history'
-                ? '0 1px 2px var(--theme-border-strong)'
+                ? '0 1px 2px var(--border-strong)'
                 : 'none',
             }}
           >
@@ -251,7 +239,7 @@ export function MapStudioTab() {
             <span>导出历史</span>
             {exports.length > 0 && (
               <span
-                className="w-1.5 h-1.5 rounded-full"
+                className="h-1.5 w-1.5 rounded-full"
                 style={{ backgroundColor: 'var(--agent-accent, #16a34a)' }}
                 aria-hidden
               />
@@ -273,7 +261,7 @@ export function MapStudioTab() {
             <StudioSection title="文档" summary={docSummary} defaultOpen>
               <div className="space-y-3">
                 <div>
-                  <label htmlFor={titleId} className="block text-[12px] font-medium mb-1.5" style={{ color: 'var(--theme-text-secondary)' }}>
+                  <label htmlFor={titleId} className="mb-1.5 block text-meta font-medium text-ink-secondary">
                     主标题
                   </label>
                   <input
@@ -282,17 +270,12 @@ export function MapStudioTab() {
                     value={exportSettings.title}
                     onChange={(e) => handleChange('title', e.target.value)}
                     placeholder="如：成都市高校分布图"
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)'
-                    }}
-                    className="w-full text-[13px] border rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)] font-medium"
+                    className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-3 py-2 text-body font-medium text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
                   />
                 </div>
 
                 <div>
-                  <label htmlFor={subtitleId} className="block text-[12px] font-medium mb-1.5" style={{ color: 'var(--theme-text-secondary)' }}>
+                  <label htmlFor={subtitleId} className="mb-1.5 block text-meta font-medium text-ink-secondary">
                     副标题
                   </label>
                   <input
@@ -301,17 +284,12 @@ export function MapStudioTab() {
                     value={exportSettings.subtitle}
                     onChange={(e) => handleChange('subtitle', e.target.value)}
                     placeholder="如：数据来源: OSM, 制图日期: 2026"
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)'
-                    }}
-                    className="w-full text-[13px] border rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)] font-medium"
+                    className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-3 py-2 text-body font-medium text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
                   />
                 </div>
 
                 <div>
-                  <label htmlFor={authorId} className="block text-[12px] font-medium mb-1.5" style={{ color: 'var(--theme-text-secondary)' }}>
+                  <label htmlFor={authorId} className="mb-1.5 block text-meta font-medium text-ink-secondary">
                     作者
                   </label>
                   <input
@@ -320,17 +298,12 @@ export function MapStudioTab() {
                     value={exportSettings.author}
                     onChange={(e) => handleChange('author', e.target.value)}
                     placeholder="制图者名称"
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)'
-                    }}
-                    className="w-full text-[13px] border rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)] font-medium"
+                    className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-3 py-2 text-body font-medium text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
                   />
                 </div>
 
                 <div>
-                  <label htmlFor={dataSourceId} className="block text-[12px] font-medium mb-1.5" style={{ color: 'var(--theme-text-secondary)' }}>
+                  <label htmlFor={dataSourceId} className="mb-1.5 block text-meta font-medium text-ink-secondary">
                     数据来源
                   </label>
                   <input
@@ -339,12 +312,7 @@ export function MapStudioTab() {
                     value={exportSettings.dataSource}
                     onChange={(e) => handleChange('dataSource', e.target.value)}
                     placeholder="如：OSM, 天地图"
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)'
-                    }}
-                    className="w-full text-[13px] border rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)] font-medium"
+                    className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-3 py-2 text-body font-medium text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
                   />
                 </div>
               </div>
@@ -358,17 +326,18 @@ export function MapStudioTab() {
                   return (
                     <label
                       key={el.key}
-                      className="flex items-center gap-2 px-3 py-2.5 rounded-lg cursor-pointer transition-all border text-[12px] font-medium"
+                      className="flex items-center gap-2 rounded-md border px-3 py-2.5 text-meta font-medium transition-all cursor-pointer"
                       style={{
                         backgroundColor: enabled
                           ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 12%, transparent)'
                           : 'transparent',
                         borderColor: enabled
                           ? 'color-mix(in srgb, var(--agent-accent, #16a34a) 35%, transparent)'
-                          : 'var(--theme-border)',
+                          : 'var(--border-subtle)',
+                        /* 选中项文字是 accent 作文字 —— 用 text-safe 变体。 */
                         color: enabled
-                          ? 'var(--agent-accent, #16a34a)'
-                          : 'var(--theme-text-secondary)'
+                          ? 'var(--agent-accent)'
+                          : 'var(--text-secondary)'
                       }}
                     >
                       <input
@@ -387,19 +356,14 @@ export function MapStudioTab() {
 
             {/* 页面与输出：纸张 / 方向 / DPI / 格式 */}
             <StudioSection title="页面与输出" summary={outputSummary}>
-              <div className="space-y-3 font-medium text-[13px]">
+              <div className="space-y-3 text-body font-medium">
                 <div className="flex items-center justify-between gap-4">
-                  <label htmlFor={formatId} style={{ color: 'var(--theme-text-muted)' }}>输出格式</label>
+                  <label htmlFor={formatId} className="text-ink-muted">输出格式</label>
                   <select
                     id={formatId}
                     value={exportSettings.format}
                     onChange={(e) => handleChange('format', e.target.value)}
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)'
-                    }}
-                    className="text-[13px] border rounded-lg px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
+                    className="rounded-md border border-edge-subtle bg-surface-sunken px-2 py-1.5 text-body text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
                   >
                     <option value="png">PNG 高清图片</option>
                     <option value="pdf">PDF 印刷文档</option>
@@ -408,17 +372,12 @@ export function MapStudioTab() {
                 </div>
 
                 <div className="flex items-center justify-between gap-4">
-                  <label htmlFor={paperSizeId} style={{ color: 'var(--theme-text-muted)' }}>纸张尺寸</label>
+                  <label htmlFor={paperSizeId} className="text-ink-muted">纸张尺寸</label>
                   <select
                     id={paperSizeId}
                     value={exportSettings.paperSize}
                     onChange={(e) => handleChange('paperSize', e.target.value)}
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)'
-                    }}
-                    className="text-[13px] border rounded-lg px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
+                    className="rounded-md border border-edge-subtle bg-surface-sunken px-2 py-1.5 text-body text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
                   >
                     <option value="screen">当前屏幕比例 (Screen)</option>
                     <option value="A4">A4 标准纸张尺寸</option>
@@ -427,18 +386,13 @@ export function MapStudioTab() {
                 </div>
 
                 <div className="flex items-center justify-between gap-4">
-                  <label htmlFor={orientationId} style={{ color: 'var(--theme-text-muted)' }}>纸张方向</label>
+                  <label htmlFor={orientationId} className="text-ink-muted">纸张方向</label>
                   <select
                     id={orientationId}
                     value={exportSettings.orientation}
                     onChange={(e) => handleChange('orientation', e.target.value)}
                     disabled={exportSettings.paperSize === 'screen'}
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)'
-                    }}
-                    className="text-[13px] border rounded-lg px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)] disabled:opacity-40"
+                    className="rounded-md border border-edge-subtle bg-surface-sunken px-2 py-1.5 text-body text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)] disabled:opacity-40"
                   >
                     <option value="landscape">横向 (Landscape)</option>
                     <option value="portrait">纵向 (Portrait)</option>
@@ -446,17 +400,12 @@ export function MapStudioTab() {
                 </div>
 
                 <div className="flex items-center justify-between gap-4">
-                  <label htmlFor={dpiId} style={{ color: 'var(--theme-text-muted)' }}>解析度 (DPI)</label>
+                  <label htmlFor={dpiId} className="text-ink-muted">解析度 (DPI)</label>
                   <select
                     id={dpiId}
                     value={exportSettings.dpi}
                     onChange={(e) => handleChange('dpi', Number(e.target.value))}
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)'
-                    }}
-                    className="text-[13px] border rounded-lg px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
+                    className="rounded-md border border-edge-subtle bg-surface-sunken px-2 py-1.5 text-body text-ink focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
                   >
                     <option value={96}>标准清晰度 (96 DPI)</option>
                     <option value={150}>高清晰度 (150 DPI)</option>
@@ -474,7 +423,7 @@ export function MapStudioTab() {
             className="p-2 space-y-1 h-full"
           >
             <div className="flex items-center justify-between px-2 py-1">
-              <span className="text-[12px] font-semibold" style={{ color: 'var(--theme-text-secondary)' }}>
+              <span className="text-meta font-semibold text-ink-secondary">
                 历史生成文件 ({exports.length})
               </span>
               {exports.length > 0 && (
@@ -489,28 +438,24 @@ export function MapStudioTab() {
                 {exports.map((item) => (
                   <div
                     key={item.id}
-                    className="flex items-center gap-2.5 p-2 rounded-lg transition-colors border"
-                    style={{
-                      backgroundColor: 'transparent',
-                      borderColor: 'var(--theme-border)'
-                    }}
-                    onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--theme-bg-hover)'; }}
+                    className="flex items-center gap-2.5 rounded-md border border-edge-subtle bg-transparent p-2 transition-colors"
+                    onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--surface-hover)'; }}
                     onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
                   >
-                    <div className="w-8 h-8 rounded-lg flex items-center justify-center text-base flex-shrink-0" style={{ backgroundColor: 'var(--theme-bg-muted)' }}>
+                    <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md bg-surface-sunken text-base">
                       {iconForType[item.type] || '📁'}
                     </div>
 
                     <div className="flex-1 min-w-0">
-                      <div className="text-[12px] font-semibold truncate" style={{ color: 'var(--theme-text-primary)' }}>
+                      <div className="truncate text-meta font-semibold text-ink">
                         {item.name}
                       </div>
-                      <div className="flex items-center gap-1.5 mt-0.5 text-[11px] font-medium">
-                        <span className="uppercase px-1 rounded font-mono" style={{ backgroundColor: 'var(--theme-bg-muted)', color: 'var(--theme-text-muted)' }}>
+                      <div className="mt-0.5 flex items-center gap-1.5 text-caption font-medium">
+                        <span className="rounded-sm bg-surface-sunken px-1 font-mono uppercase text-ink-muted">
                           {item.type}
                         </span>
-                        <span style={{ color: 'var(--theme-text-subtle)' }}>|</span>
-                        <span className="font-mono" style={{ color: 'var(--theme-text-muted)' }}>
+                        <span className="text-ink-disabled" aria-hidden>|</span>
+                        <span className="font-mono text-ink-muted">
                           {item.size}
                         </span>
                       </div>
@@ -530,15 +475,12 @@ export function MapStudioTab() {
 
       {/* Action Footer for layout */}
       {activeSubTab === 'layout' && (
-        <div
-          className="p-3 bg-transparent border-t shrink-0"
-          style={{ borderColor: 'var(--theme-border)' }}
-        >
+        <div className="shrink-0 border-t border-edge-subtle bg-transparent p-3">
           <button
-            className="w-full text-white font-bold py-2 rounded-lg shadow-md transition-all text-[13px]"
+            className="w-full rounded-md py-1.5 text-body font-semibold text-ink-on-accent transition-opacity hover:opacity-90"
             style={{
-              background: `linear-gradient(135deg, ${accentColor}, ${accentColor}dd)`,
-              boxShadow: `0 4px 12px ${accentColor}25`
+              background: 'linear-gradient(135deg, var(--agent-accent), color-mix(in srgb, var(--agent-accent) 87%, transparent))',
+              boxShadow: '0 4px 12px color-mix(in srgb, var(--agent-accent) 15%, transparent)'
             }}
             onClick={() => {
               dispatchAction({

--- a/frontend/components/sidebar/project-tab.tsx
+++ b/frontend/components/sidebar/project-tab.tsx
@@ -65,8 +65,8 @@ export function ProjectTab() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--theme-border)] px-3 py-1.5">
-        <span className="text-[12px] font-semibold text-[var(--theme-text-secondary)]">项目工作区</span>
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-edge-subtle bg-surface-panel px-panel py-1.5">
+        <span className="text-meta font-semibold text-ink-secondary">项目工作区</span>
         {ws.view === 'project' && (
           <IconButton
             label="新建项目"
@@ -78,7 +78,7 @@ export function ProjectTab() {
         )}
       </div>
 
-      <div className="flex-1 space-y-4 overflow-y-auto p-3 text-[13px]">
+      <div className="flex-1 space-y-4 overflow-y-auto px-panel py-2 text-body">
         {ws.loading ? (
           <LoadingState label="加载项目…" />
         ) : (
@@ -88,10 +88,10 @@ export function ProjectTab() {
             {ws.view === 'project' && (
               <>
                 {showCreate && (
-                  <div className="space-y-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-3">
+                  <div className="space-y-2 rounded-md border border-edge-subtle bg-surface-raised px-panel py-2.5">
                     <label
                       htmlFor={`${uid}-project-name`}
-                      className="block text-[12px] font-medium text-[var(--theme-text-secondary)]"
+                      className="block text-meta font-medium text-ink-secondary"
                     >
                       项目名称
                     </label>
@@ -101,18 +101,12 @@ export function ProjectTab() {
                       placeholder="项目名称…"
                       value={newProjName}
                       onChange={(e) => setNewProjName(e.target.value)}
-                      className="w-full rounded border px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
-                      style={{
-                        backgroundColor: 'var(--theme-bg-input)',
-                        borderColor: 'var(--theme-border)',
-                        color: 'var(--theme-text-primary)',
-                      }}
+                      className="w-full rounded-sm border border-edge-subtle bg-surface-sunken px-2.5 py-1.5 text-meta text-ink focus:outline-none focus:ring-1 focus:ring-status-accent"
                     />
                     <button
                       type="button"
                       onClick={handleCreateProject}
-                      className="w-full rounded py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
-                      style={{ background: 'var(--agent-accent, #16a34a)' }}
+                      className="w-full rounded-sm bg-status-accent py-1.5 text-meta font-medium text-ink-on-accent transition-opacity hover:opacity-90"
                     >
                       创建项目
                     </button>
@@ -122,7 +116,7 @@ export function ProjectTab() {
                 <div>
                   <label
                     htmlFor={`${uid}-project-select`}
-                    className="mb-1 block text-xs font-medium text-[var(--theme-text-secondary)]"
+                    className="mb-1 block text-meta font-medium text-ink-secondary"
                   >
                     当前项目
                   </label>
@@ -130,12 +124,7 @@ export function ProjectTab() {
                     id={`${uid}-project-select`}
                     value={ws.selectedProjectId}
                     onChange={(e) => ws.selectProject(e.target.value)}
-                    className="w-full rounded border px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-[color:var(--agent-accent)]"
-                    style={{
-                      backgroundColor: 'var(--theme-bg-input)',
-                      borderColor: 'var(--theme-border)',
-                      color: 'var(--theme-text-primary)',
-                    }}
+                    className="w-full rounded-sm border border-edge-subtle bg-surface-sunken px-2.5 py-1.5 text-meta text-ink focus:outline-none focus:ring-1 focus:ring-status-accent"
                   >
                     {ws.projects.map((p) => (
                       <option key={p.id} value={p.id}>
@@ -146,9 +135,9 @@ export function ProjectTab() {
                 </div>
 
                 <div className="space-y-2">
-                  <div className="flex items-center justify-between text-xs font-medium text-[var(--theme-text-secondary)]">
+                  <div className="flex items-center justify-between text-meta font-medium text-ink-secondary">
                     <span className="flex items-center gap-1.5">
-                      <Layers className="h-3.5 w-3.5 text-emerald-500" /> 挂载数据集 ({ws.datasets.length})
+                      <Layers size={14} className="text-ink-muted" aria-hidden /> 挂载数据集 ({ws.datasets.length})
                     </span>
                   </div>
                   {ws.datasets.length === 0 ? (
@@ -158,11 +147,11 @@ export function ProjectTab() {
                       {ws.datasets.map((d) => (
                         <div
                           key={d.id}
-                          className="flex items-center justify-between rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-2.5"
+                          className="flex items-center justify-between rounded-md border border-edge-subtle bg-surface-raised px-panel py-2"
                         >
                           <div className="min-w-0">
-                            <div className="text-xs font-medium text-[var(--theme-text-primary)]">{d.name}</div>
-                            <div className="text-[10px] text-[var(--theme-text-muted)]">
+                            <div className="text-meta font-medium text-ink">{d.name}</div>
+                            <div className="text-micro text-ink-muted">
                               {formatCrs(d.crs)} • {d.source_type}
                             </div>
                           </div>
@@ -174,9 +163,9 @@ export function ProjectTab() {
                 </div>
 
                 <div className="space-y-2">
-                  <div className="flex items-center justify-between text-xs font-medium text-[var(--theme-text-secondary)]">
+                  <div className="flex items-center justify-between text-meta font-medium text-ink-secondary">
                     <span className="flex items-center gap-1.5">
-                      <Activity className="h-3.5 w-3.5 text-amber-500" /> 已保存工作流 ({ws.workflows.length})
+                      <Activity size={14} className="text-ink-muted" aria-hidden /> 已保存工作流 ({ws.workflows.length})
                     </span>
                   </div>
                   {ws.workflows.length === 0 ? (
@@ -186,13 +175,13 @@ export function ProjectTab() {
                       {ws.workflows.map((w) => (
                         <div
                           key={w.id}
-                          className="space-y-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-3"
+                          className="space-y-2 rounded-md border border-edge-subtle bg-surface-raised px-panel py-2.5"
                         >
                           <div className="flex items-center justify-between gap-2">
                             <button
                               type="button"
                               onClick={() => ws.openWorkflow(w.id)}
-                              className="flex min-w-0 items-center gap-1 text-left text-xs font-medium text-[var(--theme-text-primary)] hover:underline"
+                              className="flex min-w-0 items-center gap-1 text-left text-meta font-medium text-ink hover:underline"
                             >
                               <span className="truncate">
                                 {w.name} (v{w.version})
@@ -206,10 +195,10 @@ export function ProjectTab() {
                                 void handleRerunWorkflow(w.id);
                               }}
                               disabled={ws.actionBusy}
-                              className="border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] text-[var(--theme-text-primary)] hover:bg-[var(--theme-bg-hover)] hover:text-[var(--theme-text-primary)] dark:text-[var(--theme-text-primary)]"
+                              className="border border-edge-subtle bg-surface-raised text-ink hover:bg-surface-sunken"
                             />
                           </div>
-                          <div className="text-[10px] text-[var(--theme-text-muted)]">步骤 {w.step_count}</div>
+                          <div className="text-micro text-ink-muted">步骤 {w.step_count}</div>
                         </div>
                       ))}
                     </div>
@@ -223,30 +212,30 @@ export function ProjectTab() {
                 <button
                   type="button"
                   onClick={ws.back}
-                  className="text-[11px] text-[var(--theme-text-secondary)] hover:underline"
+                  className="text-micro text-ink-secondary hover:underline"
                 >
                   ← 返回项目
                 </button>
                 <div>
-                  <div className="text-[13px] font-semibold text-[var(--theme-text-primary)]">
+                  <div className="text-body font-semibold text-ink">
                     {ws.selectedWorkflow.name}
                   </div>
-                  <div className="text-[10px] text-[var(--theme-text-muted)]">
+                  <div className="text-micro text-ink-muted">
                     v{ws.selectedWorkflow.version} · {ws.selectedWorkflow.step_count} 步
                   </div>
                 </div>
                 <section aria-labelledby="wf-rev-heading" className="space-y-1">
-                  <h3 id="wf-rev-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+                  <h3 id="wf-rev-heading" className="text-micro font-semibold uppercase tracking-wide text-ink-muted">
                     不可变修订
                   </h3>
                   {ws.revisions.length === 0 ? (
-                    <p className="text-[11px] text-[var(--theme-text-muted)]">暂无修订</p>
+                    <p className="text-micro text-ink-muted">暂无修订</p>
                   ) : (
                     <ul className="space-y-1">
                       {ws.revisions.map((rev) => (
                         <li
                           key={rev.id}
-                          className="flex justify-between gap-2 rounded border border-[var(--theme-border)] px-2 py-1 font-mono text-[10px] text-[var(--theme-text-secondary)]"
+                          className="flex justify-between gap-2 rounded-sm border border-edge-subtle px-2 py-1 font-mono text-micro text-ink-secondary"
                         >
                           <span>r{rev.revision_no}</span>
                           <span>{shortId(rev.graph_fingerprint, 10)}</span>
@@ -256,7 +245,7 @@ export function ProjectTab() {
                   )}
                 </section>
                 <section aria-labelledby="wf-runs-heading" className="space-y-1">
-                  <h3 id="wf-runs-heading" className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">
+                  <h3 id="wf-runs-heading" className="text-micro font-semibold uppercase tracking-wide text-ink-muted">
                     运行
                   </h3>
                   {ws.detailLoading && ws.runs.length === 0 ? (
@@ -270,21 +259,21 @@ export function ProjectTab() {
                           <button
                             type="button"
                             onClick={() => ws.openRun(r.id)}
-                            className="flex w-full items-center justify-between gap-2 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] px-2.5 py-2 text-left hover:bg-[var(--theme-bg-hover)]"
+                            className="flex w-full items-center justify-between gap-2 rounded-md border border-edge-subtle bg-surface-raised px-2.5 py-2 text-left hover:bg-surface-sunken"
                           >
                             <span className="min-w-0">
-                              <span className="block font-mono text-[11px] text-[var(--theme-text-primary)]">
+                              <span className="block font-mono text-micro text-ink">
                                 {shortId(r.id, 10)}
                               </span>
                               {r.error_message && (
-                                <span className="block truncate text-[10px] text-red-600 dark:text-red-300">
+                                <span className="block truncate text-micro text-status-danger">
                                   {r.error_message}
                                 </span>
                               )}
                             </span>
                             <span className="flex items-center gap-1">
                               <StatusBadge status={r.status} />
-                              <ChevronRight className="h-3 w-3 text-[var(--theme-text-muted)]" aria-hidden />
+                              <ChevronRight className="h-3 w-3 text-ink-muted" aria-hidden />
                             </span>
                           </button>
                         </li>
@@ -297,7 +286,7 @@ export function ProjectTab() {
                       onClick={() => {
                         void ws.loadMoreRuns();
                       }}
-                      className="w-full rounded border border-[var(--theme-border)] py-1 text-[11px] text-[var(--theme-text-secondary)] hover:bg-[var(--theme-bg-hover)]"
+                      className="w-full rounded-sm border border-edge-subtle py-1 text-micro text-ink-secondary hover:bg-surface-sunken"
                     >
                       加载更多运行
                     </button>

--- a/frontend/components/sidebar/tasks-tab.tsx
+++ b/frontend/components/sidebar/tasks-tab.tsx
@@ -28,7 +28,6 @@ import { StatusBadge } from '@/components/shared/status-badge';
 interface TasksTabProps {
   sessionId?: string | null;
   ownerToken?: string | null;
-  accentColor?: string;
 }
 
 const KIND_LABELS: Record<string, string> = {
@@ -58,14 +57,12 @@ function JobCard({
   onCancel,
   onRetry,
   now,
-  accentColor,
 }: {
   job: JobView;
   isCancelling: boolean;
   onCancel: (id: string) => void;
   onRetry: (id: string) => void;
   now: number;
-  accentColor: string;
 }) {
   // 「取消中」以本地乐观状态或后端状态任一为准；但「已取消」只认后端终态
   const displayStatus: JobStatus =
@@ -74,15 +71,18 @@ function JobCard({
   const indeterminate = job.active && job.progress === null;
 
   return (
+    /* 任务行与 layers-tab 同款交互配方：hover 底色 + 左侧预留 accent 指示条
+       位（border-l-2 border-l-transparent）。V4 之前整卡无任何悬停反馈，且
+       backdrop-blur-sm 属于审计清掉的半透明玻璃效果；垂直内边距收一步。 */
     <div
-      className="rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg-subtle)] p-3 backdrop-blur-sm"
+      className="rounded-md border border-l-2 border-edge-subtle border-l-transparent bg-surface-raised px-panel py-2.5 transition-colors hover:bg-surface-hover"
       data-testid={`job-card-${job.id}`}
       aria-busy={job.active}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <div className="truncate text-sm font-medium text-[var(--theme-text-primary)]">{job.name}</div>
-          <div className="mt-0.5 text-xs text-[var(--theme-text-muted)]">
+          <div className="truncate text-body font-medium text-ink">{job.name}</div>
+          <div className="mt-0.5 text-meta text-ink-muted">
             {KIND_LABELS[job.kind] ?? job.kind}
             {job.attempt > 1 && ` · 第 ${job.attempt} 次尝试`}
             {job.agent_step_id && ` · 来自 ${job.agent_step_id}`}
@@ -94,19 +94,21 @@ function JobCard({
       {showProgress && (
         <div className="mt-2">
           <div
-            className="h-1.5 overflow-hidden rounded-full bg-[var(--theme-bg-muted)]"
+            className="h-1.5 overflow-hidden rounded-pill bg-surface-sunken"
             role="progressbar"
             aria-valuenow={job.progress ?? 0}
             aria-valuemin={0}
             aria-valuemax={100}
             aria-label={`${job.name} 进度`}
           >
+            {/* 运行中任务 = info（蓝）：进度填充与同一任务的 StatusBadge 同色。
+                之前填充用 accent 绿、徽标是蓝，一个「运行中」出现两种颜色。 */}
             <div
-              className="h-1.5 rounded-full transition-all duration-500"
-              style={{ width: `${job.progress ?? 0}%`, backgroundColor: accentColor }}
+              className="h-1.5 rounded-pill bg-status-info transition-all duration-500"
+              style={{ width: `${job.progress ?? 0}%` }}
             />
           </div>
-          <div className="mt-1 flex justify-between text-xs text-[var(--theme-text-muted)]">
+          <div className="mt-1 flex justify-between text-meta text-ink-muted">
             <span className="truncate">{job.message ?? ''}</span>
             <span className="shrink-0 pl-2">{job.progress}%</span>
           </div>
@@ -115,18 +117,18 @@ function JobCard({
 
       {indeterminate && (
         // 不确定进度：明确显示为「进行中」而不是编造一个 99% 然后卡住
-        <div className="mt-2 text-xs text-[var(--theme-text-muted)]" data-testid={`job-indeterminate-${job.id}`}>
+        <div className="mt-2 text-meta text-ink-muted" data-testid={`job-indeterminate-${job.id}`}>
           {job.message ?? '进行中…'}
         </div>
       )}
 
-      {job.error && <div className="mt-2 text-xs text-red-600 dark:text-red-400">{job.error}</div>}
+      {job.error && <div className="mt-2 text-meta text-status-critical">{job.error}</div>}
 
-      <div className="mt-2 flex items-center justify-between text-xs text-[var(--theme-text-muted)]">
+      <div className="mt-2 flex items-center justify-between text-meta text-ink-muted">
         <span>已用 {formatElapsed(job, now)}</span>
         <div className="flex items-center gap-2">
           {job.result_ref && !job.active && (
-            <span className="max-w-[10rem] truncate text-[var(--theme-text-muted)]" title={job.result_ref}>
+            <span className="max-w-[10rem] truncate text-ink-muted" title={job.result_ref}>
               {job.result_ref.split('/').pop()}
             </span>
           )}
@@ -135,10 +137,10 @@ function JobCard({
               type="button"
               onClick={() => onCancel(job.id)}
               disabled={isCancelling || displayStatus === 'cancelling'}
-              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--theme-text-muted)] transition-colors hover:bg-[var(--theme-bg-hover)] hover:text-[var(--theme-text-primary)] disabled:opacity-40"
+              className="inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-ink-muted transition-colors hover:bg-surface-hover hover:text-ink disabled:opacity-40"
               aria-label={`取消 ${job.name}`}
             >
-              <X className="h-3 w-3" />
+              <X size={12} aria-hidden />
               取消
             </button>
           )}
@@ -146,10 +148,10 @@ function JobCard({
             <button
               type="button"
               onClick={() => onRetry(job.id)}
-              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--theme-text-muted)] transition-colors hover:bg-[var(--theme-bg-hover)] hover:text-[var(--theme-text-primary)]"
+              className="inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-ink-muted transition-colors hover:bg-surface-hover hover:text-ink"
               aria-label={`重试 ${job.name}`}
             >
-              <RotateCcw className="h-3 w-3" />
+              <RotateCcw size={12} aria-hidden />
               重试
             </button>
           )}
@@ -159,7 +161,7 @@ function JobCard({
   );
 }
 
-export function TasksTab({ sessionId, ownerToken, accentColor = '#16a34a' }: TasksTabProps) {
+export function TasksTab({ sessionId, ownerToken }: TasksTabProps) {
   // Review P2 修复：context panel 收起时 tab 内容保持挂载（visibility 隐藏），
   // 传 enabled 关闭轮询，避免看不见的面板持续打后端。
   const leftPanelOpen = useHudStore((s) => s.leftPanelOpen);
@@ -183,9 +185,9 @@ export function TasksTab({ sessionId, ownerToken, accentColor = '#16a34a' }: Tas
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* 细工具栏：活跃任务数（仅 >0 时显示）+ 刷新 */}
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--theme-border)] px-3 py-1.5">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-edge-subtle bg-surface-panel px-panel py-1.5">
         {active.length > 0 && (
-          <span className="text-[11px] font-medium text-[var(--theme-text-secondary)]">
+          <span className="text-caption font-medium text-ink-secondary">
             {active.length} 个活跃任务
           </span>
         )}
@@ -198,7 +200,7 @@ export function TasksTab({ sessionId, ownerToken, accentColor = '#16a34a' }: Tas
         </InlineNotice>
       )}
 
-      <div className="flex-1 space-y-2 overflow-y-auto p-3">
+      <div className="flex-1 space-y-2 overflow-y-auto px-panel py-2">
         {jobs.length === 0 && loading ? (
           <LoadingState label="加载任务…" />
         ) : jobs.length === 0 ? (
@@ -213,12 +215,11 @@ export function TasksTab({ sessionId, ownerToken, accentColor = '#16a34a' }: Tas
                 onCancel={cancel}
                 onRetry={retry}
                 now={now}
-                accentColor={accentColor}
               />
             ))}
 
             {finished.length > 0 && active.length > 0 && (
-              <div className="pt-2 text-xs text-[var(--theme-text-subtle)]">已结束</div>
+              <div className="pt-2 text-meta text-ink-disabled">已结束</div>
             )}
 
             {finished.map((job) => (
@@ -229,7 +230,6 @@ export function TasksTab({ sessionId, ownerToken, accentColor = '#16a34a' }: Tas
                 onCancel={cancel}
                 onRetry={retry}
                 now={now}
-                accentColor={accentColor}
               />
             ))}
           </>

--- a/frontend/components/tweaks-panel.tsx
+++ b/frontend/components/tweaks-panel.tsx
@@ -1,12 +1,111 @@
 'use client';
 
+import { useId, useRef } from 'react';
 import { useHudStore } from '@/lib/store/useHudStore';
+import { useInertWhenClosed } from '@/lib/hooks/use-inert';
+import ToggleSwitch from '@/components/shared/toggle-switch';
+import { useDialogFocus } from '@/lib/hooks/use-dialog-focus';
 
 interface TweaksPanelProps {
   children?: React.ReactNode;
 }
 
-const ACCENT_COLORS = ['#16a34a', '#2563eb', '#7c3aed', '#dc2626', '#0891b2'];
+/**
+ * 主题色预设。全部取"能承载白色文字"的一档 —— 之前的 #16a34a 与 #0891b2 配
+ * 白字只有 3.30:1 / 3.68:1，而 accent 底 + 白字正是主按钮与用户气泡的用法，
+ * 也就是说其中两个预设一旦被选中，主按钮的文字就不达 AA。
+ */
+const ACCENT_COLORS: { value: string; name: string }[] = [
+  { value: '#15803d', name: '绿色' },
+  { value: '#1d4ed8', name: '蓝色' },
+  { value: '#6d28d9', name: '紫色' },
+  { value: '#b91c1c', name: '红色' },
+  { value: '#0e7490', name: '青色' },
+];
+
+/** 供测试断言：每个预设都必须能承载 --text-on-accent 的白色文字。 */
+export const ACCENT_PRESETS = ACCENT_COLORS.map((c) => c.value);
+
+/** 分段选择器 —— 主题 / 密度共用，替代两处各写一遍的内联按钮组。 */
+function SegmentedControl<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div role="radiogroup" aria-label={label} className="flex gap-0.5 rounded-sm bg-surface-sunken p-0.5">
+      {options.map((opt) => {
+        const selected = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(opt.value)}
+            className={`flex-1 rounded-xs py-1 text-meta transition-colors ${
+              selected
+                ? 'bg-surface-raised font-medium text-ink shadow-raised'
+                : 'text-ink-muted hover:text-ink'
+            }`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** 带值读数的滑杆行。label 通过 htmlFor 绑定，之前两处滑杆都是无名控件。 */
+function SliderRow({
+  label,
+  value,
+  suffix,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  suffix: string;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  const id = useId();
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <label htmlFor={id} className="eyebrow">
+          {label}
+        </label>
+        <span className="font-mono text-caption tabular-nums text-ink-secondary">
+          {value}
+          {suffix}
+        </span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="h-1 w-full cursor-pointer appearance-none rounded-pill bg-edge-subtle"
+      />
+    </div>
+  );
+}
 
 export function TweaksPanel({ children }: TweaksPanelProps) {
   const tweaksOpen = useHudStore((s) => s.tweaksOpen);
@@ -28,176 +127,134 @@ export function TweaksPanel({ children }: TweaksPanelProps) {
   const sidebarWidth = useHudStore((s) => s.sidebarWidth);
   const setSidebarWidth = useHudStore((s) => s.setSidebarWidth);
 
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  /*
+    a11y：此前本面板常驻 DOM，仅靠 transform + opacity + pointerEvents 隐藏，
+    既没有 role=dialog / 可访问名称，也没有 Escape，读屏在它视觉隐藏时依然能读到
+    里面全部控件。现在补齐对话框语义并接入共享 useDialogFocus（与 settings /
+    history / 模板库同一套焦点契约）。
+    关闭时除了 aria-hidden 还要 inert：只写 aria-hidden 是 ARIA 违规 —— 容器里
+    仍有可聚焦控件，键盘会 Tab 进一个看不见、也不会被播报的面板。
+  */
+  useInertWhenClosed(panelRef, tweaksOpen);
+
+  useDialogFocus({
+    open: tweaksOpen,
+    containerRef: panelRef,
+    onEscape: () => setTweaksOpen(false),
+  });
+
   return (
     <>
-      {/* Tweaks panel */}
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby="tweaks-panel-title"
+        aria-hidden={!tweaksOpen}
+        /* max-h + overflow-y：审计发现本面板既无高度上限也无内部滚动，
+           视口一矮就整体溢出屏幕。 */
+        className="fixed bottom-8 left-1/2 z-[100] max-h-[min(72vh,520px)] w-[300px] -translate-x-1/2 overflow-y-auto rounded-md border border-edge-subtle bg-surface-overlay p-panel shadow-drawer transition-transform duration-200"
         style={{
-          position: 'fixed',
-          bottom: 30,
-          left: '50%',
           transform: tweaksOpen ? 'translateX(-50%)' : 'translateX(-50%) translateY(105%)',
-          zIndex: 100,
-          background: 'rgba(252,253,254,0.96)',
-          backdropFilter: 'blur(20px)',
-          WebkitBackdropFilter: 'blur(20px)',
-          border: '1px solid rgba(255,255,255,0.95)',
-          boxShadow: '0 8px 32px rgba(15,23,42,0.12)',
-          borderRadius: 16,
-          padding: 16,
-          minWidth: 300,
-          transition: 'transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
-          pointerEvents: tweaksOpen ? 'auto' : 'none',
           opacity: tweaksOpen ? 1 : 0,
+          pointerEvents: tweaksOpen ? 'auto' : 'none',
         }}
       >
-        {/* Header */}
-        <div className='flex items-center justify-between mb-3'>
-          <div className='text-xs font-semibold text-slate-800'>UI 调整</div>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 id="tweaks-panel-title" className="text-title font-semibold text-ink">
+            UI 调整
+          </h2>
           <button
+            type="button"
             onClick={() => setTweaksOpen(false)}
-            className='text-[14px] text-slate-400 hover:text-slate-600'
+            className="rounded-sm px-1.5 py-0.5 text-meta text-ink-muted transition-colors hover:bg-surface-hover hover:text-ink"
           >
             关闭
           </button>
         </div>
 
-        {/* Accent color */}
-        <div className='mb-4'>
-          <div className='text-[14px] font-semibold text-slate-400 uppercase tracking-wider mb-2'>
-            主题色
-          </div>
-          <div className='flex gap-2'>
-            {ACCENT_COLORS.map((color) => (
-              <button
-                key={color}
-                onClick={() => setAccentColor(color)}
-                style={{
-                  width: 24,
-                  height: 24,
-                  borderRadius: 6,
-                  backgroundColor: color,
-                  border: accentColor === color ? '2px solid #0f172a' : '2px solid transparent',
-                  cursor: 'pointer',
-                }}
-              />
-            ))}
-          </div>
-        </div>
-
-        {/* Font size */}
-        <div className='mb-4'>
-          <div className='flex items-center justify-between mb-2'>
-            <div className='text-[14px] font-semibold text-slate-400 uppercase tracking-wider'>
-              字体大小
+        <div className="space-y-3">
+          <div>
+            <div className="eyebrow mb-1.5">主题色</div>
+            <div className="flex gap-1.5">
+              {ACCENT_COLORS.map((color) => (
+                <button
+                  key={color.value}
+                  type="button"
+                  /* a11y：这五颗色板此前是完全空的 <button>，既无 aria-label
+                     也无 title —— 读屏只会读到「按钮」。 */
+                  aria-label={`主题色：${color.name}`}
+                  title={color.name}
+                  aria-pressed={accentColor === color.value}
+                  onClick={() => setAccentColor(color.value)}
+                  className={`h-control-sm w-control-sm rounded-sm border-2 transition-colors ${
+                    accentColor === color.value ? 'border-ink' : 'border-transparent'
+                  }`}
+                  style={{ backgroundColor: color.value }}
+                />
+              ))}
             </div>
-            <span className='text-[14px] text-slate-500 font-mono'>{fontSize}px</span>
           </div>
-          <input
-            type='range'
+
+          <SliderRow
+            label="字体大小"
+            value={fontSize}
+            suffix="px"
             min={11}
             max={16}
             step={0.5}
-            value={fontSize}
-            onChange={(e) => setFontSize(parseFloat(e.target.value))}
-            className='w-full'
+            onChange={setFontSize}
           />
-        </div>
 
-        {/* Theme */}
-        <div className='mb-4'>
-          <div className='text-[14px] font-semibold text-slate-400 uppercase tracking-wider mb-2'>
-            主题
+          <div>
+            <div className="eyebrow mb-1.5">主题</div>
+            <SegmentedControl
+              label="主题"
+              value={theme}
+              options={[
+                { value: 'light' as const, label: '亮色' },
+                { value: 'dark' as const, label: '暗色' },
+              ]}
+              onChange={setTheme}
+            />
           </div>
-          <div className='flex gap-1'>
-            {['light', 'dark'].map((t) => (
-              <button
-                key={t}
-                onClick={() => setTheme(t as 'light' | 'dark')}
-                style={{
-                  flex: 1,
-                  padding: '6px 12px',
-                  borderRadius: 8,
-                  border: 'none',
-                  cursor: 'pointer',
-                  fontSize: 13,
-                  background: theme === t ? 'rgba(15,23,42,0.06)' : 'transparent',
-                  color: theme === t ? '#0f172a' : '#64748b',
-                }}
-              >
-                {t === 'light' ? '亮色' : '暗色'}
-              </button>
-            ))}
-          </div>
-        </div>
 
-        {/* Density */}
-        <div className='mb-4'>
-          <div className='text-[14px] font-semibold text-slate-400 uppercase tracking-wider mb-2'>
-            信息密度
+          <div>
+            <div className="eyebrow mb-1.5">信息密度</div>
+            <SegmentedControl
+              label="信息密度"
+              value={density}
+              options={[
+                { value: 'compact' as const, label: '紧凑' },
+                { value: 'comfortable' as const, label: '舒适' },
+              ]}
+              onChange={setDensity}
+            />
           </div>
-          <div className='flex gap-1'>
-            {['compact', 'comfortable'].map((d) => (
-              <button
-                key={d}
-                onClick={() => setDensity(d as 'compact' | 'comfortable')}
-                style={{
-                  flex: 1,
-                  padding: '6px 12px',
-                  borderRadius: 8,
-                  border: 'none',
-                  cursor: 'pointer',
-                  fontSize: 13,
-                  background: density === d ? 'rgba(15,23,42,0.06)' : 'transparent',
-                  color: density === d ? '#0f172a' : '#64748b',
-                }}
-              >
-                {d === 'compact' ? '紧凑' : '舒适'}
-              </button>
-            ))}
-          </div>
-        </div>
 
-        {/* Sidebar width */}
-        <div className='mb-4'>
-          <div className='flex items-center justify-between mb-2'>
-            <div className='text-[14px] font-semibold text-slate-400 uppercase tracking-wider'>
-              侧边栏宽度
-            </div>
-            <span className='text-[14px] text-slate-500 font-mono'>{sidebarWidth}px</span>
-          </div>
-          <input
-            type='range'
+          <SliderRow
+            label="侧边栏宽度"
+            value={sidebarWidth}
+            suffix="px"
             min={240}
             max={480}
             step={10}
-            value={sidebarWidth}
-            onChange={(e) => setSidebarWidth(parseInt(e.target.value))}
-            className='w-full'
+            onChange={(v) => setSidebarWidth(Math.round(v))}
           />
-        </div>
 
-        {/* Toggles */}
-        <div className='space-y-2'>
-          <div className='text-[14px] font-semibold text-slate-400 uppercase tracking-wider mb-2'>
-            面板
+          <div>
+            <div className="eyebrow mb-1.5">面板</div>
+            <div className="space-y-0.5">
+              {/* 这三行原本是自绘的无名开关（无 role=switch / aria-checked，
+                  label 只是旁边一个游离的 span）。改用共享 ToggleSwitch，
+                  可访问名称由它的必填 prop 强制。 */}
+              <ToggleRow label="Agent 环境 HUD" value={hudOpen} onChange={setHudOpen} />
+              <ToggleRow label="RAG 独立面板" value={ragPanelOpen} onChange={setRagPanelOpen} />
+              <ToggleRow label="显示地图网格" value={showGrid} onChange={setShowGrid} />
+            </div>
           </div>
-
-          <ToggleRow
-            label='Agent 环境 HUD'
-            value={hudOpen}
-            onChange={setHudOpen}
-          />
-          <ToggleRow
-            label='RAG 独立面板'
-            value={ragPanelOpen}
-            onChange={setRagPanelOpen}
-          />
-          <ToggleRow
-            label='显示地图网格'
-            value={showGrid}
-            onChange={setShowGrid}
-          />
         </div>
       </div>
 
@@ -206,37 +263,19 @@ export function TweaksPanel({ children }: TweaksPanelProps) {
   );
 }
 
-function ToggleRow({ label, value, onChange }: { label: string; value: boolean; onChange: (v: boolean) => void }) {
+function ToggleRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
   return (
-    <div className='flex items-center justify-between py-1.5'>
-      <span className='text-xs text-slate-600'>{label}</span>
-      <button
-        onClick={() => onChange(!value)}
-        style={{
-          width: 36,
-          height: 20,
-          borderRadius: 10,
-          border: 'none',
-          cursor: 'pointer',
-          transition: 'background 0.2s',
-          background: value ? '#16a34a' : '#cbd5e1',
-          position: 'relative',
-        }}
-      >
-        <div
-          style={{
-            position: 'absolute',
-            top: 2,
-            left: value ? 18 : 2,
-            width: 16,
-            height: 16,
-            borderRadius: '50%',
-            background: 'white',
-            transition: 'left 0.2s',
-            boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-          }}
-        />
-      </button>
+    <div className="flex min-h-row-sm items-center justify-between">
+      <span className="text-meta text-ink-secondary">{label}</span>
+      <ToggleSwitch label={label} checked={value} onChange={() => onChange(!value)} />
     </div>
   );
 }

--- a/frontend/components/ui/toast.tsx
+++ b/frontend/components/ui/toast.tsx
@@ -59,26 +59,29 @@ export const useToastStore = create<ToastStore>((set, get) => ({
 
 /* ── Style maps ── */
 
+// V4: the same four status slots as StatusBadge / InlineNotice, so an operation's
+// toast and its badge are never two different greens. `text-hud-cyan` (info) was
+// an undefined utility and rendered as inherited colour.
 const typeStyles: Record<ToastType, { color: string; border: string; icon: React.ReactNode }> = {
   success: {
-    color: "text-emerald-400",
-    border: "border-emerald-500/30",
-    icon: <CheckCircle2 className="h-4 w-4 text-emerald-400 shrink-0" />,
+    color: "text-status-success",
+    border: "border-status-success-border",
+    icon: <CheckCircle2 className="h-icon-md w-icon-md shrink-0 text-status-success" aria-hidden />,
   },
   error: {
-    color: "text-red-400",
-    border: "border-red-500/30",
-    icon: <AlertCircle className="h-4 w-4 text-red-400 shrink-0" />,
+    color: "text-status-critical",
+    border: "border-status-critical-border",
+    icon: <AlertCircle className="h-icon-md w-icon-md shrink-0 text-status-critical" aria-hidden />,
   },
   info: {
-    color: "text-hud-cyan",
-    border: "border-hud-cyan/30",
-    icon: <Info className="h-4 w-4 text-hud-cyan shrink-0" />,
+    color: "text-status-info",
+    border: "border-status-info-border",
+    icon: <Info className="h-icon-md w-icon-md shrink-0 text-status-info" aria-hidden />,
   },
   warning: {
-    color: "text-amber-400",
-    border: "border-amber-500/30",
-    icon: <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0" />,
+    color: "text-status-warning",
+    border: "border-status-warning-border",
+    icon: <AlertTriangle className="h-icon-md w-icon-md shrink-0 text-status-warning" aria-hidden />,
   },
 }
 
@@ -89,7 +92,17 @@ export function ToastContainer() {
   const removeToast = useToastStore((s) => s.removeToast)
 
   return (
-    <div className="fixed bottom-4 right-4 z-[9999] flex flex-col-reverse gap-2 pointer-events-none">
+    /*
+      a11y（P0）：ToastContainer 之前没有任何 live region —— 「模板已应用」、
+      「数据源已删除」、连通测试结果等每一次操作反馈对读屏用户都是不存在的。
+      role="status" + aria-live="polite" 让它们在用户空闲时被读出，而不是打断。
+    */
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="false"
+      className="pointer-events-none fixed bottom-4 right-4 z-[9999] flex flex-col-reverse gap-2"
+    >
       <AnimatePresence mode="popLayout">
         {toasts.map((toast) => {
           const style = typeStyles[toast.type]
@@ -101,21 +114,19 @@ export function ToastContainer() {
               animate={{ opacity: 1, x: 0, scale: 1 }}
               exit={{ opacity: 0, x: 80, scale: 0.95 }}
               transition={{ type: "spring", stiffness: 400, damping: 30 }}
-              className={`
-                pointer-events-auto flex items-center gap-2 px-4 py-3
-                rounded-xl shadow-lg backdrop-blur-hud
-                bg-ds-surface border ${style.border}
-                max-w-sm
-              `}
+              /* `bg-ds-surface` / `backdrop-blur-hud` were never defined in the
+                 Tailwind config, so the toast rendered with no background at all
+                 — its text sat straight on the map. Now on the overlay surface. */
+              className={`pointer-events-auto flex max-w-sm items-center gap-2 rounded-md border bg-surface-overlay px-3 py-2 shadow-overlay ${style.border}`}
             >
               {style.icon}
-              <span className={`text-sm font-mono ${style.color}`}>{toast.message}</span>
+              <span className={`font-mono text-meta ${style.color}`}>{toast.message}</span>
               <button
                 onClick={() => removeToast(toast.id)}
-                className="ml-2 shrink-0 text-white/40 hover:text-white/80 transition-colors"
-                aria-label="Dismiss"
+                className="ml-2 shrink-0 text-ink-muted transition-colors hover:text-ink"
+                aria-label="关闭提示"
               >
-                <X className="h-3.5 w-3.5" />
+                <X className="h-icon-sm w-icon-sm" aria-hidden />
               </button>
             </motion.div>
           )

--- a/frontend/lib/hooks/use-inert.ts
+++ b/frontend/lib/hooks/use-inert.ts
@@ -1,0 +1,29 @@
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * Keeps an always-mounted-but-hidden panel out of the accessibility tree AND out
+ * of the tab order.
+ *
+ * `aria-hidden` alone is not enough — and is in fact an ARIA violation — when the
+ * hidden container still holds focusable elements: a keyboard user tabs into
+ * controls they cannot see, and a screen reader announces nothing when focus
+ * lands there. Several panels in this app stay mounted so they can animate in
+ * and out, so they hit exactly that case.
+ *
+ * `inert` is the platform answer (it removes the subtree from hit-testing, focus
+ * and the a11y tree in one go) but React 18 has no `inert` prop, so it is set
+ * imperatively here. Browsers without `inert` fall back to the `aria-hidden` the
+ * caller already sets, which is the pre-existing behaviour rather than a
+ * regression.
+ */
+export function useInertWhenClosed(ref: RefObject<HTMLElement | null>, open: boolean): void {
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (open) {
+      node.removeAttribute('inert');
+    } else {
+      node.setAttribute('inert', '');
+    }
+  }, [ref, open]);
+}

--- a/frontend/lib/store/slices/uiSlice.ts
+++ b/frontend/lib/store/slices/uiSlice.ts
@@ -113,7 +113,8 @@ export const createUiSlice: StateCreator<HudState, [], [], Partial<HudState>> = 
   setTweaksOpen: (open) => set({ tweaksOpen: open }),
 
   /* ─── v2 UI Tweaks ─── */
-  accentColor: '#16a34a',
+  // 与 --accent 同值：accent 底 + 白字需达 AA（旧的 #16a34a 只有 3.3:1）。
+  accentColor: '#15803d',
   setAccentColor: (color) => set({ accentColor: color }),
   theme: 'light' as const,
   setTheme: (theme) => set({ theme }),

--- a/frontend/lib/store/useHudStore.ts
+++ b/frontend/lib/store/useHudStore.ts
@@ -46,6 +46,15 @@ export {
   DEMO_CAUSAL_CHAIN,
 } from '../constants/demo';
 
+/**
+ * localStorage key for the persisted slice.
+ *
+ * Exported because `app/layout.tsx` reads the same key in an inline script to
+ * apply the theme before the first paint — a second literal there would let a
+ * rename break the no-flash path silently.
+ */
+export const PERSIST_KEY = 'geoagent-settings';
+
 export const useHudStore = create<HudState>()(
   persist(
     (...a) => ({
@@ -55,7 +64,7 @@ export const useHudStore = create<HudState>()(
       ...createUiSlice(...a),
     }) as HudState,
     {
-      name: 'geoagent-settings',
+      name: PERSIST_KEY,
       partialize: (state) => ({
         skills: state.skills,
         ragConfig: state.ragConfig,
@@ -63,6 +72,11 @@ export const useHudStore = create<HudState>()(
         baseLayer: state.baseLayer,
         // 审计 F29：accentColor 之前未持久化 -> 用户选的颜色刷新后丢失。
         accentColor: state.accentColor,
+        // UI V4：theme / fontSize 同样未持久化 —— 切到暗色后刷新会静默回到浅色。
+        // 与 app/layout.tsx 的 no-flash 内联脚本读同一个 localStorage 键，
+        // 因此首帧就是正确主题，不再有浅色闪烁。
+        theme: state.theme,
+        fontSize: state.fontSize,
         // SECURITY: 去除 apiKey 后再持久化，避免明文写入 localStorage
         // （XSS / 浏览器扩展 / DevTools 可读）。
         llmConfigFull: state.llmConfigFull

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -2,6 +2,11 @@ import type { Config } from "tailwindcss";
 import typography from "@tailwindcss/typography";
 
 const config: Config = {
+  // Without this, Tailwind v3 defaults to `darkMode: 'media'` and every `dark:`
+  // variant tracks the OS preference instead of the `dark` class that
+  // app/page.tsx puts on <html>. The V4 audit found 124 such variants across 13
+  // files, all of them inert under the in-app theme toggle.
+  darkMode: 'class',
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -10,29 +15,83 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        /* ── All is Agent — Light Glass Palette ── */
-        "agent-bg": "#dce8f2",
-        "agent-panel": "rgba(252, 253, 254, 0.88)",
-        "agent-panel2": "rgba(248, 250, 252, 0.72)",
-        "agent-glass": "rgba(255, 255, 255, 0.70)",
-        "agent-border": "rgba(15, 23, 42, 0.08)",
-        "agent-border-mid": "rgba(15, 23, 42, 0.12)",
+        /* ── Visual System V4 semantic tokens ──
+           Prefer these over raw palette classes: `bg-surface-panel` survives a
+           theme flip, `bg-slate-50` does not. The values live in
+           app/globals.css (`:root` and `.dark`). */
+        surface: {
+          canvas: "var(--surface-canvas)",
+          panel: "var(--surface-panel)",
+          raised: "var(--surface-raised)",
+          overlay: "var(--surface-overlay)",
+          sunken: "var(--surface-sunken)",
+          hover: "var(--surface-hover)",
+          selected: "var(--surface-selected)",
+          scrim: "var(--surface-scrim)",
+        },
+        edge: {
+          subtle: "var(--border-subtle)",
+          DEFAULT: "var(--border-default)",
+          strong: "var(--border-strong)",
+        },
+        ink: {
+          DEFAULT: "var(--text-primary)",
+          secondary: "var(--text-secondary)",
+          muted: "var(--text-muted)",
+          disabled: "var(--text-disabled)",
+          "on-accent": "var(--text-on-accent)",
+        },
+        status: {
+          accent: "var(--accent)",
+          "accent-vivid": "var(--accent-vivid)",
+          "accent-soft": "var(--accent-soft)",
+          "accent-border": "var(--accent-border)",
+          success: "var(--success)",
+          "success-soft": "var(--success-soft)",
+          "success-border": "var(--success-border)",
+          info: "var(--info)",
+          "info-soft": "var(--info-soft)",
+          "info-border": "var(--info-border)",
+          warning: "var(--warning)",
+          "warning-soft": "var(--warning-soft)",
+          "warning-border": "var(--warning-border)",
+          critical: "var(--critical)",
+          "critical-soft": "var(--critical-soft)",
+          "critical-border": "var(--critical-border)",
+          neutral: "var(--neutral)",
+          "neutral-soft": "var(--neutral-soft)",
+          "neutral-border": "var(--neutral-border)",
+        },
+        "map-chrome": {
+          DEFAULT: "var(--map-chrome-bg)",
+          border: "var(--map-chrome-border)",
+          ink: "var(--map-chrome-text)",
+          "ink-muted": "var(--map-chrome-text-muted)",
+        },
+
+        /* ── Pre-V4 aliases, kept so existing call sites keep compiling.
+              They now resolve through the semantic tokens above. ── */
+        "agent-bg": "var(--surface-canvas)",
+        "agent-panel": "var(--surface-panel)",
+        "agent-panel2": "var(--surface-raised)",
+        "agent-glass": "var(--surface-overlay)",
+        "agent-border": "var(--border-subtle)",
+        "agent-border-mid": "var(--border-default)",
 
         /* Text */
-        "agent-tp": "#0f172a",
-        "agent-ts": "#475569",
-        "agent-tm": "#94a3b8",
+        "agent-tp": "var(--text-primary)",
+        "agent-ts": "var(--text-secondary)",
+        "agent-tm": "var(--text-muted)",
 
         /* Accent */
-        "agent-accent": "#16a34a",
-        "agent-accent-dim": "rgba(22, 163, 74, 0.08)",
-        "agent-accent-brd": "rgba(22, 163, 74, 0.22)",
-        "agent-accent-text": "#15803d",
+        "agent-accent": "var(--agent-accent)",
+        "agent-accent-dim": "var(--accent-soft)",
+        "agent-accent-brd": "var(--accent-border)",
 
         /* Semantic */
-        "agent-blue": "#2563eb",
-        "agent-orange": "#ea580c",
-        "agent-red": "#dc2626",
+        "agent-blue": "var(--info)",
+        "agent-orange": "var(--warning)",
+        "agent-red": "var(--critical)",
 
         /* Legacy compat (CSS vars for shadcn) */
         border: "hsl(var(--border))",
@@ -69,22 +128,56 @@ const config: Config = {
           foreground: "hsl(var(--popover-foreground))",
         },
       },
+      /* Dense workbench type scale. The audit counted 309 raw `text-[Npx]`
+         across 12 distinct values; these six steps replace them. */
+      fontSize: {
+        micro: ["var(--font-micro)", { lineHeight: "var(--leading-tight)" }],
+        caption: ["var(--font-caption)", { lineHeight: "var(--leading-tight)" }],
+        meta: ["var(--font-meta)", { lineHeight: "var(--leading-normal)" }],
+        body: ["var(--font-body)", { lineHeight: "var(--leading-normal)" }],
+        title: ["var(--font-title)", { lineHeight: "var(--leading-tight)" }],
+        heading: ["var(--font-heading)", { lineHeight: "var(--leading-tight)" }],
+      },
+      /* Control/row heights and shell metrics, so `h-control-md` and `w-rail`
+         replace the scattered h-6/h-7/h-8 and the hardcoded 48/42/330. */
+      spacing: {
+        "control-sm": "var(--control-sm)",
+        "control-md": "var(--control-md)",
+        "control-lg": "var(--control-lg)",
+        "row-sm": "var(--row-sm)",
+        "row-md": "var(--row-md)",
+        "row-lg": "var(--row-lg)",
+        "icon-sm": "var(--icon-sm)",
+        "icon-md": "var(--icon-md)",
+        "icon-lg": "var(--icon-lg)",
+        panel: "var(--panel-pad)",
+        topbar: "var(--topH)",
+        statusbar: "var(--stH)",
+        rail: "var(--railW)",
+        sidebar: "var(--sw)",
+      },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
+        xs: "var(--radius-xs)",
+        sm: "var(--radius-sm)",
+        md: "var(--radius-md)",
+        lg: "var(--radius-lg)",
+        xl: "var(--radius-xl)",
+        pill: "var(--radius-pill)",
+        chrome: "var(--map-chrome-radius)",
       },
       fontFamily: {
         sans: ["DM Sans", "system-ui", "sans-serif"],
         mono: ["JetBrains Mono", "Fira Code", "monospace"],
       },
       boxShadow: {
-        "agent-sm":
-          "0 1px 4px rgba(15,23,42,0.06), 0 0 0 1px rgba(15,23,42,0.04)",
-        "agent-md":
-          "0 4px 24px rgba(15,23,42,0.09), 0 1px 4px rgba(15,23,42,0.05)",
-        "agent-lg":
-          "0 8px 40px rgba(15,23,42,0.12), 0 2px 8px rgba(15,23,42,0.06)",
+        raised: "var(--elevation-raised)",
+        overlay: "var(--elevation-overlay)",
+        drawer: "var(--elevation-drawer)",
+        chrome: "var(--map-chrome-shadow)",
+        /* Pre-V4 names, re-pointed at the elevation scale. */
+        "agent-sm": "var(--elevation-raised)",
+        "agent-md": "var(--elevation-overlay)",
+        "agent-lg": "var(--elevation-drawer)",
       },
       animation: {
         "hb-scan": "hbScan 2.2s ease-in-out infinite",

--- a/frontend/test/__mocks__/framer-motion.js
+++ b/frontend/test/__mocks__/framer-motion.js
@@ -21,4 +21,7 @@ const motion = new Proxy({}, {
 
 const AnimatePresence = ({ children }) => React.createElement(React.Fragment, null, children)
 
-export { motion, AnimatePresence }
+// 透传：不执行动画相关逻辑（reducedMotion 等配置 prop 直接剥离）。
+const MotionConfig = ({ children }) => React.createElement(React.Fragment, null, children)
+
+export { motion, AnimatePresence, MotionConfig }

--- a/frontend/test/__mocks__/framer-motion.tsx
+++ b/frontend/test/__mocks__/framer-motion.tsx
@@ -24,3 +24,6 @@ export const motion = new Proxy({}, {
 })
 
 export const AnimatePresence = ({ children }: { children: React.ReactNode }) => <>{children}</>
+
+// 透传：不执行动画相关逻辑（reducedMotion 等配置 prop 直接剥离）。
+export const MotionConfig = ({ children }: { children: React.ReactNode }) => <>{children}</>

--- a/frontend/test/design-system/contrast.test.ts
+++ b/frontend/test/design-system/contrast.test.ts
@@ -1,0 +1,237 @@
+/**
+ * WCAG contrast contract for the V4 token layer.
+ *
+ * The audit that motivated V4 measured the shipped light theme and found the
+ * muted/subtle text tokens at 2.45:1 and 1.42:1 — both used for real label copy,
+ * both far under the 4.5:1 AA floor. Those are not judgement calls, they are
+ * arithmetic, so they belong in a test rather than in a review comment.
+ *
+ * The ratios are computed from the actual values in `app/globals.css`, alpha
+ * composited over the surface they sit on, so retuning a hue without checking
+ * its contrast fails here rather than in production.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CSS = readFileSync(resolve(__dirname, '../../app/globals.css'), 'utf8');
+
+type RGB = [number, number, number];
+type RGBA = [number, number, number, number];
+
+function blockBody(selector: string): string {
+  const start = CSS.indexOf(selector);
+  const open = CSS.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < CSS.length; i += 1) {
+    if (CSS[i] === '{') depth += 1;
+    else if (CSS[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return CSS.slice(open + 1, i);
+    }
+  }
+  throw new Error(`unterminated block for ${selector}`);
+}
+
+function rawTokens(selector: string): Map<string, string> {
+  const body = blockBody(selector).replace(/\/\*[\s\S]*?\*\//g, '');
+  const out = new Map<string, string>();
+  for (const line of body.split(';')) {
+    const m = line.match(/(--[a-z0-9-]+)\s*:\s*(.+)/i);
+    if (m) out.set(m[1], m[2].trim());
+  }
+  return out;
+}
+
+const LIGHT = rawTokens(':root');
+const DARK = rawTokens(".dark,\n[data-theme='dark']");
+
+/** AA body text. Everything that can carry a sentence must clear this. */
+const AA_BODY = 4.5;
+/** AA non-text / large text. Icons, dividers, decorative marks. */
+const AA_NON_TEXT = 3.0;
+
+/** The five accent presets the tweaks panel offers. */
+const ACCENT_PRESETS = (() => {
+  const src = readFileSync(resolve(__dirname, '../../components/tweaks-panel.tsx'), 'utf8');
+  return Array.from(src.matchAll(/\{ value: '(#[0-9a-f]{6})', name:/gi)).map((m) => m[1]);
+})();
+
+/** Resolves a token to a colour, following one level of `var()` indirection. */
+function resolve_(theme: Map<string, string>, token: string): RGBA {
+  let value = theme.get(token) ?? LIGHT.get(token);
+  if (!value) throw new Error(`unknown token ${token}`);
+  const varMatch = value.match(/^var\((--[a-z0-9-]+)\)$/i);
+  if (varMatch) value = theme.get(varMatch[1]) ?? LIGHT.get(varMatch[1]) ?? '';
+  return parseColor(value, token);
+}
+
+function parseColor(value: string, token: string): RGBA {
+  const hex = value.match(/^#([0-9a-f]{6})$/i);
+  if (hex) {
+    const n = parseInt(hex[1], 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255, 1];
+  }
+  const short = value.match(/^#([0-9a-f]{3})$/i);
+  if (short) {
+    const [r, g, b] = short[1].split('').map((c) => parseInt(c + c, 16));
+    return [r, g, b, 1];
+  }
+  const rgba = value.match(/^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:[,/\s]+([\d.]+))?\s*\)$/i);
+  if (rgba) {
+    return [Number(rgba[1]), Number(rgba[2]), Number(rgba[3]), rgba[4] === undefined ? 1 : Number(rgba[4])];
+  }
+  throw new Error(`cannot parse colour for ${token}: ${value}`);
+}
+
+/** Composites a possibly-translucent colour over an opaque backdrop. */
+function over(fg: RGBA, bg: RGB): RGB {
+  const a = fg[3];
+  return [0, 1, 2].map((i) => fg[i] * a + bg[i] * (1 - a)) as RGB;
+}
+
+function luminance([r, g, b]: RGB): number {
+  const lin = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+}
+
+function contrast(fg: RGB, bg: RGB): number {
+  const [a, b] = [luminance(fg), luminance(bg)].sort((x, y) => y - x);
+  return (a + 0.05) / (b + 0.05);
+}
+
+/** Contrast of `textToken` on `surfaceToken`, each composited over the canvas. */
+function ratio(theme: Map<string, string>, textToken: string, surfaceToken: string): number {
+  const canvas = over(resolve_(theme, '--surface-canvas'), [255, 255, 255]);
+  const surface = over(resolve_(theme, surfaceToken), canvas);
+  const text = over(resolve_(theme, textToken), surface);
+  return contrast(text, surface);
+}
+
+/**
+ * The runtime accent is a CSS lever: `--agent-accent-raw` carries the exact hex
+ * the user picked, and `--agent-accent` is the theme-corrected value every
+ * consumer reads. This checks the correction actually holds for every preset —
+ * the raw presets are chosen to carry a white label on a light surface, which
+ * makes them far too dark to work on a dark one (2.09:1 as a mark, 2.66:1 under
+ * the near-black on-accent label), so a missing correction is a silent AA
+ * failure across the whole dark theme.
+ */
+describe('runtime accent correction', () => {
+  const ACCENT_MIX = /--agent-accent:\s*color-mix\(in srgb,\s*var\(--agent-accent-raw\)\s*(\d+)%,\s*#ffffff\)/;
+
+  it('derives the dark accent from the raw value rather than using it directly', () => {
+    const darkBlock = blockBody(".dark,\n[data-theme='dark']");
+    expect(darkBlock, 'dark theme must correct the raw accent').toMatch(ACCENT_MIX);
+    // Light is the identity: the presets already clear AA there.
+    expect(blockBody(':root')).toMatch(/--agent-accent:\s*var\(--agent-accent-raw\)/);
+  });
+
+  it.each(ACCENT_PRESETS)(
+    '%s stays visible as a mark and can carry a label in dark',
+    (preset) => {
+      const pct = Number(blockBody(".dark,\n[data-theme='dark']").match(ACCENT_MIX)![1]);
+      const raw = parseColor(preset, 'preset');
+      const fill: RGB = [0, 1, 2].map(
+        (i) => Math.round(raw[i] * (pct / 100) + 255 * (1 - pct / 100)),
+      ) as RGB;
+
+      const canvas = over(resolve_(DARK, '--surface-canvas'), [255, 255, 255]);
+      // Worst case surface for a mark is the lightest dark surface.
+      const overlay = over(resolve_(DARK, '--surface-overlay'), canvas);
+      expect(contrast(fill, overlay), `${preset} as a mark`).toBeGreaterThanOrEqual(AA_NON_TEXT);
+
+      const label = over(resolve_(DARK, '--text-on-accent'), fill);
+      expect(contrast(label, fill), `${preset} under its label`).toBeGreaterThanOrEqual(AA_BODY);
+    },
+  );
+
+  it.each(ACCENT_PRESETS)('%s can carry a label in light without correction', (preset) => {
+    const [r, g, b] = parseColor(preset, 'preset');
+    const fill: RGB = [r, g, b];
+    const label = over(resolve_(LIGHT, '--text-on-accent'), fill);
+    expect(contrast(label, fill)).toBeGreaterThanOrEqual(AA_BODY);
+  });
+});
+
+const THEMES: [string, Map<string, string>][] = [
+  ['light', LIGHT],
+  ['dark', DARK],
+];
+
+describe.each(THEMES)('WCAG contrast — %s theme', (_name, theme) => {
+  const SURFACES = ['--surface-panel', '--surface-raised', '--surface-overlay', '--surface-sunken'];
+
+  it.each(SURFACES)('text-primary clears AA body on %s', (surface) => {
+    expect(ratio(theme, '--text-primary', surface)).toBeGreaterThanOrEqual(AA_BODY);
+  });
+
+  it.each(SURFACES)('text-secondary clears AA body on %s', (surface) => {
+    expect(ratio(theme, '--text-secondary', surface)).toBeGreaterThanOrEqual(AA_BODY);
+  });
+
+  it.each(SURFACES)('text-muted clears AA body on %s', (surface) => {
+    // The regression that started this work: --text-muted is used for 60+ label
+    // and hint sites, so it is body text, not decoration.
+    expect(ratio(theme, '--text-muted', surface)).toBeGreaterThanOrEqual(AA_BODY);
+  });
+
+  it('text-muted clears AA body directly on the canvas', () => {
+    expect(ratio(theme, '--text-muted', '--surface-canvas')).toBeGreaterThanOrEqual(AA_BODY);
+  });
+
+  it.each(SURFACES)('text-disabled clears the AA non-text floor on %s', (surface) => {
+    // Disabled/placeholder copy is exempt from AA body, but must stay visible.
+    expect(ratio(theme, '--text-disabled', surface)).toBeGreaterThanOrEqual(AA_NON_TEXT);
+  });
+
+  it('accent clears AA body as label text on a panel', () => {
+    // `--accent` is the text-safe accent; `--accent-vivid` is fills only.
+    expect(ratio(theme, '--accent', '--surface-panel')).toBeGreaterThanOrEqual(AA_BODY);
+  });
+
+  it.each(['--success', '--info', '--warning', '--critical', '--neutral'])(
+    '%s clears AA body as status text on a panel',
+    (token) => {
+      expect(ratio(theme, token, '--surface-panel')).toBeGreaterThanOrEqual(AA_BODY);
+    },
+  );
+
+  it('the focus ring clears the AA non-text floor against every surface', () => {
+    for (const surface of [...SURFACES, '--surface-canvas']) {
+      expect(
+        ratio(theme, '--focus-ring', surface),
+        `focus ring on ${surface}`,
+      ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+    }
+  });
+
+  it('map chrome text clears AA body on the map chrome surface', () => {
+    const canvas = over(resolve_(theme, '--surface-canvas'), [255, 255, 255]);
+    const chrome = over(resolve_(theme, '--map-chrome-bg'), canvas);
+    expect(contrast(over(resolve_(theme, '--map-chrome-text'), chrome), chrome)).toBeGreaterThanOrEqual(AA_BODY);
+    expect(contrast(over(resolve_(theme, '--map-chrome-text-muted'), chrome), chrome)).toBeGreaterThanOrEqual(AA_BODY);
+  });
+
+  it('text-on-accent clears AA body on the text-bearing accent fill', () => {
+    // White on the old #16a34a measured 3.30:1 and was used for button labels
+    // and chat bubbles. The V4 rule is that text-bearing fills use `--accent`
+    // (checked here) while `--accent-vivid` is reserved for non-text marks.
+    const canvas = over(resolve_(theme, '--surface-canvas'), [255, 255, 255]);
+    const fill = over(resolve_(theme, '--accent'), canvas);
+    expect(contrast(over(resolve_(theme, '--text-on-accent'), fill), fill)).toBeGreaterThanOrEqual(AA_BODY);
+  });
+
+  it('separates the surface ladder by a perceptible step', () => {
+    // canvas → panel → raised must be visually distinguishable, otherwise the
+    // "map bed vs panel vs card" hierarchy collapses into one flat field.
+    const canvas = over(resolve_(theme, '--surface-canvas'), [255, 255, 255]);
+    const panel = over(resolve_(theme, '--surface-panel'), canvas);
+    const raised = over(resolve_(theme, '--surface-raised'), canvas);
+    expect(Math.abs(luminance(panel) - luminance(canvas))).toBeGreaterThan(0.004);
+    expect(Math.abs(luminance(raised) - luminance(panel))).toBeGreaterThan(0.004);
+  });
+});

--- a/frontend/test/design-system/tokens.contract.test.ts
+++ b/frontend/test/design-system/tokens.contract.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Design-token contract (Visual System V4).
+ *
+ * These assertions guard the *structure* of the token layer, not individual
+ * colour values — a designer must stay free to retune a hue. What must not
+ * silently break is:
+ *
+ *   - `darkMode: 'class'`. Without it Tailwind v3 falls back to `media`, and
+ *     every `dark:` variant in the app tracks the OS instead of the in-app
+ *     theme toggle. This was a real, shipped bug: 124 `dark:` variants across
+ *     13 files were inert.
+ *   - Every semantic token defined in `:root` also being defined under `.dark`.
+ *     A token that exists in one theme only is a guaranteed dark-mode hole.
+ *   - The Tailwind theme actually pointing at the CSS custom properties, so
+ *     `bg-surface-panel` and `var(--surface-panel)` cannot drift apart.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import config from '../../tailwind.config';
+
+const CSS = readFileSync(resolve(__dirname, '../../app/globals.css'), 'utf8');
+
+/** Extracts `--name: value` declarations from one CSS block. */
+function tokensIn(selector: string): Map<string, string> {
+  const start = CSS.indexOf(selector);
+  expect(start, `selector ${selector} not found in globals.css`).toBeGreaterThan(-1);
+  const open = CSS.indexOf('{', start);
+  // Walk braces so a nested block cannot truncate the scan early.
+  let depth = 0;
+  let end = open;
+  for (let i = open; i < CSS.length; i += 1) {
+    if (CSS[i] === '{') depth += 1;
+    else if (CSS[i] === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  const body = CSS.slice(open + 1, end).replace(/\/\*[\s\S]*?\*\//g, '');
+  const out = new Map<string, string>();
+  for (const line of body.split(';')) {
+    const m = line.match(/(--[a-z0-9-]+)\s*:\s*(.+)/i);
+    if (m) out.set(m[1], m[2].trim());
+  }
+  return out;
+}
+
+const LIGHT = tokensIn(':root');
+const DARK = tokensIn(".dark,\n[data-theme='dark']");
+
+/** The semantic vocabulary components are expected to reach for. */
+const REQUIRED_TOKENS = [
+  // surfaces
+  '--surface-canvas',
+  '--surface-panel',
+  '--surface-raised',
+  '--surface-overlay',
+  '--surface-sunken',
+  '--surface-hover',
+  '--surface-selected',
+  '--surface-scrim',
+  // borders
+  '--border-subtle',
+  '--border-default',
+  '--border-strong',
+  // text
+  '--text-primary',
+  '--text-secondary',
+  '--text-muted',
+  '--text-disabled',
+  '--text-on-accent',
+  // status
+  '--accent',
+  '--accent-vivid',
+  '--accent-soft',
+  '--accent-border',
+  '--success',
+  '--info',
+  '--warning',
+  '--critical',
+  '--neutral',
+  // elevation
+  '--elevation-raised',
+  '--elevation-overlay',
+  '--elevation-drawer',
+  // focus
+  '--focus-ring',
+  // map chrome
+  '--map-chrome-bg',
+  '--map-chrome-border',
+  '--map-chrome-text',
+  '--map-chrome-text-muted',
+  '--map-chrome-shadow',
+];
+
+/** Scale tokens are theme-independent: they live in `:root` only, by design. */
+const SCALE_TOKENS = [
+  '--radius-xs',
+  '--radius-sm',
+  '--radius-md',
+  '--radius-lg',
+  '--radius-xl',
+  '--radius-pill',
+  '--font-micro',
+  '--font-caption',
+  '--font-meta',
+  '--font-body',
+  '--font-title',
+  '--font-heading',
+  '--control-sm',
+  '--control-md',
+  '--control-lg',
+  '--row-sm',
+  '--row-md',
+  '--row-lg',
+  '--icon-sm',
+  '--icon-md',
+  '--icon-lg',
+  '--panel-pad',
+  '--topH',
+  '--stH',
+  '--railW',
+  '--sw',
+];
+
+describe('V4 design tokens — structure', () => {
+  it('enables class-based dark mode', () => {
+    // The single most consequential line in the config: with `media` (the v3
+    // default) the in-app theme toggle cannot reach any `dark:` variant.
+    expect(config.darkMode).toBe('class');
+  });
+
+  it.each(REQUIRED_TOKENS)('defines %s in the light theme', (token) => {
+    expect(LIGHT.has(token)).toBe(true);
+  });
+
+  it.each(REQUIRED_TOKENS)('re-defines %s in the dark theme', (token) => {
+    // A theme-dependent token defined in only one theme is a dark-mode hole.
+    expect(DARK.has(token)).toBe(true);
+  });
+
+  it.each(SCALE_TOKENS)('defines the theme-independent scale token %s', (token) => {
+    expect(LIGHT.has(token)).toBe(true);
+    expect(DARK.has(token)).toBe(false);
+  });
+
+  it('keeps the legacy --theme-* vocabulary aliased to the V4 tokens', () => {
+    // ~475 call sites still read `var(--theme-*)`. They must resolve through
+    // the V4 values, otherwise the app carries two divergent palettes again.
+    for (const theme of [LIGHT, DARK]) {
+      for (const [name, value] of Array.from(theme.entries())) {
+        if (!name.startsWith('--theme-')) continue;
+        expect(value, `${name} should alias a V4 token, got ${value}`).toMatch(/^var\(--/);
+      }
+    }
+  });
+
+  it('routes the shadcn HSL vars and the V4 surfaces at the same colours', () => {
+    // `bg-card` and `bg-surface-panel` are both used for panel chrome; if they
+    // drift the panel splits into two visibly different greys.
+    for (const theme of [LIGHT, DARK]) {
+      expect(theme.get('--background')).toBeDefined();
+      expect(theme.get('--card')).toBeDefined();
+      // HSL triples, not hex — shadcn utilities wrap them in `hsl(...)`.
+      expect(theme.get('--background')).toMatch(/^\d+ \d+% \d+%$/);
+      expect(theme.get('--card')).toMatch(/^\d+ \d+% \d+%$/);
+    }
+  });
+});
+
+describe('V4 design tokens — Tailwind exposure', () => {
+  const colors = (config.theme?.extend?.colors ?? {}) as Record<string, unknown>;
+
+  it('exposes the surface / edge / ink / status families as utilities', () => {
+    for (const family of ['surface', 'edge', 'ink', 'status', 'map-chrome']) {
+      expect(colors[family], `missing colour family: ${family}`).toBeDefined();
+    }
+  });
+
+  it('binds every V4 colour utility to a CSS custom property', () => {
+    // Hardcoding a literal here would re-introduce a value that cannot flip
+    // with the theme — the exact failure mode V4 exists to remove.
+    const walk = (value: unknown, path: string) => {
+      if (typeof value === 'string') {
+        if (!path.startsWith('surface') && !path.startsWith('edge') && !path.startsWith('ink') &&
+            !path.startsWith('status') && !path.startsWith('map-chrome')) return;
+        expect(value, `${path} must reference a CSS var, got ${value}`).toMatch(/^var\(--/);
+        return;
+      }
+      if (value && typeof value === 'object') {
+        for (const [k, v] of Object.entries(value)) walk(v, `${path}.${k}`);
+      }
+    };
+    for (const [k, v] of Object.entries(colors)) walk(v, k);
+  });
+
+  it('exposes the dense type scale, control metrics and radius scale', () => {
+    const fontSize = (config.theme?.extend?.fontSize ?? {}) as Record<string, unknown>;
+    const spacing = (config.theme?.extend?.spacing ?? {}) as Record<string, unknown>;
+    const radius = (config.theme?.extend?.borderRadius ?? {}) as Record<string, unknown>;
+
+    for (const step of ['micro', 'caption', 'meta', 'body', 'title', 'heading']) {
+      expect(fontSize[step], `missing type step: ${step}`).toBeDefined();
+    }
+    for (const step of ['control-sm', 'control-md', 'control-lg', 'row-sm', 'row-md', 'row-lg',
+      'icon-sm', 'icon-md', 'icon-lg', 'panel', 'topbar', 'statusbar', 'rail', 'sidebar']) {
+      expect(spacing[step], `missing metric: ${step}`).toBeDefined();
+    }
+    for (const step of ['xs', 'sm', 'md', 'lg', 'xl', 'pill']) {
+      expect(radius[step], `missing radius step: ${step}`).toBeDefined();
+    }
+  });
+});
+
+describe('V4 design tokens — dead CSS stays dead', () => {
+  it('does not reintroduce the unused .glass/.ib/.tb/.lc/.sq component classes', () => {
+    // They had zero call sites and hardcoded light-only colours, which is a
+    // dark-mode trap waiting for the next component to opt in.
+    for (const cls of ['.glass ', '.glass{', '.ib ', '.ib:', '.tb ', '.tb:', '.lc ', '.lc:', '.sq ', '.sq:']) {
+      expect(CSS.includes(cls), `dead class ${cls} is back in globals.css`).toBe(false);
+    }
+  });
+
+  it('keeps the shell metric tokens actually referenced', () => {
+    // `--topH/--stH/--sw` existed before V4 with zero `var()` consumers; they
+    // are now the source of truth behind the Tailwind spacing scale.
+    const spacing = JSON.stringify(config.theme?.extend?.spacing ?? {});
+    for (const token of ['--topH', '--stH', '--sw', '--railW']) {
+      expect(spacing, `${token} is defined but nothing consumes it`).toContain(token);
+    }
+  });
+});

--- a/frontend/test/design-system/visual-system.contract.test.tsx
+++ b/frontend/test/design-system/visual-system.contract.test.tsx
@@ -1,0 +1,567 @@
+/**
+ * Behaviour contracts the V4 visual pass introduced or repaired.
+ *
+ * These are deliberately about behaviour and semantics, not class strings — the
+ * one exception is the token-driven metric assertions, which exist because the
+ * whole point of `--row-*` / `--control-*` is that density is agreed once
+ * instead of re-derived per component.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { SField, STitle } from '@/components/shared/section-title';
+import ToggleSwitch from '@/components/shared/toggle-switch';
+import { IconButton } from '@/components/shared/icon-button';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { LegendCard, formatLegendValue } from '@/components/map/legends/legend-card';
+import { ACCENT_PRESETS } from '@/components/tweaks-panel';
+import { Eye } from 'lucide-react';
+
+const ROOT = resolve(__dirname, '../..');
+const read = (p: string) => readFileSync(resolve(ROOT, p), 'utf8');
+/**
+ * Source with comments stripped. Several assertions below check that a pattern
+ * is *absent*; the explanatory comments in those same files quote the pattern
+ * they removed, so a naive text search matches the explanation, not the code.
+ */
+const readCode = (p: string) =>
+  read(p)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/* ────────────────────────────── a11y contracts ───────────────────────────── */
+
+describe('form controls carry programmatic names', () => {
+  it('SField associates its visible label with the input', () => {
+    // Before V4 the label was a bare sibling with no htmlFor, so all eight
+    // settings fields (LLM / RAG / map config) were unnamed to assistive tech.
+    render(<SField label="Base URL" value="https://example.org" onChange={() => {}} />);
+    const input = screen.getByLabelText('Base URL');
+    expect(input.tagName).toBe('INPUT');
+  });
+
+  it('SField exposes its hint through aria-describedby', () => {
+    render(<SField label="Model" value="gpt" onChange={() => {}} hint="留空则使用默认模型" />);
+    const input = screen.getByLabelText('Model');
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)?.textContent).toBe('留空则使用默认模型');
+  });
+
+  it('ToggleSwitch is a named switch that reports its state', () => {
+    // `label` is a required prop precisely so an unnamed switch cannot compile.
+    const onChange = vi.fn();
+    render(<ToggleSwitch label="Prompt Caching" checked onChange={onChange} />);
+    const sw = screen.getByRole('switch', { name: 'Prompt Caching' });
+    expect(sw).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('IconButton always has an accessible name and reports pressed state', () => {
+    render(<IconButton label="显示图层" icon={Eye} active />);
+    const btn = screen.getByRole('button', { name: '显示图层' });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    expect(btn).toHaveAttribute('title', '显示图层');
+  });
+
+  it('IconButton renders a disabled state that is visually distinct', () => {
+    // Audited gap: disabled and enabled icon buttons were pixel-identical.
+    const { container } = render(<IconButton label="删除" icon={Eye} disabled />);
+    const btn = container.querySelector('button')!;
+    expect(btn).toBeDisabled();
+    expect(btn.className).toContain('text-ink-disabled');
+    expect(btn.className).toContain('cursor-not-allowed');
+  });
+});
+
+describe('overlays announce themselves and honour Escape', () => {
+  it('the tweaks panel is a named dialog that is hidden from AT when closed', async () => {
+    // It is always mounted and only visually hidden, so without aria-hidden a
+    // screen reader read its whole contents while it was invisible.
+    const { useHudStore } = await import('@/lib/store/useHudStore');
+    const { default: TweaksPanel } = await import('@/components/tweaks-panel');
+
+    useHudStore.setState({ tweaksOpen: false });
+    const { container } = render(<TweaksPanel />);
+    const dialog = container.querySelector('[role="dialog"]')!;
+    expect(dialog).toHaveAttribute('aria-hidden', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+    const titleId = dialog.getAttribute('aria-labelledby')!;
+    expect(document.getElementById(titleId)?.textContent).toBe('UI 调整');
+  });
+
+  it('the tweaks panel colour swatches are named', async () => {
+    const { useHudStore } = await import('@/lib/store/useHudStore');
+    const { default: TweaksPanel } = await import('@/components/tweaks-panel');
+    useHudStore.setState({ tweaksOpen: true });
+    render(<TweaksPanel />);
+    // Five empty <button>s with no name at all before V4.
+    expect(screen.getByRole('button', { name: '主题色：绿色' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '主题色：青色' })).toBeInTheDocument();
+  });
+
+  it('the tweaks panel sliders are labelled', async () => {
+    const { useHudStore } = await import('@/lib/store/useHudStore');
+    const { default: TweaksPanel } = await import('@/components/tweaks-panel');
+    useHudStore.setState({ tweaksOpen: true });
+    render(<TweaksPanel />);
+    expect(screen.getByLabelText('字体大小')).toBeInTheDocument();
+    expect(screen.getByLabelText('侧边栏宽度')).toBeInTheDocument();
+  });
+});
+
+describe('streaming output and operation feedback are announced', () => {
+  it('announces the turn lifecycle without narrating every token batch', async () => {
+    // Review finding: putting aria-live on the transcript itself re-reads the
+    // whole accumulated answer on every batch, because each batch re-parses the
+    // markdown and replaces the bubble's entire subtree — `aria-atomic=false`
+    // only yields increments for appends to a leaf. So the announcer reports the
+    // turn's STATE plus the finished reply once, and the list carries no live
+    // region at all.
+    const { ChatAnnouncer } = await import('@/components/chat/chat-announcer');
+    const messages = [{ role: 'assistant' as const, content: '已生成 3 个等时圈' }];
+
+    const { rerender } = render(<ChatAnnouncer messages={messages} aiStatus="thinking" />);
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    // atomic: one whole sentence per announcement, not a growing increment.
+    expect(region).toHaveAttribute('aria-atomic', 'true');
+    expect(region).toHaveTextContent('正在分析指令');
+
+    rerender(<ChatAnnouncer messages={messages} aiStatus="idle" />);
+    expect(screen.getByRole('status')).toHaveTextContent('回复已完成：已生成 3 个等时圈');
+
+    // And the transcript container itself must NOT be a live region.
+    const src = readCode('components/sidebar/chat-tab.tsx');
+    const list = src.slice(src.indexOf('messages.map') - 400, src.indexOf('messages.map'));
+    expect(list).not.toMatch(/aria-live/);
+  });
+
+  it('the toast container is a polite status region', () => {
+    const src = read('components/ui/toast.tsx');
+    expect(src).toMatch(/role="status"/);
+    expect(src).toMatch(/aria-live="polite"/);
+  });
+
+  it('does not leave undefined Tailwind utilities in the toast chrome', () => {
+    // `bg-ds-surface` / `backdrop-blur-hud` / `text-hud-cyan` were never in the
+    // config, so the toast rendered with no background at all.
+    const src = readCode('components/ui/toast.tsx');
+    for (const dead of ['bg-ds-surface', 'backdrop-blur-hud', 'text-hud-cyan']) {
+      expect(src, `${dead} is not a defined utility`).not.toContain(dead);
+    }
+  });
+});
+
+describe('keyboard reachability of mouse-only affordances', () => {
+  it('the composer keeps a keyboard focus ring', () => {
+    // It used to carry an inline `outline: 'none'`, which beats the unlayered
+    // global *:focus-visible rule — the one control in the app with no ring.
+    const src = readCode('components/sidebar/chat-tab.tsx');
+    expect(src).not.toMatch(/outline:\s*'none'/);
+    expect(src).toMatch(/focus-visible:ring/);
+  });
+
+  it('layer reordering has a keyboard path on a named control', async () => {
+    // Reordering was drag-only, i.e. the layer panel's core function was
+    // unavailable without a mouse. Review finding: hanging the keys off the row
+    // (role="group" + tabIndex) was a role misuse and added one dead tab stop
+    // per layer, so the grip is a real button and owns the keys.
+    const { useHudStore } = await import('@/lib/store/useHudStore');
+    const { LayersTab } = await import('@/components/sidebar/layers-tab');
+
+    const layer = (id: string, name: string) => ({
+      id,
+      name,
+      type: 'geojson' as const,
+      visible: true,
+      opacity: 1,
+      source: { type: 'FeatureCollection', features: [] },
+    });
+    useHudStore.setState({
+      layers: [layer('a', '路网'), layer('b', 'POI')] as never,
+    });
+
+    render(<LayersTab />);
+    const grips = screen.getAllByRole('button', { name: /重新排序/ });
+    expect(grips).toHaveLength(2);
+    // The name states position and the shortcut, so it is discoverable.
+    expect(grips[0]).toHaveAccessibleName(/第 1 \/ 2 层/);
+
+    grips[0].focus();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(useHudStore.getState().layers.map((l) => l.id)).toEqual(['b', 'a']);
+
+    // The row itself must not be a tab stop.
+    const src = readCode('components/sidebar/layers-tab.tsx');
+    expect(src).not.toMatch(/role="group"/);
+  });
+
+  it('the map centre crosshair only captures pointer events when actionable', () => {
+    // A permanently `pointerEvents: 'auto'` 24px target at dead centre swallowed
+    // feature picks even while idle.
+    const src = read('components/map/spatial-crosshair.tsx');
+    expect(src).toMatch(/pointerEvents:\s*copied \|\| isThinking \? 'auto' : 'none'/);
+  });
+
+  it('framer-motion honours the reduced-motion preference', () => {
+    // The global CSS reduced-motion kill-switch cannot reach JS-driven springs.
+    const src = read('components/providers/client-providers.tsx');
+    expect(src).toMatch(/MotionConfig/);
+    expect(src).toMatch(/reducedMotion="user"/);
+  });
+});
+
+describe('unique ids for aria relationships', () => {
+  it('collapsible think panels do not share a constant id', () => {
+    const src = readCode('components/chat/collapsible-think.tsx');
+    expect(src).not.toContain("'think-content'");
+    expect(src).toMatch(/useId\(\)/);
+  });
+
+  it('tool-call chain lists do not share a constant id', () => {
+    const src = readCode('components/chat/tool-call-card.tsx');
+    expect(src).not.toContain("'tool-call-chain-list'");
+    expect(src).toMatch(/useId\(\)/);
+  });
+});
+
+/* ─────────────────────────── visual-language contracts ───────────────────── */
+
+describe('one status colour vocabulary', () => {
+  it('renders in-progress as info and success as success', () => {
+    // Audited conflict: `active` was blue in StatusBadge and green in the data
+    // source card; "in progress" was blue for jobs and green for the agent.
+    const { container: running } = render(<StatusBadge status="running" />);
+    expect(running.firstElementChild!.className).toContain('status-info');
+
+    const { container: done } = render(<StatusBadge status="completed" />);
+    expect(done.firstElementChild!.className).toContain('status-success');
+
+    const { container: failed } = render(<StatusBadge status="failed" />);
+    expect(failed.firstElementChild!.className).toContain('status-critical');
+  });
+
+  it('treats a healthy data source as success, not as in-progress', () => {
+    const src = read('components/sidebar/data-sources/source-item-card.tsx');
+    // Both healthy and active mean "reachable" for a source; neither may borrow
+    // the pulsing blue that means "something is running".
+    expect(src).toMatch(/status === 'healthy' \|\| status === 'active'/);
+    expect(src).toMatch(/status: 'ok'/);
+  });
+
+  it('does not paint a neutral count with the accent colour', () => {
+    // `可见` was accent green, which reads as a status on a plain tally.
+    const src = readCode('components/sidebar/layers-tab.tsx');
+    const stats = src.slice(src.indexOf('总图层'), src.indexOf('要素'));
+    expect(stats).not.toMatch(/accent/);
+  });
+});
+
+describe('a single header hierarchy', () => {
+  it('keeps a section subtitle smaller than its title', () => {
+    // The shipped STitle had a 15px subtitle under a 14px title — inverted.
+    render(<STitle title="模型" sub="选择推理模型" />);
+    const title = screen.getByText('模型');
+    const sub = screen.getByText('选择推理模型');
+    expect(title.className).toContain('text-title');
+    expect(sub.className).toContain('text-meta');
+    // And the subtitle must not be re-promoted above the title step.
+    expect(sub.className).not.toContain('text-title');
+    expect(sub.className).not.toContain('text-heading');
+  });
+
+  it('uses the shared eyebrow treatment for micro labels', () => {
+    // The audit found five different 10px uppercase treatments.
+    for (const file of [
+      'components/sidebar/layers-tab.tsx',
+      'components/shared/section-title.tsx',
+      'components/tweaks-panel.tsx',
+    ]) {
+      expect(read(file), `${file} should use .eyebrow`).toContain('eyebrow');
+    }
+  });
+});
+
+describe('map chrome is one container recipe', () => {
+  it('routes every legend through the shared LegendCard', () => {
+    for (const file of [
+      'components/map/legends/categorical-legend.tsx',
+      'components/map/legends/continuous-legend.tsx',
+      'components/map/legends/graduated-legend.tsx',
+    ]) {
+      const src = read(file);
+      expect(src, `${file} should use LegendCard`).toContain('LegendCard');
+      // The container string used to be copy-pasted three times.
+      expect(src).not.toContain('backdrop-blur-md');
+    }
+  });
+
+  it('gives the legend stack the height budget, and each card scrolls inside it', () => {
+    // Review finding: capping each card individually still let two legends
+    // overflow the workspace at 1024x768 with the HUD open, clipping the top
+    // card. The stack owns the budget (pinned top + bottom, scrolls); the card
+    // just yields (min-h-0 + flex column + scrolling body).
+    const card = readCode('components/map/legends/legend-card.tsx');
+    expect(card).toMatch(/min-h-0/);
+    expect(card).toMatch(/overflow-y-auto/);
+    expect(card).not.toMatch(/max-h-\[min\(/);
+
+    const stack = readCode('components/map/map-panel.tsx');
+    const block = stack.slice(stack.indexOf('thematicLayers.length > 0'));
+    expect(block).toMatch(/overflow-y-auto/);
+    expect(block).toMatch(/--map-chrome-bottom/);
+    expect(block).toMatch(/top:/);
+  });
+
+  it('formats legend values identically everywhere', () => {
+    // continuous used 1 decimal, graduated used 0, for the same data.
+    expect(formatLegendValue(0)).toBe('0');
+    expect(formatLegendValue(1)).toBe('1');
+    expect(formatLegendValue(1234)).toBe('1,234');
+    expect(formatLegendValue(12_345)).toBe('12.3k');
+    expect(formatLegendValue(2_500_000)).toBe('2.5M');
+    expect(formatLegendValue(-1_500_000)).toBe('-1.5M');
+    expect(formatLegendValue(0.5)).toBe('0.5');
+    expect(formatLegendValue(Number.NaN)).toBe('—');
+  });
+
+  it('labels the legend renderer it is actually showing', () => {
+    render(
+      <LegendCard field="pop" kind="发散渐变渲染">
+        <span>swatches</span>
+      </LegendCard>,
+    );
+    expect(screen.getByText('发散渐变渲染')).toBeInTheDocument();
+  });
+
+  it('exposes a coordinate, zoom and CRS readout', () => {
+    // Absent before V4: a desktop GIS always tells you where and how far in.
+    const src = read('components/map/map-status-readout.tsx');
+    expect(src).toContain('EPSG:4326');
+    expect(src).toMatch(/toFixed\(4\)/);
+    expect(src).toMatch(/Z\{/);
+  });
+
+  it('stacks bottom map chrome from one baseline variable', () => {
+    // The heatmap legend and the thematic legend stack used to share an exact
+    // left/bottom, so the higher-z card simply hid the other.
+    const page = read('app/page.tsx');
+    expect(page).toContain('--map-chrome-bottom');
+    expect(read('components/map/map-decorations.tsx')).toContain('--map-chrome-bottom');
+  });
+});
+
+describe('density is token-driven', () => {
+  it('sizes the layer row from the row scale, not an ad-hoc padding', () => {
+    // Rows were 59-63px because two 28px action buttons set the height while the
+    // icons inside were 12px. QGIS-class layer trees run 22-24px.
+    const src = read('components/sidebar/layers-tab.tsx');
+    expect(src).toMatch(/min-h-row-md/);
+    expect(src).toMatch(/size="sm"/);
+  });
+
+  it('gives every appearance-none range input a visible thumb', () => {
+    // Review finding (verified in Chromium): `appearance-none` on the layer
+    // opacity slider removed the native thumb and nothing restyled it, so the
+    // control rendered as a bare 4px bar with no grabbable handle.
+    const css = read('app/globals.css');
+    expect(css).toMatch(/\.slider-track::-webkit-slider-thumb/);
+    expect(css).toMatch(/\.slider-track::-moz-range-thumb/);
+
+    const layers = readCode('components/sidebar/layers-tab.tsx');
+    const range = layers.slice(layers.indexOf("type=\"range\""), layers.indexOf("type=\"range\"") + 600);
+    expect(range).toContain('slider-track');
+    // 36px over 100 steps is 0.36px per step; the track needs real width.
+    expect(range).not.toMatch(/\bw-9\b/);
+  });
+
+  it('hides closed always-mounted panels from focus as well as from AT', () => {
+    // Review finding: `aria-hidden` on a container that still holds focusable
+    // children is an ARIA violation — keyboard users tab into invisible
+    // controls that announce nothing. `inert` removes focus, hit-testing and
+    // the a11y subtree together.
+    for (const file of ['components/tweaks-panel.tsx', 'components/panel/rag-independent-panel.tsx']) {
+      const src = readCode(file);
+      expect(src, `${file} should use useInertWhenClosed`).toContain('useInertWhenClosed');
+      expect(src).toMatch(/aria-hidden=\{!/);
+    }
+    expect(read('lib/hooks/use-inert.ts')).toMatch(/setAttribute\('inert'/);
+  });
+
+  it('keeps the control scale to three steps, none below the 24px target floor', () => {
+    // WCAG 2.2 SC 2.5.8 wants a 24x24 minimum target; the smallest control step
+    // sits inside a 30px row, so it cannot claim the spacing exemption.
+    const css = read('app/globals.css');
+    const steps = ['sm', 'md', 'lg'].map((step) => {
+      const m = css.match(new RegExp(`--control-${step}:\\s*(\\d+)px`));
+      expect(m, `--control-${step} is not defined`).not.toBeNull();
+      return Number(m![1]);
+    });
+    expect(steps[0]).toBeGreaterThanOrEqual(24);
+    expect(steps[0]).toBeLessThan(steps[1]);
+    expect(steps[1]).toBeLessThan(steps[2]);
+    expect(css).toMatch(/--row-sm:\s*24px/);
+  });
+});
+
+describe('theme survives a reload', () => {
+  it('persists the theme choice', () => {
+    // Not persisted before V4: switching to dark and reloading silently
+    // reverted to light.
+    const src = read('lib/store/useHudStore.ts');
+    const partialize = src.slice(src.indexOf('partialize'), src.indexOf('}),', src.indexOf('partialize')));
+    expect(partialize).toMatch(/theme: state\.theme/);
+    expect(partialize).toMatch(/accentColor: state\.accentColor/);
+  });
+
+  it('applies the persisted theme before the first paint', () => {
+    const src = read('app/layout.tsx');
+    expect(src).toMatch(/geoagent-settings/);
+    expect(src).toMatch(/classList\.add\('dark'\)/);
+  });
+
+  it('syncs the runtime accent into the CSS custom property', () => {
+    // `var(--agent-accent)` consumers (nav rail, panel separator) were stuck on
+    // the default green no matter what accent the user picked. The effect writes
+    // the raw accent; globals.css derives the theme-corrected --agent-accent.
+    const src = read('app/page.tsx');
+    expect(src).toMatch(/setProperty\('--agent-accent-raw'/);
+  });
+});
+
+describe('every accent preset can carry label text', () => {
+  const css = read('app/globals.css');
+  const onAccent = css.match(/--text-on-accent:\s*([^;]+);/)![1].trim();
+
+  const lum = (hex: string) => {
+    const n = parseInt(hex.replace('#', ''), 16);
+    const parts = [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((c) => {
+      const s = c / 255;
+      return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * parts[0] + 0.7152 * parts[1] + 0.0722 * parts[2];
+  };
+  const ratio = (a: string, b: string) => {
+    const [hi, lo] = [lum(a), lum(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+  };
+
+  it.each(ACCENT_PRESETS)('%s clears AA body under the on-accent text colour', (preset) => {
+    expect(onAccent).toBe('#ffffff');
+    expect(ratio(onAccent, preset)).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe('responsive behaviour at the 1024 floor', () => {
+  it('keeps the map meaningfully visible behind the right-hand drawers at 1024', () => {
+    // Visible map at the 1024 floor = 1024 - 48 (rail) - 330 (context panel) = 646px.
+    // Review finding: a nominally-clamped 62vw drawer left an 11px sliver, i.e.
+    // "technically visible" and practically covered. Both drawers now share one
+    // token, and the assertion is the outcome (map strip), not the expression.
+    const css = read('app/globals.css');
+    const rule = css.match(/--drawer-w:\s*min\((\d+)px,\s*max\((\d+)px,\s*(\d+)vw\)\);/);
+    expect(rule, '--drawer-w should be a min(cap, max(floor, Nvw)) rule').not.toBeNull();
+    const [cap, floor, vw] = rule!.slice(1).map(Number);
+
+    const mapStrip = (viewport: number) => {
+      const drawer = Math.min(cap, Math.max(floor, (vw / 100) * viewport));
+      return viewport - drawer - 378; // 378 = rail 48 + context panel 330
+    };
+    // At the minimum target the map must keep a usable strip, not a sliver.
+    expect(mapStrip(1024)).toBeGreaterThan(120);
+    // And the drawer must not keep growing past its cap on wide screens.
+    expect(mapStrip(1920)).toBeGreaterThan(700);
+
+    // Both drawers must consume the token rather than restating the formula.
+    for (const file of [
+      'components/settings/settings-panel.tsx',
+      'components/drawers/template-gallery-v2.tsx',
+    ]) {
+      const src = readCode(file);
+      expect(src, `${file} should use var(--drawer-w)`).toContain("width: 'var(--drawer-w)'");
+      expect(src, `${file} should not restate the width formula`).not.toMatch(/\d+vw/);
+    }
+  });
+
+  it('bounds the tweaks panel height and lets it scroll', () => {
+    const src = read('components/tweaks-panel.tsx');
+    expect(src).toMatch(/max-h-\[min\(/);
+    expect(src).toMatch(/overflow-y-auto/);
+  });
+});
+
+describe('no unnecessary compositing over the map', () => {
+  const OVER_MAP = [
+    'components/layout/nav-rail.tsx',
+    'components/layout/context-panel.tsx',
+    'components/layout/top-bar.tsx',
+    'components/sidebar/chat-tab.tsx',
+    'components/drawers/history-drawer.tsx',
+    'components/panel/rag-independent-panel.tsx',
+    'components/tweaks-panel.tsx',
+    'components/map/legends/legend-card.tsx',
+  ];
+
+  it.each(OVER_MAP)('%s does not blur the map behind it', (file) => {
+    // A backdrop-filter over a continuously repainting canvas is the expensive
+    // kind, and translucency lets map detail bleed through dense text.
+    const src = readCode(file);
+    expect(src).not.toMatch(/backdropFilter/);
+    expect(src).not.toMatch(/backdrop-blur/);
+  });
+});
+
+/* ───────────────────────── interaction state contracts ───────────────────── */
+
+describe('selected is distinguishable from hover', () => {
+  it('gives the nav rail active tab a different background than hover', async () => {
+    const { NavRail } = await import('@/components/layout/nav-rail');
+    const { container } = render(<NavRail />);
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    const active = tabs.find((t) => t.getAttribute('aria-selected') === 'true')!;
+    const inactive = tabs.find((t) => t.getAttribute('aria-selected') === 'false')!;
+
+    // Before V4 both used the same `bg-[var(--theme-bg-hover)]`, so hovering the
+    // selected tab produced no change at all.
+    expect(active.className).toContain('bg-status-accent-soft');
+    expect(inactive.className).not.toContain('bg-status-accent-soft');
+    expect(inactive.className).toContain('hover:bg-surface-hover');
+  });
+});
+
+describe('graduated legend classes are operable and stateful', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('toggles a class with Space as well as Enter and reports aria-pressed', async () => {
+    const { GraduatedLegend } = await import('@/components/map/legends/graduated-legend');
+    const onFilterChange = vi.fn();
+    render(
+      <GraduatedLegend
+        spec={{
+          type: 'graduated',
+          field: 'pop',
+          breaks: [0, 10, 20],
+          palette: 'Blues',
+          palette_colors: ['#deebf7', '#3182bd'],
+        }}
+        onFilterChange={onFilterChange}
+      />,
+    );
+    const rows = screen.getAllByRole('button');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveAttribute('aria-pressed', 'true');
+
+    // Space must work, not only Enter: role="button" implies both.
+    rows[0].focus();
+    await userEvent.keyboard(' ');
+    expect(onFilterChange).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByRole('button')[0]).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.keyboard('{Enter}');
+    expect(onFilterChange).toHaveBeenCalledTimes(2);
+    expect(screen.getAllByRole('button')[0]).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -63,7 +63,18 @@ if (typeof HTMLCanvasElement !== 'undefined') {
     } as any;
   };
   HTMLCanvasElement.prototype.toDataURL = function () {
-    return 'data:image/png;base64,iVBORw0KGgoAAAANSU5EUgAAAAIAAAACCAYAAABytg0kAAAAC0lEQVR4XmNgQAcAABIAAQu7JJwAAAAASUVORK5CYII=';
+    return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAC0lEQVR4XmNgQAcAABIAAQu7JJwAAAAASUVORK5CYII=';
   };
 }
+
+// jsdom 不做布局计算，offsetParent 恒为 null，而共用焦点工具
+// （lib/utils/focus.ts）以 `offsetParent !== null` 过滤可见元素 ——
+// 不垫一层的话 useDialogFocus 的 Tab 围栏在测试里永远找不到可聚焦元素。
+// 按 display:none / hidden 之外的元素返回 body，语义与浏览器一致。
+Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+  configurable: true,
+  get(this: HTMLElement) {
+    return this.style.display === 'none' || this.hidden ? null : document.body;
+  },
+});
 

--- a/frontend/test/visual/capture.mjs
+++ b/frontend/test/visual/capture.mjs
@@ -1,0 +1,481 @@
+/**
+ * Visual baseline harness (UI Visual System V4).
+ *
+ * Drives the real app in headless Chromium across the responsive matrix
+ * (1920/1440/1366/1024 x light/dark) and captures one PNG per surface, so a
+ * visual convergence pass can be reviewed as a before/after diff instead of by
+ * eye on a single window size.
+ *
+ * The backend is never contacted: every `API_BASE` call and every basemap tile
+ * request is intercepted and answered from the fixtures below, which keeps the
+ * shots deterministic and lets the run work offline.
+ *
+ * Usage (from `frontend/`):
+ *   node test/visual/capture.mjs --out .visual/before
+ *   node test/visual/capture.mjs --out .visual/after
+ *
+ * Assumes a dev/prod server is already listening on --base (default :3311).
+ */
+
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const argOf = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const OUT_ROOT = path.resolve(argOf('out', '.visual/shots'));
+const BASE_URL = argOf('base', 'http://localhost:3311');
+const ONLY = argOf('only', '');
+
+const VIEWPORTS = [
+  { name: '1920x1080', width: 1920, height: 1080 },
+  { name: '1440x900', width: 1440, height: 900 },
+  { name: '1366x768', width: 1366, height: 768 },
+  { name: '1024x768', width: 1024, height: 768 },
+];
+
+const THEMES = ['light', 'dark'];
+
+/**
+ * Each surface is reached the way a user reaches it — by clicking the nav rail
+ * tab or the top-bar button — so the shot proves the surface is production
+ * reachable, not merely that a file exists.
+ */
+const SURFACES = [
+  { name: 'chat', tab: '对话' },
+  { name: 'project', tab: '项目' },
+  { name: 'data', tab: '数据' },
+  { name: 'layers', tab: '图层' },
+  { name: 'analysis', tab: '分析' },
+  { name: 'tasks', tab: '任务' },
+  { name: 'map-studio', tab: '制图' },
+  { name: 'settings', button: '设置' },
+  { name: 'template-gallery', button: '模板库' },
+  { name: 'history', button: '历史会话' },
+  { name: 'panel-collapsed', tab: '图层', collapse: true },
+  { name: 'hud-expanded', tab: '对话', hud: true },
+  /*
+    Map overlays need layers in the store, and the store is deliberately not on
+    `window`. Rather than reach past the app, these two restore a session: the
+    real production path (`use-workspace-session`) reads `map-state`, pulls each
+    layer's geometry from `/api/v1/layers/data/<ref>` and adds it to the store,
+    all of which the fixtures below answer. So the legend stack and the heatmap
+    legend are captured through the same code path that puts them on screen in
+    production.
+  */
+  { name: 'map-legends', tab: '图层', restoreSession: true },
+  { name: 'map-legends-collapsed', tab: '图层', restoreSession: true, collapse: true },
+];
+
+/** Two features are enough to paint a thematic fill and a heatmap point. */
+const FEATURES = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: { name: '朝阳区', pop_density: 8421, value: 0.62 },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[116.40, 39.90], [116.52, 39.90], [116.52, 40.00], [116.40, 40.00], [116.40, 39.90]]],
+      },
+    },
+    {
+      type: 'Feature',
+      properties: { name: '海淀区', pop_density: 12750, value: 0.88 },
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[116.24, 39.94], [116.38, 39.94], [116.38, 40.05], [116.24, 40.05], [116.24, 39.94]]],
+      },
+    },
+  ],
+};
+
+/** Layers as the session-restore path expects them: `_refId` + `legend_spec`. */
+const RESTORED_LAYERS = [
+  {
+    id: 'lyr-graduated',
+    name: '区县人口密度（人/km²）',
+    type: 'vector',
+    visible: true,
+    opacity: 0.85,
+    group: 'analysis',
+    _refId: 'ref:graduated',
+    style: { color: '#3182bd' },
+    legend_spec: {
+      type: 'graduated',
+      field: 'pop_density',
+      breaks: [0, 4000, 8000, 12000, 16000],
+      palette: 'Blues',
+      palette_colors: ['#eff3ff', '#bdd7e7', '#6baed6', '#2171b5'],
+    },
+  },
+  {
+    id: 'lyr-categorical',
+    name: '用地分类',
+    type: 'vector',
+    visible: true,
+    opacity: 0.9,
+    group: 'analysis',
+    _refId: 'ref:categorical',
+    style: { color: '#16a34a' },
+    legend_spec: {
+      type: 'categorical',
+      field: 'landuse',
+      categories: [
+        { key: 'r', color: '#f4a261', label: '居住用地' },
+        { key: 'c', color: '#e76f51', label: '商业用地' },
+        { key: 'g', color: '#2a9d8f', label: '绿地与广场' },
+      ],
+    },
+  },
+  {
+    id: 'lyr-heatmap',
+    name: '商业 POI 热力',
+    type: 'heatmap',
+    visible: true,
+    opacity: 0.7,
+    group: 'analysis',
+    _refId: 'ref:heatmap',
+    style: { renderType: 'heatmap', palette: 'inferno' },
+  },
+];
+
+const NOW = '2026-01-01T08:30:00Z';
+
+const project = (id, name, description, status = 'active') => ({
+  id,
+  name,
+  description,
+  status,
+  metadata_json: {},
+  created_at: NOW,
+  updated_at: NOW,
+});
+
+const dataset = (id, name, sourceType, quality) => ({
+  id,
+  project_id: 'p-1',
+  name,
+  source_type: sourceType,
+  source_ref: `postgis://gis/${id}`,
+  schema_profile: { fields: 12 },
+  crs: 'EPSG:4326',
+  quality_status: quality,
+  version_fingerprint: 'a1b2c3d4',
+  created_at: NOW,
+});
+
+const job = (id, name, status, progress, message, extra = {}) => ({
+  id,
+  kind: 'analysis',
+  name,
+  status,
+  progress,
+  message,
+  cancellable: status === 'running',
+  retryable: status === 'failed',
+  active: status === 'running' || status === 'queued',
+  attempt: 1,
+  session_id: 'visual-baseline',
+  project_id: 'p-1',
+  agent_task_id: null,
+  agent_step_id: null,
+  background_job_ids: [],
+  error: status === 'failed' ? '数据源连接超时（30s）' : null,
+  result_ref: status === 'completed' ? 'artifact://result/91f3' : null,
+  step_count: 4,
+  created_at: NOW,
+  started_at: NOW,
+  finished_at: status === 'running' ? null : NOW,
+  cancel_requested_at: null,
+  ...extra,
+});
+
+const source = (id, name, sourceType, status) => ({
+  id,
+  name,
+  source_type: sourceType,
+  endpoint_url: `https://gis.example.org/${id}/wfs`,
+  status,
+  capabilities: ['query', 'preview', 'materialize'],
+  connection_profile: {},
+  last_health_check: NOW,
+});
+
+const catalogItem = (id, name, title, geometryType, featureType) => ({
+  id,
+  source_id: 'src-1',
+  name,
+  title,
+  description: '来自城市空间数据底座的要素集，含行政区划与人口统计属性。',
+  geometry_type: geometryType,
+  feature_type: featureType,
+  crs: 'EPSG:4326',
+  bbox: [116.0, 39.6, 116.8, 40.3],
+  meta_profile: { feature_count: 4213 },
+  updated_at: NOW,
+});
+
+const template = (id, kind, name, category, description) => ({
+  id,
+  kind,
+  name,
+  category,
+  keywords: ['城市', '专题'],
+  description,
+  payload: {},
+  is_builtin: true,
+  version: 1,
+  created_at: NOW,
+  updated_at: NOW,
+});
+
+/**
+ * Shape-correct fixtures for every endpoint the shell touches on mount. They
+ * are deliberately populated (and include a failed job / degraded source) so
+ * the shots exercise real information density instead of only empty states.
+ */
+const FIXTURES = [
+  // Session map state drives the layer restore, and therefore the legends.
+  // Order matters: these patterns are more specific than the session list below.
+  [
+    /\/api\/v1\/chat\/sessions\/[^/]+\/map-state/,
+    {
+      map_state: {
+        viewport: { center: [116.39, 39.95], zoom: 10.4, bearing: 0, pitch: 0 },
+        layers: RESTORED_LAYERS,
+      },
+    },
+  ],
+  [/\/api\/v1\/layers\/data\//, FEATURES],
+  [
+    /\/api\/v1\/chat\/sessions\/[^/]+$/,
+    {
+      session_id: 's-1',
+      title: '北京商业 POI 热力分析',
+      messages: [
+        { role: 'user', content: '统计北京各区人口密度并出图', created_at: NOW },
+        { role: 'assistant', content: '已生成分级设色图与商业 POI 热力图。', created_at: NOW },
+      ],
+    },
+  ],
+  [
+    /\/api\/v1\/tasks\/jobs/,
+    {
+      jobs: [
+        job('job-1', '北京市人口密度 H3 聚合', 'running', 62, '正在计算 H3 r8 网格聚合…'),
+        job('job-2', '等时圈可达性分析（15 分钟）', 'completed', 100, '已生成 3 个等时圈'),
+        job('job-3', 'ST-DBSCAN 时空聚类', 'failed', null, '任务失败'),
+        job('job-4', '路网中心性计算', 'queued', null, '排队中'),
+      ],
+      has_active: true,
+      poll_after_ms: null,
+    },
+  ],
+  [
+    /\/api\/v1\/data-fabric\/sources/,
+    {
+      sources: [
+        source('src-1', '城市空间数据底座', 'postgis', 'healthy'),
+        source('src-2', '国家地理信息公共服务平台', 'wfs', 'active'),
+        source('src-3', '气象格网服务', 'wcs', 'degraded'),
+      ],
+    },
+  ],
+  [
+    /\/api\/v1\/data-fabric\/catalog/,
+    {
+      total: 3,
+      limit: 20,
+      offset: 0,
+      items: [
+        catalogItem('ci-1', 'admin_districts', '行政区划面（区县级）', 'MultiPolygon', 'vector'),
+        catalogItem('ci-2', 'poi_commercial', '商业 POI 点位', 'Point', 'vector'),
+        catalogItem('ci-3', 'road_network', '城市路网中心线', 'MultiLineString', 'vector'),
+      ],
+    },
+  ],
+  [
+    /\/api\/v1\/templates/,
+    [
+      template('t-1', 'thematic', '人口密度分级设色', '专题制图', '五级自然断点分级，适用于区县人口密度。'),
+      template('t-2', 'basemap', '深色影像底图', '底图', '低饱和深色底图，突出专题图层。'),
+      template('t-3', 'layout', 'A3 横向出图版式', '版式', '含图例、比例尺、指北针与元数据栏。'),
+      template('t-4', 'symbology', '路网层级符号化', '符号化', '按道路等级分配线宽与颜色。'),
+    ],
+  ],
+  [
+    /\/api\/v1\/chat\/sessions/,
+    {
+      sessions: [
+        { session_id: 's-1', title: '北京商业 POI 热力分析', updated_at: NOW, message_count: 12 },
+        { session_id: 's-2', title: '15 分钟生活圈可达性', updated_at: NOW, message_count: 8 },
+        { session_id: 's-3', title: '路网中心性与拥堵关联', updated_at: NOW, message_count: 21 },
+      ],
+    },
+  ],
+  [/\/api\/v1\/chat\/skills/, { skills: [] }],
+  [/\/api\/v1\/layer-types/, { layer_types: [] }],
+  [
+    /\/projects\/[^/]+\/datasets/,
+    [
+      dataset('d-1', '区县人口统计 2025', 'postgis', 'passed'),
+      dataset('d-2', '商业 POI 点位', 'wfs', 'warning'),
+    ],
+  ],
+  [/\/projects\/[^/]+\/workflows/, []],
+  [
+    /\/projects\b/,
+    [
+      project('p-1', '城市空间体检 2026', '区县级人口、用地与可达性综合评估。'),
+      project('p-2', '生活圈可达性专题', '15 分钟生活圈等时圈与设施覆盖分析。'),
+    ],
+  ],
+];
+
+/** 1x1 transparent PNG — stands in for every basemap tile. */
+const BLANK_TILE = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+async function installStubs(page) {
+  await page.route('**/*', async (route) => {
+    const url = route.request().url();
+
+    if (/^https?:\/\/(localhost|127\.0\.0\.1):8000\//.test(url)) {
+      const hit = FIXTURES.find(([re]) => re.test(url));
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(hit ? hit[1] : []),
+      });
+    }
+
+    if (/\.(png|jpe?g|webp)(\?|$)/i.test(url) && !url.startsWith(BASE_URL)) {
+      return route.fulfill({ status: 200, contentType: 'image/png', body: BLANK_TILE });
+    }
+
+    if (/\.pbf(\?|$)/i.test(url) || /\/tiles?\//i.test(url) && !url.startsWith(BASE_URL)) {
+      return route.fulfill({ status: 204, body: '' });
+    }
+
+    if (!url.startsWith(BASE_URL) && /^https?:/.test(url)) {
+      // Google Fonts, tile JSON, telemetry — answer empty rather than hang.
+      return route.fulfill({ status: 200, contentType: 'text/plain', body: '' });
+    }
+
+    return route.continue();
+  });
+}
+
+/** Applies the theme exactly the way `app/page.tsx` does. */
+async function applyTheme(page, theme) {
+  await page.evaluate((t) => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', t === 'dark');
+    root.setAttribute('data-theme', t);
+  }, theme);
+}
+
+async function clickRailTab(page, label) {
+  const tab = page.locator(`[role="tab"][aria-label*="${label}"]`).first();
+  if (await tab.count()) {
+    await tab.click({ timeout: 5000 }).catch(() => {});
+    return true;
+  }
+  const byText = page.locator(`[role="tab"]:has-text("${label}")`).first();
+  if (await byText.count()) {
+    await byText.click({ timeout: 5000 }).catch(() => {});
+    return true;
+  }
+  return false;
+}
+
+async function clickTopBarButton(page, label) {
+  const btn = page.locator(`button[aria-label*="${label}"], button[title*="${label}"]`).first();
+  if (await btn.count()) {
+    await btn.click({ timeout: 5000 }).catch(() => {});
+    return true;
+  }
+  return false;
+}
+
+async function capture() {
+  const browser = await chromium.launch({ args: ['--force-color-profile=srgb'] });
+  const failures = [];
+  let shots = 0;
+
+  for (const vp of VIEWPORTS) {
+    for (const theme of THEMES) {
+      const context = await browser.newContext({
+        viewport: { width: vp.width, height: vp.height },
+        deviceScaleFactor: 1,
+        reducedMotion: 'reduce',
+        locale: 'zh-CN',
+      });
+      const page = await context.newPage();
+      await installStubs(page);
+      page.on('pageerror', (e) => failures.push(`${vp.name}/${theme}: ${e.message}`));
+
+      for (const surface of SURFACES) {
+        if (ONLY && !surface.name.includes(ONLY)) continue;
+        const dir = path.join(OUT_ROOT, `${vp.name}-${theme}`);
+        await mkdir(dir, { recursive: true });
+
+        try {
+          await page.goto(BASE_URL, { waitUntil: 'domcontentloaded', timeout: 45000 });
+          await page.waitForTimeout(1500);
+
+          if (surface.restoreSession) {
+            // 历史会话 → 选第一条：走真实的 selectSession → map-state → 图层恢复。
+            await clickTopBarButton(page, '历史会话');
+            await page.waitForTimeout(500);
+            const entry = page
+              .locator('[role="dialog"] button:has-text("北京商业 POI 热力分析")')
+              .first();
+            if (await entry.count()) await entry.click({ timeout: 5000 }).catch(() => {});
+            await page.waitForTimeout(1400);
+          }
+          if (surface.tab) await clickRailTab(page, surface.tab);
+          if (surface.button) await clickTopBarButton(page, surface.button);
+          if (surface.collapse) await clickRailTab(page, surface.tab);
+          if (surface.hud) {
+            const chevron = page
+              .locator('button[aria-label*="展开"], button[aria-label*="HUD"]')
+              .first();
+            if (await chevron.count()) await chevron.click({ timeout: 3000 }).catch(() => {});
+          }
+
+          await page.waitForTimeout(900);
+          // Applied last: `app/page.tsx` drives the `dark` class from a store effect that
+          // runs on hydration and would otherwise strip a theme set before then.
+          await applyTheme(page, theme);
+          await page.waitForTimeout(400);
+          await page.screenshot({ path: path.join(dir, `${surface.name}.png`) });
+          shots += 1;
+        } catch (err) {
+          failures.push(`${vp.name}/${theme}/${surface.name}: ${err.message}`);
+        }
+      }
+
+      await context.close();
+    }
+  }
+
+  await browser.close();
+  console.log(`[visual] wrote ${shots} screenshots to ${OUT_ROOT}`);
+  if (failures.length) {
+    console.log(`[visual] ${failures.length} issue(s):`);
+    for (const f of failures.slice(0, 40)) console.log(`  - ${f}`);
+  }
+}
+
+capture().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
在 #343 交付的 V3 AI GIS workspace shell 之上，对**生产可达**的前端做一次"专业 GIS 工作台级"的视觉体系收敛。

> **信息架构与地图数据面均未重写。** NavRail + ContextPanel 的 IA 保持原样；#344 的 MVT / ref descriptor / map adapter data plane / `use-sse-stream` 数据路径与 #345 的 Data Fabric 后端**一行未动**；无 API 变更。本 PR 只改视觉层、交互状态与可访问性。

---

## 1. 视觉审计

8 个只读 subagent 分头审计，先证明 **production reachability** 再记录问题 —— 从 `app/page.tsx` 出发做可达性追踪，`components/` 下若干文件因零调用点被判定为 dead code 而**排除**，没有为了"文件存在"去优化它们。

覆盖 14 个生产可达界面：chat / project / data / layers / analysis / tasks / map studio / settings / template gallery / RAG panel / history drawer / tweaks panel / HUD / map overlays。

### 视觉债矩阵（摘要）

| # | 类别 | 事实 | 影响 |
|---|---|---|---|
| **D1** | **暗色模式失效** | `tailwind.config.ts` 未设 `darkMode` → v3 默认 `media` | **13 个文件 124 个 `dark:` variant 全部失效**，跟随 OS 而非应用内开关 |
| **D2** | **对比度不达标** | `--theme-text-muted` **2.45:1**、`--theme-text-subtle` **1.42:1**，二者都承载真实标签文案 | 正文 AA 失败 |
| **D3** | 主题不持久 | `theme` / `fontSize` 不在 `partialize` 中 | 选暗色刷新即丢，看起来像开关坏了 |
| **D4** | 色彩无语义层 | 4 套并行词汇（shadcn HSL / `--theme-*` / `--agent-*` / ~470 处 raw 字面量） | "面板底色"没有单一定义，逐文件漂移 |
| **D5** | 强调色双轨 | JS 内联 hex 与 `var()` 两条独立通路 | 暗色下 accent 作正文 **3.39:1**；用户气泡 **3.8:1** |
| **D6** | 抽屉盖满地图 | settings drawer `min(720px, 92vw)` | 1024 下 646px 地图区被**完全遮挡** |
| **D7** | 挂件碰撞 | 热力图图例与专题图例共用同一 `left`/`bottom` | z-index 低者**完全不可见** |
| **D8** | 密度不足 | 图层行 59–63px（高度由包着 12px 图标的两个 28px 按钮决定） | 650px 面板仅 8–9 层 |
| **D9** | 选中态 = hover 态 | nav-rail 二者同一 class | 悬停已选 tab 无反馈，选中态语义模糊 |
| **D10** | 滑块无手柄 | `appearance-none` 且全仓无 thumb 规则 | 手柄不可见，控件看起来是坏的 |
| **D11** | 未定义工具类 | `bg-ds-surface` / `backdrop-blur-hud` / `glass-panel` / `bg-grid-hud` 等 | 编译为空 → toast 在地图上**无底色**、story 页叙事面板透明 |
| **D12** | 表面层级塌陷 | 亮色 `overlay` vs `raised` **1.01:1**、`sunken` vs `panel` **1.07:1** | 层级不可辨 |
| **D13** | 控件目标过小 | `--control-sm` 22px | 低于 WCAG 2.2 SC 2.5.8 的 24px 下限 |
| **D14** | 表单控件无名 | `SField` 裸 `<label>` 未关联 input | **8 个设置控件无可及名称** |
| **D15** | 开关无名 | `ToggleSwitch.label` 为可选，4 处调用省略 | 无名 switch |
| **D16** | 隐藏面板仍可 Tab | 常驻挂载面板未 `inert` | 键盘用户 Tab 进不可见抽屉 |
| **D17** | `role` 误用 | 图层行 `role="group"` + `tabIndex` | 每层一个死 tab stop |
| **D18** | 状态色三套 | 三种"成功绿"；"运行中"一处绿一处蓝 | 状态色不表意 |
| **D19** | 玻璃拟态堆叠 | 16 处地图之上 `backdrop-filter` | 与"地图为主体"冲突，且每帧合成开销 |
| **D20** | 图例数值错误 | `0.04` → `"0"`，`-0.04` → `"-0"` | 分级断点显示错误 |
| **D21** | 缺 GIS 基础挂件 | 无坐标 / 缩放级别 / CRS / 图廓信息 | GIS 工作台的 table stakes 缺失 |
| **D22** | 字号无刻度 | 12 个 raw px 值 | 无排版层级 |
| **D23** | 圆角/阴影漂移 | 混用 6/8/10/12 + 逐处自定义阴影 | 观感不统一 |
| **D24** | 图例容器复制 | 同一容器串**复制 3 份**，热力图图例漏改 | 改一处漏两处 |

---

## 2. Before / After

| | Before | After |
|---|---|---|
| 亮色 `--text-muted` 对比度 | 2.45:1 ❌ | **5.7:1** ✅（canvas 上 4.7:1） |
| 亮色 `--text-disabled` | 1.42:1 ❌ | **3.5:1** ✅（仅非文字） |
| 暗色 accent 作正文 | 3.39:1 ❌ | **≥5.46:1** ✅ |
| 生效的 `dark:` variant | 0 / 124 | **124 / 124** |
| 1024 下地图可见宽度 | **0px** | **175px** |
| 650px 面板可见图层数 | 8–9 | **~19** |
| 图层行高 | 59–63px | **~30px** |
| 统计头部 | 53px | **28px** |
| 地图之上 `backdrop-filter` | 16 处 | **0 处** |
| 未定义工具类 | 7 个 | **0 个** |
| 无可及名称的控件 | 12+ | **0** |
| `/` 路由 bundle | 55.6 kB / 197 kB | **54.7 kB / 196 kB** ⬇ |

截图矩阵：`frontend/.visual/before/` 与 `frontend/.visual/after/`，各 **112 张**（4 视口 × 明暗 × 14 界面）。

---

## 3. 设计 token 变更

**没有新造第四套词汇**，而是建立语义层，并把已有三套 `var()` 指回它 —— 约 475 处历史调用点无需改动即自动获得正确取值，且再也无法漂移。

```
表面   --surface-canvas / panel / raised / overlay / sunken / hover / selected / scrim
描边   --border-subtle / default / strong
文字   --text-primary / secondary / muted / disabled / on-accent
状态   accent · success · info · warning · critical · neutral（各带 -soft / -border）
层级   --elevation-flat / raised / overlay / drawer          （刻意很平）
圆角   3 / 4 / 6 / 8 / 12 / pill                            （原 6/8/12，收紧＝仪器感）
字号   micro 10 · caption 11 · meta 12 · body 13 · title 14 · heading 15
度量   control 24/26/30 · row 24/30/38 · icon 12/14/16 · panel-pad 10 · panel-gap 6
其它   --focus-ring* · --map-chrome-* · --drawer-w · --map-chrome-bottom · shell 度量
```

**两个 accent 角色**（原为一个 hex 两处用）：`--accent` 文字安全、且是 `--text-on-accent` 之下的填充；`--accent-vivid` 仅用于图例色块/指示点等非文字标记。

**用户自选强调色单一通路**：store 写 `--agent-accent-raw` → 读 `--agent-accent`（亮色恒等，暗色 `color-mix` 65% 向白校正）。五个预设已加深以保证白色标签文案达 AA。随之删除整条 `accentColor` prop 链（6 组件）与 5 处 store 订阅 —— 它们只是第二个错误的真相来源。

---

## 4. 响应式矩阵

| 视口 | 关键结果 |
|---|---|
| **1920×1080** | 抽屉 720px（`--drawer-w` 上限），地图区 > 700px |
| **1440×900** | 抽屉 662px，挂件列无碰撞 |
| **1366×768** | 图例栈滚动而非溢出 |
| **1024×768** | 抽屉 471px，**地图仍可见 175px**；HUD 开启时图例栈滚动 |

两个右侧抽屉共用 `--drawer-w = min(720px, max(400px, 46vw))` —— 共用 token 正是为了防止它们像先前那样各自漂移。

---

## 5. 可访问性

- `SField` 接 `useId` + `htmlFor` + `aria-describedby`（修复 8 个无名控件，hint 文案也被朗读）
- `ToggleSwitch.label` 改为**必填** → 由 TypeScript 强制该契约，而非依赖 review 发现
- tweaks 面板色板/滑块补可及名称 + dialog 语义（此前色板对读屏只是 "button"）
- `useInertWhenClosed`：隐藏面板退出 tab 序（React 18 无 `inert` prop，故用命令式 hook）
- `ChatAnnouncer`：**不能**把 `aria-live` 放在 transcript 上 —— markdown 重解析会替换整个气泡，读屏会每秒数次重读整段回答。改为只播报回合状态 + 完成后的回复，一次
- 图层重排移到具名 grip 按钮（可及名称含位置与快捷键），并移除 `role="group"` 误用与死 tab stop
- data-sources 改为 WAI-APG tablist + roving tabindex
- 恢复 chat 输入框焦点环（内联 `outline:none` 曾覆盖全局规则）
- `MotionConfig reducedMotion="user"`：framer-motion 与 CSS 遵守同一契约
- 全局 `*:focus-visible` 刻意置于 layer 之外，以胜过 Tailwind 的 `focus:outline-none`

---

## 6. 运行时 / 性能保障

- **渲染域不变式保持**：`page` N=20 → memo 同级 0 次；`chat-tab` N=40 → 40 次解析、0 次历史重解析。两个既有测试仍绿。新增 `MapStatusReadout` 自行订阅 `viewport`，地图平移**不触达** `Home`
- **bundle 变小**：`/` 55.6 → **54.7 kB**，First Load 197 → **196 kB**（与 BASE_SHA worktree 实测对比）。CSS 79,945 → ~85,023 B（+6%），恰是内联 JS 颜色对象移除后转移过去的字节
- **移除**地图之上全部 16 处 `backdrop-filter`
- 未新增昂贵动画；`prefers-reduced-motion` 契约保持
- 无常驻隐藏面板做无用功（`inert` 同时切断交互）

---

## 7. 测试

新增 3 个设计系统套件，每个都守护一条**在本次改动中真实被违反过**的不变式：

- **`tokens.contract.test.ts`** —— 断言 `darkMode === 'class'`（D1 的成因）、每个主题相关 token 在 `:root` 与 `.dark` 均有定义、刻度 token 只定义一次、每个 `--theme-*` 别名必须是 `var()` 而非重复字面量、每个 V4 工具类必须绑定 CSS 变量。**它抓出了 `rounded-pill` 被 10 个文件用了 18 次却从未在 config 中定义。**
- **`contrast.test.ts`** —— 解析 `globals.css`、合成 alpha、对两个主题下**每一组**文字×表面实算 WCAG 比值，另含焦点环、地图挂件、`--text-on-accent` on `--accent`、表面阶梯亮度分离；并从 `tweaks-panel.tsx` 解析出 5 个预设，证明暗色 `color-mix` 比例同时越过 3:1 标记下限与 4.5:1 标签下限 —— 即此前 3.39:1 的那条通路。
- **`visual-system.contract.test.tsx`** —— 测行为而非标记：可及名称、disabled 呈现、dialog 语义、inert、经 `userEvent` 驱动真实 store 的键盘重排、announcer 播报状态（且 transcript **不带** `aria-live`）、`formatLegendValue` 边界、以及从 token 实算的抽屉宽度结果（1024 下地图 > 120px，1920 下 > 700px）。

这些断言的是**计算结果**（比值、解析后宽度、可及名称）而非 className 相等，所以重新配色不会打破它们，只有破坏契约才会。唯一例外是"字面量本身就是契约"之处（token 绑定、被禁的 `backdrop-filter`）。

缺失类断言统一经 `readCode()` 先剥注释 —— 其中 3 条最初是在匹配自己的说明注释；而这 3 条里有 1 条是**真阳性**：`history-drawer` 的 scrim 上仍残留 `backdropFilter`。

**视觉回归工具** `test/visual/capture.mjs`：4 视口 × 明暗 × 14 界面 = 112 张 Playwright 截图，后端调用与外部瓦片全部 stub，无需真起后端。主题在截图前**最后**应用 —— 在 hydration 之前应用会被 store effect 抹掉 class，首次尝试因此产出了明暗**逐字节相同**的基线。地图叠加层界面走真实 session-restore 通路，图例栈是经生产代码渲染出来的，而非构造 prop。

### 门禁

| Gate | 结果 |
|---|---|
| `npx tsc --noEmit` | ✅ |
| `npx tsc -p tsconfig.test.json --noEmit` | ✅ |
| `npx eslint . --max-warnings 0` | ✅ |
| `npm test` | ✅ **100 files / 1075 passed / 3 skipped** |
| `npm run build` | ✅ `/` 54.7 kB / 196 kB |

---

## 8. 独立 review

6 个视角 + Matt 双轴 `/code-review`（Standards + Spec）终审。**无 P0。P1 全部修复：**

滑块手柄不可见 · `formatLegendValue` 把 0.04 压成 "0" · 1024+HUD 下图例栈裁切 · 热力图图例漏迁移 · 暗色 accent 作正文 3.39:1 · 半迁移文件混用两套词汇 · chat live region 每批重读整段 · `aria-hidden` 覆盖可聚焦内容 · 可聚焦行上的 `role="group"` · 1024 下抽屉遮挡 98% 地图。

Matt 的 Standards 发现同样全部解决：抽屉宽度公式重复、persist key 魔法字符串、死 compat prop、top-bar 成对 hex。

**刻意保留并记录的 P2**（不阻塞，均为既有行为）：`© OpenStreetMap` 对 10 个瓦片源中的 9 个是错的；坐标只读中心而非跟随光标（性能/可访问性权衡）；比例尺与指北针仅在存在专题图层时渲染；z≥20 时比例尺宽度膨胀；HUD 遥测与新读数重复；`transition-[bottom]`/`[left]` 触发布局而非合成（仅在 HUD 开合/面板缩放时触发一次）。

---

## 9. 证据位置

- 截图：`frontend/.visual/before/` · `frontend/.visual/after/`（各 112 张，`{视口}-{主题}/{界面}.png`）
- 重新生成：`npm run dev` 后 `node test/visual/capture.mjs --out .visual/after`
- token 契约文档：`frontend/README.md` 的「🎨 设计规范 (Visual System V4)」

---

## 10. 边界声明

- ✅ **NavRail / ContextPanel 信息架构未推翻** —— 未改导航结构、tab 集合或面板层次
- ✅ **地图数据面未重写** —— #344 的 MVT / ref descriptor / map adapter / `use-sse-stream` 数据路径未触碰
- ✅ **#345 Data Fabric 后端未触碰**
- ✅ **无 API 变更**
- ✅ **未为"好看"重写业务功能** —— 唯一的行为性新增是 `MapStatusReadout`（只读挂件）；其余均为视觉层、交互状态与可访问性
- ✅ 保留既有中文业务用语
