### PR TITLE
fix(runtime): harden lifecycle, recovery and fault semantics

### DIFF
--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel
 
 from app.utils.sse import sse_event, sse_event_type
 from app.services.chat.pi_event_mapper import map_event_to_sse, _extract_text_from_event
+from app.services.jobs.cancellation import CancellationToken, use_token
 from app.services.tool_dispatch_service import ToolDispatchService
 from app.lib.harness.pi_agent_harness import PiAgentHarness
 from app.lib.harness.tool_call_event import ToolCallEvent
@@ -265,7 +266,14 @@ async def dispatch_tool(request: PiToolRequest) -> PiToolResponse:
     # and truncate error_msg so a multi-KB llm_payload doesn't flood telemetry.
     t0 = time.monotonic()
     try:
-        result = await service.dispatch(tc, request.sessionId or "", executed)
+        # F24: bind the active turn's CancellationToken so checkpoint()-
+        # cooperative tools observe abort/disconnect and stop early instead of
+        # running to completion against an abandoned turn. asyncio.to_thread
+        # (registry's sync-tool path) copies the context, so the token reaches
+        # worker threads without changing tool signatures (ADR-0052).
+        # use_token(None) is a no-op, so dispatch outside a turn is unchanged.
+        with use_token(_active_turn_token):
+            result = await service.dispatch(tc, request.sessionId or "", executed)
     except Exception as exc:
         duration_ms = int((time.monotonic() - t0) * 1000)
         if _harness is not None:
@@ -337,6 +345,13 @@ async def dispatch_tool(request: PiToolRequest) -> PiToolResponse:
 # 每个 session 的已执行工具集合，供重复调用拦截（service 接受外部 set）。
 _session_executed_sets: dict[str, set[tuple[str, str]]] = {}
 
+# F24: 当前在飞 turn 的 CancellationToken。stream_prompt 在持锁期间设置/清除；
+# dispatch_tool（Pi HTTP 回调适配器）通过 use_token() 绑定它，使 checkpoint()
+# 协作式工具在 abort/disconnect 后及时停止，而不是对已被抛弃的 turn 跑到底。
+# 模块级而非实例级：dispatch_tool 是模块函数（ADR-0022 rendezvous），拿不到
+# bridge 实例；turn 在单例 bridge 上严格串行，全局唯一在飞 turn 语义安全。
+_active_turn_token: Optional[CancellationToken] = None
+
 
 # ── Optional evaluation harness (opt-in via PI_HARNESS_ENABLED=true) ──
 # V2（HARNESS-V2）：注入真实证据 resolver —— ref 解析走 SessionStore，
@@ -381,6 +396,11 @@ class PiBridge:
     between the two adapters and cannot move.
     """
 
+    # Session id of the turn currently holding the bridge lock (set/cleared by
+    # stream_prompt). Class-level default so tests that bypass __init__
+    # (PiBridge.__new__) still read None. None = no turn in flight.
+    _active_turn_sid: Optional[str] = None
+
     def __init__(
         self,
         pi_rpc_entry: Optional[Path] = None,
@@ -403,6 +423,7 @@ class PiBridge:
                 extension_paths=extension_paths or [],
             )
         self._lock = asyncio.Lock()
+        self._active_turn_sid: Optional[str] = None
 
     @property
     def _process_died(self) -> bool:
@@ -419,13 +440,22 @@ class PiBridge:
         """Stop the Pi subprocess (delegates to the RPC client)."""
         await self._rpc.stop()
 
-    async def abort(self) -> dict:
+    async def abort(self, session_id: Optional[str] = None) -> dict:
         """Abort the currently-running Pi prompt (fire-and-forget from callers).
 
         BUG-18 fix re-added: ADR-0031 F3 extraction removed the abort wrapper,
         leaving chat.py:320's `await pi_bridge.abort()` to AttributeError into
         a swallowed `except Exception` — the in-flight prompt kept consuming
         tokens and writing files after session deletion.
+
+        Session scoping (F5): the abort RPC and ``fail_all_pending`` are
+        GLOBAL — they hit whatever turn currently owns the singleton
+        subprocess. When a turn for a DIFFERENT session is in flight, an
+        abort meant for an already-dead session would kill the wrong
+        session's turn; skip the RPC + fail_all_pending and log a warning
+        instead. When ``session_id`` matches the active turn, is None
+        (back-compat: existing callers pass nothing), or no turn is active,
+        behave as before.
 
         The RPC client's `request("abort")` matches vendor/pi's rpc-mode.js
         `case "abort"` handler. Failures (no process, RPC error) propagate;
@@ -438,8 +468,52 @@ class PiBridge:
         deadlock against the in-flight turn it is trying to cancel. The
         ``request("abort")`` RPC + ``fail_all_pending`` below provide
         cancellation without the lock.
+
+        Knock-on note (fail_all_pending scoping): ``fail_all_pending`` fails
+        EVERY pending future, which looks over-broad — but on this singleton
+        client requests are serialized by the turn lock, so the only futures
+        that can be pending at abort time belong to the in-flight turn (the
+        abort RPC's own future has already resolved, and the F5 guard above
+        skips this call entirely when the in-flight turn is another
+        session's). The failed futures are therefore already exactly the
+        abort-relevant ones; a per-command pending registry would add
+        bookkeeping for no additional safety.
         """
+        active = self._active_turn_sid
+        if session_id is not None and active is not None and session_id != active:
+            logger.warning(
+                "[PiBridge] abort(session_id=%s) skipped: turn for session %s "
+                "is in flight on the singleton bridge; a global abort would "
+                "kill the wrong session's turn",
+                session_id, active,
+            )
+            return {}
         result = await self._rpc.request("abort")
+        # F24: ignite the active turn's cancellation token so checkpoint()-
+        # cooperative tool dispatches (HTTP callback path) stop promptly too,
+        # not just the Pi subprocess.
+        if _active_turn_token is not None:
+            _active_turn_token.cancel("abort requested")
+        # P1 (TOCTOU): the active sid above was read lock-free BEFORE the abort
+        # RPC was awaited. In that gap the matching turn can end and a
+        # DIFFERENT session's turn start — the global abort RPC then hits the
+        # wrong turn. The damage is done by the time we can observe it, but
+        # re-reading the sid and logging the flip explicitly documents the
+        # known limit (futures already failed by fail_all_pending cannot be
+        # un-failed) instead of silently killing the wrong turn.
+        active_after = self._active_turn_sid
+        if (
+            session_id is not None
+            and active_after is not None
+            and active_after != session_id
+        ):
+            logger.warning(
+                "[PiBridge] abort(session_id=%s) TOCTOU: the active turn "
+                "flipped %s -> %s while the abort RPC was in flight; the "
+                "global abort may have hit session %s's turn (known limit — "
+                "cannot un-fail futures)",
+                session_id, active, active_after, active_after,
+            )
         # Cancel any pending request future the client hasn't resolved yet.
         # Without this, an in-flight `prompt` would keep waiting for its
         # response up to the stream timeout (30s) and then emit a generic
@@ -523,6 +597,7 @@ class PiBridge:
         Raises:
             PiRpcError: If the Pi agent returns an error or the request fails.
         """
+        global _active_turn_token
         # Turn-scoped session id: attribution uses this local, never the
         # mutable self._session_id field (which a concurrent/preceding turn
         # could overwrite). Pi events carry no session of their own.
@@ -542,6 +617,15 @@ class PiBridge:
         # in the shared queue. Abort bypasses the lock (see abort()).
         await self._lock.acquire()
         try:
+            # F5/F24: publish the active turn's identity + cancellation token
+            # while the lock is held — abort() reads the sid for session
+            # scoping, dispatch_tool binds the token via use_token. Same as
+            # stream_prompt; cleared in the finally. P1: prompt() previously
+            # never set these, so abort(session_id=other) saw active=None and
+            # the GLOBAL abort killed this turn, and HTTP-callback tool
+            # dispatches ran unbounded (F24 no-op) on this path.
+            self._active_turn_sid = turn_sid
+            _active_turn_token = CancellationToken(job_id=turn_sid or None)
             # Drop any residual events from a prior turn before sending, so they
             # cannot be attributed to this turn.
             await self._drain_stale_events()
@@ -563,6 +647,9 @@ class PiBridge:
             await self._drain_remaining_turn_events()
         finally:
             _cleanup_turn_state(turn_sid)
+            # Clear the active-turn markers before releasing the lock.
+            self._active_turn_sid = None
+            _active_turn_token = None
             self._lock.release()
 
         return {
@@ -582,6 +669,7 @@ class PiBridge:
         Yields:
             SSE-formatted event strings
         """
+        global _active_turn_token
         # Turn-scoped session id: every SSE payload is stamped with this local
         # value, not the mutable self._session_id field. Pi events carry no
         # session of their own, so attribution must come from the request that
@@ -610,6 +698,12 @@ class PiBridge:
         # Abort deliberately bypasses this lock (see abort()).
         await self._lock.acquire()
         cancelled = False
+        timed_out = False
+        # F5/F24: publish the active turn's identity + cancellation token while
+        # the lock is held — abort() reads the sid for session scoping,
+        # dispatch_tool binds the token via use_token. Cleared in the finally.
+        self._active_turn_sid = turn_sid
+        _active_turn_token = CancellationToken(job_id=turn_id)
         try:
             # Drop residual events from a prior turn so they can't be dequeued
             # and attributed to this session.
@@ -632,7 +726,6 @@ class PiBridge:
             # Stream events from Pi
             yield sse_event("task_start", {"task_id": turn_sid, "session_id": turn_sid, "turn_id": turn_id})
 
-            timed_out = False
             silence_seconds = 0.0
             while True:
                 try:
@@ -678,14 +771,19 @@ class PiBridge:
             cancelled = True
             raise
         finally:
-            if cancelled:
-                # Tell Pi to stop generating tokens / executing tools. Awaiting
-                # inline (shielded + bounded) rather than fire-and-forget so no
-                # detached task retains the bridge (transport goal leak test).
-                # On GeneratorExit (aclose) the driving task is not cancelled, so
-                # this completes normally; on CancelledError the shield keeps the
-                # abort running while wait_for returns promptly. A failure or
-                # timeout here must never raise into generator cleanup.
+            if cancelled or timed_out:
+                # Tell Pi to stop generating tokens / executing tools. F10:
+                # this now covers the stall-timeout path too — previously a
+                # stalled turn yielded error+done and returned WITHOUT the
+                # abort RPC, so Pi kept executing tools (up to the 300s RPC
+                # timeout) and a user retry duplicated side effects.
+                # Awaiting inline (shielded + bounded) rather than fire-and-
+                # forget so no detached task retains the bridge (transport
+                # goal leak test). On GeneratorExit (aclose) the driving task
+                # is not cancelled, so this completes normally; on
+                # CancelledError the shield keeps the abort running while
+                # wait_for returns promptly. A failure or timeout here must
+                # never raise into generator cleanup.
                 try:
                     await asyncio.wait_for(
                         asyncio.shield(self._abort_on_disconnect(turn_sid)),
@@ -704,6 +802,10 @@ class PiBridge:
             # results (written by the HTTP callback, never consumed after a
             # disconnect). Without this they accumulate across sessions.
             _cleanup_turn_state(turn_sid)
+            # Clear the active-turn markers AFTER the abort above (abort reads
+            # them to cancel the token) and before releasing the lock.
+            self._active_turn_sid = None
+            _active_turn_token = None
             self._lock.release()
 
 

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -28,11 +28,21 @@ router = APIRouter(prefix="/chat", tags=["对话"])
 registry: ToolRegistry = None  # type: ignore[assignment]
 engine: ChatEngine = None  # type: ignore[assignment]
 
-# DUP-1: process-local SSE turn-resume buffer. One ring buffer per session key
-# (most recent turn only; LRU-capped), filled by the route as events are
+# DUP-1: process-local SSE turn-resume buffer. A small bounded list of recent
+# turn buffers per session key (LRU-capped), filled by the route as events are
 # emitted. A POST with Last-Event-ID / last_event_id replays from it without
 # starting a new turn. Cross-restart persistence is a non-goal.
 _turn_resume_registry = TurnResumeRegistry()
+
+# F20: a resume that races a still-live (or queued, never-started) turn holds
+# for the real terminal instead of fabricating ``done`` — capped so a stalled
+# turn can't pin the reconnect forever; on expiry the client gets a truthful
+# terminal error and may reconnect again with a newer Last-Event-ID.
+# Hold is DISABLED for anonymous (''-key) sessions (P1): the shared anonymous
+# key skips ownership checks, so holding would let anyone who knows the
+# victim's message + Last-Event-ID tail a stranger's live turn — anonymous
+# resumes of live turns get the truthful pending error immediately instead.
+_RESUME_LIVE_HOLD_S = 30.0
 
 # SSE 流式响应头（Pi 和 legacy 路径共用）
 SSE_HEADERS = {
@@ -176,14 +186,31 @@ async def _resume_generator(
     A POST /chat/stream carrying ``Last-Event-ID`` / ``last_event_id`` is a
     RESUME — a read, never a new execution. The route sends no prompt RPC and
     dispatches no tool; it replays what the dropped connection missed from the
-    per-session ring buffer and then ends:
+    per-session ring buffers and then ends:
 
-      * buffer hit + message match → replay every buffered event with
-        ``id > last_event_id`` in order; then terminate with the buffered
-        terminal event if it was replayed, a synthesized ``done {resumed:
-        true}`` if the client already consumed the terminal (``last_event_id >=
-        terminal id`` — the stream must never hang), or a synthesized ``error``
-        if the turn was interrupted (aborted on disconnect; no terminal exists).
+      * unique buffer hit (message match + Last-Event-ID valid for that turn)
+        → replay every buffered event with ``id > last_event_id`` in order;
+        then terminate with the buffered terminal event if it was replayed, a
+        synthesized ``done {resumed: true}`` if the client already consumed
+        the terminal (``last_event_id >= terminal id`` — the stream must never
+        hang), or a synthesized ``error`` if the turn was interrupted (aborted
+        on disconnect; no terminal exists).
+      * the matched turn is still LIVE (or queued, never started) → after the
+        replay the stream HOLDS (F20): new events are forwarded as the turn
+        records them, until the real terminal arrives or the turn ends. A live
+        turn NEVER yields a fabricated ``done {resumed: true}``. If the turn
+        outlives ``_RESUME_LIVE_HOLD_S`` (stalled), the resume ends with a
+        truthful terminal ``error {resumed: true, pending: true}`` — the
+        client may reconnect again with a newer Last-Event-ID. Anonymous
+        (``""``-key) sessions never hold (P1): the shared anonymous key skips
+        ownership checks, so holding would let anyone who knows the message +
+        Last-Event-ID tail a stranger's live turn — an anonymous resume of a
+        live turn replays the already-buffered tail and immediately ends with
+        that truthful pending error instead.
+      * ambiguous hit (multiple concurrent turns on this session key match —
+        e.g. two anonymous ``""``-key turns with the same message, F2) →
+        terminal ``error {resumed: false}``: fail safe, never replay the WRONG
+        turn's events into this client's stream (cross-turn leak).
       * buffer miss (server restart / LRU eviction / message mismatch) → a
         terminal ``error {resumed: false}``; no new turn starts, so a stale
         reconnect can never double-execute the message. The client stops
@@ -192,20 +219,99 @@ async def _resume_generator(
     Synthesized terminal events carry no ``id:`` (they are not part of the
     original turn's id sequence); the client consumes them for status and
     stops, so ids are not needed for dedup there.
+
+    P2 (round-2 review): anonymous (``""``-key) resumes additionally require
+    ``last_event_id > 0``. The ``""`` key is shared by ALL anonymous clients
+    and skips ownership checks, so a resume from id 0 would replay a
+    stranger's whole buffered turn to anyone who knows the message + session
+    id. A nonzero Last-Event-ID is (weak) proof of prior contact with THAT
+    turn — the requester must have received events from it. An anonymous
+    resume with ``last_event_id <= 0`` is refused with a terminal
+    ``error {resumed: false}``: no replay, no fabricated done. Named-session
+    resumes are unchanged (``last_event_id == 0`` remains legal there).
+    Residual (documented): anonymous + no-auth still share the ``""``
+    namespace by design, so a nonzero id is not strong ownership — it only
+    removes the whole-turn replay.
     """
-    buffered = _turn_resume_registry.get(session_key)
-    if buffered is None or buffered.message != message:
+    if session_key == "" and last_event_id <= 0:
+        # P2 (round-2 review): anonymous resume without proof of prior contact
+        # is refused outright (no replay of a shared-key stranger's turn from
+        # the start; no fabricated done). Terminal — the client stops
+        # auto-retrying and surfaces the error.
+        yield sse_event("error", {
+            "session_id": session_key,
+            "error": (
+                "匿名会话续传需要携带已接收事件编号（Last-Event-ID > 0）；"
+                "从 0 重放存在跨用户泄漏风险，请重新发送消息。"
+            ),
+            "resumed": False,
+        })
+        return
+    buffered, ambiguous = _turn_resume_registry.find(session_key, message, last_event_id)
+    if buffered is None:
+        if ambiguous:
+            logger.warning(
+                "ambiguous resume for session key %r: multiple concurrent turns "
+                "match — refusing to replay (possible cross-turn leak)",
+                session_key,
+            )
         yield sse_event("error", {
             "error": (
                 "Resume unavailable: the turn buffer is gone (server restarted "
-                "or the session expired). Please resend your message."
+                "or the session expired)."
+                if not ambiguous else
+                "Resume ambiguous: multiple concurrent turns on this session "
+                "match this request — refusing to replay the wrong one. Wait "
+                "for the in-flight turn to finish and reconnect, or start a "
+                "new message."
             ),
             "resumed": False,
         })
         return
 
-    for event in buffered.replay_after(last_event_id):
-        yield event
+    # Replay (catching up to the live tail), then — while the turn is still
+    # live — hold for newly recorded events instead of terminating (F20).
+    # Single-threaded asyncio: replay + ended check are await-free, so no
+    # recorded event can be missed between iterations.
+    cursor = last_event_id
+    while True:
+        for event in buffered.replay_after(cursor):
+            yield event
+        if buffered.last_id is not None and buffered.last_id > cursor:
+            cursor = buffered.last_id
+        if buffered.ended:
+            break
+        if session_key == "":
+            # P1 (review): anonymous (''-key) sessions NEVER live-hold. The ''
+            # key is shared by ALL anonymous clients and skips ownership checks,
+            # so holding would let anyone who knows the victim's message +
+            # Last-Event-ID tail a stranger's live turn in real time
+            # (shadow-stream). Replay the already-buffered tail, then end with
+            # the truthful pending terminal — never fabricate done, never
+            # forward events recorded after this resume connected.
+            yield sse_event("error", {
+                "session_id": session_key,
+                "error": (
+                    "本轮仍在执行中；匿名会话不支持实时续传，请稍后携带 "
+                    "Last-Event-ID 重新连接接收剩余内容。"
+                ),
+                "resumed": True,
+                "pending": True,
+            })
+            return
+        if not await buffered.wait_for_update(timeout=_RESUME_LIVE_HOLD_S):
+            # Stalled live turn: end truthfully — the turn is still in
+            # progress and can be picked up by another resume. Never a fake done.
+            yield sse_event("error", {
+                "session_id": session_key,
+                "error": (
+                    "本轮仍在执行中（续传等待超时）；请携带 Last-Event-ID "
+                    "重新连接继续接收。"
+                ),
+                "resumed": True,
+                "pending": True,
+            })
+            return
 
     if buffered.terminal_event is not None:
         terminal_id = sse_event_id(buffered.terminal_event)
@@ -213,18 +319,16 @@ async def _resume_generator(
             # Client already consumed the terminal; reconnect for nothing but
             # a clean close — synthesize one so the stream terminates.
             yield sse_event("done", {"session_id": session_key, "resumed": True})
-    elif buffered.aborted:
-        # Turn was cut by a client disconnect (server aborted the prompt):
-        # replaying the partial content must NOT look like a complete answer.
+        # Otherwise the terminal was replayed above — nothing more to add.
+    else:
+        # Ended without a terminal: the turn was interrupted (client
+        # disconnect → server aborted the prompt). Replayed partial content
+        # must NOT look like a complete answer.
         yield sse_event("error", {
             "session_id": session_key,
             "error": "连接已中断，本轮未完成且不会自动续跑；请重新发送消息。",
             "resumed": True,
         })
-    else:
-        # Buffered turn still streaming (a resume racing the live turn):
-        # nothing more to add — terminate cleanly.
-        yield sse_event("done", {"session_id": session_key, "resumed": True})
 
 
 class ChatRequest(BaseModel):
@@ -591,6 +695,15 @@ async def push_map_action_acks(
     不可达仅丢事件），端点成败不影响地图交互。harness 评估时直接从 session
     存储读取 ACK（单一事实源），此处不再另写 harness。
 
+    F26: 存储层 append 返回 False 有两种含义 —— 真重复（首达终态获胜，事件
+    已在库里）与降级丢弃（Redis 不可达，事件根本没入库）。之前两者都计入
+    duplicates，客户端无法区分"丢了"与"重了"、也就不会重试真正的丢失。现在
+    对 False 的 ACK 回读一次：action_id 在库 → duplicate；不在 → 计入 additive
+    的 ``dropped`` 字段（仅在有丢弃时出现，响应形状向后兼容）。客户端可对
+    dropped 重试。回读竞态（判重后被并发淘汰/并发首达）只影响计数归类，不
+    影响存储正确性。P2 (round-2 review): 回读只做一次前置快照 + 仅在刚有
+    append 成功（快照可能过期）时刷新，不再逐条被拒 ACK 全量回读（O(n^2)）。
+
     限速 per client IP（同 ws.py/auth.py）：Redis 不可达时 is_allowed fail-open
     放行，不阻断正常交互。
     """
@@ -602,12 +715,35 @@ async def push_map_action_acks(
         raise HTTPException(status_code=429, detail="Too many map action acks")
     from app.services.session_data import session_data_manager
     accepted = 0
+    duplicates = 0
+    dropped = 0
+    # P2 (round-2 review): hoist ONE readback before the loop instead of
+    # re-reading the store per rejected ack (up to 50 full reads = O(n^2) —
+    # e.g. a retrying client spamming 50 duplicates). The snapshot is
+    # refreshed ONLY after an accepted append (only then can it be stale for
+    # an in-batch duplicate of a just-appended id); rejects never read.
+    stored = await session_data_manager.get_map_action_events(session_id)
+    snapshot_stale = False
     for ack in req.acks:
         if await session_data_manager.append_map_action_event(
             session_id, ack.model_dump(exclude_none=True)
         ):
             accepted += 1
-    return {"accepted": accepted, "duplicates": len(req.acks) - accepted}
+            snapshot_stale = True
+            continue
+        if snapshot_stale:
+            # An append landed since the snapshot — an in-batch duplicate of
+            # it would be misread as "dropped". Refresh once, then classify.
+            stored = await session_data_manager.get_map_action_events(session_id)
+            snapshot_stale = False
+        if any(e.get("action_id") == ack.action_id for e in stored):
+            duplicates += 1
+        else:
+            dropped += 1
+    result = {"accepted": accepted, "duplicates": duplicates}
+    if dropped:
+        result["dropped"] = dropped
+    return result
 
 
 @router.get("/skills")
@@ -631,9 +767,11 @@ async def clear_session(
     # 但 Pi agent 子进程里该 session 的在途 prompt 不会被中断，会继续消耗
     # token / 写文件。现在先对 Pi bridge 发 abort（fire-and-forget RPC，
     # 失败仅记日志，不影响后续 DB 清理），再走 legacy 清理。
+    # F5: abort 携带被删会话的 id —— session-blind 的 abort 会把*别的*会话的
+    # 在途 turn 一起杀掉；bridge 据此在其它会话的 turn 在途时跳过并记日志。
     if _use_pi_bridge():
         try:
-            await pi_bridge.abort()
+            await pi_bridge.abort(session_id=session_id)
         except Exception as e:  # noqa: BLE001 — abort 失败不能阻塞删除流程
             logger.warning("Pi bridge abort failed for session %s: %s", session_id, e)
 
@@ -642,6 +780,13 @@ async def clear_session(
     )
     if not ok:
         raise HTTPException(status_code=404, detail="Session not found")
+    # P2 (round-2 review): purge the deleted session's resume buffers. Without
+    # this, anyone holding session_id + the message could keep replaying the
+    # deleted session's buffered SSE events from the process-local resume
+    # registry until LRU eviction. The '' key (shared by ALL anonymous
+    # sessions) is deliberately never purged here — clear_session only ever
+    # targets a real (named) session id.
+    _turn_resume_registry.clear_session(session_id)
     return {"status": "ok"}
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,14 @@ from app.tools import init_tools
 from app.services.chat_engine import ChatEngine
 from app.services.tool_catalog import ToolCatalog
 
+# F15-wiring：teardown 前排空 chat 侧 fire-and-forget 背景任务（标题生成 / ws 广播），
+# 避免它们在资源关闭后继续写。drain_background_tasks 由 chat 执行引擎模块提供；
+# 未提供时降级为 None，不阻塞启动。
+try:
+    from app.services.chat.execution_engine import drain_background_tasks
+except ImportError:  # pragma: no cover - 旧版 execution_engine 没有该函数
+    drain_background_tasks = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 
@@ -86,6 +94,14 @@ async def lifespan(app: FastAPI):
         except asyncio.CancelledError:
             pass
 
+    # F15-wiring：teardown 前排空 chat fire-and-forget 背景任务（标题生成、
+    # ws 广播等），避免它们在 engine/http client 关闭后继续写已失效资源。
+    if drain_background_tasks is not None:
+        try:
+            await drain_background_tasks()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[lifespan] drain_background_tasks failed: {e}")
+
     # 输出工具调用 digest（top 累计 / top p99 / 错误），便于运维定位最慢工具
     try:
         from app.services.tool_metrics import emit_digest
@@ -115,6 +131,16 @@ async def lifespan(app: FastAPI):
             await shutdown_pi_bridge()
         except Exception as e:  # noqa: BLE001
             logger.warning(f"[lifespan] Pi bridge shutdown failed: {e}")
+
+    # F11：之前只 dispose 同步 Engine，async 池仍绑定在已关闭的 event loop 上，
+    # 跨 lifespan 周期复用时第一次 async DB 调用直接 'Event loop is closed'。
+    # best-effort，与周围邻居一致；inline import 与上方 init_db 同款，便于测试 patch。
+    from app.core.database import AsyncEngine
+    if AsyncEngine is not None:
+        try:
+            await AsyncEngine.dispose()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[lifespan] async engine dispose failed: {e}")
 
     Engine.dispose()
 

--- a/app/services/chat/event_resume.py
+++ b/app/services/chat/event_resume.py
@@ -18,26 +18,49 @@ Semantics (documented contract, see ``app.api.routes.chat._resume_generator``):
 
   - a POST /chat/stream carrying ``Last-Event-ID`` / ``last_event_id`` is a
     RESUME (read-only), never a new execution;
-  - buffer hit + matching message: replay every buffered event with
-    ``id > Last-Event-ID`` in order, then terminate with the buffered terminal
-    event if it was replayed, a synthesized ``done {resumed: true}`` if the
-    terminal was already consumed, or a synthesized ``error`` if the turn was
-    interrupted (aborted on disconnect — no terminal was ever produced);
+  - buffer hit + UNAMBIGUOUS message match: replay every buffered event with
+    ``id > Last-Event-ID`` in order; if the turn is still live (or queued, not
+    yet started), the resume HOLDS — replaying new events as they are recorded
+    — until the real terminal arrives or the hold cap expires. It terminates
+    with the buffered terminal event, a synthesized ``done {resumed: true}``
+    if the terminal was already consumed, a synthesized ``error`` if the turn
+    was interrupted (aborted on disconnect — no terminal was ever produced),
+    or a truthful ``error {resumed: true, pending: true}`` if the live turn
+    outlived the hold cap. A live/never-started turn NEVER yields a fabricated
+    ``done`` (F20). Anonymous (``""``-key) sessions NEVER hold (P1): the
+    shared anonymous key skips ownership checks, so holding would let anyone
+    who knows the victim's message + Last-Event-ID tail a stranger's live turn
+    — an anonymous resume of a live turn replays the already-buffered tail and
+    immediately ends with that truthful pending error instead;
+  - ambiguous match (multiple concurrent turns on the same session key match
+    the message + Last-Event-ID — e.g. two anonymous ``""``-key turns with the
+    same message, F2): emit ``error {resumed: false}`` and close. Failing safe
+    is the whole point: replaying the WRONG turn would leak one user's events
+    into another's stream;
   - buffer miss (process restart, LRU eviction, message mismatch): emit
     ``error {resumed: false}`` and close — the client stops auto-retrying and
     surfaces the error instead of silently re-executing the message.
+  - P2 (round-2 review): anonymous (``""``-key) resumes require
+    ``Last-Event-ID > 0`` — id 0 (no proof of prior contact with that turn) is
+    refused with a terminal ``error {resumed: false}``, no replay and no
+    fabricated done. RESIDUAL (documented, by design): anonymous + no-auth
+    still share the ``""`` namespace, so a nonzero id is only weak ownership —
+    this guard removes the whole-turn replay, not the namespace sharing.
 
 Bounds: ``RESUME_MAX_EVENTS`` per turn (ring buffer — only the tail survives,
-which is exactly what a dropped connection missed), and
-``RESUME_MAX_SESSIONS`` process-wide (oldest buffered turn evicted first).
-Cross-restart resume is explicitly out of scope (non-goal): the buffer lives
-in this process only.
+which is exactly what a dropped connection missed),
+``RESUME_MAX_BUFFERS_PER_SESSION`` recent turn buffers per session key (F4: a
+queued second POST registers its buffer WITHOUT clobbering the live turn's),
+and ``RESUME_MAX_SESSIONS`` process-wide (oldest buffered session evicted
+first). Cross-restart resume is explicitly out of scope (non-goal): the buffer
+lives in this process only.
 
-The registry is asyncio-single-threaded (a plain dict): every access happens
-inside a request/stream task, so no locking is needed.
+The registry is asyncio-single-threaded (plain dicts/deques): every access
+happens inside a request/stream task, so no locking is needed.
 """
 from __future__ import annotations
 
+import asyncio
 from collections import deque
 from typing import Optional
 
@@ -50,8 +73,13 @@ from app.utils.sse import _is_terminal_event, sse_event_id
 # small — while staying bounded per turn (Round-2 P3: was 64, which could
 # silently evict un-replayed step_results under a long multi-command turn).
 RESUME_MAX_EVENTS = 256
-# Process-wide cap on buffered turns (one per session); oldest evicted first.
+# Process-wide cap on buffered sessions; oldest evicted first.
 RESUME_MAX_SESSIONS = 32
+# F4: recent turn buffers kept per session key. A queued second POST registers
+# its buffer alongside the live turn's instead of clobbering it, so a resume
+# of the live turn still finds it (matched by message + Last-Event-ID). Small
+# bound: a client only ever resumes the live turn or the most recent ones.
+RESUME_MAX_BUFFERS_PER_SESSION = 4
 
 
 class TurnEventBuffer:
@@ -71,6 +99,8 @@ class TurnEventBuffer:
         "ended",
         "terminal_event",
         "aborted",
+        "_version",
+        "_waiters",
     )
 
     def __init__(
@@ -89,6 +119,11 @@ class TurnEventBuffer:
         self.ended: bool = False  # a terminal was recorded (or mark_ended called)
         self.terminal_event: Optional[str] = None
         self.aborted: bool = False  # turn ended by client disconnect, not normally
+        # F20 live-hold support: monotonic change counter + one-shot waiter
+        # Events so a resume racing this live turn can park until new events
+        # are recorded or the turn ends (instead of fabricating a terminal).
+        self._version: int = 0
+        self._waiters: list[asyncio.Event] = []
 
     def record(self, event_str: str, *, force_terminal: bool = False) -> None:
         """Record one emitted event (call before yielding it to the wire).
@@ -106,6 +141,8 @@ class TurnEventBuffer:
         if force_terminal or _is_terminal_event(event_str):
             self.ended = True
             self.terminal_event = event_str
+        self._version += 1
+        self._notify()
 
     def mark_ended(self, aborted: bool) -> None:
         """Called in the route generator's ``finally`` when no terminal was
@@ -115,6 +152,41 @@ class TurnEventBuffer:
         if not self.ended:
             self.ended = True
             self.aborted = aborted
+            self._version += 1
+            self._notify()
+
+    def _notify(self) -> None:
+        for waiter in self._waiters:
+            waiter.set()
+
+    async def wait_for_update(self, timeout: float) -> bool:
+        """Wait until the buffer changes (events recorded or turn ended).
+
+        Returns True on change, False on ``timeout``. Used by a resume that
+        raced this still-live turn: it holds for the real terminal instead of
+        fabricating a ``done`` (F20). Single-threaded asyncio: the version
+        snapshot and waiter subscription are await-free, so no change can be
+        missed between them — a ``record``/``mark_ended`` after the snapshot
+        always fires ``_notify`` on this waiter (no redundant re-check is
+        needed before the await). ``timeout <= 0`` returns immediately
+        (``asyncio.wait_for`` with an unset event raises TimeoutError at the
+        next loop checkpoint), which the stalled-turn tests use instead of a
+        wall-clock hold.
+        """
+        seen = self._version
+        if self.ended:
+            return True
+        waiter = asyncio.Event()
+        self._waiters.append(waiter)
+        try:
+            try:
+                await asyncio.wait_for(waiter.wait(), timeout)
+            except TimeoutError:
+                return self._version != seen or self.ended
+            return True
+        finally:
+            if waiter in self._waiters:
+                self._waiters.remove(waiter)
 
     def replay_after(self, last_event_id: int) -> list[str]:
         """Buffered events with ``id > last_event_id``, in original order.
@@ -132,36 +204,110 @@ class TurnEventBuffer:
 
 
 class TurnResumeRegistry:
-    """Session-keyed registry of the most recent turn buffer per session.
+    """Session-keyed registry of the most recent turn buffers per session.
 
-    One buffer per session key (``session_id or ""`` — the Pi path runs first
-    anonymous turns under the empty key). Registering a new turn replaces the
-    previous one; the registry is LRU-capped at ``max_sessions``.
+    Keeps a small bounded list of recent buffers per session key
+    (``session_id or ""`` — the Pi path runs first anonymous turns under the
+    empty key, shared by ALL anonymous sessions). F4: registering a new turn
+    APPENDS — a queued second POST can no longer clobber the live turn's
+    buffer. Resumes locate their turn via :meth:`find` (message +
+    Last-Event-ID match) and fail safe on ambiguity. The registry is
+    LRU-capped at ``max_sessions`` session keys.
     """
 
-    def __init__(self, max_sessions: int = RESUME_MAX_SESSIONS) -> None:
+    def __init__(
+        self,
+        max_sessions: int = RESUME_MAX_SESSIONS,
+        max_buffers_per_session: int = RESUME_MAX_BUFFERS_PER_SESSION,
+    ) -> None:
         if max_sessions < 1:
             raise ValueError("max_sessions must be >= 1")
+        if max_buffers_per_session < 1:
+            raise ValueError("max_buffers_per_session must be >= 1")
         self._max_sessions = max_sessions
-        self._buffers: dict[str, TurnEventBuffer] = {}
+        self._max_buffers_per_session = max_buffers_per_session
+        self._buffers: dict[str, deque[TurnEventBuffer]] = {}
         self._order: deque[str] = deque()
 
     def register(self, session_id: str, buffer: TurnEventBuffer) -> None:
         if session_id not in self._buffers:
             self._order.append(session_id)
-        self._buffers[session_id] = buffer
+            self._buffers[session_id] = deque()
+        buffers = self._buffers[session_id]
+        buffers.append(buffer)
+        while len(buffers) > self._max_buffers_per_session:
+            # P2 (review): over cap — evict an ENDED buffer first (its turn is
+            # complete; a resume of it already has the terminal), so N
+            # concurrent registrations on one key (e.g. five anonymous POSTs
+            # sharing the '' key) can't evict a still-LIVE turn's buffer before
+            # its turn runs — that would make a resume fail, the client resend,
+            # and the tool side effects re-execute. A live buffer is only
+            # evicted when every buffer in the deque is live (oldest first).
+            for i, candidate in enumerate(buffers):
+                if candidate.ended:
+                    del buffers[i]
+                    break
+            else:
+                buffers.popleft()
         while len(self._order) > self._max_sessions:
             oldest = self._order.popleft()
             if oldest in self._buffers:
                 del self._buffers[oldest]
 
     def get(self, session_id: str) -> Optional[TurnEventBuffer]:
-        return self._buffers.get(session_id)
+        """Most recently registered buffer for the key (introspection/tests)."""
+        buffers = self._buffers.get(session_id)
+        return buffers[-1] if buffers else None
+
+    def find(
+        self, session_id: str, message: str, last_event_id: int
+    ) -> tuple[Optional[TurnEventBuffer], bool]:
+        """Locate the UNIQUE buffer a resume refers to.
+
+        A buffer matches when the message is identical (same turn — the client
+        re-POSTs the same message) and the Last-Event-ID is meaningful for it:
+        ``0`` means "from the beginning of this turn" (also matches a
+        never-started buffer holding no events yet), otherwise the id must not
+        lie beyond the buffer's highest recorded id (per-turn id scopes make
+        ids from a LATER turn meaningless for an earlier one).
+
+        Returns ``(buffer, False)`` on a unique match, ``(None, True)`` when
+        MULTIPLE buffers match (ambiguous — e.g. two concurrent anonymous
+        same-message turns sharing the ``""`` key, F2): the caller must fail
+        safe rather than replay the wrong turn's events (cross-turn leak).
+        ``(None, False)`` = plain miss.
+        """
+        matches = [
+            b
+            for b in self._buffers.get(session_id, ())
+            if b.message == message
+            and (last_event_id == 0 or (b.last_id is not None and last_event_id <= b.last_id))
+        ]
+        if len(matches) == 1:
+            return matches[0], False
+        return None, len(matches) > 1
 
     def clear(self) -> None:
         """Drop all buffered turns (test isolation; also safe on shutdown)."""
         self._buffers.clear()
         self._order.clear()
+
+    def clear_session(self, session_id: str) -> None:
+        """Drop all buffered turns for ONE session key (round-2 P2).
+
+        Called from the ``clear_session`` route on DELETE /sessions/{id}: a
+        deleted session must not stay replayable through its stale resume
+        buffers (anyone holding the session id + the message could otherwise
+        replay its events until LRU eviction). The key is removed from both
+        ``_buffers`` and ``_order`` so a re-registration starts a fresh LRU
+        slot instead of appending a duplicate order entry. Unknown keys are a
+        no-op; other sessions' buffers are untouched (the shared ``""`` key is
+        never purged here — it is shared by ALL anonymous sessions).
+        """
+        if session_id in self._buffers:
+            del self._buffers[session_id]
+            if session_id in self._order:
+                self._order.remove(session_id)
 
     def __len__(self) -> int:
         return len(self._buffers)

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -69,6 +69,99 @@ def _has_non_plan_refs(refs: dict) -> bool:
     return False
 
 
+#: F9/F28: 非流式工具波被抢占式取消时，未完成任务的结果槽用哨兵占位 ——
+#: 结果对齐循环据此跳过（不写成工具失败），孤儿 tool_call 由
+#: _repair_orphaned_tool_calls 以「已取消」补齐。
+_CANCELLED_TOOL = object()
+
+
+class SessionClearingError(RuntimeError):
+    """Raised when a new turn is started for a session that is mid-``clear_session``.
+
+    P1: clear_session deletes the conversation rows and cancels the in-flight
+    turn; a turn that starts in that window would race the delete — either
+    writing into a deleted conversation (resurrecting rows) or being cancelled
+    mid-start. Callers should surface this as a clean refusal, not retry into
+    the race.
+    """
+
+
+#: F15: fire-and-forget 背景任务的进程内注册表 —— main.py lifespan shutdown
+#: 通过 drain_background_tasks() 等待它们收尾，避免任务跨事件循环泄漏。
+_background_tasks: set = set()
+
+
+def _track_background_task(task) -> None:
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def drain_background_tasks(timeout: float = 5.0) -> None:
+    """等待 fire-and-forget 背景任务收尾（lifespan shutdown 调用）。
+
+    P1 round-2（原实现两个缺陷）：
+      (a) 超时只是记日志返回 —— 慢 _generate_title 会在 lifespan 关闭共享
+          client / dispose 引擎之后继续写死资源。现在超时后 cancel 剩余任务
+          并短暂 gather（best-effort，try/except TimeoutError）。
+      (b) 模块级注册表跨事件循环粘连 —— 绑定已关闭/其它 loop 的任务永不完成，
+          之后每次 drain 都把它算进去吃满整个 timeout。现在只收集绑定当前
+          running loop 的任务，陈旧条目（get_loop() 不是当前 loop）直接从
+          注册表丢弃并记日志。
+    cancellation-safe：等待期间调用方自己被取消时 CancelledError 正常传播。
+    """
+    loop = asyncio.get_running_loop()
+    stale: list = []
+    current: list = []
+    for t in list(_background_tasks):
+        if t.done():
+            continue
+        try:
+            bound_loop = t.get_loop()
+        except RuntimeError:
+            bound_loop = None
+        if bound_loop is not loop:
+            stale.append(t)
+        else:
+            current.append(t)
+    if stale:
+        for t in stale:
+            _background_tasks.discard(t)
+        logger.warning(
+            "drain_background_tasks: dropped %d stale background task(s) bound "
+            "to a closed/different event loop; they can never complete here",
+            len(stale),
+        )
+    if not current:
+        return
+    _done, pending = await asyncio.wait(current, timeout=timeout)
+    if pending:
+        logger.warning(
+            "drain_background_tasks: %d background tasks still pending after "
+            "%.1fs — cancelling them (best-effort)",
+            len(pending), timeout,
+        )
+        for t in pending:
+            t.cancel()
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            pass
+
+
+def _lock_in_use(lock: asyncio.Lock) -> bool:
+    """锁被持有或有等待者时为 True —— 这样的锁不可逐出/丢弃（F1）。
+
+    只看 ``locked()`` 有一个 check-then-pop 竞态：release() 唤醒等待者用的是
+    call_soon，等待者还没重新拿到锁的窗口里 locked() 已经是 False。
+    """
+    if lock.locked():
+        return True
+    waiters = getattr(lock, "_waiters", None)
+    return bool(waiters)
+
+
 class ChatExecutionEngine:
     """Agent 对话与流式响应执行引擎"""
 
@@ -134,6 +227,22 @@ class ChatExecutionEngine:
         self._MAX_LOCKS = 200
         self._session_owner_tokens: LRUCache = LRUCache(capacity=_SESSION_CACHE_SIZE)
 
+        # P1: per-session 'clearing' marker + active-turn task registry.
+        # clear_session sets the marker BEFORE deleting rows so the in-flight
+        # turn's cleanup (repair + saves) cannot resurrect history; new turns
+        # for a marked session are refused cleanly. The task registry lets
+        # clear_session quiesce the cancelled turn (bounded) before clearing
+        # the marker.
+        self._clearing_sessions: set[str] = set()
+        self._active_turn_tasks: dict[str, asyncio.Task] = {}
+        self._clear_quiesce_timeout = float(_os.getenv("CLEAR_QUIESCE_TIMEOUT", "5.0"))
+        # P1: bounded cancel-and-await budget for the cancel/finally cleanup
+        # paths — a straggler tool that cannot be interrupted (worker thread
+        # parked in long GIS compute) must not hold the session lock for the
+        # worker's full duration; the bounded wait returns promptly and the
+        # straggler's result is discarded.
+        self._cancel_wait_timeout = float(_os.getenv("CANCEL_WAIT_TIMEOUT", "5.0"))
+
     def _select_tools(self, session_id: Optional[str], messages: list[dict]) -> Optional[list[dict]]:
         """选出本轮要推给 LLM 的工具 schema 列表。"""
         if self.catalog is not None:
@@ -195,8 +304,9 @@ class ChatExecutionEngine:
         import inspect
         if inspect.iscoroutinefunction(func):
             task = asyncio.create_task(func(*args, **kwargs))
+            _track_background_task(task)  # F15
             task.add_done_callback(lambda t: (
-                logger.error(f"Background async task failed: {t.exception()}") 
+                logger.error(f"Background async task failed: {t.exception()}")
                 if not t.cancelled() and t.exception() else None
             ))
         else:
@@ -206,6 +316,7 @@ class ChatExecutionEngine:
                 logger.error(f"Background sync task failed: {f.exception()}")
                 if f.exception() else None
             ))
+            _track_background_task(asyncio.wrap_future(future))  # F15
 
     def _db_msg_to_llm(self, msg) -> dict:
         """将 DB 消息转换成 LLM 格式 dict"""
@@ -225,8 +336,8 @@ class ChatExecutionEngine:
         self,
         session_id: str,
         user_id: Optional[str] = None,
-    ) -> list[dict]:
-        """从 DB 加载历史对话"""
+    ) -> Optional[list[dict]]:
+        """从 DB 加载历史对话。失败返回 None（F23：调用方不得缓存失败 stub）。"""
         try:
             history_svc = AsyncHistoryService()
             ctx = await history_svc.load_context(
@@ -239,7 +350,7 @@ class ChatExecutionEngine:
             return ctx.llm_messages
         except Exception as e:
             logger.warning(f"History: failed to load conversation {session_id}: {e}")
-            return [{"role": "system", "content": self._build_system_prompt()}]
+            return None
 
     def get_session_owner_token(self, session_id: str) -> Optional[str]:
         """取出并消费 session 的 owner_token（SEC-08）"""
@@ -279,6 +390,15 @@ class ChatExecutionEngine:
     def _build_last_analysis_context(self, messages: list[dict]) -> str:
         return _build_last_analysis_context(messages)
 
+    def _evict_idle_locks(self) -> None:
+        """逐出空闲 session 锁。被持有或有等待者的锁绝不可逐出（F1）。"""
+        if len(self._session_locks) > self._MAX_LOCKS:
+            evict_count = self._MAX_LOCKS // 4
+            for sid in list(self._session_locks.keys())[:evict_count]:
+                lock_to_evict = self._session_locks[sid]
+                if not _lock_in_use(lock_to_evict):
+                    self._session_locks.pop(sid, None)
+
     async def _get_or_create_session(
         self,
         session_id: str,
@@ -287,17 +407,18 @@ class ChatExecutionEngine:
         if session_id in self._sessions:
             return self._sessions[session_id]
 
-        if len(self._session_locks) > self._MAX_LOCKS:
-            evict_count = self._MAX_LOCKS // 4
-            for sid in list(self._session_locks.keys())[:evict_count]:
-                lock_to_evict = self._session_locks[sid]
-                if not lock_to_evict.locked():
-                    self._session_locks.pop(sid, None)
+        self._evict_idle_locks()
         lock = self._session_locks.setdefault(session_id, asyncio.Lock())
         async with lock:
-            if session_id not in self._sessions:
-                self._sessions[session_id] = await self._load_session_from_db(session_id, user_id=user_id)
-        return self._sessions[session_id]
+            if session_id in self._sessions:
+                return self._sessions[session_id]
+            loaded = await self._load_session_from_db(session_id, user_id=user_id)
+            if loaded is None:
+                # F23: DB 抖动时本轮降级为仅 system prompt 的临时历史，
+                # 但不写进缓存 —— 否则 DB 恢复后该会话仍永远顶着空历史。
+                return [{"role": "system", "content": self._build_system_prompt()}]
+            self._sessions[session_id] = loaded
+            return loaded
 
     def _apply_skill(self, messages: list[dict], skill_name: Optional[str]) -> None:
         """注入或刷新 Skill 指令"""
@@ -356,8 +477,81 @@ class ChatExecutionEngine:
             kept = turn + kept
         messages[:] = [messages[0], *kept]
 
+    async def _repair_orphaned_tool_calls(self, session_id: str, messages: list[dict]) -> None:
+        """F9: 补齐孤儿 assistant tool_calls 的取消占位 tool 消息。
+
+        cancel / disconnect 会打断「assistant(tool_calls) → N 条 tool 响应」的
+        配对（见 _trim_session_tail 的 turn 分组说明）：LLM API 拒绝带孤儿
+        tool_calls 的历史，下一轮调用直接报错，会话永久损坏。每条缺失的
+        tool_call_id 补一条「已取消」tool 消息 —— 内存与 DB 同步补齐。
+        幂等：已配对的 tool_call 不会重复补。
+        """
+        answered = {
+            m.get("tool_call_id") for m in messages if m.get("role") == "tool"
+        }
+        orphan_ids: list[str] = []
+        for m in messages:
+            if m.get("role") != "assistant":
+                continue
+            for tc in m.get("tool_calls") or []:
+                tc_id = tc.get("id") if isinstance(tc, dict) else None
+                if tc_id and tc_id not in answered and tc_id not in orphan_ids:
+                    orphan_ids.append(tc_id)
+        for tc_id in orphan_ids:
+            payload = "工具执行已被用户取消"
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc_id,
+                "content": payload,
+            })
+            await self._save_msg_async(session_id, "tool", "", None, payload, tc_id)
+
+    async def _persist_tool_messages(
+        self,
+        session_id: str,
+        pending_tools: list[dict],
+        completion_results: dict[str, dict],
+        standard_calls: list,
+        messages: list[dict],
+        tool_result_msgs: list[str],
+    ) -> None:
+        """把已完成工具的结果按原始 tc 顺序对齐 LLM 上下文 + 落库。
+
+        Phase 3（正常出口）与抢占式取消路径共用：取消路径在 Phase 3 之前
+        return，已完成的工具（F9: 已完成 ≠ 已取消）必须在 abort 前同样落库，
+        否则它们的 tool_call_id 会被 _repair_orphaned_tool_calls 误标成
+        「工具执行已被用户取消」—— 而工具可能已创建图层、已 spawn durable job，
+        首达终态使真实成功不可恢复。
+        """
+        for p in pending_tools:
+            res = completion_results.get(p["step"].id)
+            if res is None:
+                continue  # 极端取消场景：该工具未完成，跳过
+            tc = res["tc"]
+            msg_result_str = res["msg_result_str"]
+            tool_name = res["tool_name"]
+            if standard_calls:
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc["id"],
+                    "content": msg_result_str,
+                })
+                db_save_content = msg_result_str[:100000] if len(msg_result_str) > 100000 else msg_result_str
+                await self._save_msg_async(session_id, "tool", "", None, db_save_content, tc["id"])
+            else:
+                tool_result_msgs.append(f"{tool_name}: {msg_result_str}")
+
     async def _save_msg_async(self, session_id: str, role: str, content: str, tool_calls=None, tool_result=None, tool_call_id=None, reasoning_content=None):
         """异步保存消息到数据库"""
+        if session_id in self._clearing_sessions:
+            # P1: clear_session 刚删了该会话的 conversation 行 —— 现在写入会
+            # 复活历史（SQLite: FK off → 孤儿 Message 行；Postgres: FK →
+            # IntegrityError 被下方吞掉）。clear 期间抑制 DB 写；在途 turn 的
+            # 内存 repair（_repair_orphaned_tool_calls 的 append）不受影响。
+            logger.debug(
+                "save_message suppressed for %s: session is being cleared", session_id
+            )
+            return
         try:
             if tool_result is not None and isinstance(tool_result, str) and len(tool_result) > 100000:
                 tool_result = tool_result[:100000] + "...[truncated]"
@@ -572,6 +766,10 @@ class ChatExecutionEngine:
         if not session_id:
             session_id = str(uuid.uuid4())
 
+        # P1: 快速路径拒绝 clearing 中的 session 的新 turn（避免
+        # _get_or_create_session 的 DB 副作用）；权威检查在持锁后再次执行。
+        self._reject_if_clearing(session_id)
+
         if map_state:
             await self._persist_map_state(session_id, map_state)
             from app.services.viewport_naming import schedule_populate_from_map_state
@@ -590,6 +788,10 @@ class ChatExecutionEngine:
         messages = await self._get_or_create_session(session_id, user_id=user_id)
         lock = self._get_session_lock(session_id)
         async with lock:
+            self._reject_if_clearing(session_id)
+            _task = asyncio.current_task()
+            if _task is not None:
+                self._active_turn_tasks[session_id] = _task
             try:
                 return await self._chat_locked(
                     message, session_id, messages, skill_name, user_id, project_id,
@@ -597,6 +799,9 @@ class ChatExecutionEngine:
             finally:
                 # design-v3：把本进程 canonical 计划（含打勾进度）持久化到 store。
                 await self._flush_plan(session_id)
+                # P1: the turn's cleanup drained — deregister the turn task so
+                # clear_session's quiesce doesn't wait on a finished turn.
+                self._active_turn_tasks.pop(session_id, None)
                 # C-F12: bound the in-memory tail once the turn's appends are
                 # complete (every exit path — return, exception, cancel).
                 self._trim_session_tail(messages)
@@ -681,25 +886,73 @@ class ChatExecutionEngine:
                     await self._save_msg_async(session_id, "assistant", content_text, tc_list, reasoning_content=reasoning)
 
                     tool_result_msgs: list[str] = []
-                    if len(tc_list) > 1:
-                        tasks = [
+                    # F28: 与流式路径（chat_stream 并行 wave）同款抢占式取消 ——
+                    # cancel token 点燃立即 cancel 在飞工具，而不是等它自然跑完。
+                    # 循环每轮重挂 cancel_watch：任一工具完成或取消点燃都会从
+                    # asyncio.wait 返回，取消在整波完成前始终被检查（旧实现单次
+                    # FIRST_COMPLETED wait 后直接 gather 整波 —— 多工具轮次里
+                    # 取消要等所有工具自然跑完才生效，抢占是死的）。
+                    tool_tasks = [
+                        asyncio.create_task(
                             self.tool_pipeline.execute_tool_call(
                                 tc, session_id, task.id, executed_tools,
                                 owner_id=user_id, owner_token=owner_token,
                             )
-                            for tc in tc_list
-                        ]
-                        exec_results = await asyncio.gather(*tasks, return_exceptions=True)
-                    else:
-                        exec_results = [
-                            await self.tool_pipeline.execute_tool_call(
-                                tc_list[0], session_id, task.id, executed_tools,
-                                owner_id=user_id, owner_token=owner_token,
+                        )
+                        for tc in tc_list
+                    ]
+                    cancel_watch: Optional[asyncio.Task] = None
+                    if task.cancel_token is not None:
+                        cancel_watch = asyncio.create_task(task.cancel_token.wait())
+                    exec_results: list = [_CANCELLED_TOOL] * len(tool_tasks)
+                    cancelled = False
+                    try:
+                        remaining: set = set(tool_tasks)
+                        while remaining:
+                            wait_set = set(remaining)
+                            if cancel_watch is not None:
+                                wait_set.add(cancel_watch)
+                            done, _pending = await asyncio.wait(
+                                wait_set, return_when=asyncio.FIRST_COMPLETED
                             )
-                        ]
+                            if cancel_watch is not None and cancel_watch in done:
+                                # F28: 抢占式取消 —— 同一批里已完成的工具先收走
+                                # 结果（F9: 已完成 ≠ 已取消），未完成的立即 cancel。
+                                cancelled = True
+                                for t in done & remaining:
+                                    idx = tool_tasks.index(t)
+                                    try:
+                                        exec_results[idx] = t.result()
+                                    except Exception as e:  # noqa: BLE001
+                                        exec_results[idx] = e
+                                # P1: 有界等待 —— 顽固 straggler 不能拖住会话锁
+                                await self._cancel_and_await(remaining)
+                                remaining = set()
+                                break
+                            done_tools = done & remaining
+                            remaining -= done_tools
+                            for t in done_tools:
+                                idx = tool_tasks.index(t)
+                                try:
+                                    exec_results[idx] = t.result()
+                                except Exception as e:  # noqa: BLE001
+                                    exec_results[idx] = e
+                    finally:
+                        # 外部取消（chat 协程被 cancel）时回收在飞工具与 watch。
+                        # P1: 有界等待 —— 顽固 straggler 不能拖住会话锁。
+                        await self._cancel_and_await(
+                            [t for t in tool_tasks if not t.done()]
+                        )
+                        if cancel_watch is not None and not cancel_watch.done():
+                            cancel_watch.cancel()
+                            await self._cancel_and_await([cancel_watch])
 
                     for tc, exec_res in zip(tc_list, exec_results):
+                        if exec_res is _CANCELLED_TOOL:
+                            continue  # 被抢占/未完成 —— 由 repair 以「已取消」补齐
                         if isinstance(exec_res, Exception):
+                            if cancelled:
+                                continue  # 取消路径：已完成但失败的工具不写失败消息
                             logger.error("Tool execution parallel exception for %s: %s", tc, exec_res)
                             llm_payload = f"Tool execution failed: {exec_res}"
                         else:
@@ -738,6 +991,12 @@ class ChatExecutionEngine:
                             "role": "user",
                             "content": "[工具执行结果]\n" + "\n".join(tool_result_msgs),
                         })
+
+                    if cancelled:
+                        # F9: 已完成工具的消息已在上方落库；这里只补真正孤儿的
+                        # tool_call（幂等），随后以取消收尾本轮。
+                        await self._repair_orphaned_tool_calls(session_id, messages)
+                        return {"session_id": session_id, "content": "任务已取消", **({"owner_token": owner_token} if owner_token else {})}
                     continue
                 else:
                     content = raw_content
@@ -752,20 +1011,62 @@ class ChatExecutionEngine:
             self.tracker.complete_task(task.id)
             return {"content": "达到最大工具调用轮数", "session_id": session_id, **({"owner_token": owner_token} if owner_token else {})}
         except (asyncio.CancelledError, GeneratorExit):
-            self.tracker.fail_task(task.id, "cancelled")
+            # F8: 取消必须呈现为 cancelled 终态，而不是 failed。
+            self.tracker.cancel(task.id)
+            # F9: 补齐孤儿 tool_call，避免会话历史永久损坏。
+            # P1: shield + 有界 wait_for —— 二次取消不能截断 repair 的中途写；
+            # GC 驱动的 GeneratorExit 也不会因 except 内的 suspend 报
+            # 'async generator ignored GeneratorExit'。aclose() 路径行为不变。
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(
+                        self._repair_orphaned_tool_calls(session_id, messages)
+                    ),
+                    timeout=self._cancel_wait_timeout,
+                )
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                pass
             raise
         except Exception:
             self.tracker.fail_task(task.id, "non-streaming chat exception")
             raise
 
     def _get_session_lock(self, session_id: str) -> asyncio.Lock:
-        if len(self._session_locks) > self._MAX_LOCKS:
-            evict_count = self._MAX_LOCKS // 4
-            for sid in list(self._session_locks.keys())[:evict_count]:
-                lock_to_evict = self._session_locks[sid]
-                if not lock_to_evict.locked():
-                    self._session_locks.pop(sid, None)
+        self._evict_idle_locks()
         return self._session_locks.setdefault(session_id, asyncio.Lock())
+
+    def _reject_if_clearing(self, session_id: str) -> None:
+        """Raise SessionClearingError if the session is mid-clear_session.
+
+        P1: blocks NEW turn start for a clearing session — return a clean
+        error, not a race into the delete.
+        """
+        if session_id in self._clearing_sessions:
+            raise SessionClearingError(
+                f"session {session_id} is being cleared; start a new turn after it completes"
+            )
+
+    async def _cancel_and_await(self, tasks, timeout: Optional[float] = None) -> None:
+        """Cancel a batch of tool tasks and await them briefly (bounded).
+
+        P1: a straggler tool that cannot be interrupted (worker thread parked
+        in long GIS compute) would make ``await asyncio.gather(*tasks,
+        return_exceptions=True)`` hold the session lock for the worker's full
+        duration on cancel/disconnect. Cancel everything first, then await up
+        to ``timeout`` seconds so the turn's cancel/finally path returns
+        promptly and the session lock is released — stragglers finish whenever
+        their workers return and their results are discarded. Task-level
+        CancelledError is collected by asyncio.wait; a re-cancel of THIS task
+        propagates as before.
+        """
+        if not tasks:
+            return
+        if timeout is None:
+            timeout = self._cancel_wait_timeout
+        for t in tasks:
+            if not t.done():
+                t.cancel()
+        await asyncio.wait(tasks, timeout=timeout)
 
     async def chat_stream(
         self,
@@ -780,6 +1081,10 @@ class ChatExecutionEngine:
         if not session_id:
             session_id = str(uuid.uuid4())
 
+        # P1: 快速路径拒绝 clearing 中的 session 的新 turn（避免
+        # _get_or_create_session 的 DB 副作用）；权威检查在持锁后再次执行。
+        self._reject_if_clearing(session_id)
+
         # RUN-03: the session lock now covers the ENTIRE turn (not just
         # map_state setup), serializing concurrent requests on the same
         # session_id — messages.append / executed_tools writes were previously
@@ -793,6 +1098,10 @@ class ChatExecutionEngine:
         messages = await self._get_or_create_session(session_id, user_id=user_id)
         lock = self._get_session_lock(session_id)
         async with lock:
+            self._reject_if_clearing(session_id)
+            _task = asyncio.current_task()
+            if _task is not None:
+                self._active_turn_tasks[session_id] = _task
             if map_state:
                 await self._persist_map_state(session_id, map_state)
                 from app.services.viewport_naming import schedule_populate_from_map_state
@@ -984,6 +1293,25 @@ class ChatExecutionEngine:
                         task_to_pending = {p["task"]: p for p in pending_tools}
                         completion_results: dict[str, dict] = {}  # step.id -> {tc, msg_result_str}
 
+                        def _aborted_step_events() -> list[str]:
+                            """F7/F8: 取消/断连路径上把未完成的 step 记 cancelled
+                            （绝不留 running），并生成对应的 step_cancelled SSE 事件。"""
+                            evts: list[str] = []
+                            for p in pending_tools:
+                                if p["step"].id in completion_results:
+                                    continue
+                                try:
+                                    self.tracker.cancel_step(task.id, p["step"].id)
+                                except Exception:
+                                    continue
+                                evts.append(sse_event("step_cancelled", {
+                                    "task_id": task.id,
+                                    "step_id": p["step"].id,
+                                    "tool": p["tool_name"],
+                                    "session_id": session_id,
+                                }))
+                            return evts
+
                         # ADR-0052 抢占式取消：以前只在「某个工具跑完之后」才检查
                         # is_cancelled，所以用户点 Cancel 要等当前工具自然结束
                         # （长 GIS 计算 30–60s）。现在把 token.wait() 一起放进
@@ -1003,20 +1331,10 @@ class ChatExecutionEngine:
                                     wait_set, timeout=5.0, return_when=asyncio.FIRST_COMPLETED
                                 )
 
-                                if cancel_watch is not None and cancel_watch in done:
-                                    for r in remaining:
-                                        r.cancel()
-                                    await asyncio.gather(*remaining, return_exceptions=True)
-                                    remaining = set()
-                                    pf = _maybe_plan_finalized_event()
-                                    if pf:
-                                        yield pf
-                                    yield sse_event("task_cancelled", {"task_id": task.id})
-                                    return
-
                                 done_tools = done & remaining
                                 remaining -= done_tools
-                                if not done_tools:
+                                cancel_fired = cancel_watch is not None and cancel_watch in done
+                                if not done_tools and not cancel_fired:
                                     yield sse_event("keep_alive", {"message": "ping"})
                                     logger.debug("SSE Heartbeat sent for parallel tool wave")
                                     continue
@@ -1029,6 +1347,17 @@ class ChatExecutionEngine:
                                     try:
                                         exec_res = t.result()
                                     except asyncio.CancelledError:
+                                        # F7/F8: 被抢占取消的 step 记 cancelled，不留 running
+                                        try:
+                                            self.tracker.cancel_step(task.id, step.id)
+                                        except Exception:
+                                            pass
+                                        yield sse_event("step_cancelled", {
+                                            "task_id": task.id,
+                                            "step_id": step.id,
+                                            "tool": tool_name,
+                                            "session_id": session_id,
+                                        })
                                         continue
                                     except Exception as e:  # noqa: BLE001 防御（execute_tool_call 内部已兜底）
                                         logger.error(f"[chat_execution_engine] tool task raised for {tool_name}: {e}")
@@ -1089,7 +1418,21 @@ class ChatExecutionEngine:
 
                                     msg_result_str = outcome.llm_payload
 
-                                    if outcome.status == "repeated":
+                                    if getattr(exec_res, "cancelled", False):
+                                        # F8: 取消不是工具故障 —— step 记 cancelled
+                                        # 并发 step_cancelled，区别于 step_error。
+                                        try:
+                                            self.tracker.cancel_step(task.id, step.id)
+                                        except Exception:
+                                            pass
+                                        yield sse_event("step_cancelled", {
+                                            "task_id": task.id,
+                                            "step_id": step.id,
+                                            "tool": tool_name,
+                                            "session_id": session_id,
+                                        })
+                                        yield sse_event("tool_result", {"name": tool_name, "result": msg_result_str, "session_id": session_id})
+                                    elif outcome.status == "repeated":
                                         # Reviewer BLOCKING fix (RUN-02): chat_stream
                                         # owns the step lifecycle now (pre_created_step
                                         # skips the pipeline's track_step, whose
@@ -1148,52 +1491,58 @@ class ChatExecutionEngine:
                                         "tool_name": tool_name,
                                     }
 
-                                    if self.tracker.is_cancelled(task.id):
-                                        for r in remaining:
-                                            r.cancel()
-                                        await asyncio.gather(*remaining, return_exceptions=True)
-                                        pf = _maybe_plan_finalized_event()
-                                        if pf:
-                                            yield pf
-                                        yield sse_event("task_cancelled", {"task_id": task.id})
-                                        return
+                                # 取消（cancel_watch 点燃或 tracker is_cancelled）：
+                                # 先收割同一批里已完成的工具（F9: 已完成 ≠ 已取消），
+                                # 再抢占式 cancel 真正未完成的在飞任务（F28）。
+                                if cancel_fired or self.tracker.is_cancelled(task.id):
+                                    # F9: 已完成工具的消息先正常落库 —— 否则 repair
+                                    # 会把它们的 tool_call_id 写成「已取消」占位，而
+                                    # 工具可能已创建图层 / 已 spawn durable job，首达
+                                    # 终态使真实成功不可恢复。
+                                    await self._persist_tool_messages(
+                                        session_id, pending_tools, completion_results,
+                                        standard_calls, messages, tool_result_msgs,
+                                    )
+                                    # P1: 有界等待 —— 顽固 straggler 不能拖住会话锁
+                                    await self._cancel_and_await(remaining)
+                                    remaining = set()
+                                    # F7/F8: 只有真正未完成的 step 记 cancelled
+                                    for evt in _aborted_step_events():
+                                        yield evt
+                                    # F9: 补齐孤儿 tool_call（已完成工具不在其列）
+                                    await self._repair_orphaned_tool_calls(session_id, messages)
+                                    pf = _maybe_plan_finalized_event()
+                                    if pf:
+                                        yield pf
+                                    yield sse_event("task_cancelled", {"task_id": task.id})
+                                    return
                         finally:
-                            # 生成器被外部取消（GeneratorExit/CancelledError）时清理未完成任务
-                            for t in all_tasks:
-                                if not t.done():
-                                    t.cancel()
-                            if all_tasks:
-                                await asyncio.gather(*all_tasks, return_exceptions=True)
+                            # 生成器被外部取消（GeneratorExit/CancelledError）时清理未完成任务。
+                            # P1: 有界等待 —— 顽固 straggler 不能拖住会话锁。
+                            await self._cancel_and_await(all_tasks)
                             # ADR-0052: cancel_watch 是纯等待任务，正常路径永不完成，
                             # 必须显式回收，否则每个工具 wave 泄漏一个 pending task。
                             if cancel_watch is not None and not cancel_watch.done():
                                 cancel_watch.cancel()
-                                await asyncio.gather(cancel_watch, return_exceptions=True)
+                                await self._cancel_and_await([cancel_watch])
 
                         # Phase 3: 按原始 tc 顺序对齐 LLM 上下文 + 落库
-                        for p in pending_tools:
-                            res = completion_results.get(p["step"].id)
-                            if res is None:
-                                continue  # 极端取消场景：该工具未完成，跳过
-                            tc = res["tc"]
-                            msg_result_str = res["msg_result_str"]
-                            tool_name = res["tool_name"]
-                            if standard_calls:
-                                messages.append({
-                                    "role": "tool",
-                                    "tool_call_id": tc["id"],
-                                    "content": msg_result_str,
-                                })
-                                db_save_content = msg_result_str[:100000] if len(msg_result_str) > 100000 else msg_result_str
-                                await self._save_msg_async(session_id, "tool", "", None, db_save_content, tc["id"])
-                            else:
-                                tool_result_msgs.append(f"{tool_name}: {msg_result_str}")
+                        await self._persist_tool_messages(
+                            session_id, pending_tools, completion_results,
+                            standard_calls, messages, tool_result_msgs,
+                        )
 
                         if xml_calls and tool_result_msgs:
                             messages.append({
                                 "role": "user",
                                 "content": "[工具执行结果]\n" + "\n".join(tool_result_msgs),
                             })
+
+                        # F9: 正常出口也兜底补齐孤儿 tool_call —— per-tool 处理里的
+                        # except CancelledError: continue / 防御 except Exception:
+                        # continue 分支不落库，会留下孤儿 assistant tool_calls；repair
+                        # 幂等，已配对的 tool_call 不会重复补。
+                        await self._repair_orphaned_tool_calls(session_id, messages)
 
                         continue
                     else:
@@ -1230,9 +1579,27 @@ class ChatExecutionEngine:
             except (asyncio.CancelledError, GeneratorExit):
                 # B-P2-17: 客户端断连/生成器被关闭时终止 tracker 任务，
                 # 避免任务永远停留在 running（直到 MAX_TOTAL_TASKS 逐出）。
+                # F8: 断连/取消呈现为 cancelled 终态而不是 failed；
+                # cancel() 顺带把仍 running 的 step 收尾（F7）。
                 task_info = self.tracker.get(task.id)
                 if task_info is not None and task_info.status == TaskStatus.running:
-                    self.tracker.fail_task(task.id, "cancelled")
+                    self.tracker.cancel(task.id)
+                else:
+                    self.tracker.terminalize_running_steps(task.id)
+                # F9: 补齐孤儿 tool_call —— 否则下一轮 LLM 调用被拒，
+                # 会话永久损坏。_save_msg_async 内部已吞异常。
+                # P1: shield + 有界 wait_for —— 二次取消不能截断 repair 的
+                # 中途写；GC 驱动的 GeneratorExit 也不会因 except 内的 suspend
+                # 报 'async generator ignored GeneratorExit'。aclose() 行为不变。
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(
+                            self._repair_orphaned_tool_calls(session_id, messages)
+                        ),
+                        timeout=self._cancel_wait_timeout,
+                    )
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    pass
                 raise
             except Exception:
                 # B-P2-17: 流中异常同样终止任务（与 _chat_locked 一致）。
@@ -1243,6 +1610,9 @@ class ChatExecutionEngine:
             finally:
                 # design-v3：把本进程 canonical 计划（含打勾进度）持久化到 store。
                 await self._flush_plan(session_id)
+                # P1: the turn's cleanup drained — deregister the turn task so
+                # clear_session's quiesce doesn't wait on a finished turn.
+                self._active_turn_tasks.pop(session_id, None)
                 # C-F12: bound the in-memory tail once the turn's appends
                 # are complete (every exit path — done, cancelled, max rounds,
                 # disconnect/exception via generator close).
@@ -1282,36 +1652,80 @@ class ChatExecutionEngine:
         owner_token: Optional[str] = None,
     ) -> bool:
         """删除会话"""
-        deleted = False
+        # P1: 在删行之前把该 session 标记为 clearing —— 在途 turn 的清理
+        # （repair + _save_msg_async）在标记下运行，DB 写被抑制，不可能复活
+        # 已删除的 conversation；新的 turn 被干净地拒绝。标记在 finally 中、
+        # 有界 quiesce 之后清除。
+        self._clearing_sessions.add(session_id)
         try:
-            async with async_db_session() as db:
-                deleted = await AsyncHistoryService(db).delete_session(
-                    session_id, user_id=user_id, owner_token=owner_token
-                )
-        except Exception as e:
-            logger.warning(f"History: failed to delete session {session_id}: {e}")
-            return False
-        if deleted:
-            if session_id in self._sessions:
-                del self._sessions[session_id]
-            self._session_locks.pop(session_id, None)
-            self._session_owner_tokens.pop(session_id, None)
-            await session_data_manager.clear_session(session_id)
-            from app.services.chat import planner
-            planner.clear_plan(session_id)
+            deleted = False
             try:
-                from app.services.planning.store import plan_store
-                await plan_store.clear(session_id)
+                async with async_db_session() as db:
+                    deleted = await AsyncHistoryService(db).delete_session(
+                        session_id, user_id=user_id, owner_token=owner_token
+                    )
             except Exception as e:
-                logger.warning(f"[chat_execution_engine] plan_store.clear 失败: {e}")
-            try:
-                from app.services.chat.context.layer_schema import clear_layer_schema_cache
-                clear_layer_schema_cache(session_id)
-            except ImportError:
-                pass
-            if self.catalog is not None:
-                self.catalog.reset_session(session_id)
-        return deleted
+                logger.warning(f"History: failed to delete session {session_id}: {e}")
+                return False
+            if deleted:
+                # F1: 先取消该 session 的在途 turn —— 否则持有会话锁的 turn 会在
+                # 会话删除后继续往 messages/DB 追加（消息复活、重复工具执行）。
+                for task_info in self.tracker.list_by_session(session_id):
+                    if task_info.status == TaskStatus.running:
+                        self.tracker.cancel(task_info.id)
+                # P1: 有界 quiesce —— 在清标记之前等被取消 turn 的清理排空
+                # （cancel 点燃 token → wave 抢占在飞工具 → repair → turn 结束）。
+                # 不等待的话，turn 的 repair/save 可能与标记清除竞态、复活行。
+                turn_task = self._active_turn_tasks.get(session_id)
+                if (
+                    turn_task is not None
+                    and not turn_task.done()
+                    and turn_task is not asyncio.current_task()
+                ):
+                    try:
+                        await asyncio.wait(
+                            {turn_task}, timeout=self._clear_quiesce_timeout
+                        )
+                    except (asyncio.TimeoutError, asyncio.CancelledError):
+                        pass
+                self._sessions.pop(session_id, None)
+                # F1: 锁被在途 turn 持有（或有等待者）时不能丢弃 —— 丢弃后下一个
+                # 并发请求拿到的是新锁，会与旧锁并行，破坏按会话串行化。
+                lock = self._session_locks.get(session_id)
+                if lock is not None and not _lock_in_use(lock):
+                    self._session_locks.pop(session_id, None)
+                self._session_owner_tokens.pop(session_id, None)
+                # F21: 每一项进程内清理都可能独立失败（Redis 抖动 / 可选模块缺失），
+                # 隔离失败，保证其余清理总能执行；路由语义不变（仍按 DB 删除结果返回）。
+                try:
+                    await session_data_manager.clear_session(session_id)
+                except Exception as e:
+                    logger.warning(f"clear_session: session_data cleanup failed for {session_id}: {e}")
+                try:
+                    from app.services.chat import planner
+                    planner.clear_plan(session_id)
+                except Exception as e:
+                    logger.warning(f"clear_session: plan cleanup failed for {session_id}: {e}")
+                try:
+                    from app.services.planning.store import plan_store
+                    await plan_store.clear(session_id)
+                except Exception as e:
+                    logger.warning(f"clear_session: plan_store cleanup failed for {session_id}: {e}")
+                try:
+                    from app.services.chat.context.layer_schema import clear_layer_schema_cache
+                    clear_layer_schema_cache(session_id)
+                except ImportError:
+                    pass
+                except Exception as e:
+                    logger.warning(f"clear_session: layer schema cleanup failed for {session_id}: {e}")
+                if self.catalog is not None:
+                    try:
+                        self.catalog.reset_session(session_id)
+                    except Exception as e:
+                        logger.warning(f"clear_session: catalog reset failed for {session_id}: {e}")
+            return deleted
+        finally:
+            self._clearing_sessions.discard(session_id)
 
     def _detect_suspicious_result(self, result: Any) -> bool:
         return _is_suspicious_result_fn(result)

--- a/app/services/chat/pi_rpc_client.py
+++ b/app/services/chat/pi_rpc_client.py
@@ -406,8 +406,14 @@ class PiRpcClient:
             result = await asyncio.wait_for(future, timeout=PI_RPC_TIMEOUT)
             return result
         except asyncio.TimeoutError:
-            self._pending_requests.pop(request_id, None)
             raise PiRpcError(f"Pi request timeout: {command}")
         except (BrokenPipeError, OSError) as e:
-            self._pending_requests.pop(request_id, None)
             raise PiRpcError(f"Pi pipe error: {e}")
+        finally:
+            # F19: pop unconditionally, not just on TimeoutError/pipe errors.
+            # A caller cancellation (CancelledError) previously leaked the
+            # registry entry — one dead future per cancelled request, and a
+            # late response for that id would resolve a future nobody awaits.
+            # Idempotent: the normal response path already popped the entry
+            # in _handle_response, so this is a no-op there.
+            self._pending_requests.pop(request_id, None)

--- a/app/services/chat/tool_pipeline.py
+++ b/app/services/chat/tool_pipeline.py
@@ -163,7 +163,15 @@ class ToolExecutionPipeline:
                 outcome = _error_outcome(e)
             is_error = (outcome.status == "error")
             pre_created_step.result = outcome.raw_result
-            if is_error:
+            if cancelled:
+                # F8: 取消 ≠ 失败 —— step 记 cancelled。终态不可变，与引擎侧
+                # （chat_stream 持有 pre_created step 的收尾权）谁先谁生效。
+                if task_id:
+                    try:
+                        self.tracker.cancel_step(task_id, pre_created_step.id)
+                    except Exception:
+                        pass
+            elif is_error:
                 pre_created_step.error = str(outcome.raw_result)
             pre_created_step.background_job_ids = list(origin.created_job_ids)
         else:
@@ -183,7 +191,15 @@ class ToolExecutionPipeline:
                 is_error = (outcome.status == "error")
                 if step is not None:
                     step.result = outcome.raw_result
-                    if is_error:
+                    if cancelled:
+                        # F8: 取消先记 cancelled；track_step 的 __aexit__ 随后
+                        # complete_step 会因终态不可变而空操作。
+                        if task_id:
+                            try:
+                                self.tracker.cancel_step(task_id, step.id)
+                            except Exception:
+                                pass
+                    elif is_error:
                         step.error = str(outcome.raw_result)
                     step.background_job_ids = list(origin.created_job_ids)
 

--- a/app/services/distributed_lock.py
+++ b/app/services/distributed_lock.py
@@ -28,6 +28,16 @@ from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+#: F12: 旧 loop 上 client 的异步关闭任务是 fire-and-forget —— 丢弃引用会让它
+#: 在运行前被 GC，且对任何 background-task drain 不可见。保持强引用直到任务
+#: 完成（与 execution_engine 的 _background_tasks 同一模式）。
+_client_close_tasks: set = set()
+
+
+def _track_client_close(task) -> None:
+    _client_close_tasks.add(task)
+    task.add_done_callback(_client_close_tasks.discard)
+
 _DEFAULT_TTL_MS = 30_000          # 30s base TTL
 _RENEW_INTERVAL_S = 8.0           # renew well before TTL expiry
 _FALLBACK_CAP = 4096              # bound the in-process fallback registry
@@ -148,11 +158,40 @@ class SessionLockRegistry:
 
     def __init__(self):
         self._client = None
+        # The cached client's connection pool is bound to the event loop that
+        # was running when it was created (F12); tracked here so a loop change
+        # (event-loop restart, pytest per-test loops) triggers a rebuild.
+        self._bound_loop: Optional[asyncio.AbstractEventLoop] = None
         self._last_check_s: float = 0.0
         self._fallback_locks: Dict[str, _InProcessLock] = {}
 
+    @staticmethod
+    async def _close_client(client) -> None:
+        """Best-effort close of a client bound to a dead loop; failures expected."""
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+
     def _get_client(self):
         import time as _time
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        # F12: if the running loop changed, the cached client's pool is bound to
+        # the old (likely closed) loop — every op raises "Event loop is closed"
+        # and locking silently degrades to in-process. Rebuild on the current
+        # loop (same pattern as RedisRateLimiter._ensure_client /
+        # RedisSessionStore._ensure_connected).
+        if self._client is not None and self._bound_loop is not loop:
+            old, self._client = self._client, None
+            self._bound_loop = None
+            self._last_check_s = 0.0  # don't let the 60s re-verify gate delay the rebuild
+            if loop is not None:
+                # F12: 保持强引用直到关闭任务完成 —— create_task 的返回值被丢弃
+                # 时任务可能在运行前就被 GC，且对 background-task drain 不可见。
+                _track_client_close(loop.create_task(self._close_client(old)))
         now = _time.monotonic()
         # Re-verify at most every 60s so a transient Redis outage is recovered.
         if self._client is not None or (now - self._last_check_s) < 60.0:
@@ -165,6 +204,7 @@ class SessionLockRegistry:
         try:
             import redis.asyncio as aioredis  # local import: don't pay cost if unused
             self._client = aioredis.from_url(redis_url, decode_responses=False)
+            self._bound_loop = loop
             logger.info("SessionLockRegistry: Redis-backed distributed locks enabled")
         except Exception as e:  # noqa: BLE001
             logger.warning("SessionLockRegistry: Redis unavailable, using in-process locks: %s", e)

--- a/app/services/jobs/submit.py
+++ b/app/services/jobs/submit.py
@@ -19,6 +19,7 @@ import json
 import logging
 from typing import Any, Optional
 
+from app.services.jobs.cancellation import registry as cancellation_registry
 from app.services.jobs.context import current_origin
 from app.services.jobs.lifecycle import JobKind, JobStatus
 from app.services.jobs.store import DurableJobStore
@@ -101,6 +102,10 @@ def submit_durable_job(
         existing_celery_id = job.celery_task_id
         already_terminal = DurableJobStore.is_terminal_job(job)
         db.commit()
+
+    # F17: 提交时注册进程内取消 token —— 否则 TaskTracker.cancel() 的级联
+    # cancellation_registry.cancel(job_id) 找不到 token，变成空操作。
+    cancellation_registry.register(job_id)
 
     if origin is not None:
         origin.record_job(job_id)

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -32,6 +32,22 @@ from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "partially_completed"})
+
+
+async def _cancel_wave_tasks(wave_tasks: set[asyncio.Task]) -> None:
+    """取消并回收当前波次的 pending 任务（F6 收敛前的最后一步）。
+
+    镜像 execution_engine 的 finally 清理模式：外层被取消 / 内部异常时，
+    GIS 工具不能在 turn 结束后继续产生副作用，pending 任务必须被取消并
+    await 回收。两个 except 子句共用。
+    """
+    for t in wave_tasks:
+        if not t.done():
+            t.cancel()
+    if wave_tasks:
+        await asyncio.gather(*wave_tasks, return_exceptions=True)
+
 
 # ─────────────────── per-plan 执行锁（P1-C + 跨进程 claim） ───────────────────
 # 把 execute_plan 的「status 检查 → running 写入 → 执行」整段按 plan 串行化，
@@ -313,10 +329,25 @@ async def update_plan_status(session_id: str, plan_id: str, **updates: Any) -> N
 
     每次写回都会自动刷新 ``__updated_at__``（stale-running 判定用），除非
     调用方显式传了该字段。
+
+    首达终态获胜 (P2)：一旦 completed/failed/cancelled，后到的状态写入（包括
+    running「复活」）全部忽略。
     """
     plan_data = await load_plan(session_id, plan_id)
     if plan_data is None:
         logger.warning(f"update_plan_status: plan {plan_id} 不存在")
+        return
+    current_status = plan_data.get("__status__")
+    new_status = updates.get("__status__")
+    if (
+        new_status is not None
+        and current_status in _TERMINAL_STATUSES
+        and new_status != current_status
+    ):
+        logger.warning(
+            f"update_plan_status: plan {plan_id} 已处于终态 {current_status}，"
+            f"忽略后到的 {new_status} 覆盖（首达终态获胜）",
+        )
         return
     updates.setdefault("__updated_at__", time.time())
     plan_data.update(updates)
@@ -657,179 +688,210 @@ async def _execute_plan_locked(
                 in_degree[step.id] += 1
 
     ready: list[str] = [sid for sid, d in in_degree.items() if d == 0]
+    wave_tasks: set[asyncio.Task] = set()
 
-    while ready:
-        # 同一波次：入度均为 0 的独立步骤，按拓扑序确定排布
-        wave = sorted(ready, key=topo_idx.__getitem__)
-        ready = []
+    try:
+        while ready:
+            # 同一波次：入度均为 0 的独立步骤，按拓扑序确定排布
+            wave = sorted(ready, key=topo_idx.__getitem__)
+            ready = []
 
-        # 波次内 args 解析：只依赖已完成步骤，解析失败即中止本波次
-        resolved_args: dict[str, dict] = {}
-        for sid in wave:
-            step = step_by_id[sid]
-            try:
-                r = resolve_arg_refs(step.args, step_results)
-            except MissingRefError as e:
-                hint = str(e)
-                await _write_terminal(
-                    __status__=_failure_status(),
-                    __failed_step__=sid,
-                    __error__=hint,
-                    __failure_class__="missing_ref",
-                    __step_results__=await _persist_step_results(session_id, plan_id, step_results),
-                )
-                return _fail(
-                    sid,
-                    f"步骤 {sid!r} 引用解析失败: {hint}",
-                    failure_class="missing_ref",
-                    recovery_action="reuse_ref",
-                    correction_hint=hint,
-                )
-            except Exception as e:  # noqa: BLE001
-                await _write_terminal(
-                    __status__=_failure_status(),
-                    __failed_step__=sid,
-                    __error__=f"args 解析异常: {e}",
-                    __step_results__=await _persist_step_results(session_id, plan_id, step_results),
-                )
-                return _fail(
-                    sid,
-                    f"步骤 {sid!r} args 解析异常: {e}",
-                    failure_class="internal",
-                    recovery_action="replan_remaining",
-                )
-            if not isinstance(r, dict):
-                await _write_terminal(
-                    __status__=_failure_status(),
-                    __failed_step__=sid,
-                    __error__=f"args 解析后不是 dict: {type(r).__name__}",
-                    __step_results__=await _persist_step_results(session_id, plan_id, step_results),
-                )
-                return _fail(
-                    sid,
-                    f"步骤 {sid!r} args 解析后不是 dict",
-                    failure_class="validation",
-                    recovery_action="correct_args",
-                )
-
-            resolved_args[sid] = r
-
-        # 并发 dispatch 整个波次。注意：Python 3.12 的 asyncio.as_completed
-        # yield 的是内部 _wait_for_one 协程而非原始 Task，无法映射回 sid；
-        # 因此改用 asyncio.wait(FIRST_COMPLETED)，它返回原始 Task 对象。
-        tasks = {
-            sid: asyncio.create_task(
-                registry.dispatch(
-                    step_by_id[sid].tool, resolved_args[sid], session_id=session_id
-                )
-            )
-            for sid in wave
-        }
-        task_to_sid = {t: sid for sid, t in tasks.items()}
-
-        wave_successes: dict[str, Any] = {}
-        # (sid, error, last_result, failure_class, recovery_action)
-        failure: Optional[tuple[str, str, Optional[Any], Optional[str], Optional[str]]] = None
-        pending: set[asyncio.Task] = set(tasks.values())
-        while pending:
-            done, pending = await asyncio.wait(
-                pending, return_when=asyncio.FIRST_COMPLETED
-            )
-            for t in done:
-                sid = task_to_sid[t]
+            # 波次内 args 解析：只依赖已完成步骤，解析失败即中止本波次
+            resolved_args: dict[str, dict] = {}
+            for sid in wave:
+                step = step_by_id[sid]
                 try:
-                    result = t.result()
-                except asyncio.CancelledError:
-                    continue  # 外部取消（如引擎关闭），忽略该任务
-                except OperationCancelled as e:
-                    # P1-C：用户取消不是工具故障 —— 写终态 cancelled（terminal），
-                    # 用 logger.info 记录（不是 exception）。走 _write_terminal：
-                    # 若计划已在途中被 superseded，保留 superseded 不被覆盖。
-                    logger.info(f"[PlanMode] plan {plan_id} 执行被取消: {e}")
+                    r = resolve_arg_refs(step.args, step_results)
+                except MissingRefError as e:
+                    hint = str(e)
                     await _write_terminal(
-                        __status__="cancelled",
-                        __error__=str(e) or "用户取消",
+                        __status__=_failure_status(),
+                        __failed_step__=sid,
+                        __error__=hint,
+                        __failure_class__="missing_ref",
                         __step_results__=await _persist_step_results(session_id, plan_id, step_results),
                     )
-                    return {
-                        "success": False,
-                        "plan_id": plan_id,
-                        "status": "cancelled",
-                        "error": f"plan {plan_id} 已取消",
-                        "executed": _ordered_executed(),
-                        "results": step_results,
-                        "failure_class": "cancelled",
-                    }
-                except Exception as e:
-                    logger.exception(f"[PlanMode] step {sid} raised")
-                    fc, ra = _classify_failure(exception=e)
-                    failure = (sid, str(e), None, fc, ra)
-                    break
-                # 工具返回 success=False（V3.x Exception As Thought 包装）也视为失败
-                if isinstance(result, dict) and result.get("success") is False:
-                    err = result.get("message") or result.get("error", "tool failed")
-                    fc, ra = _classify_failure(result=result)
-                    failure = (sid, err, result, fc, ra)
-                    break
-                wave_successes[sid] = result
-            if failure is not None:
-                break
+                    return _fail(
+                        sid,
+                        f"步骤 {sid!r} 引用解析失败: {hint}",
+                        failure_class="missing_ref",
+                        recovery_action="reuse_ref",
+                        correction_hint=hint,
+                    )
+                except Exception as e:  # noqa: BLE001
+                    await _write_terminal(
+                        __status__=_failure_status(),
+                        __failed_step__=sid,
+                        __error__=f"args 解析异常: {e}",
+                        __step_results__=await _persist_step_results(session_id, plan_id, step_results),
+                    )
+                    return _fail(
+                        sid,
+                        f"步骤 {sid!r} args 解析异常: {e}",
+                        failure_class="internal",
+                        recovery_action="replan_remaining",
+                    )
+                if not isinstance(r, dict):
+                    await _write_terminal(
+                        __status__=_failure_status(),
+                        __failed_step__=sid,
+                        __error__=f"args 解析后不是 dict: {type(r).__name__}",
+                        __step_results__=await _persist_step_results(session_id, plan_id, step_results),
+                    )
+                    return _fail(
+                        sid,
+                        f"步骤 {sid!r} args 解析后不是 dict",
+                        failure_class="validation",
+                        recovery_action="correct_args",
+                    )
 
-        # 失败处理：按本函数契约（见 docstring / line 252），同波次已 dispatch 的
-        # 兄弟步骤应跑到完成、其成功结果计入 executed；"立即中止"指不再启动 *新波次*。
-        # 此前这里 cancel 了 pending 兄弟，在较慢的 runner 上 s2 快速失败会 race 掉
-        # 即将完成的 s1，导致 flaky executed=[]（master CI 间歇性失败）。
-        if failure is not None and pending:
-            done_siblings, _ = await asyncio.wait(pending)  # 不 cancel，让兄弟完成
-            for t in done_siblings:
-                sid_sib = task_to_sid.get(t)
-                if sid_sib is None:
-                    continue
-                try:
-                    r_sib = t.result()
-                except Exception:
-                    continue  # 兄弟也失败；已记录首个 failure，忽略
-                if isinstance(r_sib, dict) and r_sib.get("success") is not False:
-                    wave_successes[sid_sib] = r_sib
+                resolved_args[sid] = r
 
-        # 按拓扑序提交成功结果（确定性）
-        for sid in wave:
-            if sid in wave_successes:
-                step_results[sid] = wave_successes[sid]
-
-        if failure is not None:
-            sid, err, last_result, fc, ra = failure
-            updates: dict[str, Any] = {
-                "__status__": _failure_status(),
-                "__failed_step__": sid,
-                "__error__": err,
-                # design-v3 §4：失败也保留已完成结果，供下次 execute_plan resume。
-                # P3 #1：持久化 slim 摘要（完整结果在 ref:planresult-*）。
-                "__step_results__": await _persist_step_results(session_id, plan_id, step_results),
+            # 并发 dispatch 整个波次。注意：Python 3.12 的 asyncio.as_completed
+            # yield 的是内部 _wait_for_one 协程而非原始 Task，无法映射回 sid；
+            # 因此改用 asyncio.wait(FIRST_COMPLETED)，它返回原始 Task 对象。
+            tasks = {
+                sid: asyncio.create_task(
+                    registry.dispatch(
+                        step_by_id[sid].tool, resolved_args[sid], session_id=session_id
+                    )
+                )
+                for sid in wave
             }
-            if fc is not None:
-                updates["__failure_class__"] = fc
-            await _write_terminal(**updates)
-            return _fail(sid, err, last_result, failure_class=fc, recovery_action=ra)
+            wave_tasks = set(tasks.values())
+            task_to_sid = {t: sid for sid, t in tasks.items()}
 
-        # 波次完成 → 推进依赖图，解锁下一波次
-        for sid in wave:
-            for nxt in edges[sid]:
-                in_degree[nxt] -= 1
-                if in_degree[nxt] == 0:
-                    ready.append(nxt)
+            wave_successes: dict[str, Any] = {}
+            # (sid, error, last_result, failure_class, recovery_action)
+            failure: Optional[tuple[str, str, Optional[Any], Optional[str], Optional[str]]] = None
+            pending: set[asyncio.Task] = set(tasks.values())
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+                for t in done:
+                    sid = task_to_sid[t]
+                    try:
+                        result = t.result()
+                    except asyncio.CancelledError:
+                        continue  # 外部取消（如引擎关闭），忽略该任务
+                    except OperationCancelled as e:
+                        # P1-C：用户取消不是工具故障 —— 写终态 cancelled（terminal），
+                        # 用 logger.info 记录（不是 exception）。走 _write_terminal：
+                        # 若计划已在途中被 superseded，保留 superseded 不被覆盖。
+                        logger.info(f"[PlanMode] plan {plan_id} 执行被取消: {e}")
+                        await _write_terminal(
+                            __status__="cancelled",
+                            __error__=str(e) or "用户取消",
+                            __step_results__=await _persist_step_results(session_id, plan_id, step_results),
+                        )
+                        return {
+                            "success": False,
+                            "plan_id": plan_id,
+                            "status": "cancelled",
+                            "error": f"plan {plan_id} 已取消",
+                            "executed": _ordered_executed(),
+                            "results": step_results,
+                            "failure_class": "cancelled",
+                        }
+                    except Exception as e:
+                        logger.exception(f"[PlanMode] step {sid} raised")
+                        fc, ra = _classify_failure(exception=e)
+                        failure = (sid, str(e), None, fc, ra)
+                        break
+                    # 工具返回 success=False（V3.x Exception As Thought 包装）也视为失败
+                    if isinstance(result, dict) and result.get("success") is False:
+                        err = result.get("message") or result.get("error", "tool failed")
+                        fc, ra = _classify_failure(result=result)
+                        failure = (sid, err, result, fc, ra)
+                        break
+                    wave_successes[sid] = result
+                if failure is not None:
+                    break
 
-    await _write_terminal(
-        __status__="completed",
-        __step_results__=await _persist_step_results(session_id, plan_id, step_results),
-    )
-    return {
-        "success": True,
-        "plan_id": plan_id,
-        "status": "completed",
-        "executed": _ordered_executed(),
-        "results": step_results,
-    }
+            # 失败处理：按本函数契约（见 docstring / line 252），同波次已 dispatch 的
+            # 兄弟步骤应跑到完成、其成功结果计入 executed；"立即中止"指不再启动 *新波次*。
+            # 此前这里 cancel 了 pending 兄弟，在较慢的 runner 上 s2 快速失败会 race 掉
+            # 即将完成的 s1，导致 flaky executed=[]（master CI 间歇性失败）。
+            if failure is not None and pending:
+                done_siblings, _ = await asyncio.wait(pending)  # 不 cancel，让兄弟完成
+                for t in done_siblings:
+                    sid_sib = task_to_sid.get(t)
+                    if sid_sib is None:
+                        continue
+                    try:
+                        r_sib = t.result()
+                    except Exception:
+                        continue  # 兄弟也失败；已记录首个 failure，忽略
+                    if isinstance(r_sib, dict) and r_sib.get("success") is not False:
+                        wave_successes[sid_sib] = r_sib
+
+            # 按拓扑序提交成功结果（确定性）
+            for sid in wave:
+                if sid in wave_successes:
+                    step_results[sid] = wave_successes[sid]
+
+            if failure is not None:
+                sid, err, last_result, fc, ra = failure
+                updates: dict[str, Any] = {
+                    "__status__": _failure_status(),
+                    "__failed_step__": sid,
+                    "__error__": err,
+                    # design-v3 §4：失败也保留已完成结果，供下次 execute_plan resume。
+                    # P3 #1：持久化 slim 摘要（完整结果在 ref:planresult-*）。
+                    "__step_results__": await _persist_step_results(session_id, plan_id, step_results),
+                }
+                if fc is not None:
+                    updates["__failure_class__"] = fc
+                await _write_terminal(**updates)
+                return _fail(sid, err, last_result, failure_class=fc, recovery_action=ra)
+
+            # 波次完成 → 推进依赖图，解锁下一波次
+            for sid in wave:
+                for nxt in edges[sid]:
+                    in_degree[nxt] -= 1
+                    if in_degree[nxt] == 0:
+                        ready.append(nxt)
+
+        await _write_terminal(
+            __status__="completed",
+            __step_results__=await _persist_step_results(session_id, plan_id, step_results),
+        )
+        return {
+            "success": True,
+            "plan_id": plan_id,
+            "status": "completed",
+            "executed": _ordered_executed(),
+            "results": step_results,
+        }
+    except asyncio.CancelledError:
+        # 外层被取消（客户端断连等）：取消并回收本波次 pending 任务，
+        # 状态收敛到 cancelled 后原样上抛（不吞取消）。
+        await _cancel_wave_tasks(wave_tasks)
+        try:
+            await _write_terminal(
+                __status__="cancelled",
+                __error__="cancelled",
+                __step_results__=await _persist_step_results(session_id, plan_id, step_results),
+            )
+        except Exception as e:  # noqa: BLE001 —— 收敛写失败不能替换 CancelledError
+            logger.warning(f"[PlanMode] 取消后计划状态收敛写失败: {e}")
+        raise
+    except Exception as e:  # noqa: BLE001
+        # 非预期的内部异常：同样回收波次任务并把状态收敛到终态，
+        # 避免计划永久卡在 running。
+        await _cancel_wave_tasks(wave_tasks)
+        logger.exception(f"[PlanMode] execute_plan_async aborted: {e}")
+        try:
+            await _write_terminal(
+                __status__=_failure_status(),
+                __error__=f"执行异常: {e}",
+                __step_results__=await _persist_step_results(session_id, plan_id, step_results),
+            )
+        except Exception as e2:  # noqa: BLE001 —— 收敛写失败不能替换原始异常
+            logger.warning(f"[PlanMode] 失败后计划状态收敛写失败: {e2}")
+        raise
+
 
 
 def _recovery_action_for_class(failure_class: str) -> Optional[str]:

--- a/app/services/session_data.py
+++ b/app/services/session_data.py
@@ -36,6 +36,10 @@ class MemorySessionStore(BaseSessionStore):
         # A single instance lock is sufficient for the in-memory backend (it is
         # only a fallback when Redis is unavailable).
         self._lock = asyncio.Lock()
+        # F27: dedicated lock for the append_map_action_event dedupe critical
+        # section (see its docstring). Kept separate from `self._lock` so ACK
+        # appends don't serialize against layer mutations.
+        self._map_action_lock = asyncio.Lock()
 
     async def store(self, session_id: str, data: Any, prefix: str = "data") -> str:
         """存储数据并返回生成的游标 ID"""
@@ -228,17 +232,23 @@ class MemorySessionStore(BaseSessionStore):
         首达终态获胜：同一 action_id 已存在时拒绝并返回 False（前端重连/重试
         会重复上报，首个到达的终态即真相）。每 session 上限
         MAX_MAP_ACTION_EVENTS，超出时按插入序淘汰最旧条目。
+
+        F27 不变量：action_id 判重 + 插入是 check-then-insert 临界区，全程持有
+        ``_map_action_lock``。此前临界区碰巧没有 await（原子性是"偶然"成立的）；
+        任何未来在临界区内引入的 await 都必须保持在锁内，否则并发重复写会
+        同时通过判重，破坏首达终态获胜语义。
         """
         action_id = str(event.get("action_id") or "")
         if not action_id:
             return False
-        events = self._map_action_events.setdefault(session_id, OrderedDict())
-        if action_id in events:
-            return False
-        while len(events) >= MAX_MAP_ACTION_EVENTS:
-            events.popitem(last=False)
-        events[action_id] = dict(event)
-        return True
+        async with self._map_action_lock:
+            events = self._map_action_events.setdefault(session_id, OrderedDict())
+            if action_id in events:
+                return False
+            while len(events) >= MAX_MAP_ACTION_EVENTS:
+                events.popitem(last=False)
+            events[action_id] = dict(event)
+            return True
 
     async def get_map_action_events(self, session_id: str) -> list[dict]:
         """返回该 session 当前全部地图动作 ACK（按到达顺序）。"""

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -298,16 +298,35 @@ class RedisSessionStore(BaseSessionStore):
         return True
 
     async def set_alias(self, session_id: str, ref_id: str, alias: str) -> None:
+        """写路径 best-effort：Redis 不可达时 log warning 并丢弃，不抛。
+
+        F22：alias 写入失败不应杀死整个 chat turn（审计 C3 同款隔离）。
+        """
         await self._ensure_connected()
-        async with self._r.pipeline() as pipe:
-            pipe.hset(self._aliases_key(session_id), alias, ref_id)
-            pipe.hset(self._refs_key(session_id), ref_id, alias)
-            self._refresh_session_ttl(pipe, session_id)
-            await pipe.execute()
+        try:
+            async with self._r.pipeline() as pipe:
+                pipe.hset(self._aliases_key(session_id), alias, ref_id)
+                pipe.hset(self._refs_key(session_id), ref_id, alias)
+                self._refresh_session_ttl(pipe, session_id)
+                await pipe.execute()
+        except aioredis.RedisError as e:
+            logger.warning(
+                "Redis set_alias failed for session %s ref %s: %s — alias dropped",
+                session_id, ref_id, e,
+            )
 
     async def resolve_alias(self, session_id: str, ref_or_alias: str) -> str:
+        """读路径 cache-miss 语义：Redis 不可达时原样返回输入（与 memory 后端
+        未命中别名一致），不抛（F22）。"""
         await self._ensure_connected()
-        ref_id = await self._r.hget(self._aliases_key(session_id), ref_or_alias)
+        try:
+            ref_id = await self._r.hget(self._aliases_key(session_id), ref_or_alias)
+        except aioredis.RedisError as e:
+            logger.warning(
+                "Redis resolve_alias failed for session %s: %s — returning input unchanged",
+                session_id, e,
+            )
+            return ref_or_alias
         if ref_id is None:
             return ref_or_alias
         return ref_id.decode() if isinstance(ref_id, bytes) else ref_id
@@ -318,11 +337,21 @@ class RedisSessionStore(BaseSessionStore):
         The registry resolves every string argument of a tool call; doing it
         one resolve_alias (HGET) at a time cost N serialized round-trips per
         dispatch. One HMGET collapses that to a single round-trip.
+
+        F22：本方法在每次 tool dispatch 上运行（chat/registry.py），Redis 抖动
+        不能让所有工具调用失败 —— 不可达时返回 identity map（cache-miss 语义）。
         """
         if not strings:
             return {}
         await self._ensure_connected()
-        ref_ids = await self._r.hmget(self._aliases_key(session_id), strings)
+        try:
+            ref_ids = await self._r.hmget(self._aliases_key(session_id), strings)
+        except aioredis.RedisError as e:
+            logger.warning(
+                "Redis resolve_aliases failed for session %s: %s — returning identity map",
+                session_id, e,
+            )
+            return {s: s for s in strings}
         out = {}
         for s, ref in zip(strings, ref_ids):
             if ref is None:
@@ -373,17 +402,26 @@ class RedisSessionStore(BaseSessionStore):
     # (both overridden below), which carry the backend-specific logic.
 
     async def list_refs(self, session_id: str) -> dict[str, str]:
+        """读路径 cache-miss 语义：Redis 不可达时返回空表，不抛（F22）。
+        本方法在每次 tool dispatch 上运行（chat/registry.py）。"""
         await self._ensure_connected()
-        ref_ids_bytes = await self._r.zrange(self._refs_order_key(session_id), 0, -1)
-        if not ref_ids_bytes:
+        try:
+            ref_ids_bytes = await self._r.zrange(self._refs_order_key(session_id), 0, -1)
+            if not ref_ids_bytes:
+                return {}
+            ref_ids = [r.decode() if isinstance(r, bytes) else r for r in ref_ids_bytes]
+            raw_refs = await self._r.hgetall(self._refs_key(session_id))
+            ref_to_alias = {
+                (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
+                for k, v in raw_refs.items()
+            }
+            return {rid: ref_to_alias.get(rid, "") for rid in ref_ids}
+        except aioredis.RedisError as e:
+            logger.warning(
+                "Redis list_refs failed for session %s: %s — returning empty",
+                session_id, e,
+            )
             return {}
-        ref_ids = [r.decode() if isinstance(r, bytes) else r for r in ref_ids_bytes]
-        raw_refs = await self._r.hgetall(self._refs_key(session_id))
-        ref_to_alias = {
-            (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
-            for k, v in raw_refs.items()
-        }
-        return {rid: ref_to_alias.get(rid, "") for rid in ref_ids}
 
     async def set_map_state(self, session_id: str, key: str, value: Any, seq: Optional[int] = None) -> bool:
         await self._ensure_connected()
@@ -439,8 +477,16 @@ class RedisSessionStore(BaseSessionStore):
         return False
 
     async def get_started_at(self, session_id: str) -> Optional[str]:
+        """读路径 cache-miss 语义：Redis 不可达时返回 None，不抛（F22）。"""
         await self._ensure_connected()
-        raw = await self._r.hget(self._state_key(session_id), "_started_at")
+        try:
+            raw = await self._r.hget(self._state_key(session_id), "_started_at")
+        except aioredis.RedisError as e:
+            logger.warning(
+                "Redis get_started_at failed for session %s: %s — returning None",
+                session_id, e,
+            )
+            return None
         return self._decode_started_at(raw)
 
     @staticmethod
@@ -615,8 +661,16 @@ class RedisSessionStore(BaseSessionStore):
         self._l1_invalidate_session(session_id)
 
     async def get_event_log(self, session_id: str) -> list[dict]:
+        """读路径 cache-miss 语义：Redis 不可达时返回空列表，不抛（F22）。"""
         await self._ensure_connected()
-        raw_list = await self._r.lrange(self._events_key(session_id), 0, -1)
+        try:
+            raw_list = await self._r.lrange(self._events_key(session_id), 0, -1)
+        except aioredis.RedisError as e:
+            logger.warning(
+                "Redis get_event_log failed for session %s: %s — returning empty",
+                session_id, e,
+            )
+            return []
         return [
             json.loads(item.decode() if isinstance(item, bytes) else item)
             for item in raw_list
@@ -795,6 +849,10 @@ class RedisSessionStore(BaseSessionStore):
             )
             pipe.srem(self._active_key(), session_id)
             await pipe.execute()
+        # F13: write-through invalidation, like every other writer — otherwise a
+        # session recreated with the same id within L1_TTL_SECONDS reads the
+        # DELETED session's map_state/refs/event_log from L1.
+        self._l1_invalidate_session(session_id)
 
     async def cleanup_idle_sessions(self, max_sessions: int = 100) -> None:
         await self._ensure_connected()

--- a/app/services/task_queue.py
+++ b/app/services/task_queue.py
@@ -1,5 +1,6 @@
 """任务队列服务 - Celery 初始化"""
 import logging
+from collections import OrderedDict
 from celery import Celery
 from app.core.config import settings
 
@@ -55,13 +56,22 @@ class TaskQueueService:
     }
 
     # 审计 S34：celery task_id → user_id 映射，用于状态/撤销端点的所有权校验
-    _task_owners: dict[str, str] = {}
+    # P2 (F29): 该 dict 原本只增不减 —— 每次 Celery 提交都永久增长一个条目
+    # （explorer orchestrator 按任务注册），进程生命周期内无界。改为 LRU 有界：
+    # 超过 _OWNERS_MAX_ENTRIES 时逐出最旧条目。所有权校验在任务存续期内有效
+    # （过期条目回退为「不属于该用户」→ 端点 404，与「从未注册」语义一致，
+    # 因为 durable job 行才是任务中心的权威事实源）。
+    _task_owners: "OrderedDict[str, str]" = OrderedDict()
+    _OWNERS_MAX_ENTRIES = 20_000
 
     @classmethod
     def register_owner(cls, task_id: str, user_id: str) -> None:
         """记录 celery task_id 所属用户。仅在已知归属时调用。"""
         if user_id:
             cls._task_owners[task_id] = user_id
+            cls._task_owners.move_to_end(task_id)
+            while len(cls._task_owners) > cls._OWNERS_MAX_ENTRIES:
+                cls._task_owners.popitem(last=False)
 
     @classmethod
     def verify_owner(cls, task_id: str, user_id: str) -> bool:
@@ -69,6 +79,8 @@ class TaskQueueService:
         owner = cls._task_owners.get(task_id)
         if owner is None:
             return False
+        # 命中即刷新 recency，热任务不被 LRU 逐出。
+        cls._task_owners.move_to_end(task_id)
         return owner == user_id
 
     @staticmethod

--- a/app/services/task_tracker.py
+++ b/app/services/task_tracker.py
@@ -8,6 +8,7 @@ agent turn」的热态视图，durable 事实在 analysis_tasks 表（见 app/se
 ``await token.wait()`` 从而**抢占式**打断在飞的工具，而不是等当前工具自然跑完；
 token 还通过 contextvar 传进同步 GIS 代码，让长循环能在 checkpoint 处协作退出。
 """
+import asyncio
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -23,6 +24,9 @@ class StepStatus(str, Enum):
     running = "running"
     completed = "completed"
     failed = "failed"
+    #: F7/F8：被用户取消（或被抢占式打断）的步骤 —— 与 failed 区分开，
+    #: 取消绝不等于工具故障。
+    cancelled = "cancelled"
 
 
 class TaskStatus(str, Enum):
@@ -110,6 +114,13 @@ class _TrackStepContext:
             return False
 
         if exc_type is not None:
+            if issubclass(exc_type, asyncio.CancelledError):
+                # F7/F8：asyncio 抢占式取消不是步骤失败。
+                try:
+                    self.tracker.cancel_step(self.task_id, self.step.id)
+                except Exception:
+                    pass
+                return False  # Re-raise CancelledError
             err_msg = str(exc_val) if exc_val else f"Exception: {exc_type.__name__}"
             try:
                 self.tracker.fail_step(self.task_id, self.step.id, err_msg)
@@ -172,9 +183,9 @@ class TaskTracker:
         # Per-session task limit
         session_task_ids = self._session_tasks[session_id]
         while len(session_task_ids) > self.MAX_TASKS_PER_SESSION:
-            old_id = session_task_ids.pop(0)
-            self._tasks.pop(old_id, None)
-            self._step_counters.pop(old_id, None)
+            # F18: 走 _drop_task —— running 任务先点燃 cancel token 再逐出，
+            # 不能静默丢弃一个在飞的执行体。
+            self._drop_task(session_task_ids[0])
 
         # 初始化步骤计数器
         self._step_counters[task_id] = 0
@@ -191,9 +202,10 @@ class TaskTracker:
         Finished tasks are evicted first (existing behavior); if the cap is
         still exceeded — e.g. many running tasks abandoned by streams whose
         client disconnected mid-turn — the oldest remaining tasks are evicted
-        regardless of status, so the tracker stays bounded. Evicting a running
-        task is safe: _TrackStepContext and start_step/complete_step guard on
-        task existence and no-op for unknown ids.
+        regardless of status, so the tracker stays bounded. A running task is
+        NEVER silently dropped (F18): _drop_task lights its cancel token
+        first, so the in-flight execution actually stops instead of becoming
+        an invisible, uncancellable orphan.
         """
         if len(self._tasks) <= self.MAX_TOTAL_TASKS:
             return
@@ -205,13 +217,20 @@ class TaskTracker:
             self._drop_task(tid)
 
         # Still over the cap: evict the oldest tasks (dict insertion order)
-        # regardless of status.
+        # regardless of status — _drop_task cancels running ones first.
         for tid in list(self._tasks)[:max(0, len(self._tasks) - self.MAX_TOTAL_TASKS)]:
             self._drop_task(tid)
 
     def _drop_task(self, tid: str) -> None:
         """Remove a task and its bookkeeping; drop now-empty session keys."""
-        self._tasks.pop(tid, None)
+        task = self._tasks.pop(tid, None)
+        if task is not None and task.status == TaskStatus.running:
+            # F18: running 任务绝不能被静默逐出 —— 那会让在飞执行体既不可见也
+            # 不可取消。逐出前先点燃它的 cancel token：asyncio 侧（引擎的
+            # cancel_watch）与线程侧（GIS 循环的 checkpoint）都能立刻停下。
+            token = task.cancel_token or cancellation_registry.get(tid)
+            if token is not None:
+                token.cancel("task evicted from tracker")
         self._step_counters.pop(tid, None)
         # ADR-0052: token 随 task 一起回收，避免 registry 随进程寿命单调增长
         cancellation_registry.discard(tid)
@@ -251,6 +270,8 @@ class TaskTracker:
         if not step:
             raise ValueError(f"Step {step_id} not found in task {task_id}")
 
+        if step.status != StepStatus.running:
+            return  # 终态不可变（first terminal wins）
         step.status = StepStatus.completed
         step.result = result
         step.finished_at = datetime.now(timezone.utc)
@@ -265,9 +286,46 @@ class TaskTracker:
         if not step:
             raise ValueError(f"Step {step_id} not found in task {task_id}")
 
+        if step.status != StepStatus.running:
+            return  # 终态不可变
         step.status = StepStatus.failed
         step.error = error
         step.finished_at = datetime.now(timezone.utc)
+
+    def cancel_step(self, task_id: str, step_id: str) -> None:
+        """标记步骤已取消（F7/F8：取消 ≠ 失败，与 OperationCancelled 对应）。"""
+        task = self._tasks.get(task_id)
+        if not task:
+            raise ValueError(f"Task {task_id} not found")
+
+        step = next((s for s in task.steps if s.id == step_id), None)
+        if not step:
+            raise ValueError(f"Step {step_id} not found in task {task_id}")
+
+        if step.status != StepStatus.running:
+            return  # 终态不可变
+        step.status = StepStatus.cancelled
+        step.finished_at = datetime.now(timezone.utc)
+
+    def terminalize_running_steps(
+        self,
+        task_id: str,
+        status: StepStatus = StepStatus.cancelled,
+        error: str | None = None,
+    ) -> None:
+        """F7: 把 task 下仍 running 的 step 一并收尾。
+
+        任务终态化（cancel/fail/complete）与断连路径都必须调用它 ——
+        GET /tasks/{id} 绝不允许在终态任务上显示 running 步骤。
+        """
+        task = self._tasks.get(task_id)
+        if not task:
+            return
+        for step in task.steps:
+            if step.status == StepStatus.running:
+                step.status = status
+                step.error = error
+                step.finished_at = datetime.now(timezone.utc)
 
     def complete_task(self, task_id: str) -> None:
         """完成任务"""
@@ -275,6 +333,13 @@ class TaskTracker:
         if not task:
             raise ValueError(f"Task {task_id} not found")
 
+        if task.status != TaskStatus.running:
+            # F3: 终态不可变（first terminal wins，与 durable-jobs 层不变量一致）
+            # —— cancel 后迟到的 complete 不得把 cancelled 改写回 completed。
+            return
+        self.terminalize_running_steps(
+            task_id, StepStatus.failed, "task completed while step still running"
+        )
         task.status = TaskStatus.completed
         task.finished_at = datetime.now(timezone.utc)
 
@@ -284,6 +349,9 @@ class TaskTracker:
         if not task:
             raise ValueError(f"Task {task_id} not found")
 
+        if task.status != TaskStatus.running:
+            return  # F3: 终态不可变
+        self.terminalize_running_steps(task_id, StepStatus.failed, error)
         task.status = TaskStatus.failed
         task.finished_at = datetime.now(timezone.utc)
         # 可选：记录失败原因到任务中
@@ -312,6 +380,13 @@ class TaskTracker:
         if not task:
             return False
 
+        if task.status == TaskStatus.cancelled:
+            return True  # 幂等：重复取消返回 True 但不重复点燃 token（规范 §5）
+        if task.status != TaskStatus.running:
+            # F3: 终态不可变 —— completed/failed 的任务不能被 cancel 覆盖。
+            return False
+        # F7: 仍 running 的 step 随任务一起取消，GET /tasks/{id} 不再显示 running。
+        self.terminalize_running_steps(task_id, StepStatus.cancelled)
         task.status = TaskStatus.cancelled
         task._cancelled = True
         task.finished_at = datetime.now(timezone.utc)

--- a/app/services/ws_service.py
+++ b/app/services/ws_service.py
@@ -1,8 +1,13 @@
+import asyncio
 import logging
 from typing import Dict, List, Any
 from fastapi import WebSocket
 
 logger = logging.getLogger(__name__)
+
+# F16: 单个 socket 的 send 有界等待上限（秒）。卡死（不报错但也不 flush）的连接
+# 不能无限期拖住同 session 的其它连接；超时后按死连接处理并驱逐。
+WS_SEND_TIMEOUT = 2.0
 
 class ConnectionManager:
     """Handles active WebSocket connections for real-time GIS data broadcasting"""
@@ -26,12 +31,39 @@ class ConnectionManager:
         logger.info(f"WebSocket disconnected for session: {session_id}")
 
     async def broadcast(self, session_id: str, message: dict):
-        if session_id in self.active_connections:
-            for connection in self.active_connections[session_id]:
-                try:
-                    await connection.send_json(message)
-                except Exception as e:
-                    logger.error(f"Error sending WebSocket message: {e}")
+        connections = self.active_connections.get(session_id)
+        if not connections:
+            return
+        # 快照迭代 + 并发发送（P2 round-2）：所有连接同一轮内并行 send，每路
+        # send 各自被 WS_SEND_TIMEOUT 封顶 —— N 个卡死连接的总耗时约等于一个
+        # 超时（顺序发送时是 N×WS_SEND_TIMEOUT）。发送失败/超时的连接记入
+        # dead，本轮结束后统一驱逐（快照迭代语义不变：在循环里 remove 会跳过
+        # 元素）。
+        dead: List[WebSocket] = []
+
+        async def _send(connection: WebSocket) -> None:
+            try:
+                await asyncio.wait_for(
+                    connection.send_json(message), timeout=WS_SEND_TIMEOUT
+                )
+            except Exception as e:  # noqa: BLE001 — 含 TimeoutError；坏连接不能影响其余连接
+                logger.error(f"Error sending WebSocket message: {e}")
+                dead.append(connection)
+
+        await asyncio.gather(*(_send(c) for c in list(connections)))
+        for connection in dead:
+            self.disconnect(connection, session_id)
+            # P2 (round-2 review): 驱逐后尽力关闭底层 socket。路由可能正阻塞在
+            # receive_json() 上等下一条消息 —— 只从 active_connections 移除而
+            # 不 close，那条路由会一直挂在那里（僵尸连接，接收循环永不退出）。
+            # close 本身也可能卡在坏连接上，所以同样加超时；失败仅记日志
+            # （best-effort，关闭失败不阻塞广播）。
+            try:
+                await asyncio.wait_for(
+                    connection.close(), timeout=WS_SEND_TIMEOUT
+                )
+            except Exception as e:  # noqa: BLE001 — close 是 best-effort
+                logger.warning(f"Error closing evicted WebSocket: {e}")
 
 # Global instance for the entire application
 manager = ConnectionManager()

--- a/tests/test_chat_engine.py
+++ b/tests/test_chat_engine.py
@@ -95,10 +95,16 @@ async def test_session_persistence(registry):
     engine = ChatEngine(registry)
     mock_response = {"choices": [{"message": {"content": "OK", "tool_calls": None}}]}
 
-    with patch.object(engine, "_call_llm", new_callable=AsyncMock, return_value=mock_response):
-        with patch.object(engine, "_save_msg_async", new_callable=AsyncMock):
-            r1 = await engine.chat("hello", session_id="s1")
-            r2 = await engine.chat("world", session_id="s1")
-            assert r1["session_id"] == "s1"
-            assert r2["session_id"] == "s1"
-            assert len(engine._sessions["s1"]) >= 4
+    # F23 之后 DB 加载失败不再缓存空 stub —— 这里显式 stub 加载成功，
+    # 才能断言「同一 session 两轮共享缓存的消息列表」。
+    async def fake_load(session_id, user_id=None):
+        return [{"role": "system", "content": "sys"}]
+
+    with patch.object(engine, "_load_session_from_db", side_effect=fake_load):
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock, return_value=mock_response):
+            with patch.object(engine, "_save_msg_async", new_callable=AsyncMock):
+                r1 = await engine.chat("hello", session_id="s1")
+                r2 = await engine.chat("world", session_id="s1")
+                assert r1["session_id"] == "s1"
+                assert r2["session_id"] == "s1"
+                assert len(engine._sessions["s1"]) >= 4

--- a/tests/test_chat_engine_tracking.py
+++ b/tests/test_chat_engine_tracking.py
@@ -402,8 +402,8 @@ async def test_stream_disconnect_fails_tracker_task(engine):
 
     fix 前 chat_stream 没有 GeneratorExit/CancelledError 处理：客户端断连
     （Starlette 对 StreamingResponse 调用 aclose）会让任务一直 running，
-    直到 MAX_TOTAL_TASKS 上限才被逐出。fix 后任务应转为 failed（原因
-    cancelled）。
+    直到 MAX_TOTAL_TASKS 上限才被逐出。fix 后任务会终止；F8 之后终态从
+    failed 改为 cancelled —— 断连/取消必须与真正的失败区分开。
     """
     with patch.object(engine, "_save_msg_async", new_callable=AsyncMock):
         gen = engine.chat_stream("断连测试", session_id="test-disc")
@@ -416,17 +416,18 @@ async def test_stream_disconnect_fails_tracker_task(engine):
 
         task = engine.tracker.get(task_id)
         assert task is not None, "任务应仍存在于 tracker"
-        assert task.status == TaskStatus.failed, (
-            f"断连后任务应为 failed，实际 {task.status}"
+        assert task.status == TaskStatus.cancelled, (
+            f"断连后任务应为 cancelled（F8），实际 {task.status}"
         )
 
 
 @pytest.mark.asyncio
 async def test_stream_cancelled_mid_turn_fails_tracker_task(engine):
-    """B-P2-17 (CancelledError 分支)：流式对话中途被取消时任务也必须转为 failed。
+    """B-P2-17 (CancelledError 分支)：流式对话中途被取消时任务也必须终止。
 
     StreamingResponse 在客户端断连时对生成器投递的正是 CancelledError（不是
     GeneratorExit），因此两个分支都要终止任务。fix 前任务停留在 running（泄漏）。
+    F8 之后终态从 failed 改为 cancelled —— 取消必须与失败可区分。
     """
     token_consumed = asyncio.Event()
     parked = asyncio.Event()
@@ -454,6 +455,6 @@ async def test_stream_cancelled_mid_turn_fails_tracker_task(engine):
 
             task = engine.tracker.get(task_id)
             assert task is not None, "任务应仍存在于 tracker"
-            assert task.status == TaskStatus.failed, (
-                f"取消后任务应为 failed，实际 {task.status}"
+            assert task.status == TaskStatus.cancelled, (
+                f"取消后任务应为 cancelled（F8），实际 {task.status}"
             )

--- a/tests/test_runtime_chaos_engine.py
+++ b/tests/test_runtime_chaos_engine.py
@@ -1,0 +1,1360 @@
+"""WP-ENGINE runtime chaos / recovery regression tests.
+
+Covers the Agent Runtime hardening defects:
+  F1  clear_session 在 turn 持锁期间丢弃 session 锁/状态（锁逐出 check-then-pop 竞态）
+  F3  终态覆盖：complete_task/fail_task 无条件改写 cancelled
+  F7  cancel/disconnect 后 step 永远停在 running
+  F8  取消与失败不可区分（step/task 两级）
+  F9  DB 中遗留孤儿 assistant tool_calls，下一轮 LLM 调用被拒
+  F15 _fire_and_forget 任务无跟踪， lifespan 无法 drain
+  F17 durable job id 未注册进取消 registry，cancel 级联是空操作
+  F18 running 任务被静默逐出（不可见也不可取消）
+  F21 clear_session 进程内清理部分失败 → 500 + 跳过其余清理
+  F23 DB 加载失败 stub 被永久缓存
+  F28 非流式 _chat_locked 无 cancel_watch，取消不能抢占在飞工具
+
+模式遵循 tests/test_chat_engine_tracking.py / tests/test_sse_resume.py /
+tests/jobs/test_job_agent_bridge.py：asyncio.Event 屏障 + monkeypatch 引擎
+接缝，无 wall-clock 依赖。
+"""
+import asyncio
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.chat_engine import ChatEngine
+from app.services.chat import execution_engine as ee_mod
+from app.services.chat.tool_pipeline import ToolExecutionPipeline
+from app.services.jobs.cancellation import registry as cancellation_registry
+from app.services.task_tracker import StepStatus, TaskStatus, TaskTracker
+from app.services.tool_dispatch_service import ToolDispatchResult
+from app.tools.registry import ToolRegistry
+
+
+# ─── helpers / fixtures ──────────────────────────────────────────────
+
+
+def _fake_stream(response_msg):
+    """Single-round fake _call_llm_stream yielding one 'done' event."""
+
+    async def stream(*args, **kwargs):
+        yield ("done", {"message": response_msg})
+
+    return stream
+
+
+def _ok_dispatch_result(name: str = "tool") -> ToolDispatchResult:
+    return ToolDispatchResult(
+        status="ok",
+        llm_payload=f"{name} ok",
+        slim_event={"result": f"{name} ok"},
+        geojson_ref=None,
+        raw_result={"result": f"{name} ok"},
+        error_msg=None,
+    )
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    """ChatEngine with DB/planner/title side effects stubbed (mirrors the
+    fixture pattern in test_chat_engine_tracking.py)."""
+    eng = ChatEngine(ToolRegistry())
+
+    async def fake_get_or_create_session(session_id, user_id=None):
+        return []
+
+    async def fake_maybe_plan(*a, **kw):
+        return None
+
+    monkeypatch.setattr(eng, "_get_or_create_session", fake_get_or_create_session)
+    monkeypatch.setattr(eng, "_maybe_plan", fake_maybe_plan)
+    monkeypatch.setattr(eng, "_generate_title", AsyncMock())
+    monkeypatch.setattr(eng, "_save_msg_async", AsyncMock())
+    return eng
+
+
+def _mock_history_delete(deleted=True):
+    """Patch the DB delete path of engine.clear_session."""
+    mock_history = AsyncMock()
+    mock_history.delete_session = AsyncMock(return_value=deleted)
+    db_ctx = patch("app.services.chat.execution_engine.async_db_session")
+    svc = patch(
+        "app.services.chat.execution_engine.AsyncHistoryService",
+        return_value=mock_history,
+    )
+    return db_ctx, svc
+
+
+def _enter_db_ctx(mock_db_ctx):
+    mock_db_ctx.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_db_ctx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+
+def _stream_task_id(events):
+    for e in events:
+        if "task_start" in e:
+            return json.loads(e.split("data: ")[1])["task_id"]
+    return None
+
+
+# ─── F3: terminal states are immutable (first terminal wins) ─────────
+
+
+class TestF3TerminalImmutability:
+    def test_complete_task_does_not_overwrite_cancelled(self):
+        tracker = TaskTracker()
+        task = tracker.create("s", "r")
+        assert tracker.cancel(task.id) is True
+        tracker.complete_task(task.id)
+        assert tracker.get(task.id).status == TaskStatus.cancelled, (
+            "complete_task overwrote a cancelled task (F3)"
+        )
+        tracker.fail_task(task.id, "late failure")
+        assert tracker.get(task.id).status == TaskStatus.cancelled
+
+    def test_fail_task_does_not_overwrite_completed(self):
+        tracker = TaskTracker()
+        task = tracker.create("s", "r")
+        tracker.complete_task(task.id)
+        tracker.fail_task(task.id, "late failure")
+        assert tracker.get(task.id).status == TaskStatus.completed
+
+    @pytest.mark.asyncio
+    async def test_streaming_cancel_then_llm_complete_stays_cancelled(self, engine, monkeypatch):
+        """Drive cancel-vs-complete deterministically: cancel lands while the
+        FINAL LLM round is streaming (after the is_cancelled poll), so the
+        content branch reaches tracker.complete_task (execution_engine
+        :1002). First terminal (cancelled) must win."""
+        sid = "sess-f3-race"
+        round2_started = asyncio.Event()
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "geocode", "arguments": "{}"}}
+            ],
+        }
+
+        async def round2_stream(*args, **kwargs):
+            # Cancel AFTER the round-2 is_cancelled check but BEFORE
+            # complete_task — the exact F3 race window.
+            task = next(t for t in engine.tracker.list_all() if t.session_id == sid)
+            engine.tracker.cancel(task.id)
+            round2_started.set()
+            yield ("done", {"message": {"content": "final answer", "tool_calls": None}})
+
+        with patch.object(
+            engine, "_call_llm_stream",
+            side_effect=[_fake_stream(msg1)(), round2_stream()],
+        ):
+            events = []
+            async for event in engine.chat_stream("测试", session_id=sid):
+                events.append(event)
+
+        assert round2_started.is_set()
+        task_id = _stream_task_id(events)
+        assert engine.tracker.get(task_id).status == TaskStatus.cancelled, (
+            "complete_task at end of stream overwrote the cancelled terminal state (F3)"
+        )
+
+
+# ─── F7: no step stays running on a terminal task ────────────────────
+
+
+class TestF7StepsTerminalized:
+    def test_cancel_terminalizes_running_steps(self):
+        tracker = TaskTracker()
+        task = tracker.create("s", "r")
+        s1 = tracker.start_step(task.id, "tool_a", {})
+        s2 = tracker.start_step(task.id, "tool_b", {})
+        tracker.complete_step(task.id, s1.id, {"ok": 1})
+        tracker.cancel(task.id)
+
+        steps = {s.id: s for s in tracker.get(task.id).steps}
+        assert steps[s1.id].status == StepStatus.completed
+        assert steps[s2.id].status == StepStatus.cancelled, (
+            "cancelled task still has a running step (F7)"
+        )
+
+    def test_fail_task_terminalizes_running_steps(self):
+        tracker = TaskTracker()
+        task = tracker.create("s", "r")
+        step = tracker.start_step(task.id, "tool_a", {})
+        tracker.fail_task(task.id, "boom")
+        assert tracker.get(task.id).steps[0].status != StepStatus.running, (
+            "failed task still shows a running step (F7)"
+        )
+        assert tracker.get(task.id).steps[0].id == step.id
+
+    def test_complete_task_terminalizes_running_steps(self):
+        tracker = TaskTracker()
+        task = tracker.create("s", "r")
+        tracker.start_step(task.id, "tool_a", {})
+        tracker.complete_task(task.id)
+        assert all(
+            s.status != StepStatus.running for s in tracker.get(task.id).steps
+        ), "terminal task must not expose running steps via GET /tasks/{id} (F7)"
+
+
+# ─── F8: cancellation observable as cancellation ─────────────────────
+
+
+class TestF8CancelNotFailure:
+    @pytest.mark.asyncio
+    async def test_pipeline_marks_step_cancelled_not_failed(self):
+        """Cancelled tool must terminalize its step as cancelled, not failed."""
+        from app.services.jobs.cancellation import checkpoint
+        from app.services.tool_dispatch_service import ToolDispatchService
+
+        registry = ToolRegistry()
+
+        def cancellable_tool() -> dict:
+            checkpoint()
+            return {"unreachable": True}
+
+        registry.register(
+            name="cancellable_tool",
+            description="test tool",
+            func=cancellable_tool,
+            parameters={"type": "object", "properties": {}},
+        )
+
+        tracker = TaskTracker()
+        task = tracker.create("sess-1", "req")
+        tracker.cancel(task.id)
+
+        pipeline = ToolExecutionPipeline(
+            registry=registry,
+            tracker=tracker,
+            dispatch_service=ToolDispatchService(registry=registry),
+        )
+        tc = {"id": "c1", "function": {"name": "cancellable_tool", "arguments": "{}"}}
+        result = await pipeline.execute_tool_call(tc, "sess-1", task.id)
+
+        assert result.cancelled is True
+        step = tracker.get(task.id).steps[0]
+        assert step.status == StepStatus.cancelled, (
+            f"cancelled tool step recorded as {step.status} — indistinguishable "
+            "from a failure (F8)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_streaming_preemptive_cancel_marks_step_and_task_cancelled(
+        self, engine, monkeypatch
+    ):
+        """Cancel preempts an in-flight tool (cancel_watch): the step must end
+        cancelled, the task must end cancelled, and SSE must carry
+        step_cancelled + task_cancelled — never step_error/failed."""
+        sid = "sess-f8"
+        tool_started = asyncio.Event()
+        release_tool = asyncio.Event()
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            await release_tool.wait()
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "slow_tool", "arguments": "{}"}}
+            ],
+        }
+        msg2 = {"content": "done", "tool_calls": None}
+
+        with patch.object(
+            engine, "_call_llm_stream",
+            side_effect=[_fake_stream(msg1)(), _fake_stream(msg2)()],
+        ):
+            events = []
+
+            async def _consume():
+                async for event in engine.chat_stream("测试", session_id=sid):
+                    events.append(event)
+
+            consumer = asyncio.create_task(_consume())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            task = next(t for t in engine.tracker.list_all() if t.session_id == sid)
+            engine.tracker.cancel(task.id)
+            await asyncio.wait_for(consumer, timeout=5)
+
+        assert any("task_cancelled" in e for e in events)
+        assert any("step_cancelled" in e for e in events), (
+            "preempted tool step did not surface as cancelled in SSE (F8)"
+        )
+        task = engine.tracker.get(task.id)
+        assert task.status == TaskStatus.cancelled
+        assert all(s.status != StepStatus.running for s in task.steps), (
+            "cancelled task still has running steps (F7)"
+        )
+        assert task.steps[0].status == StepStatus.cancelled, (
+            f"preempted step recorded as {task.steps[0].status} (F8)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_disconnect_marks_task_cancelled_not_failed(self, engine, monkeypatch):
+        """Client disconnect mid-tool: task must terminalize as cancelled
+        (today fail_task(..., 'cancelled') records status=failed)."""
+        sid = "sess-f8-disconnect"
+        tool_started = asyncio.Event()
+        release_tool = asyncio.Event()
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            await release_tool.wait()
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "slow_tool", "arguments": "{}"}}
+            ],
+        }
+
+        with patch.object(
+            engine, "_call_llm_stream", return_value=_fake_stream(msg1)()
+        ):
+            events = []
+
+            async def _consume():
+                async for event in engine.chat_stream("测试", session_id=sid):
+                    events.append(event)
+
+            consumer = asyncio.create_task(_consume())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            consumer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await consumer
+
+        task = next(t for t in engine.tracker.list_all() if t.session_id == sid)
+        assert task.status == TaskStatus.cancelled, (
+            f"disconnect recorded task as {task.status} — cancel must be "
+            "distinguishable from failure (F8)"
+        )
+        assert all(s.status != StepStatus.running for s in task.steps), (
+            "disconnect left a step running (F7)"
+        )
+
+
+# ─── F9: orphaned assistant tool_calls repaired on abort ─────────────
+
+
+class TestF9OrphanedToolCalls:
+    @pytest.mark.asyncio
+    async def test_cancel_repairs_orphaned_tool_calls(self, engine, monkeypatch):
+        """After a cancel mid-tool, the in-memory history AND the persisted
+        history must contain a tool message for every assistant tool_call —
+        otherwise the next turn's LLM call rejects the orphaned tool_calls."""
+        sid = "sess-f9"
+        tool_started = asyncio.Event()
+        release_tool = asyncio.Event()
+        captured_messages: list[dict] = []
+
+        async def fake_get_or_create_session(session_id, user_id=None):
+            return captured_messages
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            await release_tool.wait()
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_get_or_create_session", fake_get_or_create_session)
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "function": {"name": "slow_tool", "arguments": "{}"}}
+            ],
+        }
+
+        with patch.object(
+            engine, "_call_llm_stream", return_value=_fake_stream(msg1)()
+        ):
+            events = []
+
+            async def _consume():
+                async for event in engine.chat_stream("测试", session_id=sid):
+                    events.append(event)
+
+            consumer = asyncio.create_task(_consume())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            task = next(t for t in engine.tracker.list_all() if t.session_id == sid)
+            engine.tracker.cancel(task.id)
+            await asyncio.wait_for(consumer, timeout=5)
+
+        # in-memory repair
+        answered = {
+            m.get("tool_call_id") for m in captured_messages if m.get("role") == "tool"
+        }
+        orphans = [
+            tc["id"]
+            for m in captured_messages
+            if m.get("role") == "assistant"
+            for tc in (m.get("tool_calls") or [])
+            if tc.get("id") and tc["id"] not in answered
+        ]
+        assert not orphans, (
+            f"assistant tool_calls left orphaned in history after cancel: {orphans} (F9)"
+        )
+
+        # persisted repair: a tool message must have been saved for call_1
+        tool_saves = [
+            c for c in engine._save_msg_async.call_args_list
+            if len(c.args) >= 6 and c.args[1] == "tool" and c.args[5] == "call_1"
+        ]
+        assert tool_saves, (
+            "no tool response message persisted for the orphaned tool_call — "
+            "next turn's LLM call would be rejected (F9)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_disconnect_repairs_orphaned_tool_calls(self, engine, monkeypatch):
+        sid = "sess-f9b"
+        tool_started = asyncio.Event()
+        release_tool = asyncio.Event()
+        captured_messages: list[dict] = []
+
+        async def fake_get_or_create_session(session_id, user_id=None):
+            return captured_messages
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            await release_tool.wait()
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_get_or_create_session", fake_get_or_create_session)
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_9", "function": {"name": "slow_tool", "arguments": "{}"}}
+            ],
+        }
+
+        with patch.object(
+            engine, "_call_llm_stream", return_value=_fake_stream(msg1)()
+        ):
+            async def _consume():
+                async for _ in engine.chat_stream("测试", session_id=sid):
+                    pass
+
+            consumer = asyncio.create_task(_consume())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            consumer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await consumer
+
+        answered = {
+            m.get("tool_call_id") for m in captured_messages if m.get("role") == "tool"
+        }
+        assert "call_9" in answered, (
+            "disconnect left an orphaned assistant tool_call in history (F9)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancel_same_batch_keeps_completed_tool_success(self, engine, monkeypatch):
+        """F9 (cancel-vs-success batch): cancel and the fast tool's completion
+        land in the SAME ``asyncio.wait`` done set. The completed tool must be
+        harvested as a success — step completed, real tool message persisted —
+        NOT marked cancelled / given the '工具执行已被用户取消' placeholder;
+        the genuinely in-flight tool is preempted and its orphaned tool_call
+        is still repaired."""
+        sid = "sess-f9-batch"
+        fast_gate = asyncio.Event()
+        slow_started = asyncio.Event()
+        slow_release = asyncio.Event()
+        slow_cancelled = {"ok": False}
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            name = tc["function"]["name"]
+            if name == "fast_tool":
+                await fast_gate.wait()
+                return _ok_dispatch_result("fast")
+            slow_started.set()
+            try:
+                await slow_release.wait()
+            except asyncio.CancelledError:
+                slow_cancelled["ok"] = True
+                raise
+            return _ok_dispatch_result("slow")
+
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_fast", "function": {"name": "fast_tool", "arguments": "{}"}},
+                {"id": "call_slow", "function": {"name": "slow_tool", "arguments": "{}"}},
+            ],
+        }
+
+        with patch.object(
+            engine, "_call_llm_stream", return_value=_fake_stream(msg1)()
+        ):
+            events = []
+
+            async def _consume():
+                async for e in engine.chat_stream("测试", session_id=sid):
+                    events.append(e)
+
+            consumer = asyncio.create_task(_consume())
+            await asyncio.wait_for(slow_started.wait(), timeout=5)
+            task = next(t for t in engine.tracker.list_all() if t.session_id == sid)
+            # 取消与 fast 完成落在同一个事件循环调度批 → 二者同批进入 wave 的
+            # asyncio.wait done 集合。经 token 直接点燃（不经 tracker.cancel 的
+            # terminalize_running_steps），隔离验证 wave 自身的「已完成 ≠ 已取消」
+            # 收割逻辑。
+            task.cancel_token.cancel("test")
+            fast_gate.set()
+            try:
+                await asyncio.wait_for(consumer, timeout=5)
+            finally:
+                slow_release.set()  # 任何路径下都不让 gated 工具泄漏
+
+        task = engine.tracker.get(task.id)
+        fast_step = next(s for s in task.steps if s.tool == "fast_tool")
+        slow_step = next(s for s in task.steps if s.tool == "slow_tool")
+        assert fast_step.status == StepStatus.completed, (
+            f"completed tool recorded as {fast_step.status} — success lost to cancel (F9)"
+        )
+        assert slow_step.status == StepStatus.cancelled, (
+            f"in-flight tool recorded as {slow_step.status} — must be cancelled (F7/F9)"
+        )
+        assert slow_cancelled["ok"] is True, "in-flight tool was not preempted"
+        assert any("task_cancelled" in e for e in events)
+
+        # 已完成工具的 tool 消息以真实结果落库，而不是「已取消」占位
+        fast_saves = [
+            c for c in engine._save_msg_async.call_args_list
+            if len(c.args) >= 6 and c.args[1] == "tool" and c.args[5] == "call_fast"
+        ]
+        assert fast_saves, "completed tool's tool message was not persisted (F9)"
+        assert fast_saves[-1].args[4] == "fast ok", (
+            f"completed tool's message is {fast_saves[-1].args[4]!r} — placeholder for a success (F9)"
+        )
+        # 真正在飞的 slow 的孤儿 tool_call 仍被补齐（幂等 repair 只补孤儿）
+        assert any(
+            len(c.args) >= 6 and c.args[1] == "tool" and c.args[5] == "call_slow"
+            and c.args[4] == "工具执行已被用户取消"
+            for c in engine._save_msg_async.call_args_list
+        ), "orphaned in-flight tool_call was not repaired (F9)"
+
+
+# ─── F1: clear_session vs in-flight turn + lock eviction race ────────
+
+
+class TestF1ClearSessionLockSafety:
+    @pytest.mark.asyncio
+    async def test_clear_session_keeps_in_use_lock(self):
+        """A lock held by an in-flight turn (or with waiters) must NOT be
+        dropped — a new lock would re-enable concurrent turns on the same
+        session while the old turn still runs."""
+        eng = ChatEngine(ToolRegistry())
+        sid = "sess-busy"
+        lock = eng._get_session_lock(sid)
+        await lock.acquire()
+        eng._sessions[sid] = [{"role": "system", "content": "x"}]
+
+        db_ctx, svc = _mock_history_delete(deleted=True)
+        try:
+            with db_ctx as mock_db_ctx, svc, patch(
+                "app.services.chat.execution_engine.session_data_manager"
+            ) as mock_sdm:
+                _enter_db_ctx(mock_db_ctx)
+                mock_sdm.clear_session = AsyncMock()
+                result = await eng.clear_session(sid)
+        finally:
+            lock.release()
+
+        assert result is True
+        assert sid not in eng._sessions
+        assert eng._session_locks.get(sid) is lock, (
+            "clear_session dropped a session lock that an in-flight turn holds (F1)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_clear_session_cancels_inflight_tasks(self):
+        """clear_session must cancel the session's in-flight turns so they
+        terminalize instead of resurrecting messages into a deleted session."""
+        eng = ChatEngine(ToolRegistry())
+        sid = "sess-running"
+        task = eng.tracker.create(sid, "req")
+
+        db_ctx, svc = _mock_history_delete(deleted=True)
+        with db_ctx as mock_db_ctx, svc, patch(
+            "app.services.chat.execution_engine.session_data_manager"
+        ) as mock_sdm:
+            _enter_db_ctx(mock_db_ctx)
+            mock_sdm.clear_session = AsyncMock()
+            result = await eng.clear_session(sid)
+
+        assert result is True
+        assert eng.tracker.get(task.id).status == TaskStatus.cancelled, (
+            "clear_session left an in-flight task running — the turn keeps "
+            "appending into a deleted session (F1)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lock_eviction_keeps_lock_with_waiters(self):
+        """`if not lock.locked(): pop` evicts a lock whose waiters have been
+        woken but not yet re-acquired — a check-then-pop race (F1)."""
+        eng = ChatEngine(ToolRegistry())
+        eng._MAX_LOCKS = 4  # evict_count = _MAX_LOCKS // 4 = 1 (oldest entry)
+
+        contested = asyncio.Lock()
+        await contested.acquire()
+        waiter = asyncio.create_task(contested.acquire())
+        await asyncio.sleep(0)  # waiter is queued
+        contested.release()
+        # No yield here: the waiter is woken (call_soon) but has NOT
+        # re-acquired yet — locked() is False while a waiter exists.
+
+        eng._session_locks["old-contended"] = contested
+        for i in range(4):
+            eng._session_locks[f"old-idle-{i}"] = asyncio.Lock()
+        try:
+            eng._get_session_lock("new-session")  # triggers eviction pass
+            assert eng._session_locks.get("old-contended") is contested, (
+                "eviction dropped a lock with a pending waiter (F1)"
+            )
+        finally:
+            waiter.cancel()
+            await asyncio.gather(waiter, return_exceptions=True)
+            if contested.locked():
+                contested.release()
+
+
+# ─── F15: background task tracking + drain ───────────────────────────
+
+
+class TestF15BackgroundTaskDrain:
+    @pytest.mark.asyncio
+    async def test_fire_and_forget_is_tracked_and_drained(self):
+        eng = ChatEngine(ToolRegistry())
+        done = asyncio.Event()
+
+        async def bg():
+            done.set()
+
+        eng._fire_and_forget(bg)
+        tracked = [t for t in ee_mod._background_tasks if not t.done()]
+        assert tracked, "fire-and-forget task is untracked (F15)"
+
+        await ee_mod.drain_background_tasks(timeout=5.0)
+        assert done.is_set()
+        assert not [t for t in ee_mod._background_tasks if not t.done()]
+
+    @pytest.mark.asyncio
+    async def test_drain_background_tasks_cancels_pending_on_timeout(self, caplog):
+        """P1 (drain): a background task still pending at the drain deadline
+        must be CANCELLED (bounded best-effort gather), not left to outlive
+        lifespan shutdown and write into closed resources — the old contract
+        (log + return, task left pending) let a slow _generate_title keep
+        writing to dead shared clients."""
+        async def never():
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(never())
+        ee_mod._background_tasks.add(task)
+        task.add_done_callback(ee_mod._background_tasks.discard)
+        try:
+            with caplog.at_level(logging.WARNING):
+                await ee_mod.drain_background_tasks(timeout=0.05)  # must not raise
+            assert task.done(), "drain returned while the task was still pending"
+            assert task.cancelled(), "drain must cancel pending tasks on timeout (P1)"
+            assert any(
+                "cancelling" in r.message for r in caplog.records
+            ), "drain did not log the cancel warning"
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_drain_drops_stale_tasks_bound_to_other_loop(self, caplog):
+        """P1 (drain): the module-global registry is cross-loop sticky — a
+        task bound to a closed/other event loop never completes, so every
+        later drain includes it and eats the full timeout. drain must filter
+        to tasks of the CURRENT running loop and drop stale ones (with a
+        log) instead of waiting them out."""
+        other_loop = asyncio.new_event_loop()
+
+        class _StaleTask:
+            """Minimal stand-in for a task bound to a closed/different loop:
+            never done, get_loop() != the running loop (its loop can't be run
+            from this thread while the pytest loop is running)."""
+
+            def done(self):
+                return False
+
+            def get_loop(self):
+                return other_loop
+
+        stale = _StaleTask()
+        ee_mod._background_tasks.add(stale)
+        try:
+            with caplog.at_level(logging.WARNING):
+                # Must return promptly — the stale task must not consume the
+                # whole drain budget (30s here would hang the old code).
+                await asyncio.wait_for(
+                    ee_mod.drain_background_tasks(timeout=30.0), timeout=1.0
+                )
+            assert stale not in ee_mod._background_tasks, (
+                "stale cross-loop task left in the registry (P1)"
+            )
+            assert any(
+                "stale" in r.message for r in caplog.records
+            ), "stale drop was not logged"
+        finally:
+            other_loop.close()
+
+    @pytest.mark.asyncio
+    async def test_drain_signature(self):
+        import inspect
+
+        sig = inspect.signature(ee_mod.drain_background_tasks)
+        assert list(sig.parameters) == ["timeout"]
+        assert sig.parameters["timeout"].default == 5.0
+
+
+# ─── F17: durable job ids registered in the cancellation registry ────
+
+
+class TestF17CancelCascadeRegistration:
+    def test_submit_registers_job_cancellation_token(self, tmp_path, monkeypatch):
+        """submit_durable_job must register the job id in the in-process
+        cancellation registry — otherwise TaskTracker.cancel()'s cascade
+        (cancellation_registry.cancel(job_id)) is a no-op."""
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from app.models.db_model import Base
+        from app.services.jobs.submit import submit_durable_job
+
+        engine = create_engine(f"sqlite:///{tmp_path / 'f17.db'}")
+        Base.metadata.create_all(engine)
+        Sess = sessionmaker(bind=engine)
+
+        import contextlib
+
+        @contextlib.contextmanager
+        def fake_db_session():
+            db = Sess()
+            try:
+                yield db
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
+            finally:
+                db.close()
+
+        monkeypatch.setattr("app.services.jobs.submit.db_session", fake_db_session)
+
+        class _FakeTask:
+            name = "tests.fake_task"
+
+            def apply_async(self, args=None, kwargs=None, **_):
+                class _R:
+                    id = "celery-f17"
+
+                return _R()
+
+        try:
+            result = submit_durable_job(
+                celery_task=_FakeTask(),
+                task_type="ndvi",
+                display_name="NDVI 分析",
+                params={"raster_path": "/data/a.tif"},
+                task_args=("/data/a.tif",),
+                session_id="sess-f17",
+            )
+            job_id = result["job_id"]
+
+            token = cancellation_registry.get(job_id)
+            assert token is not None, (
+                "durable job id never registered — the agent-task cancel "
+                "cascade cannot reach it (F17)"
+            )
+
+            # The full cascade: agent task cancel must light the job's token
+            # WITHOUT the hand-registration done in test_job_agent_bridge.py:396.
+            tracker = TaskTracker()
+            task = tracker.create("sess-f17", "req")
+            step = tracker.start_step(task.id, "analyze", {})
+            step.background_job_ids = [job_id]
+            tracker.cancel(task.id)
+            assert token.cancelled is True, "cancel cascade did not fire (F17)"
+        finally:
+            cancellation_registry.discard(str(result["job_id"]) if "result" in dir() else "")
+            engine.dispose()
+
+
+# ─── F18: running-task eviction ──────────────────────────────────────
+
+
+class TestF18Eviction:
+    def test_evicted_running_task_is_cancelled_not_orphaned(self):
+        """Evicting a RUNNING task without lighting its cancel token leaves an
+        invisible, uncancellable execution running in the background."""
+        tracker = TaskTracker()
+        victim = tracker.create("s-victim", "r")
+        for i in range(TaskTracker.MAX_TOTAL_TASKS + 60):
+            tracker.create(f"s-{i}", f"r-{i}")
+
+        assert victim.id not in tracker._tasks, "precondition: victim was evicted"
+        assert victim.cancel_token is not None and victim.cancel_token.cancelled, (
+            "running task evicted while still executing — its in-flight tools "
+            "never observe cancellation (F18)"
+        )
+
+    def test_per_session_eviction_cancels_running_task(self):
+        tracker = TaskTracker()
+        first = tracker.create("s", "r0")
+        for i in range(TaskTracker.MAX_TASKS_PER_SESSION):
+            tracker.create("s", f"r{i + 1}")
+
+        assert first.id not in tracker._tasks
+        assert first.cancel_token is not None and first.cancel_token.cancelled, (
+            "per-session eviction orphaned a running task (F18)"
+        )
+
+
+# ─── F21: clear_session partial failure isolation ────────────────────
+
+
+class TestF21ClearSessionIsolation:
+    @pytest.mark.asyncio
+    async def test_inprocess_cleanup_failure_is_isolated(self):
+        """session_data_manager.clear_session raising must not 500 the route
+        nor skip the remaining in-process cleanup."""
+        eng = ChatEngine(ToolRegistry())
+        sid = "sess-f21"
+        eng._sessions[sid] = [{"role": "system", "content": "x"}]
+        eng._session_locks[sid] = asyncio.Lock()
+
+        from app.services.chat import planner
+
+        clear_plan = MagicMock()
+        db_ctx, svc = _mock_history_delete(deleted=True)
+        with db_ctx as mock_db_ctx, svc, patch(
+            "app.services.chat.execution_engine.session_data_manager"
+        ) as mock_sdm, patch.object(planner, "clear_plan", clear_plan):
+            _enter_db_ctx(mock_db_ctx)
+            mock_sdm.clear_session = AsyncMock(side_effect=RuntimeError("redis down"))
+            result = await eng.clear_session(sid)  # currently raises → 500
+
+        assert result is True, (
+            "in-process cleanup failure must not change route semantics (F21)"
+        )
+        assert sid not in eng._sessions
+        assert sid not in eng._session_locks
+        clear_plan.assert_called_once_with(sid)
+
+
+# ─── F23: failed DB load must not be cached ──────────────────────────
+
+
+class TestF23LoadFailureNotCached:
+    @pytest.mark.asyncio
+    async def test_failed_load_not_cached(self):
+        """A post-DB-outage stub must not poison the session cache — the next
+        turn must retry the DB load."""
+        eng = ChatEngine(ToolRegistry())
+        sid = "sess-f23"
+
+        mock_svc = AsyncMock()
+        mock_svc.load_context = AsyncMock(side_effect=RuntimeError("db down"))
+        with patch(
+            "app.services.chat.execution_engine.AsyncHistoryService",
+            return_value=mock_svc,
+        ):
+            msgs = await eng._get_or_create_session(sid)
+
+        # Current turn degrades to system-prompt-only (kept behavior) ...
+        assert msgs[0]["role"] == "system"
+        # ... but the failure stub must NOT be cached.
+        assert sid not in eng._sessions, (
+            "failed DB load cached an empty stub — every later turn runs with "
+            "permanently empty history (F23)"
+        )
+
+        # DB "recovers": the next turn loads the real history.
+        mock_svc.load_context = AsyncMock(return_value=SimpleNamespace(
+            owner_token=None,
+            llm_messages=[
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "real history"},
+            ],
+        ))
+        with patch(
+            "app.services.chat.execution_engine.AsyncHistoryService",
+            return_value=mock_svc,
+        ):
+            msgs2 = await eng._get_or_create_session(sid)
+        assert msgs2[-1]["content"] == "real history"
+        assert eng._sessions[sid] is msgs2
+
+
+# ─── F28: non-streaming chat() preemptive cancel ─────────────────────
+
+
+class TestF28NonStreamingCancelWatch:
+    @pytest.mark.asyncio
+    async def test_cancel_preempts_inflight_tool(self, engine, monkeypatch):
+        """User cancel must preempt an in-flight tool in the non-streaming
+        path (today chat() waits for the tool to finish naturally)."""
+        sid = "sess-f28"
+        tool_started = asyncio.Event()
+        release_tool = asyncio.Event()
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            await release_tool.wait()
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        async def fake_call_llm(*a, **k):
+            return {
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {"id": "call_1", "function": {"name": "slow_tool", "arguments": "{}"}}
+                        ],
+                    },
+                }]
+            }
+
+        monkeypatch.setattr(engine, "_call_llm", fake_call_llm)
+
+        chat_task = asyncio.create_task(engine.chat("hi", session_id=sid))
+        await asyncio.wait_for(tool_started.wait(), timeout=5)
+        task = next(t for t in engine.tracker.list_all() if t.session_id == sid)
+        engine.tracker.cancel(task.id)
+
+        result = await asyncio.wait_for(chat_task, timeout=5)
+        assert result["content"] == "任务已取消", (
+            f"non-streaming cancel did not preempt the in-flight tool (F28): {result}"
+        )
+        assert not release_tool.is_set(), "tool ran to completion despite cancel"
+        assert engine.tracker.get(task.id).status == TaskStatus.cancelled
+
+    @pytest.mark.asyncio
+    async def test_cancel_preempts_slow_tool_and_keeps_fast_result(self, engine, monkeypatch):
+        """F28 hole (multi-tool wave): with TWO tools of unequal duration and
+        cancel firing AFTER the fast tool completes, the slow tool must be
+        preempted (its task cancelled) while the fast tool's result is still
+        recorded. The single-shot cancel_watch wait (old code) fell into
+        ``await asyncio.gather(*tool_tasks)`` after the fast tool completed and
+        never re-checked the token until the WHOLE wave finished naturally."""
+        sid = "sess-f28-multi"
+        fast_gate = asyncio.Event()
+        slow_started = asyncio.Event()
+        slow_release = asyncio.Event()
+        slow_cancelled = {"ok": False}
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            name = tc["function"]["name"]
+            if name == "fast_tool":
+                await fast_gate.wait()
+                return _ok_dispatch_result("fast")
+            slow_started.set()
+            try:
+                await slow_release.wait()
+            except asyncio.CancelledError:
+                slow_cancelled["ok"] = True
+                raise
+            return _ok_dispatch_result("slow")
+
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        async def fake_call_llm(*a, **k):
+            return {
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {"id": "call_fast", "function": {"name": "fast_tool", "arguments": "{}"}},
+                            {"id": "call_slow", "function": {"name": "slow_tool", "arguments": "{}"}},
+                        ],
+                    },
+                }]
+            }
+
+        monkeypatch.setattr(engine, "_call_llm", fake_call_llm)
+
+        chat_task = asyncio.create_task(engine.chat("hi", session_id=sid))
+        await asyncio.wait_for(slow_started.wait(), timeout=5)
+        task = next(t for t in engine.tracker.list_all() if t.session_id == sid)
+
+        # 先让 fast 完成并被 wave 处理，再点燃取消 —— 复现 F28 hole：旧实现
+        # 第一次 wait 返回 fast 后直接 gather 等整波自然结束，cancel 永不重查，
+        # slow 会一直跑（此处 slow_release 永不 set → chat 挂死）。
+        fast_gate.set()
+        await asyncio.sleep(0)  # 纯调度 yield（非 wall-clock）：让 wave 处理 fast
+        await asyncio.sleep(0)
+        engine.tracker.cancel(task.id)
+        try:
+            result = await asyncio.wait_for(chat_task, timeout=5)
+        finally:
+            slow_release.set()  # 任何路径下都释放 gated 工具，避免测试泄漏
+
+        assert result["content"] == "任务已取消", (
+            f"cancel did not preempt the slow tool after fast completed (F28): {result}"
+        )
+        assert slow_cancelled["ok"] is True, "slow tool was not preempted (F28)"
+        assert engine.tracker.get(task.id).status == TaskStatus.cancelled
+
+        # fast 的结果必须真实落库，而不是「已取消」占位
+        fast_saves = [
+            c for c in engine._save_msg_async.call_args_list
+            if len(c.args) >= 6 and c.args[1] == "tool" and c.args[5] == "call_fast"
+        ]
+        assert fast_saves, "fast tool's result was not recorded after cancel (F9)"
+        assert fast_saves[-1].args[4] == "fast ok", (
+            f"fast tool's recorded message is {fast_saves[-1].args[4]!r} — success lost (F9)"
+        )
+        assert not any(c.args[4] == "工具执行已被用户取消" for c in fast_saves), (
+            "a completed tool must not be marked cancelled (F9)"
+        )
+
+
+# ─── P1 round-2: clear_session must not resurrect deleted history ─────
+
+
+class TestC1ClearSessionNoResurrect:
+    @pytest.mark.asyncio
+    async def test_clear_session_suppresses_history_persistence_during_turn(
+        self, engine, monkeypatch
+    ):
+        """P1: clear_session during a streaming turn must not let the
+        cancelled turn's cleanup resurrect the deleted conversation — the DB
+        write is suppressed (real _save_msg_async funnels into a recorded
+        save_message) while the in-memory orphan repair still runs."""
+        import types as _types
+        sid = "sess-p1-resurrect"
+        captured_messages: list[dict] = []
+        tool_started = asyncio.Event()
+        release_tool = asyncio.Event()
+        save_calls: list[tuple] = []
+
+        async def fake_get_or_create_session(session_id, user_id=None):
+            return captured_messages
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            await release_tool.wait()
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_get_or_create_session", fake_get_or_create_session)
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+        # Re-bind the REAL _save_msg_async (the fixture stubs it) so the
+        # clearing-suppression is exercised; the DB write lands in the mock.
+        engine._save_msg_async = _types.MethodType(
+            ee_mod.ChatExecutionEngine._save_msg_async, engine
+        )
+
+        async def _recording_save(*args, **kwargs):
+            save_calls.append(args)
+
+        mock_history = AsyncMock()
+        mock_history.delete_session = AsyncMock(return_value=True)
+        mock_history.save_message = AsyncMock(side_effect=_recording_save)
+        db_ctx = patch("app.services.chat.execution_engine.async_db_session")
+        svc = patch(
+            "app.services.chat.execution_engine.AsyncHistoryService",
+            return_value=mock_history,
+        )
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_p1", "function": {"name": "slow_tool", "arguments": "{}"}}
+            ],
+        }
+        with db_ctx as mock_db_ctx, svc, patch(
+            "app.services.chat.execution_engine.session_data_manager"
+        ) as mock_sdm, patch.object(
+            engine, "_call_llm_stream", return_value=_fake_stream(msg1)()
+        ):
+            _enter_db_ctx(mock_db_ctx)
+            mock_sdm.clear_session = AsyncMock()
+
+            async def _consume():
+                async for _ in engine.chat_stream("hi", session_id=sid):
+                    pass
+
+            consumer = asyncio.create_task(_consume())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            before = len(save_calls)
+            try:
+                ok = await engine.clear_session(sid)
+            finally:
+                release_tool.set()  # 任何路径下都不让 gated 工具泄漏
+            assert ok is True
+            await asyncio.wait_for(consumer, timeout=5)
+
+        # No history write for the deleted conversation after the clear began
+        new_calls = save_calls[before:]
+        assert not any(call[0] == sid for call in new_calls), (
+            f"cancelled turn's cleanup persisted into the deleted conversation: "
+            f"{[c[:2] for c in new_calls]} (P1)"
+        )
+        # ...while the in-memory orphan repair still ran
+        assert any(
+            m.get("role") == "tool" and m.get("tool_call_id") == "call_p1"
+            for m in captured_messages
+        ), "in-memory orphan repair did not run during clear (P1)"
+
+    @pytest.mark.asyncio
+    async def test_new_turn_refused_while_session_clearing(self, engine, monkeypatch):
+        """P1: a NEW turn POSTed while clear_session is mid-flight must be
+        refused cleanly (SessionClearingError), not raced into the delete."""
+        sid = "sess-p1-refuse"
+        clear_entered = asyncio.Event()
+        release_clear = asyncio.Event()
+
+        async def blocking_sdm_clear(_sid):
+            clear_entered.set()
+            await release_clear.wait()
+
+        async def should_not_run(*a, **k):
+            raise AssertionError("a new turn started during clear_session (P1)")
+
+        monkeypatch.setattr(engine, "_call_llm", should_not_run)
+        monkeypatch.setattr(engine, "_call_llm_stream", should_not_run)
+
+        db_ctx, svc = _mock_history_delete(deleted=True)
+        with db_ctx as mock_db_ctx, svc, patch(
+            "app.services.chat.execution_engine.session_data_manager"
+        ) as mock_sdm:
+            _enter_db_ctx(mock_db_ctx)
+            mock_sdm.clear_session = AsyncMock(side_effect=blocking_sdm_clear)
+
+            clear_task = asyncio.create_task(engine.clear_session(sid))
+            await asyncio.wait_for(clear_entered.wait(), timeout=5)
+
+            with pytest.raises(ee_mod.SessionClearingError):
+                await engine.chat("new turn", session_id=sid)
+            with pytest.raises(ee_mod.SessionClearingError):
+                async for _ in engine.chat_stream("new turn", session_id=sid):
+                    pass
+
+            release_clear.set()
+            await asyncio.wait_for(clear_task, timeout=5)
+        assert sid not in engine._clearing_sessions
+
+
+# ─── P1 round-2: bounded cleanup on cancel (no unbounded gather) ──────
+
+
+class TestC1BoundedCancelCleanup:
+    # NOTE: the straggler tool below deliberately IGNORES cancellation (the
+    # while-loop re-waits on CancelledError). That models a tool whose worker
+    # genuinely cannot be interrupted — a thread parked in a long GIS compute
+    # on runtimes where cancelling an asyncio.to_thread task does not retire
+    # the task (older/newer CPython differ). The unbounded
+    # `await asyncio.gather(...)` then blocks the cancel/finally path for the
+    # worker's full duration; the bounded wait must return promptly and the
+    # session lock must be released regardless.
+
+    @pytest.mark.asyncio
+    async def test_cancel_returns_promptly_with_stubborn_straggler_tool(
+        self, engine, monkeypatch
+    ):
+        """P1: cancel mid-tool where the in-flight tool task cannot be
+        interrupted must return promptly (bounded cancel wait) and release
+        the session lock — the unbounded gather held the lock until the
+        straggler finished."""
+        sid = "sess-p1-cancel-stubborn"
+        gate = asyncio.Event()      # never set -> the tool parks forever
+        die = asyncio.Event()       # test teardown: let the straggler exit
+        tool_started = asyncio.Event()
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            while not die.is_set():
+                try:
+                    await gate.wait()
+                except asyncio.CancelledError:
+                    continue  # a straggler that can't be cancelled
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+        engine._cancel_wait_timeout = 0.05
+
+        async def fake_call_llm(*a, **k):
+            return {
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {"id": "call_t", "function": {"name": "slow_tool", "arguments": "{}"}}
+                        ],
+                    },
+                }]
+            }
+
+        monkeypatch.setattr(engine, "_call_llm", fake_call_llm)
+
+        chat_task = asyncio.create_task(engine.chat("hi", session_id=sid))
+        await asyncio.wait_for(tool_started.wait(), timeout=5)
+        task = next(t for t in engine.tracker.list_all() if t.session_id == sid)
+        try:
+            engine.tracker.cancel(task.id)
+            result = await asyncio.wait_for(chat_task, timeout=2.0)
+        finally:
+            die.set()
+            gate.set()  # 让 straggler 任务退出，避免测试泄漏
+        assert result["content"] == "任务已取消", (
+            f"cancel did not return promptly with a stubborn straggler (P1): {result}"
+        )
+        # session lock is released even though the straggler tool is still alive
+        lock = engine._get_session_lock(sid)
+        try:
+            await asyncio.wait_for(lock.acquire(), timeout=0.5)
+        finally:
+            if lock.locked():
+                lock.release()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_returns_promptly_with_stubborn_straggler_tool(
+        self, engine, monkeypatch
+    ):
+        """P1: client disconnect mid-tool (streaming finally path) with an
+        in-flight tool task that cannot be interrupted must return promptly
+        and release the session lock."""
+        sid = "sess-p1-disc-stubborn"
+        gate = asyncio.Event()      # never set -> the tool parks forever
+        die = asyncio.Event()       # test teardown: let the straggler exit
+        tool_started = asyncio.Event()
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            while not die.is_set():
+                try:
+                    await gate.wait()
+                except asyncio.CancelledError:
+                    continue  # a straggler that can't be cancelled
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+        engine._cancel_wait_timeout = 0.05
+
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_t", "function": {"name": "slow_tool", "arguments": "{}"}}
+            ],
+        }
+        with patch.object(engine, "_call_llm_stream", return_value=_fake_stream(msg1)()):
+            async def _consume():
+                async for _ in engine.chat_stream("hi", session_id=sid):
+                    pass
+
+            consumer = asyncio.create_task(_consume())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            try:
+                consumer.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(consumer, timeout=2.0)
+            finally:
+                die.set()
+                gate.set()  # 让 straggler 任务退出，避免测试泄漏
+
+        lock = engine._get_session_lock(sid)
+        try:
+            await asyncio.wait_for(lock.acquire(), timeout=0.5)
+        finally:
+            if lock.locked():
+                lock.release()
+
+
+# ─── P1 round-2: second cancel must not truncate the orphan repair ────
+
+
+class TestC1ShieldedRepair:
+    @pytest.mark.asyncio
+    async def test_second_cancel_does_not_truncate_orphan_repair(
+        self, engine, monkeypatch
+    ):
+        """P1: a second cancellation arriving while the
+        (CancelledError/GeneratorExit) handler runs _repair_orphaned_tool_calls
+        must not truncate the repair mid-write — the shielded repair's DB
+        write still completes."""
+        sid = "sess-p1-repair"
+        captured_messages: list[dict] = []
+        tool_started = asyncio.Event()
+        release_tool = asyncio.Event()
+        repair_started = asyncio.Event()
+        release_repair = asyncio.Event()
+
+        async def fake_get_or_create_session(session_id, user_id=None):
+            return captured_messages
+
+        async def fake_dispatch(tc, session_id, executed_tools):
+            tool_started.set()
+            await release_tool.wait()
+            return _ok_dispatch_result(tc["function"]["name"])
+
+        monkeypatch.setattr(engine, "_get_or_create_session", fake_get_or_create_session)
+        monkeypatch.setattr(engine, "_dispatch_tool", fake_dispatch)
+
+        orig_repair = engine._repair_orphaned_tool_calls
+
+        async def gated_repair(session_id, messages):
+            repair_started.set()
+            await release_repair.wait()
+            await orig_repair(session_id, messages)
+
+        monkeypatch.setattr(engine, "_repair_orphaned_tool_calls", gated_repair)
+
+        msg1 = {
+            "content": None,
+            "tool_calls": [
+                {"id": "call_rep", "function": {"name": "slow_tool", "arguments": "{}"}}
+            ],
+        }
+        with patch.object(engine, "_call_llm_stream", return_value=_fake_stream(msg1)()):
+            async def _consume():
+                async for _ in engine.chat_stream("hi", session_id=sid):
+                    pass
+
+            consumer = asyncio.create_task(_consume())
+            await asyncio.wait_for(tool_started.wait(), timeout=5)
+            consumer.cancel()  # first cancel -> except handler -> gated repair
+            await asyncio.wait_for(repair_started.wait(), timeout=5)
+
+            consumer.cancel()  # second cancel while the repair is mid-flight
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(consumer, timeout=5)
+
+            release_repair.set()
+            for _ in range(10):  # 纯调度 yield —— 让 shield 的 repair 跑完
+                await asyncio.sleep(0)
+            release_tool.set()
+
+        assert any(
+            len(c.args) >= 6
+            and c.args[0] == sid
+            and c.args[1] == "tool"
+            and c.args[5] == "call_rep"
+            for c in engine._save_msg_async.call_args_list
+        ), "second cancellation truncated the orphan repair (P1)"

--- a/tests/test_runtime_chaos_lifecycle.py
+++ b/tests/test_runtime_chaos_lifecycle.py
@@ -1,0 +1,341 @@
+"""Runtime chaos / lifecycle hardening regressions (WP-LIFECYCLE).
+
+Covers:
+- F11: async engine must be disposed at shutdown (was: only sync Engine disposed,
+  leaving the async pool bound to a closed loop across lifespan cycles).
+- F15-wiring: lifespan shutdown must drain chat fire-and-forget background tasks
+  via ``app.services.chat.execution_engine.drain_background_tasks``.
+- F14: async_db_session() must always close the session
+  (success / exception-rollback / cancellation paths).
+- F16: ConnectionManager.broadcast — bounded per-send wait, dead-socket eviction,
+  snapshot iteration.
+- Repeated-lifecycle invariant: N full lifespan cycles in one loop leave no
+  orphan asyncio tasks and dispose the async engine every cycle.
+"""
+import asyncio
+
+import pytest
+
+
+# ─── F14: async_db_session close guarantees ─────────────────────────────────
+
+
+class _TrackingSession:
+    def __init__(self):
+        self.commits = 0
+        self.rollbacks = 0
+        self.closes = 0
+
+    async def commit(self):
+        self.commits += 1
+
+    async def rollback(self):
+        self.rollbacks += 1
+
+    async def close(self):
+        self.closes += 1
+
+
+@pytest.fixture
+def tracking_sessions(monkeypatch):
+    """Replace AsyncSessionLocal with a factory producing close-tracking fakes."""
+    import app.core.database as db_module
+
+    made = []
+
+    def factory():
+        session = _TrackingSession()
+        made.append(session)
+        return session
+
+    monkeypatch.setattr(db_module, "AsyncSessionLocal", factory)
+    return made
+
+
+@pytest.mark.asyncio
+async def test_async_db_session_closes_on_success(tracking_sessions):
+    from app.tools._utils import async_db_session
+
+    async with async_db_session() as db:
+        assert db is tracking_sessions[0]
+
+    session = tracking_sessions[0]
+    assert session.commits == 1
+    assert session.rollbacks == 0
+    assert session.closes == 1
+
+
+@pytest.mark.asyncio
+async def test_async_db_session_closes_and_rolls_back_on_error(tracking_sessions):
+    from app.tools._utils import async_db_session
+
+    with pytest.raises(ValueError, match="boom"):
+        async with async_db_session():
+            raise ValueError("boom")
+
+    session = tracking_sessions[0]
+    assert session.commits == 0
+    assert session.rollbacks == 1
+    assert session.closes == 1
+
+
+@pytest.mark.asyncio
+async def test_async_db_session_closes_on_cancellation(tracking_sessions):
+    """Cancellation must still close the session (finally path).
+
+    Characterization note: CancelledError is BaseException, so the
+    ``except Exception`` rollback branch is intentionally skipped — only
+    the finally/close guarantee is asserted here.
+    """
+    from app.tools._utils import async_db_session
+
+    entered = asyncio.Event()
+
+    async def _use_session():
+        async with async_db_session():
+            entered.set()
+            await asyncio.Event().wait()  # park until cancelled
+
+    task = asyncio.create_task(_use_session())
+    await asyncio.wait_for(entered.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    session = tracking_sessions[0]
+    assert session.commits == 0
+    assert session.closes == 1
+
+
+# ─── F16: ConnectionManager.broadcast ───────────────────────────────────────
+
+
+class _HealthyWS:
+    def __init__(self):
+        self.sent = []
+
+    async def accept(self):
+        pass
+
+    async def send_json(self, message):
+        self.sent.append(message)
+
+
+class _StuckWS:
+    """send_json parks forever — simulates a dead-but-not-errored socket."""
+
+    def __init__(self):
+        self.release = asyncio.Event()
+        self.closed = False
+
+    async def accept(self):
+        pass
+
+    async def send_json(self, message):
+        await self.release.wait()
+
+    async def close(self):
+        self.closed = True
+
+
+class _FailingWS:
+    def __init__(self):
+        self.attempts = 0
+        self.closed = False
+
+    async def accept(self):
+        pass
+
+    async def send_json(self, message):
+        self.attempts += 1
+        raise RuntimeError("socket dead")
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def fast_ws_timeout(monkeypatch):
+    """Shrink the per-send bound so tests don't pay the production timeout."""
+    import app.services.ws_service as ws_module
+
+    monkeypatch.setattr(ws_module, "WS_SEND_TIMEOUT", 0.05, raising=False)
+    return ws_module
+
+
+@pytest.mark.asyncio
+async def test_broadcast_stuck_socket_does_not_block_healthy(fast_ws_timeout):
+    """F16 repro: stuck socket first in the list must not starve later sockets."""
+    ws_module = fast_ws_timeout
+    mgr = ws_module.ConnectionManager()
+    stuck, healthy = _StuckWS(), _HealthyWS()
+    await mgr.connect(stuck, "s1")
+    await mgr.connect(healthy, "s1")
+
+    # Outer bound only to turn "hangs forever" (old behavior) into a failure.
+    await asyncio.wait_for(mgr.broadcast("s1", {"event": "x"}), timeout=5)
+
+    assert healthy.sent == [{"event": "x"}]
+    # Stuck socket evicted AND closed; healthy one kept.
+    remaining = mgr.active_connections.get("s1", [])
+    assert stuck not in remaining
+    assert healthy in remaining
+    assert stuck.closed is True, "an evicted socket must be closed, not left parked"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_evicts_failed_socket(fast_ws_timeout):
+    ws_module = fast_ws_timeout
+    mgr = ws_module.ConnectionManager()
+    failing, healthy = _FailingWS(), _HealthyWS()
+    await mgr.connect(failing, "s1")
+    await mgr.connect(healthy, "s1")
+
+    await mgr.broadcast("s1", {"event": "x"})
+
+    assert failing.attempts == 1
+    assert healthy.sent == [{"event": "x"}]
+    remaining = mgr.active_connections.get("s1", [])
+    assert failing not in remaining
+    assert healthy in remaining
+    assert failing.closed is True, "an evicted socket must be closed, not left parked"
+
+    # Evicted socket must not receive (or error on) later broadcasts.
+    await mgr.broadcast("s1", {"event": "y"})
+    assert failing.attempts == 1
+    assert healthy.sent == [{"event": "x"}, {"event": "y"}]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_round_bounded_by_single_timeout_with_stuck_sockets(fast_ws_timeout):
+    """P2 (round-2 review): sends are CONCURRENT — N stalled sockets cost ~one
+    WS_SEND_TIMEOUT per round, not N× (sequential sends were N×WS_SEND_TIMEOUT).
+    3 stuck sockets at a 0.1s timeout would take >= 0.3s sequentially; the
+    concurrent round finishes well under that, and every evicted socket is
+    closed."""
+    ws_module = fast_ws_timeout
+    ws_module.WS_SEND_TIMEOUT = 0.1
+    mgr = ws_module.ConnectionManager()
+    stuck = [_StuckWS() for _ in range(3)]
+    healthy = _HealthyWS()
+    for ws in stuck:
+        await mgr.connect(ws, "s1")
+    await mgr.connect(healthy, "s1")
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    await mgr.broadcast("s1", {"event": "x"})
+    elapsed = loop.time() - start
+
+    assert healthy.sent == [{"event": "x"}]
+    assert elapsed < 0.25, (
+        f"concurrent round must complete within ~one timeout, took {elapsed:.3f}s"
+    )
+    remaining = mgr.active_connections.get("s1", [])
+    for ws in stuck:
+        assert ws not in remaining
+        assert ws.closed is True
+    assert healthy in remaining
+
+
+@pytest.mark.asyncio
+async def test_broadcast_healthy_sockets_no_message_loss(fast_ws_timeout):
+    ws_module = fast_ws_timeout
+    mgr = ws_module.ConnectionManager()
+    sockets = [_HealthyWS() for _ in range(3)]
+    for ws in sockets:
+        await mgr.connect(ws, "s1")
+
+    for i in range(3):
+        await mgr.broadcast("s1", {"event": f"m{i}"})
+
+    for ws in sockets:
+        assert ws.sent == [{"event": "m0"}, {"event": "m1"}, {"event": "m2"}]
+    assert len(mgr.active_connections["s1"]) == 3
+
+
+# ─── F11 + F15-wiring + repeated-lifecycle invariant ────────────────────────
+
+
+class _FakeAsyncEngine:
+    def __init__(self):
+        self.dispose_calls = 0
+
+    async def dispose(self):
+        self.dispose_calls += 1
+
+
+def _drive_lifespan_cycles(monkeypatch, cycles: int):
+    """Drive ``lifespan(app)`` through N full startup/shutdown cycles in one loop.
+
+    Returns (fake_async_engine, drain_calls, orphans_per_cycle, cycle_errors).
+    Module globals (init_db / AsyncEngine / drain_background_tasks) are
+    monkeypatched per the established tests/test_sse_resume.py pattern.
+    """
+    import app.core.database as db_module
+    import app.main as main_module
+
+    monkeypatch.setattr(db_module, "init_db", lambda: None)
+
+    fake_async_engine = _FakeAsyncEngine()
+    monkeypatch.setattr(db_module, "AsyncEngine", fake_async_engine)
+
+    drain_calls = []
+
+    async def fake_drain(timeout: float = 5.0):
+        drain_calls.append(timeout)
+
+    monkeypatch.setattr(main_module, "drain_background_tasks", fake_drain)
+
+    orphans_per_cycle = []
+    cycle_errors = []
+
+    async def _drive():
+        for _ in range(cycles):
+            baseline = asyncio.all_tasks()
+            async with main_module.lifespan(main_module.app):
+                # First async DB use of the cycle must not hit a closed loop.
+                try:
+                    from app.tools._utils import async_db_session
+
+                    async with async_db_session() as db:
+                        await db.commit()
+                except Exception as e:  # noqa: BLE001
+                    cycle_errors.append(e)
+            orphans_per_cycle.append(asyncio.all_tasks() - baseline)
+
+    asyncio.run(_drive())
+    return fake_async_engine, drain_calls, orphans_per_cycle, cycle_errors
+
+
+def test_lifespan_shutdown_disposes_async_engine(monkeypatch, tracking_sessions):
+    """F11: every shutdown must dispose the async engine, not just the sync one."""
+    fake_async_engine, _, _, _ = _drive_lifespan_cycles(monkeypatch, cycles=2)
+    assert fake_async_engine.dispose_calls == 2
+
+
+def test_lifespan_shutdown_drains_background_tasks(monkeypatch, tracking_sessions):
+    """F15-wiring: lifespan shutdown calls drain_background_tasks each cycle."""
+    _, drain_calls, _, _ = _drive_lifespan_cycles(monkeypatch, cycles=2)
+    assert drain_calls == [5.0, 5.0]
+
+
+def test_repeated_lifespan_cycles_leave_no_orphans(monkeypatch, tracking_sessions):
+    """Invariant: 3 cycles — no orphan tasks, no 'Event loop is closed' on
+    the next cycle's first async DB use, async engine disposed every cycle."""
+    fake_async_engine, drain_calls, orphans_per_cycle, cycle_errors = (
+        _drive_lifespan_cycles(monkeypatch, cycles=3)
+    )
+
+    assert fake_async_engine.dispose_calls == 3
+    assert len(drain_calls) == 3
+    for i, orphans in enumerate(orphans_per_cycle):
+        names = [getattr(t.get_coro(), "__qualname__", repr(t)) for t in orphans]
+        assert not orphans, f"cycle {i}: orphan asyncio tasks after shutdown: {names}"
+    closed_loop_errors = [
+        e for e in cycle_errors if "Event loop is closed" in str(e)
+    ]
+    assert not closed_loop_errors, (
+        f"async DB use after shutdown hit a closed loop: {closed_loop_errors}"
+    )
+    assert not cycle_errors, f"unexpected errors during cycles: {cycle_errors}"

--- a/tests/test_runtime_chaos_pi.py
+++ b/tests/test_runtime_chaos_pi.py
@@ -1,0 +1,521 @@
+"""Runtime-chaos hardening tests for the Pi bridge / RPC client (WP-PI).
+
+Covers four defects, one test class each:
+
+  - F5:  ``PiBridge.abort(session_id=...)`` must not kill a DIFFERENT
+    session's in-flight turn on the singleton bridge.
+  - F10: the stall-timeout path (``PI_EVENT_STREAM_TIMEOUT``) must send the
+    abort RPC, not just yield error+done while Pi keeps executing tools.
+  - F19: ``PiRpcClient.request`` must drop its ``_pending_requests`` entry
+    when the caller is cancelled (previously only TimeoutError/BrokenPipeError
+    popped it).
+  - F24: the Pi HTTP-callback ``dispatch_tool`` must run under the active
+    turn's ``CancellationToken`` so checkpoint()-cooperative tools stop when
+    the turn is aborted.
+
+Deterministic: fake RPC clients with asyncio.Queue event streams, Event
+barriers, and tiny patched timeout constants (no wall-clock-dependent
+assertions).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app import agent_pi_bridge as bridge_mod
+from app.agent_pi_bridge import PiBridge, PiToolRequest, dispatch_tool
+from app.services.chat.pi_rpc_client import PiRpcClient
+from app.services.jobs.cancellation import (
+    OperationCancelled,
+    checkpoint,
+    current_token,
+)
+from app.services.tool_dispatch_service import ToolDispatchResult
+from tests.fixtures.pi_mocks import make_token_event
+
+
+# ── shared fakes ─────────────────────────────────────────────────────
+
+
+def _make_rpc(seed_events: list[dict] | None = None) -> MagicMock:
+    """MagicMock PiRpcClient: ``prompt`` seeds events, ``abort`` is recorded.
+
+    No ``agent_end`` is seeded unless asked, so the turn parks awaiting the
+    next event — the mid-turn state every chaos test here needs.
+    """
+    rpc = MagicMock()
+    rpc.events = asyncio.Queue()
+    rpc.start = AsyncMock()
+    rpc.stop = AsyncMock()
+    rpc.process_died = False
+    rpc.fail_all_pending = MagicMock()
+
+    async def _request(cmd: str, data: dict | None = None):
+        if cmd == "prompt":
+            for ev in seed_events or []:
+                await rpc.events.put(ev)
+            return {"ok": True}
+        if cmd == "abort":
+            return {"ok": True}
+        return {}
+
+    rpc.request = AsyncMock(side_effect=_request)
+    return rpc
+
+
+def _rpc_commands(rpc: MagicMock) -> list[str]:
+    return [c.args[0] for c in rpc.request.call_args_list if c.args]
+
+
+@pytest.fixture(autouse=True)
+def _clean_bridge_state():
+    bridge_mod._session_executed_sets.clear()
+    bridge_mod._dispatch_result_cache.clear()
+    yield
+    bridge_mod._session_executed_sets.clear()
+    bridge_mod._dispatch_result_cache.clear()
+
+
+# ── F5: session-scoped abort ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_abort_skips_when_other_session_turn_in_flight(caplog):
+    """F5: abort(session_id=B) while session A's turn is in flight must NOT
+    send the global abort RPC nor fail pending futures — that would kill A's
+    turn (the singleton bridge serializes turns; the in-flight turn owns the
+    subprocess). It must log a warning instead.
+    """
+    rpc = _make_rpc([make_token_event("hi")])
+    bridge = PiBridge(rpc=rpc)
+
+    gen = bridge.stream_prompt("hi", session_id="sess-A")
+    first = await gen.__anext__()
+    assert "task_start" in first  # turn A is in flight, parked on next event
+
+    with caplog.at_level(logging.WARNING, logger="app.agent_pi_bridge"):
+        result = await bridge.abort(session_id="sess-B")
+
+    assert result == {}
+    assert "abort" not in _rpc_commands(rpc), (
+        f"abort RPC must be skipped when another session's turn is in flight; "
+        f"calls={_rpc_commands(rpc)}"
+    )
+    rpc.fail_all_pending.assert_not_called()
+    assert any(
+        "sess-B" in rec.message and "sess-A" in rec.message
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    ), "a warning naming both sessions must be logged"
+
+    # Cleanup: disconnecting turn A still aborts (existing B-P0-1 behavior).
+    await gen.aclose()
+    assert "abort" in _rpc_commands(rpc)
+
+
+@pytest.mark.asyncio
+async def test_abort_proceeds_for_matching_session_and_when_idle():
+    """F5 contract: abort(session_id) matching the active turn — or called
+    while no turn is active — behaves exactly as the old unscoped abort.
+    """
+    rpc = _make_rpc([make_token_event("hi")])
+    bridge = PiBridge(rpc=rpc)
+
+    # Idle bridge: session_id given, no turn in flight -> abort fires.
+    result = await bridge.abort(session_id="sess-idle")
+    assert result == {"ok": True}
+    assert "abort" in _rpc_commands(rpc)
+    rpc.fail_all_pending.assert_called_once_with("abort requested")
+
+    rpc.request.reset_mock()
+    rpc.fail_all_pending.reset_mock()
+
+    # Matching session: abort fires while the turn is parked mid-stream.
+    gen = bridge.stream_prompt("hi", session_id="sess-A")
+    first = await gen.__anext__()
+    assert "task_start" in first
+    result = await bridge.abort(session_id="sess-A")
+    assert result == {"ok": True}
+    assert "abort" in _rpc_commands(rpc)
+    rpc.fail_all_pending.assert_called_once_with("abort requested")
+
+    await gen.aclose()
+
+
+# ── F10: stall timeout must abort ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stall_timeout_sends_abort_and_terminates_stream(monkeypatch):
+    """F10: when Pi goes silent past PI_EVENT_STREAM_TIMEOUT the stream must
+    tell Pi to abort (same bounded shielded abort as the disconnect path) —
+    otherwise Pi keeps executing tools up to the 300s RPC timeout and a user
+    retry duplicates side effects.
+    """
+    monkeypatch.setattr(bridge_mod, "PI_HEARTBEAT_INTERVAL", 0.02)
+    monkeypatch.setattr(bridge_mod, "PI_EVENT_STREAM_TIMEOUT", 0.05)
+
+    rpc = _make_rpc([make_token_event("partial")])
+    bridge = PiBridge(rpc=rpc)
+
+    events = [ev async for ev in bridge.stream_prompt("hi", session_id="sess-stall")]
+
+    # The abort RPC was sent even though the client never disconnected.
+    assert "abort" in _rpc_commands(rpc), (
+        f"stall-timeout must send the abort RPC; calls={_rpc_commands(rpc)}"
+    )
+
+    # Terminal sequence: an error event, then done, and NOTHING after done —
+    # no late Pi event may be processed once the turn is declared stalled.
+    structured = [e for e in events if not e.startswith(":")]
+    assert structured[-1].startswith("event: done"), structured
+    assert structured[-2].startswith("event: error"), structured
+    assert "stalled" in structured[-2]
+
+    # Leftover events were drained so the next turn starts clean.
+    assert rpc.events.empty()
+    assert bridge._lock.locked() is False
+
+
+@pytest.mark.asyncio
+async def test_stall_abort_also_cancels_turn_token(monkeypatch):
+    """F10+F24 integration: the stall-path abort ignites the turn's
+    CancellationToken, so a dispatch in flight via the HTTP callback stops at
+    its next checkpoint()."""
+    monkeypatch.setattr(bridge_mod, "PI_HEARTBEAT_INTERVAL", 0.02)
+    monkeypatch.setattr(bridge_mod, "PI_EVENT_STREAM_TIMEOUT", 0.05)
+
+    class _StubRegistry:
+        def list_tools(self):
+            return ["query_map_features"]
+
+        def metadata(self, name):
+            return {"tier": 1}
+
+    monkeypatch.setattr(bridge_mod, "get_tool_registry", lambda: _StubRegistry())
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    observed_tokens: list = []
+
+    async def _fake_dispatch(self, tc, session_id, executed):
+        observed_tokens.append(current_token())
+        started.set()
+        await release.wait()
+        checkpoint()  # cooperative cancellation point
+        return ToolDispatchResult(
+            status="ok", llm_payload="ok", slim_event={}, geojson_ref=None,
+            raw_result={}, error_msg=None,
+        )
+
+    monkeypatch.setattr(bridge_mod.ToolDispatchService, "dispatch", _fake_dispatch)
+
+    rpc = _make_rpc([])  # no events at all -> immediate stall
+    bridge = PiBridge(rpc=rpc)
+
+    async def _consume():
+        return [ev async for ev in bridge.stream_prompt("hi", session_id="sess-stall2")]
+
+    stream = asyncio.create_task(_consume())
+    # Wait for the turn to be active, then dispatch a tool via the callback.
+    for _ in range(1000):
+        if bridge._active_turn_sid == "sess-stall2":
+            break
+        await asyncio.sleep(0)
+    dispatch = asyncio.create_task(dispatch_tool(PiToolRequest(
+        name="query_map_features", toolCallId="tc-stall", arguments={},
+        sessionId=None,
+    )))
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+
+    events = await stream  # stall fires -> abort -> token cancelled
+    assert any(e.startswith("event: error") for e in events)
+
+    token = observed_tokens[0]
+    assert token is not None, "dispatch must run under the turn's token"
+    assert token.cancelled, "stall-path abort must cancel the turn token"
+
+    release.set()
+    with pytest.raises(OperationCancelled):
+        await dispatch
+
+
+# ── F19: request() cancellation must clear _pending_requests ─────────
+
+
+@pytest.mark.asyncio
+async def test_request_cancellation_clears_pending_request():
+    """F19: cancelling a caller of PiRpcClient.request must not leak the
+    _pending_requests entry — a later response for that id would resolve a
+    dead future and the registry would grow by one entry per cancelled call.
+    """
+    client = PiRpcClient()
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+    client._process = mock_proc
+
+    task = asyncio.create_task(client.request("prompt", {"message": "hi"}))
+    for _ in range(1000):
+        if client._pending_requests:
+            break
+        await asyncio.sleep(0)
+    assert client._pending_requests, "request never registered its future"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert client._pending_requests == {}, (
+        f"cancelled request leaked pending entries: {client._pending_requests}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_normal_response_path_still_pops():
+    """F19 guard: the finally-pop must not break normal response delivery —
+    _handle_response pops and resolves the future, request returns its data.
+    """
+    client = PiRpcClient()
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+    client._process = mock_proc
+
+    task = asyncio.create_task(client.request("get_state", {}))
+    for _ in range(1000):
+        if client._pending_requests:
+            break
+        await asyncio.sleep(0)
+    rid = next(iter(client._pending_requests))
+    await client._handle_response(
+        {"type": "response", "id": rid, "success": True, "data": {"state": "ok"}}
+    )
+    assert await task == {"state": "ok"}
+    assert client._pending_requests == {}
+
+
+# ── F24: HTTP-callback dispatch bound to the turn's token ────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_binds_active_turn_cancellation_token(monkeypatch):
+    """F24: dispatch_tool (Pi HTTP callback) must run under the active turn's
+    CancellationToken so abort/disconnect stops checkpoint()-cooperative
+    tools instead of letting them run to completion against an abandoned turn.
+    """
+    class _StubRegistry:
+        def list_tools(self):
+            return ["query_map_features"]
+
+        def metadata(self, name):
+            return {"tier": 1}
+
+    monkeypatch.setattr(bridge_mod, "get_tool_registry", lambda: _StubRegistry())
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    observed_tokens: list = []
+
+    async def _fake_dispatch(self, tc, session_id, executed):
+        observed_tokens.append(current_token())
+        started.set()
+        await release.wait()
+        checkpoint()  # raises OperationCancelled once the token is ignited
+        return ToolDispatchResult(
+            status="ok", llm_payload="ok", slim_event={}, geojson_ref=None,
+            raw_result={}, error_msg=None,
+        )
+
+    monkeypatch.setattr(bridge_mod.ToolDispatchService, "dispatch", _fake_dispatch)
+
+    rpc = _make_rpc([make_token_event("hi")])
+    bridge = PiBridge(rpc=rpc)
+
+    gen = bridge.stream_prompt("hi", session_id="sess-cancel")
+    first = await gen.__anext__()
+    assert "task_start" in first  # turn parked mid-stream
+
+    dispatch = asyncio.create_task(dispatch_tool(PiToolRequest(
+        name="query_map_features", toolCallId="tc-1", arguments={},
+        sessionId=None,
+    )))
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+
+    # Client disconnects -> finally aborts -> turn token ignites.
+    await gen.aclose()
+
+    token = observed_tokens[0]
+    assert token is not None, (
+        "dispatch_tool must bind the active turn's CancellationToken via "
+        "use_token so in-flight tools observe abort"
+    )
+    assert token.cancelled, "abort must ignite the bound token"
+
+    release.set()
+    with pytest.raises(OperationCancelled):
+        await dispatch
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_without_active_turn_runs_uncancelled(monkeypatch):
+    """F24 guard: with no active turn the token is None and dispatch behaves
+    exactly as before (use_token(None) is a no-op)."""
+    class _StubRegistry:
+        def list_tools(self):
+            return ["query_map_features"]
+
+        def metadata(self, name):
+            return {"tier": 1}
+
+    monkeypatch.setattr(bridge_mod, "get_tool_registry", lambda: _StubRegistry())
+    observed_tokens: list = []
+
+    async def _fake_dispatch(self, tc, session_id, executed):
+        observed_tokens.append(current_token())
+        return ToolDispatchResult(
+            status="ok", llm_payload="ok", slim_event={}, geojson_ref=None,
+            raw_result={}, error_msg=None,
+        )
+
+    monkeypatch.setattr(bridge_mod.ToolDispatchService, "dispatch", _fake_dispatch)
+
+    resp = await dispatch_tool(PiToolRequest(
+        name="query_map_features", toolCallId="tc-solo", arguments={},
+        sessionId=None,
+    ))
+    assert resp.isError is False
+    assert observed_tokens == [None]
+
+
+# ── P1 round-2: prompt() must publish the active-turn markers ─────────
+
+
+@pytest.mark.asyncio
+async def test_prompt_publishes_active_turn_markers(monkeypatch, caplog):
+    """P1: prompt() (non-streaming Pi path) must set/clear
+    _active_turn_sid/_active_turn_token like stream_prompt — otherwise
+    abort(session_id=other) sees active=None and the GLOBAL abort kills this
+    turn, and dispatch_tool binds no token (F24 no-op) on this path."""
+    class _StubRegistry:
+        def list_tools(self):
+            return ["query_map_features"]
+
+        def metadata(self, name):
+            return {"tier": 1}
+
+    monkeypatch.setattr(bridge_mod, "get_tool_registry", lambda: _StubRegistry())
+    monkeypatch.setattr(bridge_mod, "PI_EVENT_DRAIN_TIMEOUT", 3600.0)  # park the drain
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    observed_tokens: list = []
+
+    async def _fake_dispatch(self, tc, session_id, executed):
+        observed_tokens.append(current_token())
+        started.set()
+        await release.wait()
+        checkpoint()  # raises OperationCancelled once the token is ignited
+        return ToolDispatchResult(
+            status="ok", llm_payload="ok", slim_event={}, geojson_ref=None,
+            raw_result={}, error_msg=None,
+        )
+
+    monkeypatch.setattr(bridge_mod.ToolDispatchService, "dispatch", _fake_dispatch)
+
+    rpc = _make_rpc([make_token_event("hi")])  # one event, no agent_end
+    bridge = PiBridge(rpc=rpc)
+
+    prompt_task = asyncio.create_task(bridge.prompt("hi", session_id="sess-P"))
+    for _ in range(1000):
+        if bridge._active_turn_sid == "sess-P":
+            break
+        await asyncio.sleep(0)
+    assert bridge._active_turn_sid == "sess-P", (
+        "prompt() did not publish the active sid (P1)"
+    )
+
+    # F5: abort for ANOTHER session is skipped (would otherwise be a global kill)
+    with caplog.at_level(logging.WARNING, logger="app.agent_pi_bridge"):
+        result = await bridge.abort(session_id="sess-OTHER")
+    assert result == {}
+    assert any(
+        "sess-OTHER" in rec.message and "sess-P" in rec.message
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    ), "abort for another session must be skipped + logged during prompt()"
+    rpc.fail_all_pending.assert_not_called()
+
+    rpc.request.reset_mock()
+    rpc.fail_all_pending.reset_mock()
+
+    # F5: abort for the ACTIVE session proceeds
+    result = await bridge.abort(session_id="sess-P")
+    assert result == {"ok": True}
+    assert "abort" in _rpc_commands(rpc)
+    rpc.fail_all_pending.assert_called_once_with("abort requested")
+
+    # F24: dispatch during prompt() is bound to the turn's token
+    dispatch = asyncio.create_task(dispatch_tool(PiToolRequest(
+        name="query_map_features", toolCallId="tc-prompt", arguments={},
+        sessionId=None,
+    )))
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    token = observed_tokens[0]
+    assert token is not None, "dispatch during prompt() must bind the turn token"
+    assert token.cancelled, "abort must ignite the prompt-turn token"
+
+    release.set()
+    with pytest.raises(OperationCancelled):
+        await dispatch
+
+    # teardown: cancel the parked prompt turn; markers + lock must clear
+    prompt_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await prompt_task
+    assert bridge._active_turn_sid is None
+    assert bridge_mod._active_turn_token is None
+
+
+# ── P1 round-2: abort() TOCTOU sid re-read ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_abort_toctou_sid_flip_logs_warning(caplog):
+    """P1: abort() reads _active_turn_sid lock-free, then awaits the abort
+    RPC — in that gap the matched turn can end and a different session's
+    turn start, so the GLOBAL abort kills the wrong turn. The post-RPC
+    re-read must log a warning naming both sessions and must not raise."""
+    rpc = _make_rpc([make_token_event("hi")])
+    bridge = PiBridge(rpc=rpc)
+
+    original_request = rpc.request
+
+    async def flipping_request(cmd, data=None):
+        if cmd == "abort":
+            # Simulate the flip DURING the abort RPC: the matched turn ends
+            # and a different session's turn takes over the bridge.
+            bridge._active_turn_sid = "sess-OTHER"
+            return {"ok": True}
+        return await original_request(cmd, data)
+
+    rpc.request = AsyncMock(side_effect=flipping_request)
+
+    gen = bridge.stream_prompt("hi", session_id="sess-A")
+    first = await gen.__anext__()
+    assert "task_start" in first  # turn A in flight
+
+    with caplog.at_level(logging.WARNING, logger="app.agent_pi_bridge"):
+        result = await bridge.abort(session_id="sess-A")
+
+    assert result == {"ok": True}
+    assert any(
+        "TOCTOU" in rec.message
+        and "sess-A" in rec.message
+        and "sess-OTHER" in rec.message
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    ), "sid flip during the abort RPC must log a TOCTOU warning (P1)"
+
+    await gen.aclose()

--- a/tests/test_runtime_chaos_plan_mode.py
+++ b/tests/test_runtime_chaos_plan_mode.py
@@ -1,0 +1,255 @@
+"""Runtime chaos tests for plan_mode.execute_plan_async（WP-PLAN / F6）。
+
+缺陷 F6：execute_plan_async 用 asyncio.create_task 派发整波工具任务，但没有
+try/finally 兜底。若外层 task 被取消（客户端断连）：
+- pending 的波次任务继续跑到完成 —— GIS 工具在 turn 结束后仍产生副作用；
+- __status__ 停留在 'running'，之后所有 execute_plan 都被
+  「plan 已在执行中」拒绝（永久卡死）。
+
+测试完全确定性：工具协程用 asyncio.Event 门控，无任何 wall-clock sleep。
+"""
+import asyncio
+
+import pytest
+
+from app.services import plan_mode as svc
+from app.tools.registry import ToolRegistry
+
+
+@pytest.fixture
+def registry():
+    return ToolRegistry()
+
+
+def _register_gated_tool(
+    registry: ToolRegistry,
+    name: str,
+    release: asyncio.Event,
+    started_counter: dict,
+    all_started: asyncio.Event,
+    total: int,
+    state: dict,
+) -> None:
+    """注册一个门控 async 工具：等待 release 事件；记录 cancelled/completed。
+
+    async 函数在 registry 里默认 ASYNC policy（事件循环内直接 await），
+    因此取消能真实传播进 ``release.wait()``。
+    """
+
+    @registry.tool(name=name, description=f"gated tool {name}")
+    async def _gated() -> dict:
+        started_counter["n"] += 1
+        if started_counter["n"] == total:
+            all_started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            state["cancelled"] = True
+            raise
+        state["completed"] = True
+        return {"success": True, "data": {"tool": name}}
+
+
+@pytest.mark.asyncio
+async def test_f6_cancel_mid_wave_cancels_pending_tasks_and_converges_status(registry):
+    """波次执行中取消外层 task：兄弟任务必须全部被取消回收，状态收敛到终态。"""
+    sid = "sess-chaos-f6-cancel"
+    release = asyncio.Event()
+    all_started = asyncio.Event()
+    counter = {"n": 0}
+    states = {}
+    for name in ("g1", "g2", "g3"):
+        states[name] = {"cancelled": False, "completed": False}
+        _register_gated_tool(registry, name, release, counter, all_started, 3, states[name])
+
+    plan = svc.PlanProposal(
+        title="chaos-cancel",
+        steps=[svc.PlanStep(id=n, tool=n) for n in ("g1", "g2", "g3")],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    baseline = asyncio.all_tasks()
+    exec_task = asyncio.create_task(svc.execute_plan_async(sid, plan_id, registry))
+    await asyncio.wait_for(all_started.wait(), timeout=10)
+
+    exec_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await exec_task
+
+    # (a) 所有兄弟任务收到取消；没有任何一个在取消后跑到完成
+    for name, st in states.items():
+        assert st["cancelled"], f"{name} 未收到取消（任务泄漏，仍在运行）"
+        assert not st["completed"], f"{name} 在取消后仍跑完（副作用窗口）"
+
+    # (b) plan 状态收敛到非 running 终态
+    plan_data = await svc.load_plan(sid, plan_id)
+    assert plan_data["__status__"] == "cancelled"
+
+    # (d) 任务集合回到基线（无泄漏的 pending task）
+    assert asyncio.all_tasks() - baseline == set()
+
+    # (c) 后续 execute_plan 不再被「已在执行中」拒绝。
+    # 347 P1-C: cancelled 是终态，resume 必须拒绝（不是卡在 running）。
+    release.set()
+    result = await svc.execute_plan_async(sid, plan_id, registry)
+    assert "已在执行中" not in str(result.get("error", ""))
+    assert result["success"] is False
+    assert result.get("status") == "cancelled" or "已取消" in str(result.get("error", ""))
+
+
+@pytest.mark.asyncio
+async def test_f6_cancel_during_failure_drain_also_converges(registry):
+    """兄弟失败后的 drain（asyncio.wait 无超时）阶段被取消，同样必须收敛。
+
+    f_fail 等两个门控兄弟都启动后立即失败 → execute_plan 进入 failure-drain
+    （等待 g1/g2 收尾）。此刻取消外层 task：g1/g2 必须被取消回收，
+    __status__ 收敛，后续 execute_plan 不被拒绝。
+    """
+    sid = "sess-chaos-f6-drain"
+    release = asyncio.Event()
+    both_started = asyncio.Event()
+    failing_returned = asyncio.Event()
+    counter = {"n": 0}
+    states = {n: {"cancelled": False, "completed": False} for n in ("g1", "g2")}
+    for name in ("g1", "g2"):
+        _register_gated_tool(registry, name, release, counter, both_started, 2, states[name])
+
+    @registry.tool(name="f_fail", description="等兄弟启动后立刻失败")
+    async def _f_fail() -> dict:
+        await asyncio.wait_for(both_started.wait(), timeout=10)
+        failing_returned.set()
+        return {"success": False, "code": "TOOL_ERROR", "message": "boom"}
+
+    plan = svc.PlanProposal(
+        title="chaos-drain",
+        steps=[
+            svc.PlanStep(id="g1", tool="g1"),
+            svc.PlanStep(id="g2", tool="g2"),
+            svc.PlanStep(id="f1", tool="f_fail"),
+        ],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    baseline = asyncio.all_tasks()
+    exec_task = asyncio.create_task(svc.execute_plan_async(sid, plan_id, registry))
+    await asyncio.wait_for(failing_returned.wait(), timeout=10)
+    # 让执行循环消费掉 f_fail 的 done 事件并进入 drain（纯调度 yield，非 wall-clock）。
+    # 注意：无论取消落在 FIRST_COMPLETED 循环还是 drain 的 asyncio.wait，
+    # 修复后的行为都必须一致，因此此处的调度位置不影响断言正确性。
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    exec_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await exec_task
+
+    for name, st in states.items():
+        assert st["cancelled"], f"{name} 在 drain 取消时未被回收"
+        assert not st["completed"], f"{name} 在取消后仍跑完"
+
+    plan_data = await svc.load_plan(sid, plan_id)
+    assert plan_data["__status__"] in ("cancelled", "failed")
+    assert plan_data["__status__"] != "running"
+
+    assert asyncio.all_tasks() - baseline == set()
+
+    # 后续 execute_plan 不被「已在执行中」拒绝。
+    # drain 取消后状态是 cancelled（347 拒绝 resume）或 failed（首达终态 /
+    # livelock 守卫会再次失败），两种都证明没有卡在 running。
+    release.set()
+    result = await svc.execute_plan_async(sid, plan_id, registry)
+    assert "已在执行中" not in str(result.get("error", ""))
+    assert result["success"] is False
+    if result.get("failed_step") is not None:
+        assert result["failed_step"] == "f1"
+    else:
+        assert result.get("status") == "cancelled" or "已取消" in str(result.get("error", ""))
+
+
+# ─── P2: 计划状态首达终态获胜 + 收敛写失败不替换原始异常 ──────────
+
+
+@pytest.mark.asyncio
+async def test_plan_status_first_terminal_wins():
+    """P2: update_plan_status 首达终态获胜 —— 一旦 completed/failed/cancelled，
+    后到的终态/非终态写入都不能覆盖（失败分支写 failed 后，并发取消不能把它
+    翻成 cancelled，反之亦然；终态也不能被 running 复活）。"""
+    sid = "sess-chaos-terminal-wins"
+    plan = svc.PlanProposal(
+        title="first-terminal",
+        steps=[svc.PlanStep(id="s1", tool="g1")],
+    )
+
+    # failed 先到达，cancelled 后到 —— 不能翻转
+    plan_id = await svc.store_plan(sid, plan)
+    await svc.update_plan_status(sid, plan_id, __status__="failed", __error__="boom")
+    await svc.update_plan_status(sid, plan_id, __status__="cancelled", __error__="cancelled")
+    data = await svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "failed", "cancelled overwrote failed (P2 first-terminal-wins)"
+    assert data["__error__"] == "boom"
+
+    # cancelled 先到达，failed 后到不翻转；running 也不能复活终态
+    plan_id2 = await svc.store_plan(sid, plan)
+    await svc.update_plan_status(sid, plan_id2, __status__="cancelled")
+    await svc.update_plan_status(sid, plan_id2, __status__="failed", __error__="late")
+    await svc.update_plan_status(sid, plan_id2, __status__="running")
+    data2 = await svc.load_plan(sid, plan_id2)
+    assert data2["__status__"] == "cancelled", "failed/running overwrote cancelled (P2)"
+    assert "__error__" not in data2, "companion fields of a losing write leaked"
+
+    # 非终态更新不受影响（pending -> running）
+    plan_id3 = await svc.store_plan(sid, plan)
+    await svc.update_plan_status(sid, plan_id3, __status__="running")
+    assert (await svc.load_plan(sid, plan_id3))["__status__"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_cancel_handler_convergence_write_failure_reraises_cancelled(
+    registry, monkeypatch, caplog
+):
+    """P2: cancel handler 里 update_plan_status 抛错（Redis 抖动）不能替换
+    CancelledError —— 原异常必须原样传播（旧实现把 RuntimeError 抛给调用方，
+    cancel 语义丢失），收敛写失败只记 warning；波次任务照常回收。
+
+    注意：收敛写本身失败时状态停在 running 是存储宕机的真实结果（写没落库）；
+    本修复保证的是「能收敛时收敛、不能时也不吞原始异常」。
+    """
+    import logging as _logging
+
+    sid = "sess-chaos-failwrite"
+    release = asyncio.Event()
+    started = asyncio.Event()
+    counter = {"n": 0}
+    state = {}
+    _register_gated_tool(registry, "g1", release, counter, started, 1, state)
+
+    plan = svc.PlanProposal(
+        title="chaos-failwrite",
+        steps=[svc.PlanStep(id="g1", tool="g1")],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    real_update = svc.update_plan_status
+
+    async def flaky_update(sid_, pid_, **updates):
+        if updates.get("__status__") in ("cancelled", "failed"):
+            raise RuntimeError("redis down")
+        await real_update(sid_, pid_, **updates)
+
+    monkeypatch.setattr(svc, "update_plan_status", flaky_update)
+
+    baseline = asyncio.all_tasks()
+    exec_task = asyncio.create_task(svc.execute_plan_async(sid, plan_id, registry))
+    await asyncio.wait_for(started.wait(), timeout=10)
+
+    exec_task.cancel()
+    with caplog.at_level(_logging.WARNING, logger="app.services.plan_mode"):
+        with pytest.raises(asyncio.CancelledError):
+            await exec_task
+
+    # 波次任务全部回收（无泄漏）
+    assert asyncio.all_tasks() - baseline == set()
+    # 收敛写失败被降级为 warning，而不是替换原始 CancelledError
+    assert any("收敛写失败" in r.message for r in caplog.records), (
+        "convergence write failure was not logged as a warning"
+    )

--- a/tests/test_runtime_chaos_resume.py
+++ b/tests/test_runtime_chaos_resume.py
@@ -125,6 +125,7 @@ class _GatedEngine:
         map_state: Optional[dict] = None,
         skill_name: Optional[str] = None,
         user_id: Optional[str] = None,
+        project_id: Optional[str] = None,  # #348: route passes project_id through
     ) -> AsyncIterator[str]:
         self.stream_calls += 1
         if self._queue_second and self.stream_calls == 2:

--- a/tests/test_runtime_chaos_resume.py
+++ b/tests/test_runtime_chaos_resume.py
@@ -1,0 +1,859 @@
+"""Runtime chaos hardening: SSE resume edge cases (WP-ROUTE).
+
+Regression coverage for the resume/turn-lifecycle defects:
+
+  - F2: two concurrent ANONYMOUS (shared ``""`` session key) same-message turns
+    must never replay each other's events — an ambiguous resume fails safe with
+    ``error {resumed: false}`` instead of leaking one user's turn into
+    another's stream (cross-session leak).
+  - F4: a queued/running second POST must not clobber the live turn's resume
+    buffer — resume of turn A works while turn B is queued for the same
+    session, and a reconnect with Last-Event-ID never re-executes completed
+    tool calls (dispatch invocations are counted).
+  - F20: a resume racing a LIVE turn (or a never-yet-started turn) must not
+    fabricate a terminal ``done {resumed: true}`` — it replays the buffered
+    tail, then holds for the real terminal; a stalled turn ends with a
+    truthful ``error {resumed: true, pending: true}`` instead.
+  - F5: DELETE /chat/sessions/{id} passes the deleted session's id to
+    ``pi_bridge.abort(session_id=...)`` (session-blind abort killed OTHER
+    sessions' in-flight turns).
+  - F26: the map-action-ack endpoint distinguishes backend-DROPPED events
+    (e.g. Redis unreachable) from true duplicates via an additive ``dropped``
+    field, so clients can retry real losses.
+
+  - P1 (review follow-up): anonymous (``""``-key) sessions never live-hold a
+    matched turn — the ``""`` key is shared by ALL anonymous clients and skips
+    ownership checks, so holding would let anyone who knows the victim's
+    message + Last-Event-ID tail a stranger's live turn (shadow-stream). An
+    anonymous resume of a live/never-started buffer terminates immediately
+    with the truthful pending error; ended buffers replay as before.
+  - P2 (review follow-up): per-session buffer eviction prefers ENDED buffers,
+    so five concurrent anonymous POSTs can't evict a still-live turn's buffer.
+  - P2 (round-2 review): DELETE /sessions/{X} purges X's resume buffers (a
+    deleted session must not stay replayable); anonymous (''-key) resumes
+    require Last-Event-ID > 0 — id 0 (no proof of prior contact) is refused
+    with a terminal ``error {resumed: false}`` so a stranger can't replay a
+    shared-key turn from the start.
+
+Deterministic: gated fake bridges/engines + asyncio.Event barriers; no wall
+clocks (the only timeout is the monkeypatched live-hold cap set to 0.0 — a
+zero-wait ``asyncio.wait_for`` that raises TimeoutError immediately when the
+event is unset, so the stalled-turn outcome is deterministic and instant).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.requests import Request
+
+import app.services.session_data as session_data_mod
+from app.api.routes import chat as chat_route
+from app.services.chat.event_resume import TurnEventBuffer, TurnResumeRegistry
+from app.services.session_data import MemorySessionStore
+from app.utils.sse import sse_event, sse_event_id
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+class _GatedBridge:
+    """Deterministic Pi bridge with per-call asyncio.Event gates.
+
+    Each ``stream_prompt`` invocation (call index ``idx``):
+      * sets ``entered[idx]`` as soon as the route starts consuming it (the
+        route has registered its resume buffer by then);
+      * with ``idx`` in ``park_before``: waits on ``gates[idx]`` BEFORE the
+        first yield (models a turn queued behind the bridge/engine lock —
+        buffer registered, zero events);
+      * otherwise yields task_start/token/step_result, sets ``parked[idx]``
+        (by then the route has recorded all three into the resume buffer),
+        waits on ``gates[idx]``, then yields token + done.
+    """
+
+    def __init__(self, turns: int = 1, park_before: frozenset[int] = frozenset()) -> None:
+        self.prompt_calls = 0
+        self.entered = [asyncio.Event() for _ in range(turns)]
+        self.parked = [asyncio.Event() for _ in range(turns)]
+        self.gates = [asyncio.Event() for _ in range(turns)]
+        self._park_before = set(park_before)
+
+    async def stream_prompt(
+        self, message: str, session_id: Optional[str] = None
+    ) -> AsyncIterator[str]:
+        idx = self.prompt_calls
+        self.prompt_calls += 1
+        sid = session_id or "s"
+        self.entered[idx].set()
+        if idx in self._park_before:
+            await self.gates[idx].wait()  # queued behind the (simulated) lock
+            yield sse_event("task_start", {"task_id": f"t{idx}", "session_id": sid})
+            yield sse_event("token", {"content": f"a{idx} ", "session_id": sid})
+            yield sse_event("done", {"session_id": sid})
+            return
+        yield sse_event("task_start", {"task_id": f"t{idx}", "session_id": sid})
+        yield sse_event("token", {"content": f"a{idx} ", "session_id": sid})
+        yield sse_event(
+            "step_result",
+            {"tool": "search_poi", "result": {"ok": True}, "session_id": sid},
+        )
+        self.parked[idx].set()
+        await self.gates[idx].wait()
+        yield sse_event("token", {"content": f"b{idx} ", "session_id": sid})
+        yield sse_event("done", {"session_id": sid})
+
+
+class _GatedEngine:
+    """Legacy-path fake engine: counts stream invocations and (simulated)
+    side-effecting tool dispatches. With ``queue_second=True`` the second call
+    parks at entry (queued behind the per-session engine lock) until released.
+    """
+
+    def __init__(self, queue_second: bool = False) -> None:
+        self.stream_calls = 0
+        self.tool_dispatches = 0
+        self.second_entered = asyncio.Event()
+        self.second_gate = asyncio.Event()
+        self._queue_second = queue_second
+
+    async def chat_stream(
+        self,
+        message: str,
+        session_id: Optional[str] = None,
+        map_state: Optional[dict] = None,
+        skill_name: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> AsyncIterator[str]:
+        self.stream_calls += 1
+        if self._queue_second and self.stream_calls == 2:
+            self.second_entered.set()
+            await self.second_gate.wait()
+            return
+        sid = session_id or "s"
+        yield sse_event("task_start", {"task_id": "t", "session_id": sid})
+        yield sse_event("tool_call", {"tool": "search_poi", "call_id": "c1", "session_id": sid})
+        self.tool_dispatches += 1  # side effect: must never happen twice
+        yield sse_event(
+            "step_result",
+            {"tool": "search_poi", "call_id": "c1", "result": {"ok": True}, "session_id": sid},
+        )
+        yield sse_event("token", {"content": "answer", "session_id": sid})
+        yield sse_event("done", {"session_id": sid})
+
+
+def _block_events(chunk: str) -> list[str]:
+    return [p for p in chunk.split("\n\n") if p]
+
+
+def _event_id(block: str) -> Optional[int]:
+    return sse_event_id(block)
+
+
+def _event_type(block: str) -> str:
+    for line in block.split("\n"):
+        if line.startswith("event: "):
+            return line[len("event: "):].strip()
+    return ""
+
+
+async def _drain_into(resp, out: list[str]) -> None:
+    async for chunk in resp.body_iterator:
+        out.extend(_block_events(chunk))
+
+
+async def _until(cond, attempts: int = 500) -> None:
+    """Event-loop-turn barrier (no wall clock): spin on sleep(0) until cond."""
+    for _ in range(attempts):
+        if cond():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("barrier condition not reached")
+
+
+async def _start_stream(message: str, session_id: Optional[str] = None):
+    """POST a turn and consume it in a dedicated task (each stream gets its
+    own task context so per-turn ``sse_event_id_scope`` ContextVars never leak
+    across interleaved streams)."""
+    resp = await chat_route.chat_stream(
+        chat_route.ChatRequest(message=message, session_id=session_id, map_state=None),
+        _user={},
+        owner_token=None,
+        db=None,
+    )
+    out: list[str] = []
+    return out, asyncio.create_task(_drain_into(resp, out))
+
+
+async def _open_resume(message: str, last_event_id: int, session_id: Optional[str] = None):
+    """POST a resume (Last-Event-ID) and consume it in a dedicated task."""
+    resp = await chat_route.chat_stream(
+        chat_route.ChatRequest(message=message, session_id=session_id, map_state=None),
+        _user={},
+        owner_token=None,
+        db=None,
+        last_event_id_header=last_event_id,
+    )
+    out: list[str] = []
+    return out, asyncio.create_task(_drain_into(resp, out))
+
+
+@pytest.fixture(autouse=True)
+def _fresh_resume_registry(monkeypatch):
+    """Isolate the process-local resume registry per test."""
+    monkeypatch.setattr(chat_route, "_turn_resume_registry", TurnResumeRegistry())
+    yield
+
+
+@pytest.fixture
+def _pi_path(monkeypatch):
+    """Force the Pi streaming path; caller installs the fake bridge."""
+
+    def _install(bridge) -> None:
+        monkeypatch.setattr(chat_route, "USE_NEW_AGENT", True)
+        monkeypatch.setattr(chat_route, "pi_bridge", bridge)
+
+    return _install
+
+
+@pytest.fixture
+def _pass_ownership(monkeypatch):
+    """Session-scoped tests call the route with db=None; make the body-session
+    guard see the session as owned (same seam as
+    tests/unit/test_map_action_acks.py::_pass_ownership)."""
+    monkeypatch.setattr(
+        chat_route.AsyncHistoryService,
+        "get_session",
+        AsyncMock(return_value=MagicMock()),
+    )
+
+
+# ─── F2: concurrent anonymous same-message turns never cross-replay ─────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_anonymous_same_message_turns_never_cross_replay(_pi_path):
+    """F2: two live anonymous turns (shared ``""`` key) with the SAME message.
+
+    A resume matches both buffered turns — the route must fail safe with a
+    terminal ``error {resumed: false}`` (client stops auto-retrying; it is
+    never told to resend) instead of replaying one user's turn into the
+    other's stream. No new turn is started.
+    """
+    bridge = _GatedBridge(turns=2)
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("same message")
+    await bridge.parked[0].wait()
+    out_b, task_b = await _start_stream("same message")
+    await bridge.parked[1].wait()
+    assert bridge.prompt_calls == 2
+
+    resumed, rtask = await _open_resume("same message", last_event_id=1)
+    await rtask
+
+    assert bridge.prompt_calls == 2, "a failed-safe resume must never start a turn"
+    assert len(resumed) == 1, (
+        f"ambiguous resume must fail safe, got {[_event_type(b) for b in resumed]}"
+    )
+    assert _event_type(resumed[0]) == "error"
+    assert '"resumed": false' in resumed[0]
+
+    # cleanup: release both live turns
+    bridge.gates[0].set()
+    bridge.gates[1].set()
+    await task_a
+    await task_b
+
+
+@pytest.mark.asyncio
+async def test_single_anonymous_turn_resume_still_works(_pi_path):
+    """F2 companion: with only ONE anonymous turn buffered, the same-message
+    resume is unambiguous and replays normally (the ''-key contract is kept)."""
+    bridge = _GatedBridge(turns=1)
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("solo")
+    await bridge.parked[0].wait()
+    bridge.gates[0].set()
+    await task_a
+    assert [_event_id(b) for b in out_a] == [1, 2, 3, 4, 5]
+
+    resumed, rtask = await _open_resume("solo", last_event_id=2)
+    await rtask
+    assert [_event_id(b) for b in resumed] == [3, 4, 5]
+    assert _event_type(resumed[-1]) == "done"
+    assert bridge.prompt_calls == 1
+
+
+# ─── F4: queued second turn must not clobber the live turn's buffer ─────────
+
+
+@pytest.mark.asyncio
+async def test_resume_turn_a_while_turn_b_queued_same_session(_pi_path, _pass_ownership):
+    """F4(a): turn B (same session, different message) is queued behind the
+    bridge lock — its buffer registration must NOT clobber live turn A's
+    buffer. Resuming A replays A's buffered tail, holds while A is live, then
+    delivers A's real terminal; no turn is re-executed."""
+    bridge = _GatedBridge(turns=2, park_before=frozenset({1}))
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("first", session_id="s9")
+    await bridge.parked[0].wait()
+    # Turn B POSTed while A live: registers its (empty) buffer and parks.
+    out_b, task_b = await _start_stream("second", session_id="s9")
+    await bridge.entered[1].wait()
+    assert bridge.prompt_calls == 2
+
+    resumed, rtask = await _open_resume("first", last_event_id=1, session_id="s9")
+    await _until(lambda: len(resumed) >= 2)  # replayed A's buffered tail 2..3
+    assert [_event_id(b) for b in resumed] == [2, 3]
+
+    bridge.gates[0].set()  # live turn A resumes producing
+    await rtask
+    assert [_event_id(b) for b in resumed] == [2, 3, 4, 5], resumed
+    assert _event_type(resumed[-1]) == "done", "must deliver A's REAL terminal"
+    assert bridge.prompt_calls == 2, "resume never starts a new turn"
+
+    # cleanup: release queued turn B
+    bridge.gates[1].set()
+    await task_a
+    await task_b
+
+
+@pytest.mark.asyncio
+async def test_resume_never_reexecutes_completed_tool_calls(monkeypatch, _pass_ownership):
+    """F4(b), legacy path: turn A completed (its tool dispatched exactly once);
+    turn B is queued behind the engine lock. A reconnect with Last-Event-ID
+    must replay A's tail and NEVER re-dispatch the completed tool call."""
+    engine = _GatedEngine(queue_second=True)
+    monkeypatch.setattr(chat_route, "USE_NEW_AGENT", False)
+    monkeypatch.setattr(chat_route, "pi_bridge", None)
+    monkeypatch.setattr(chat_route, "engine", engine)
+
+    out_a, task_a = await _start_stream("run tool", session_id="s1")
+    await task_a
+    assert [_event_id(b) for b in out_a] == [1, 2, 3, 4, 5]
+    assert engine.stream_calls == 1
+    assert engine.tool_dispatches == 1
+
+    # Turn B queued (buffer registered, no events yet) — must not clobber A.
+    out_b, task_b = await _start_stream("queued work", session_id="s1")
+    await engine.second_entered.wait()
+    assert engine.stream_calls == 2
+
+    resumed, rtask = await _open_resume("run tool", last_event_id=2, session_id="s1")
+    await rtask
+    assert [_event_id(b) for b in resumed] == [3, 4, 5], resumed
+    assert _event_type(resumed[-1]) == "done"
+    assert engine.stream_calls == 2, "resume is a read — no new turn"
+    assert engine.tool_dispatches == 1, "completed tool calls never re-execute"
+
+    # cleanup: release queued turn B
+    engine.second_gate.set()
+    await task_b
+
+
+# ─── F20: resume racing a live/never-started turn must not fabricate done ───
+
+
+@pytest.mark.asyncio
+async def test_resume_racing_live_turn_holds_then_delivers_real_terminal(_pi_path, _pass_ownership):
+    """F20: resume lands mid-turn — replay the buffered tail, HOLD (no fake
+    done), then stream the rest live and end with the turn's real terminal."""
+    bridge = _GatedBridge(turns=1)
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("live", session_id="s7")
+    await bridge.parked[0].wait()
+
+    resumed, rtask = await _open_resume("live", last_event_id=1, session_id="s7")
+    await _until(lambda: len(resumed) >= 2)
+    assert [_event_id(b) for b in resumed] == [2, 3]
+    assert not rtask.done(), "resume must HOLD for the live turn, not terminate"
+
+    bridge.gates[0].set()
+    await rtask
+    await task_a
+    assert [_event_id(b) for b in resumed] == [2, 3, 4, 5]
+    assert _event_type(resumed[-1]) == "done"
+    assert bridge.prompt_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_resume_racing_stalled_turn_emits_truthful_error_not_done(
+    _pi_path, monkeypatch, _pass_ownership
+):
+    """F20: the live turn stalls past the hold cap — the resume ends with a
+    truthful terminal ``error {resumed: true, pending: true}`` (turn still in
+    progress, reconnect again with Last-Event-ID), NEVER a fabricated done.
+
+    Spec (review follow-up): the hold cap is monkeypatched to 0.0 — a ZERO-WAIT
+    ``asyncio.wait_for(timeout=0)`` that raises TimeoutError immediately when
+    the event is unset (no wall-clock sleep), so the outcome is deterministic.
+    """
+    monkeypatch.setattr(chat_route, "_RESUME_LIVE_HOLD_S", 0.0)
+    bridge = _GatedBridge(turns=1)
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("stalled", session_id="s8")
+    await bridge.parked[0].wait()
+
+    resumed, rtask = await _open_resume("stalled", last_event_id=1, session_id="s8")
+    await rtask
+
+    assert [_event_id(b) for b in resumed] == [2, 3, None]
+    assert _event_type(resumed[-1]) == "error"
+    assert '"resumed": true' in resumed[-1]
+    assert '"pending": true' in resumed[-1]
+    assert all(
+        not (_event_type(b) == "done" and '"resumed": true' in b) for b in resumed
+    ), "a live turn must never produce a fabricated done"
+    assert bridge.prompt_calls == 1
+
+    # cleanup: release the stalled turn
+    bridge.gates[0].set()
+    await task_a
+
+
+@pytest.mark.asyncio
+async def test_resume_never_started_turn_replays_real_events_not_fake_done(_pi_path, _pass_ownership):
+    """F20: the turn was registered but never started (queued behind the lock,
+    zero events). A resume must hold for the real events — not claim success
+    with a fabricated ``done`` for a turn that hasn't terminated."""
+    bridge = _GatedBridge(turns=1, park_before=frozenset({0}))
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("queued", session_id="s6")
+    await bridge.entered[0].wait()  # buffer registered, zero events
+
+    resumed, rtask = await _open_resume("queued", last_event_id=0, session_id="s6")
+    await asyncio.sleep(0)  # let the resume replay (nothing) and park
+    assert not rtask.done(), "never-started turn must not claim success"
+
+    bridge.gates[0].set()
+    await rtask
+    await task_a
+    assert [_event_id(b) for b in resumed] == [1, 2, 3], resumed
+    assert _event_type(resumed[0]) == "task_start"
+    assert _event_type(resumed[-1]) == "done"
+    assert bridge.prompt_calls == 1
+
+
+# ─── REVIEW FOLLOW-UP: anonymous live-hold + buffer eviction ────────────────
+
+
+@pytest.mark.asyncio
+async def test_anonymous_resume_of_live_turn_does_not_tail(_pi_path):
+    """P1 (review): anonymous (''-key) sessions NEVER live-hold a matched turn.
+
+    The '' key is shared by ALL anonymous clients and skips ownership checks,
+    so holding would let anyone who knows the victim's message + Last-Event-ID
+    tail a stranger's live turn in real time (shadow-stream). An anonymous
+    resume of a LIVE buffer replays the already-buffered tail, then ends with
+    the truthful pending terminal — events recorded after the resume connects
+    must NOT be forwarded, and no done is fabricated.
+    """
+    bridge = _GatedBridge(turns=1)
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("secret")
+    await bridge.parked[0].wait()
+
+    resumed, rtask = await _open_resume("secret", last_event_id=1)
+    await _until(lambda: len(resumed) >= 2)  # replayed tail 2..3, never holds
+
+    bridge.gates[0].set()  # live turn keeps producing — must NOT be tailed
+    await rtask
+    await task_a
+    assert [_event_id(b) for b in resumed] == [2, 3, None], resumed
+    assert _event_type(resumed[-1]) == "error"
+    assert '"resumed": true' in resumed[-1]
+    assert '"pending": true' in resumed[-1], (
+        "anonymous live-hold must end with the truthful pending terminal, "
+        "not a fabricated done"
+    )
+    assert bridge.prompt_calls == 1, "the resume never starts a new turn"
+
+
+@pytest.mark.asyncio
+async def test_anonymous_resume_of_never_started_turn_does_not_tail(_pi_path):
+    """P1 companion + P2 (round-2): a queued/never-started anonymous turn
+    (buffer registered, zero events) resumed with ``last_event_id=0`` has no
+    proof of prior contact — the resume is REFUSED outright (terminal
+    ``error {resumed: false}``, no pending, no fabricated done) and never
+    parks to tail the turn's events once it starts."""
+    bridge = _GatedBridge(turns=1, park_before=frozenset({0}))
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("queued")
+    await bridge.entered[0].wait()  # buffer registered, zero events
+
+    resumed, rtask = await _open_resume("queued", last_event_id=0)
+    await rtask  # refused immediately — no hold, no wait
+    assert [_event_type(b) for b in resumed] == ["error"], resumed
+    assert '"resumed": false' in resumed[0]
+    assert '"pending"' not in resumed[0], "refusal is terminal, not pending"
+
+    bridge.gates[0].set()  # the turn starts now — the resume is already closed
+    await task_a
+    assert len(resumed) == 1, "never-started anonymous turn must not be tailed"
+    assert bridge.prompt_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_anonymous_resume_without_prior_contact_is_refused(_pi_path):
+    """P2 (round-2 review): an anonymous (''-key) resume with Last-Event-ID 0
+    is REFUSED — no proof of prior contact with THAT turn. The '' key is
+    shared by ALL anonymous clients and skips ownership checks, so a resume
+    from id 0 would let anyone who knows the victim's message replay a
+    stranger's whole buffered turn. Refusal is a terminal
+    ``error {resumed: false}``: no replay of any event, no fabricated done."""
+    bridge = _GatedBridge(turns=1)
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("secret")
+    bridge.gates[0].set()
+    await task_a
+    assert [_event_id(b) for b in out_a] == [1, 2, 3, 4, 5]
+
+    resumed, rtask = await _open_resume("secret", last_event_id=0)
+    await rtask
+    assert [_event_type(b) for b in resumed] == ["error"], [
+        _event_type(b) for b in resumed
+    ]
+    assert '"resumed": false' in resumed[0]
+    assert len(resumed) == 1, "the refused resume replays nothing"
+    assert bridge.prompt_calls == 1, "the refused resume never starts a turn"
+
+
+def test_register_evicts_ended_before_live_when_over_cap():
+    """P2 (review): over the per-session buffer cap an ENDED buffer is evicted
+    first — a still-LIVE turn's buffer must survive N concurrent registrations
+    on the same key (e.g. five anonymous POSTs sharing ''), or a resume of the
+    live turn fails → client resends → duplicate execution. A live buffer is
+    only evicted when every buffer in the deque is live."""
+    reg = TurnResumeRegistry(max_buffers_per_session=4)
+    live = TurnEventBuffer("", "live")
+    reg.register("", live)  # oldest registration, still LIVE
+    for i in range(4):
+        ended = TurnEventBuffer("", f"ended{i}")
+        ended.record(sse_event("done", {"session_id": ""}))  # terminal → ended
+        reg.register("", ended)
+
+    survivors = list(reg._buffers[""])  # noqa: SLF001 — eviction asserted directly
+    assert len(survivors) == 4
+    assert live in survivors, "the still-live buffer must survive eviction"
+    assert all(b.ended for b in survivors if b is not live)
+
+    # All-live overflow still caps (falls back to oldest-first eviction).
+    all_live = TurnResumeRegistry(max_buffers_per_session=2)
+    for _ in range(3):
+        all_live.register("", TurnEventBuffer("", "x"))
+    assert len(all_live._buffers[""]) == 2  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_wait_for_update_zero_timeout_returns_immediately():
+    """Spec (review follow-up): ``wait_for_update(timeout=0.0)`` must return
+    False right away when the buffer has not changed — ``asyncio.wait_for``
+    with timeout=0 raises TimeoutError immediately for an unset event (this is
+    what the stalled-turn test's monkeypatched ``_RESUME_LIVE_HOLD_S = 0.0``
+    relies on — no wall-clock sleep)."""
+    buffer = TurnEventBuffer("s", "msg")
+    assert await buffer.wait_for_update(timeout=0.0) is False
+    assert buffer._waiters == []  # noqa: SLF001 — waiter must be drained
+
+
+@pytest.mark.asyncio
+async def test_waiters_drained_when_buffer_ends():
+    """F20 (review follow-up): a parked ``wait_for_update`` is woken AND removed
+    when the turn ends (``mark_ended``) — no unbounded ``_waiters`` growth for
+    aborted/ended buffers."""
+    buffer = TurnEventBuffer("s", "msg")
+
+    async def park():
+        return await buffer.wait_for_update(timeout=60)
+
+    task = asyncio.create_task(park())
+    await _until(lambda: len(buffer._waiters) == 1)  # noqa: SLF001
+    buffer.mark_ended(aborted=False)
+    assert await task is True, "mark_ended must wake the parked waiter"
+    assert buffer._waiters == []  # noqa: SLF001 — drained after the wake
+
+
+# ─── P2 (round-2): clear_session must purge the deleted session's buffers ────
+
+
+def test_registry_clear_session_purges_one_key():
+    """P2 (round-2 review): ``TurnResumeRegistry.clear_session(key)`` drops only
+    that key's buffers (and its LRU order entry) — other sessions' buffers
+    survive, a purged key finds nothing, and an unknown key is a no-op."""
+    reg = TurnResumeRegistry()
+    a = TurnEventBuffer("s1", "m1")
+    b = TurnEventBuffer("s2", "m2")
+    reg.register("s1", a)
+    reg.register("s2", b)
+
+    reg.clear_session("s1")
+    assert reg.find("s1", "m1", 0) == (None, False), (
+        "a purged key must be a plain miss (no replay of deleted events)"
+    )
+    assert reg.find("s2", "m2", 0)[0] is b, "other sessions' buffers survive"
+    assert len(reg) == 1
+
+    reg.clear_session("no-such-key")  # no-op, no exception
+    assert len(reg) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_session_route_purges_resume_buffers(_pi_path, monkeypatch, _pass_ownership):
+    """P2 (round-2 review): DELETE /chat/sessions/{X} must purge X's resume
+    buffers — after the delete, anyone holding session_id X + the message must
+    NOT be able to replay X's buffered events (they'd be replayable until LRU
+    eviction otherwise). The resume fails safe with ``error {resumed: false}``
+    and never starts a new turn."""
+
+    class _ClearableEngine:
+        async def clear_session(self, session_id, user_id=None, owner_token=None):
+            return True
+
+    bridge = _GatedBridge(turns=1)
+    _pi_path(bridge)
+
+    # Turn runs and completes; its buffer is registered under the session key.
+    out_a, task_a = await _start_stream("victim msg", session_id="victim-session")
+    bridge.gates[0].set()
+    await task_a
+    assert [_event_id(b) for b in out_a] == [1, 2, 3, 4, 5]
+
+    # Resume works BEFORE the delete.
+    resumed, rtask = await _open_resume("victim msg", last_event_id=1, session_id="victim-session")
+    await rtask
+    assert [_event_id(b) for b in resumed] == [2, 3, 4, 5], resumed
+
+    # DELETE the session (legacy path — engine reports success).
+    monkeypatch.setattr(chat_route, "USE_NEW_AGENT", False)
+    monkeypatch.setattr(chat_route, "pi_bridge", None)
+    monkeypatch.setattr(chat_route, "engine", _ClearableEngine())
+    result = await chat_route.clear_session(
+        session_id="victim-session",
+        _user={"user_id": None},
+        owner_token=None,
+        _conv=MagicMock(),
+    )
+    assert result == {"status": "ok"}
+
+    # Resume now fails safe: no replay of the deleted session's events.
+    resumed2, rtask2 = await _open_resume("victim msg", last_event_id=1, session_id="victim-session")
+    await rtask2
+    assert [_event_type(b) for b in resumed2] == ["error"], [
+        _event_type(b) for b in resumed2
+    ]
+    assert '"resumed": false' in resumed2[0]
+    assert bridge.prompt_calls == 1, "a refused resume never starts a new turn"
+
+
+# ─── F5: clear_session aborts the DELETED session, not whatever is live ─────
+
+
+@pytest.mark.asyncio
+async def test_clear_session_aborts_deleted_session(monkeypatch):
+    """F5: the route must pass the deleted session's id to
+    ``pi_bridge.abort(session_id=...)`` so the bridge can skip the abort when
+    a DIFFERENT session's turn is in flight (contract:
+    ``PiBridge.abort(session_id: str | None = None)``)."""
+
+    class _RecordingBridge:
+        def __init__(self) -> None:
+            self.abort_calls: list[Optional[str]] = []
+
+        async def abort(self, session_id: Optional[str] = None) -> dict:
+            self.abort_calls.append(session_id)
+            return {}
+
+    class _ClearableEngine:
+        async def clear_session(self, session_id, user_id=None, owner_token=None):
+            return True
+
+    bridge = _RecordingBridge()
+    monkeypatch.setattr(chat_route, "USE_NEW_AGENT", True)
+    monkeypatch.setattr(chat_route, "pi_bridge", bridge)
+    monkeypatch.setattr(chat_route, "engine", _ClearableEngine())
+
+    result = await chat_route.clear_session(
+        session_id="victim-session",
+        _user={"user_id": None},
+        owner_token=None,
+        _conv=MagicMock(),
+    )
+    assert result == {"status": "ok"}
+    assert bridge.abort_calls == ["victim-session"], (
+        "clear_session must scope the abort to the deleted session"
+    )
+
+
+# ─── F26: map-action-ack endpoint exposes dropped-vs-duplicate ───────────────
+
+
+class _DroppingStore:
+    """Degraded backend: every append is dropped (Redis-unreachable path of
+    session_data_redis returns False), nothing is stored."""
+
+    def __init__(self) -> None:
+        self.append_calls = 0
+
+    async def append_map_action_event(self, session_id: str, event: dict) -> bool:
+        self.append_calls += 1
+        return False
+
+    async def get_map_action_events(self, session_id: str) -> list[dict]:
+        return []
+
+
+def _fake_request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/",
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+        }
+    )
+
+
+def _ack_payload(action_id: str) -> chat_route.MapActionAck:
+    return chat_route.MapActionAck(action_id=action_id, command="fly_to", status="succeeded")
+
+
+@pytest.fixture(autouse=True)
+def _stub_ack_rate_limiter(monkeypatch):
+    """Real get_rate_limiter() would try to reach Redis (no network in unit
+    tests); stub it to always allow (limit itself is covered elsewhere)."""
+    limiter = MagicMock()
+
+    async def _is_allowed(key, max_requests, window_seconds):
+        return True
+
+    limiter.is_allowed = _is_allowed
+
+    async def _get_stub():
+        return limiter
+
+    monkeypatch.setattr(chat_route, "get_rate_limiter", _get_stub)
+
+
+@pytest.mark.asyncio
+async def test_ack_endpoint_reports_dropped_separately_from_duplicates(monkeypatch):
+    """F26: a backend-dropped ACK is NOT a duplicate — the response must expose
+    the loss (additive ``dropped`` field) so the client knows to retry."""
+    store = _DroppingStore()
+    monkeypatch.setattr(session_data_mod, "session_data_manager", store)
+
+    resp = await chat_route.push_map_action_acks(
+        "sess-x",
+        chat_route.MapActionAckRequest(acks=[_ack_payload("ma-1"), _ack_payload("ma-2")]),
+        _fake_request(),
+        MagicMock(),
+    )
+    assert resp == {"accepted": 0, "duplicates": 0, "dropped": 2}, resp
+    assert store.append_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_ack_endpoint_true_duplicate_not_reported_as_dropped(monkeypatch):
+    """F26 companion: a real duplicate (first-terminal-wins) stays
+    ``duplicates`` — and when nothing was dropped the ``dropped`` key is
+    absent (backward-compatible response shape)."""
+    store = MemorySessionStore()
+    monkeypatch.setattr(session_data_mod, "session_data_manager", store)
+
+    first = await chat_route.push_map_action_acks(
+        "sess-x",
+        chat_route.MapActionAckRequest(acks=[_ack_payload("ma-1")]),
+        _fake_request(),
+        MagicMock(),
+    )
+    assert first == {"accepted": 1, "duplicates": 0}, first
+
+    dup = await chat_route.push_map_action_acks(
+        "sess-x",
+        chat_route.MapActionAckRequest(acks=[_ack_payload("ma-1")]),
+        _fake_request(),
+        MagicMock(),
+    )
+    assert dup == {"accepted": 0, "duplicates": 1}, dup
+
+
+class _ReadCountingStore:
+    """Wraps a real store while counting ``get_map_action_events`` readbacks
+    (the O(n^2) vector: the route used to re-read per rejected ack)."""
+
+    def __init__(self, inner=None) -> None:
+        self._inner = inner or MemorySessionStore()
+        self.read_calls = 0
+
+    async def append_map_action_event(self, session_id: str, event: dict) -> bool:
+        return await self._inner.append_map_action_event(session_id, event)
+
+    async def get_map_action_events(self, session_id: str) -> list[dict]:
+        self.read_calls += 1
+        return await self._inner.get_map_action_events(session_id)
+
+
+@pytest.mark.asyncio
+async def test_ack_endpoint_all_rejected_reads_store_once(monkeypatch):
+    """P2 (round-2 review): a batch where every ack is rejected (dropped) must
+    trigger exactly ONE readback, not one read per rejected ack (50 reads was
+    the O(n^2) path — e.g. a retrying client spamming 50 duplicates)."""
+    store = _ReadCountingStore(inner=_DroppingStore())
+    monkeypatch.setattr(session_data_mod, "session_data_manager", store)
+
+    resp = await chat_route.push_map_action_acks(
+        "sess-x",
+        chat_route.MapActionAckRequest(
+            acks=[_ack_payload(f"ma-{i:02d}") for i in range(50)]
+        ),
+        _fake_request(),
+        MagicMock(),
+    )
+    assert resp == {"accepted": 0, "duplicates": 0, "dropped": 50}, resp
+    assert store.read_calls == 1, (
+        f"one hoisted readback must classify all 50 rejects, got {store.read_calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ack_endpoint_mixed_batch_bounded_reads_keeps_semantics(monkeypatch):
+    """P2 companion: mixed accept/reject batch — readbacks stay bounded
+    (hoisted snapshot; refreshed only after an accepted append) while
+    dropped-vs-duplicate semantics are preserved (in-batch duplicates of
+    just-appended ids still count as duplicates)."""
+    store = _ReadCountingStore()
+    monkeypatch.setattr(session_data_mod, "session_data_manager", store)
+    # Pre-seed two already-stored acks so a later reject of them is a duplicate.
+    await store._inner.append_map_action_event(
+        "sess-x", _ack_payload("ma-old-1").model_dump(exclude_none=True)
+    )
+    await store._inner.append_map_action_event(
+        "sess-x", _ack_payload("ma-old-2").model_dump(exclude_none=True)
+    )
+
+    resp = await chat_route.push_map_action_acks(
+        "sess-x",
+        chat_route.MapActionAckRequest(acks=[
+            _ack_payload("ma-new-1"),  # accepted (new)
+            _ack_payload("ma-old-1"),  # duplicate of pre-seeded
+            _ack_payload("ma-new-2"),  # accepted (new)
+            _ack_payload("ma-new-1"),  # duplicate of the just-accepted id
+            _ack_payload("ma-old-2"),  # duplicate of pre-seeded
+        ]),
+        _fake_request(),
+        MagicMock(),
+    )
+    assert resp == {"accepted": 2, "duplicates": 3}, resp
+    assert store.read_calls <= 3, (
+        f"readbacks must stay bounded by accepted appends, got {store.read_calls}"
+    )

--- a/tests/test_runtime_chaos_store.py
+++ b/tests/test_runtime_chaos_store.py
@@ -1,0 +1,292 @@
+"""Runtime chaos hardening tests for the session store layer (WP-STORE).
+
+F13: RedisSessionStore.clear_session must invalidate the L1 cache — every
+     other writer does; without it a recreated session reads the DELETED
+     session's map_state/refs/event_log within L1_TTL_SECONDS.
+F22: Redis fault isolation — set_alias / resolve_alias / resolve_aliases /
+     list_refs / get_started_at / get_event_log must degrade like their
+     siblings (reads → cache-miss/empty, writes → best-effort) instead of
+     propagating RedisError into every tool dispatch.
+F12: SessionLockRegistry must rebuild its cached Redis client when the
+     running event loop changes, instead of silently degrading to
+     in-process locking on "Event loop is closed".
+F27: MemorySessionStore.append_map_action_event first-terminal-wins must be
+     guarded by a lock, not by the accidental absence of awaits.
+"""
+import asyncio
+import logging
+
+import fakeredis.aioredis
+import pytest
+import redis.asyncio as aioredis
+
+from app.services.distributed_lock import SessionLockRegistry
+from app.services.session_data import MemorySessionStore
+from app.services.session_data_redis import RedisSessionStore
+
+
+def _redis_store():
+    return RedisSessionStore(
+        redis_url="redis://unused",
+        redis=fakeredis.aioredis.FakeRedis(decode_responses=False),
+    )
+
+
+# ── F13: clear_session must invalidate L1 ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_f13_clear_session_invalidates_l1():
+    """Write state, populate L1, clear, immediately re-read → must be empty.
+
+    Without the invalidation, get_map_state / get_session_metadata serve the
+    DELETED session's data from L1 for up to L1_TTL_SECONDS.
+    """
+    store = _redis_store()
+    await store.set_map_state("s1", "viewport", {"zoom": 5})
+    await store.store("s1", {"foo": "bar"})
+    await store.append_event("s1", "tool_executed", {"tool": "buffer_analysis"})
+    # Populate both L1 buckets within L1_TTL_SECONDS.
+    await store.get_map_state("s1")
+    await store.get_session_metadata("s1")
+    assert ("s1", "map_state") in store._l1
+    assert ("s1", "metadata") in store._l1
+
+    await store.clear_session("s1")
+
+    # All L1 entries for the session must be dropped by clear_session.
+    assert not [k for k in store._l1 if k[0] == "s1"]
+    # Immediate re-read (well within L1_TTL_SECONDS) must reflect the deletion.
+    assert await store.get_map_state("s1") == {}
+    meta = await store.get_session_metadata("s1")
+    assert meta["map_state"] == {}
+    assert meta["list_refs"] == {}
+    assert meta["event_log"] == []
+    assert meta["started_at"] is None
+
+
+# ── F22: Redis fault isolation ────────────────────────────────────────────
+
+
+class _FaultyPipeline:
+    """Pipeline stand-in whose execute() always raises RedisError."""
+
+    def __getattr__(self, name):
+        return lambda *a, **kw: self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return None
+
+    async def execute(self):
+        raise aioredis.RedisError("pipeline execute timed out")
+
+
+class _FaultyRedis:
+    """Every read raises RedisError — simulates a mid-turn Redis outage."""
+
+    def pipeline(self, *a, **kw):
+        return _FaultyPipeline()
+
+    async def hget(self, *a, **kw):
+        raise aioredis.RedisError("hget timed out")
+
+    async def hmget(self, *a, **kw):
+        raise aioredis.RedisError("hmget timed out")
+
+    async def zrange(self, *a, **kw):
+        raise aioredis.RedisError("zrange timed out")
+
+    async def hgetall(self, *a, **kw):
+        raise aioredis.RedisError("hgetall timed out")
+
+    async def lrange(self, *a, **kw):
+        raise aioredis.RedisError("lrange timed out")
+
+
+def _faulty_store():
+    return RedisSessionStore(redis_url="redis://unused", redis=_FaultyRedis())
+
+
+@pytest.mark.asyncio
+async def test_f22_resolve_alias_degrades_to_identity():
+    """Read path → cache-miss semantics: return the input unchanged."""
+    store = _faulty_store()
+    assert await store.resolve_alias("s1", "my-alias") == "my-alias"
+
+
+@pytest.mark.asyncio
+async def test_f22_resolve_aliases_degrades_to_identity_map():
+    """Read path on EVERY tool dispatch — must not propagate RedisError."""
+    store = _faulty_store()
+    out = await store.resolve_aliases("s1", ["a", "b"])
+    assert out == {"a": "a", "b": "b"}
+
+
+@pytest.mark.asyncio
+async def test_f22_list_refs_degrades_to_empty():
+    store = _faulty_store()
+    assert await store.list_refs("s1") == {}
+
+
+@pytest.mark.asyncio
+async def test_f22_get_started_at_degrades_to_none():
+    store = _faulty_store()
+    assert await store.get_started_at("s1") is None
+
+
+@pytest.mark.asyncio
+async def test_f22_get_event_log_degrades_to_empty():
+    store = _faulty_store()
+    assert await store.get_event_log("s1") == []
+
+
+@pytest.mark.asyncio
+async def test_f22_set_alias_best_effort_no_raise(caplog):
+    """Write path → best-effort with a warning, never raises."""
+    store = _faulty_store()
+    with caplog.at_level(logging.WARNING, logger="app.services.session_data_redis"):
+        await store.set_alias("s1", "ref:x", "alias-x")  # must not raise
+    assert any("set_alias" in r.message for r in caplog.records)
+
+
+# ── F12: SessionLockRegistry event-loop rebinding ─────────────────────────
+
+
+def test_f12_lock_registry_rebuilds_client_on_loop_change(monkeypatch):
+    """Client cached on loop A must be rebuilt when driven from loop B.
+
+    Uses two sequential asyncio.run() calls: each run is a genuinely fresh
+    event loop and the previous one is closed — exactly the event-loop
+    restart scenario where the cached client's connection pool raises
+    'Event loop is closed' on every op and locking silently degrades to
+    in-process. The registry must detect the loop change and rebuild.
+    """
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("USE_REDIS", "true")
+    created = []
+
+    class _FakeClient:
+        async def aclose(self):
+            return None
+
+    def _from_url(*a, **kw):
+        client = _FakeClient()
+        created.append(client)
+        return client
+
+    monkeypatch.setattr("redis.asyncio.from_url", _from_url)
+    registry = SessionLockRegistry()
+
+    holder = {}
+
+    async def _grab(key):
+        holder[key] = registry._get_client()
+        await asyncio.sleep(0)  # let the best-effort close task run
+
+    asyncio.run(_grab("first"))
+    asyncio.run(_grab("second"))  # fresh loop; the first loop is closed
+
+    assert holder["second"] is not holder["first"], (
+        "stale client bound to the closed loop was reused"
+    )
+    assert len(created) == 2
+    assert holder["second"] is created[-1]
+
+
+@pytest.mark.asyncio
+async def test_f12_lock_registry_reuses_client_on_same_loop(monkeypatch):
+    """No loop change → the cached client is reused (no churn)."""
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("USE_REDIS", "true")
+    created = []
+
+    class _FakeClient:
+        async def aclose(self):
+            return None
+
+    def _from_url(*a, **kw):
+        client = _FakeClient()
+        created.append(client)
+        return client
+
+    monkeypatch.setattr("redis.asyncio.from_url", _from_url)
+    registry = SessionLockRegistry()
+
+    first = registry._get_client()
+    assert registry._get_client() is first
+    assert len(created) == 1
+
+
+# ── F27: memory-backend ACK atomicity ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_f27_concurrent_duplicate_appends_first_terminal_wins():
+    """Characterization: N concurrent duplicate appends → exactly one accepted.
+
+    Currently passes because the critical section has no awaits; it guards the
+    first-terminal-wins invariant against regressions.
+    """
+    store = MemorySessionStore()
+    n = 8
+    start = asyncio.Event()
+
+    async def _append(i):
+        await start.wait()
+        return await store.append_map_action_event(
+            "s1", {"action_id": "ma-dup", "status": "succeeded", "i": i}
+        )
+
+    tasks = [asyncio.create_task(_append(i)) for i in range(n)]
+    start.set()
+    results = await asyncio.gather(*tasks)
+    assert sum(results) == 1
+    events = await store.get_map_action_events("s1")
+    assert [e["action_id"] for e in events] == ["ma-dup"]
+
+
+@pytest.mark.asyncio
+async def test_f27_first_wins_survives_injected_suspension_point():
+    """A future await inside the dedupe critical section must not break
+    first-terminal-wins — the store's ``_map_action_lock`` must serialize it.
+
+    Injects the suspension by wrapping ``_map_action_lock`` so its held
+    section yields the event loop; concurrent duplicate appends must still
+    resolve to exactly one winner.
+    """
+    store = MemorySessionStore()
+
+    class _SuspendingLock:
+        def __init__(self, inner):
+            self._inner = inner
+
+        async def __aenter__(self):
+            await self._inner.acquire()
+            # Simulate a future await INSIDE the critical section (e.g. an
+            # added metrics hook). The lock must stay held while other
+            # appends queue up.
+            await asyncio.sleep(0)
+
+        async def __aexit__(self, *exc):
+            self._inner.release()
+
+    store._map_action_lock = _SuspendingLock(store._map_action_lock)
+
+    n = 4
+    start = asyncio.Event()
+
+    async def _append(i):
+        await start.wait()
+        return await store.append_map_action_event(
+            "s1", {"action_id": "ma-dup", "status": "succeeded", "i": i}
+        )
+
+    tasks = [asyncio.create_task(_append(i)) for i in range(n)]
+    start.set()
+    results = await asyncio.gather(*tasks)
+    assert sum(results) == 1
+    events = await store.get_map_action_events("s1")
+    assert [e["action_id"] for e in events] == ["ma-dup"]

--- a/tests/test_sse_resume.py
+++ b/tests/test_sse_resume.py
@@ -250,7 +250,12 @@ async def test_resume_after_completion_all_events_seen_terminates(monkeypatch):
 async def test_resume_after_aborted_turn_replays_then_errors(monkeypatch):
     """A turn cut by a client disconnect (server aborts the prompt; no terminal
     was produced) resumes as: replay the partial content, then a terminal
-    ``error`` — partial content is never presented as a complete answer."""
+    ``error`` — partial content is never presented as a complete answer.
+
+    P2 (round-2 review): the anonymous (''-key) resume uses ``last_event_id=1``
+    — the client demonstrably received event 1 before the disconnect. Resuming
+    from 0 is now refused for anonymous sessions (no proof of prior contact),
+    so a reconnect must always carry the last id it actually saw."""
     bridge = _AbortableBridge()
     monkeypatch.setattr(chat_route, "USE_NEW_AGENT", True)
     monkeypatch.setattr(chat_route, "pi_bridge", bridge)
@@ -275,13 +280,14 @@ async def test_resume_after_aborted_turn_replays_then_errors(monkeypatch):
     assert buffer.terminal_event is None
 
     resumed, bridge_after = await _collect_route(
-        monkeypatch, bridge, last_event_id=0
+        monkeypatch, bridge, last_event_id=1
     )
     assert bridge_after.prompt_calls == 1, "resume must not re-execute the aborted turn"
     ids = [_event_id(b) for b in resumed]
-    # Buffered partial turn (task_start/token/step_result) replayed in order,
-    # then the synthesized error terminal (no id — not part of the turn).
-    assert ids[:3] == [1, 2, 3], f"replay must deliver the buffered partial turn, got {ids}"
+    # Buffered partial turn (task_start/token/step_result) replayed after the
+    # client's last-seen id (1), then the synthesized error terminal (no id —
+    # not part of the turn).
+    assert ids == [2, 3, None], f"replay must deliver the buffered partial turn, got {ids}"
     assert ids[-1] is None
     assert _event_type(resumed[-1]) == "error"
     assert '"resumed": true' in resumed[-1]


### PR DESCRIPTION
# PR body draft — fix(runtime): harden lifecycle, recovery and fault semantics

> Template with all required sections; fill FINAL_SHA after push.

## Summary
Deterministic fault-injection / concurrency / repeated-lifecycle / disconnect-resume campaign over the core Agent Runtime seams (chat runtime, session lifecycle, SSE resume, tool execution, map-action ACK, cancellation, in-process resource release). Every fix is backed by a reproducible regression test (63 new chaos tests + extended existing suites). 24 defects reproduced and fixed; 2 review-follow-up rounds closed all P0/P1 findings.

- **BASE_SHA:** `84c73fa85063957c81f80b877fbb0e3f9387f7ae`
- **FINAL_SHA:** `2d42c81f08fa4d40b43eb0d1fcc9c6a21fec2a39`
- **Branch:** `stability/runtime-chaos-recovery-kimi`

## Conflict isolation from #344 / #345
PR #344 (perf/large-map-data-plane-v3) and #345 (feat/data-fabric-v3-zcode2) are still OPEN and were NOT merged at BASE. This branch does not touch `app/services/data_fabric/`, `app/services/mvt.py`, tile-cache/MapSpec COW files, `app/services/chat/llm_client.py`, ChatContextAssembler, or visual styling. Verified: `git diff` over those paths = 0 lines.

## Fault matrix
Deterministic, no new wall-clock tests (asyncio.Event barriers, fake rpc with real queues, fakeredis, injectable clocks, monkeypatched timeouts, timeout=0):

1. Client disconnect during reasoning/token stream, tool execution, map-command-awaiting-ACK
2. Reconnect via Last-Event-ID: replay missed events, no duplicate tool execution, no duplicate terminal side effects
3. Cancellation races: cancel vs success/error/ACK, repeated cancel, session close during cancel
4. Stale/out-of-order evidence: previous-session response after session switch, late/duplicate map ACK, terminal-after-terminal
5. Resource lifecycle: repeated lifespan startup/shutdown, repeated session create/close, no orphan asyncio tasks, no readers/watchdogs/listeners left behind, no clients bound to closed loops, locks released on exception/cancel
6. Degraded dependencies: Redis unavailable/timeout, DB operation failure, Pi bridge dies, disabled Celery backend, ACK endpoint transient failure

Covered by: `tests/test_runtime_chaos_{engine,resume,pi,store,lifecycle,plan_mode}.py` (63 tests) + pre-existing suites.

## Bugs actually found (fixed)
P0 (correctness / data isolation):
- F1 clear_session dropped a *held* per-session lock → broken serialization, duplicate tool execution, message resurrection (engine + route)
- F2 anonymous `""` resume-buffer key → cross-user event replay
- F3 TaskTracker terminal overwrite: cancel → completed/failed
- F4 resume buffer clobbered by queued second POST → live turn unresumable → re-execution
- F5 session-blind `pi_bridge.abort()` on DELETE session killed another session's in-flight turn (+ `prompt()` path + abort TOCTOU)

P1 (stuck state / leak / dup / recovery):
- F6 plan-mode wave tasks leaked on cancel; plan stuck `running`
- F7 steps stuck `running` after cancel/disconnect
- F8 cancellation indistinguishable from failure (step/task/SSE level)
- F9 orphaned assistant `tool_calls` persisted on cancel/disconnect → every later turn in the session rejected; completed tools mis-recorded as cancelled (cancel-vs-success same-batch)
- F10 Pi stall-timeout never aborted → tools kept executing, retry duplicated side effects
- F12 SessionLockRegistry Redis client bound to dead loop (silent degrade to in-process locking)
- F13 Redis `clear_session` missing L1 invalidation → deleted-session state served to recreated id
- F15/F16 fire-and-forget tasks untracked; ws broadcast unbounded on stuck socket + dead conns never closed
- F17 dead cancel cascade for durable jobs created by in-flight tools
- F18 running-task eviction made turns uncancellable/invisible
- F19 PiRpcClient `_pending_requests` leak on caller cancellation
- F20 resume racing a live/never-started turn fabricated `done{resumed:true}`
- F21 engine clear_session partial failure (Redis raise after DB delete → 500 + skipped cleanup)
- F22 uneven Redis fault isolation → outage failed every tool dispatch
- F23 failed DB session load cached as empty stub → post-outage turns ran with empty history
- F24 Pi HTTP-callback tool dispatch not bound to cancellation token
- F26 map-ACK endpoint reported Redis-dropped events as duplicates (O(n²) readback fixed)
- F28 non-streaming path had no preemptive cancel watch (hole fixed: multi-tool race)
- F11 AsyncEngine never disposed across lifespan cycles
- F27 memory-backend ACK atomicity made explicit (lock + documented invariant)

## State invariants now enforced
- No stuck running/cancelling task or step after a terminal event
- First terminal result cannot be overwritten (task, step, plan status)
- Reconnect (Last-Event-ID) never re-executes completed tool calls
- Disconnect releases session locks/work within a bounded wait (even for uncancellable threads)
- One session cannot receive another session's events (buffer keying + ambiguity fail-safe + anonymous prior-contact gate)
- One turn's state does not leak into the next (clearing marker, repair idempotence)
- Bounded structures stay bounded (per-session buffer lists, background-task registry, waiter lists drained)
- Error state is observable; cancellation is distinct from generic failure (`StepStatus.cancelled`, `step_cancelled` event, `cancelled` task terminal)
- Repeated lifespan loops do not leak tasks/clients (drain + dispose + loop-rebind)
- Deleted sessions cannot be resurrected in history (clearing marker suppresses persistence)

## Before / after
- Before: 24 defects reproducible via new tests (all RED pre-fix); after: all GREEN.
- Chaos+adjacent gate: 1794 passed, 2 skipped (0 failed)
- Broad backend suite (`-m "not perf and not cartography"`): 2774 passed, 2 skipped, 1 failed — `tests/benchmarks/test_perf_harness_v2.py::test_network_event_loop_lag_offload`, a timing assertion (`max_lag_ms < 25`) that fails under full-suite CPU load. **Verified pre-existing**: fails identically on a clean BASE (84c73fa) worktree under the same full-suite conditions, passes solo; its modules (`app/services/network/*`, the test file) are untouched by this diff.
- `ruff check app/ tests/` — clean

## Resource / leak evidence
- Repeated-lifespan test (3 cycles): zero orphan `asyncio.all_tasks()` per cycle, AsyncEngine disposed per cycle
- `drain_background_tasks`: tracked tasks drained at shutdown; stale cross-loop tasks filtered; pending tasks cancelled on timeout
- Pi pending-request registry: empty after cancelled requests
- Resume waiter lists drained on terminal
- Session lock eviction never drops locked/in-use locks (waiters counted)

## Review findings (adversarial, 2 rounds)
Round 1 (7/8 reviewers; Matt standards+spec axes, gstack pass-1 + specialists, cancellation/data-isolation/resource adversaries): 4 P1s (non-streaming cancel-watch hole; cancel-vs-success same-batch; plan terminal overwrite + convergence under Redis failure; anonymous live-hold shadow-stream) + P2s → all fixed (FIX-A/B).
Round 2 (3/4 reviewers): 3 P1s (clear_session history resurrection; unbounded cleanup gathers; prompt() not instrumented for F5/F24 + abort TOCTOU) + P2s → all fixed (FIX-C).
One reviewer (test-fidelity audit) could not run (provider quota); its scope was covered by the other reviewers' seam-fidelity checks plus the RED-phase discipline (every fix test failed pre-fix).

## Known limits
- Anonymous sessions share the `""` resume namespace by design (no auth at that seam); anonymous resume now requires a nonzero Last-Event-ID and never tails live turns — whole-turn replay without prior contact is refused; residual exposure documented in `event_resume.py`.
- `step_cancelled` is a new additive SSE event; current frontend ignores unknown events safely (step rows resolve at stream end) — no frontend change in this PR.
- Abort RPC TOCTOU cannot un-fail already-failed RPC futures; a post-RPC re-check logs the misfire (worst case: a turn cancelled in the milliseconds around another turn's completion).
- Queued Pi turns for a deleted session may still run if already past the route guard (narrow window; bridge turn markers now set on both paths).
- `asyncio.Lock._waiters` private-API read for in-use detection (documented; CPython 3.12/3.13 semantics verified).

## Local validation statement
All work performed in a dedicated worktree (`webgis-ai-agent-wt-runtime-chaos`) on BASE `84c73fa`, committed per-file below. Gates run locally: chaos+adjacent suites, broad backend suite, `ruff check app/ tests/`. CI/CD intentionally not awaited per task contract.
