### PR TITLE
feat(analysis): add GIS result workbench and map-linked output inspection

### DIFF
--- a/frontend/components/layout/context-panel.test.tsx
+++ b/frontend/components/layout/context-panel.test.tsx
@@ -22,6 +22,7 @@ const store: Record<string, unknown> = {
   setSidebarWidth,
   layers: [],
   exports: [],
+  results: [],
 };
 
 vi.mock('@/lib/store/useHudStore', () => ({
@@ -36,6 +37,7 @@ vi.mock('@/components/sidebar/analysis-tab', () => ({ AnalysisTab: () => <div da
 vi.mock('@/components/sidebar/data-sources-tab', () => ({ DataSourcesTab: () => <div data-testid="tab-data-sources" /> }));
 vi.mock('@/components/sidebar/map-studio-tab', () => ({ MapStudioTab: () => <div data-testid="tab-map-studio" /> }));
 vi.mock('@/components/sidebar/tasks-tab', () => ({ TasksTab: () => <div data-testid="tab-tasks" /> }));
+vi.mock('@/components/sidebar/results-tab', () => ({ ResultsTab: () => <div data-testid="tab-results" /> }));
 
 // Import AFTER the mocks are registered.
 import { ContextPanel } from './context-panel';

--- a/frontend/components/layout/context-panel.tsx
+++ b/frontend/components/layout/context-panel.tsx
@@ -18,6 +18,7 @@ import {
   Triangle,
   ListChecks,
   Printer,
+  ClipboardList,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
@@ -30,6 +31,7 @@ import { MapStudioTab } from '@/components/sidebar/map-studio-tab';
 import { ProjectTab } from '@/components/sidebar/project-tab';
 import { DataSourcesTab } from '@/components/sidebar/data-sources-tab';
 import { TasksTab } from '@/components/sidebar/tasks-tab';
+import { ResultsTab } from '@/components/sidebar/results-tab';
 
 export interface ContextPanelProps {
   messages: Array<{
@@ -39,6 +41,7 @@ export interface ContextPanelProps {
     timestamp: Date | number | null;
     isThinking?: boolean;
     charts?: unknown[];
+    resultId?: string;
   }>;
   aiStatus: AiStatus;
   onSend: (text: string) => void;
@@ -66,6 +69,7 @@ const PANEL_META: Record<string, PanelMeta> = {
   layers: { icon: Layers, title: '图层', description: '可见性 · 样式 · 顺序' },
   analysis: { icon: Triangle, title: '分析', description: '空间分析工具' },
   tasks: { icon: ListChecks, title: '任务', description: '后台作业中心' },
+  results: { icon: ClipboardList, title: '分析结果', description: '结果工作台 · 输入 · 指标 · 输出' },
   export_layout: { icon: Printer, title: '制图工坊', description: '排版与导出' },
 };
 
@@ -84,13 +88,18 @@ export function ContextPanel({
   const setSidebarWidth = useHudStore((s) => s.setSidebarWidth);
   const layerCount = useHudStore((s) => s.layers.length);
   const exportCount = useHudStore((s) => s.exports.length);
+  const resultCount = useHudStore((s) => s.results.length);
   // HUD 展开时面板整体上移避让（与 nav rail / floating legend 一致），
   // 否则 composer 与 tab 底部内容被 210px HUD 遮住。
   const hudOpen = useHudStore((s) => s.hudOpen);
 
   const metaKey = activeTab === 'exports' ? 'export_layout' : activeTab;
   const meta = PANEL_META[metaKey] ?? PANEL_META.chat;
-  const badge = metaKey === 'layers' ? layerCount : metaKey === 'export_layout' ? exportCount : undefined;
+  const badge =
+    metaKey === 'layers' ? layerCount
+    : metaKey === 'export_layout' ? exportCount
+    : metaKey === 'results' ? resultCount
+    : undefined;
 
   /* ─── 右缘拖拽调宽 ─── */
   const [dragging, setDragging] = useState(false);
@@ -192,6 +201,9 @@ export function ContextPanel({
         {(activeTab === 'export_layout' || activeTab === 'exports') && <MapStudioTab />}
         {activeTab === 'tasks' && (
           <TasksTab sessionId={sessionId} ownerToken={ownerToken} />
+        )}
+        {activeTab === 'results' && (
+          <ResultsTab sessionId={sessionId} ownerToken={ownerToken} onSend={onSend} />
         )}
       </div>
 

--- a/frontend/components/layout/nav-rail.test.tsx
+++ b/frontend/components/layout/nav-rail.test.tsx
@@ -5,11 +5,11 @@ import { render, screen, fireEvent } from '@testing-library/react';
  * NavRail (UI V3) — 主导航竖排图标栏。
  *
  * Pin 的契约：
- *   - 7 个 tab（chat/project/data_sources/layers/analysis/tasks/export_layout）
+ *   - 8 个 tab（chat/project/data_sources/layers/analysis/tasks/results/export_layout）
  *     带 role=tab + aria-selected + roving tabindex；
  *   - 点击 inactive tab → setActiveLeftTab；点击 active tab → toggleLeftPanel；
  *   - ArrowUp/Down/Home/End 键盘导航（自动激活语义）；
- *   - 图层/导出徽标计数；模板库按钮 → setTemplatesOpen(true)。
+ *   - 图层/导出/结果徽标计数；模板库按钮 → setTemplatesOpen(true)。
  */
 
 const setActiveLeftTab = vi.fn();
@@ -24,6 +24,7 @@ const store: Record<string, unknown> = {
   setTemplatesOpen,
   layers: [],
   exports: [],
+  results: [],
 };
 
 vi.mock('@/lib/store/useHudStore', () => ({
@@ -33,7 +34,7 @@ vi.mock('@/lib/store/useHudStore', () => ({
 // Import AFTER the mock is registered.
 import { NavRail } from './nav-rail';
 
-const TAB_ORDER = ['chat', 'project', 'data_sources', 'layers', 'analysis', 'tasks', 'export_layout'];
+const TAB_ORDER = ['chat', 'project', 'data_sources', 'layers', 'analysis', 'tasks', 'results', 'export_layout'];
 const TAB_LABELS: Record<string, string> = {
   chat: '对话',
   project: '项目',
@@ -41,6 +42,7 @@ const TAB_LABELS: Record<string, string> = {
   layers: '图层',
   analysis: '分析',
   tasks: '任务',
+  results: '结果',
   export_layout: '制图',
 };
 
@@ -51,16 +53,17 @@ describe('NavRail', () => {
     store.leftPanelOpen = true;
     store.layers = [];
     store.exports = [];
+    store.results = [];
   });
 
-  it('renders 7 tabs with tablist semantics and roving tabindex', () => {
+  it('renders 8 tabs with tablist semantics and roving tabindex', () => {
     render(<NavRail />);
 
     const tablist = screen.getByRole('tablist', { name: '工作区面板' });
     expect(tablist).toHaveAttribute('aria-orientation', 'vertical');
 
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(7);
+    expect(tabs).toHaveLength(8);
     expect(tabs.map((t) => t.getAttribute('aria-label'))).toEqual(
       TAB_ORDER.map((k) => TAB_LABELS[k])
     );

--- a/frontend/components/layout/nav-rail.tsx
+++ b/frontend/components/layout/nav-rail.tsx
@@ -22,6 +22,7 @@ import {
   LayoutTemplate,
   PanelLeftClose,
   PanelLeftOpen,
+  ClipboardList,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
@@ -45,6 +46,7 @@ const RAIL_GROUPS: Array<Array<RailTabDef>> = [
   [
     { key: 'analysis', icon: Triangle, label: '分析' },
     { key: 'tasks', icon: ListChecks, label: '任务' },
+    { key: 'results', icon: ClipboardList, label: '结果' },
   ],
   [{ key: 'export_layout', icon: Printer, label: '制图' }],
 ];
@@ -59,12 +61,14 @@ export function NavRail() {
   const setTemplatesOpen = useHudStore((s) => s.setTemplatesOpen);
   const layerCount = useHudStore((s) => s.layers.length);
   const exportCount = useHudStore((s) => s.exports.length);
+  const resultCount = useHudStore((s) => s.results.length);
   // Review P2 修复：HUD 展开（210px,z-50）会盖住 rail 底部工具区，整体上移避让。
   const hudOpen = useHudStore((s) => s.hudOpen);
 
   const badges: Partial<Record<LeftTab, number | undefined>> = {
     layers: layerCount > 0 ? layerCount : undefined,
     export_layout: exportCount > 0 ? exportCount : undefined,
+    results: resultCount > 0 ? resultCount : undefined,
   };
 
   const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());

--- a/frontend/components/sidebar/chat-tab.tsx
+++ b/frontend/components/sidebar/chat-tab.tsx
@@ -4,6 +4,7 @@ import { memo, useState, useRef, useEffect, useCallback, type KeyboardEvent } fr
 import dynamic from 'next/dynamic';
 import { Send, Sparkles, CheckCircle2 } from 'lucide-react';
 import type { AiStatus } from '@/lib/store/hud-types';
+import { useHudStore } from '@/lib/store/useHudStore';
 import { ToolCallChain } from '@/components/chat/tool-call-card';
 import { CollapsibleThink } from '@/components/chat/collapsible-think';
 import { PlanProposalCard } from '@/components/chat/plan-proposal-card';
@@ -89,6 +90,7 @@ interface ChatMessage {
   plan?: import('@/lib/store/hud-types').PlanProposalPayload;
   agentPlan?: import('@/lib/types/agent-plan').AgentPlanState;
   layerAdded?: string;
+  resultId?: string;
 }
 
 interface ChatTabProps {
@@ -177,7 +179,21 @@ const ChatMessageItem = memo(function ChatMessageItem({
             }}
           >
             <CheckCircle2 size={10} />
-            感知图层已挂载：{msg.layerAdded}
+            <span>感知图层已挂载：{msg.layerAdded}</span>
+            {msg.resultId && (
+              <button
+                type="button"
+                onClick={() => {
+                  const s = useHudStore.getState();
+                  s.selectResult(msg.resultId!);
+                  s.setActiveLeftTab('results');
+                }}
+                className="ml-1 inline-flex items-center gap-0.5 rounded-full bg-white/20 px-1.5 py-0.5 text-[11px] font-medium text-white transition-colors hover:bg-white/30"
+                aria-label="在结果工作台查看分析结果"
+              >
+                查看结果
+              </button>
+            )}
           </div>
         )}
 

--- a/frontend/components/sidebar/results-tab.tsx
+++ b/frontend/components/sidebar/results-tab.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+/**
+ * ResultsTab — GIS Analysis Result Workbench (left-tab, master-detail).
+ *
+ * One canonical result-detail experience with the list as its primary entry
+ * point. The registry is session-scoped + bounded (spec §11/§16): we do not
+ * create a persistence DB; we represent session-only results truthfully and
+ * clear on session switch (wired in use-workspace-session).
+ */
+import { useMemo } from 'react';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { ResultList } from '@/components/sidebar/results/result-list';
+import { ResultDetail } from '@/components/sidebar/results/result-detail';
+
+interface ResultsTabProps {
+  sessionId?: string | null;
+  ownerToken?: string | null;
+  onSend: (text: string) => void;
+}
+
+export function ResultsTab({ sessionId, ownerToken, onSend }: ResultsTabProps) {
+  const results = useHudStore((s) => s.results);
+  const selectedResultId = useHudStore((s) => s.selectedResultId);
+  const selectResult = useHudStore((s) => s.selectResult);
+
+  const selected = useMemo(
+    () => (selectedResultId ? results.find((r) => r.id === selectedResultId) ?? null : null),
+    [results, selectedResultId],
+  );
+
+  if (selected) {
+    return (
+      <ResultDetail
+        result={selected}
+        sessionId={sessionId}
+        ownerToken={ownerToken}
+        onBack={() => selectResult(null)}
+        onSend={onSend}
+      />
+    );
+  }
+
+  return <ResultList results={results} selectedId={selectedResultId} onSelect={selectResult} />;
+}
+
+export default ResultsTab;

--- a/frontend/components/sidebar/results/result-detail.tsx
+++ b/frontend/components/sidebar/results/result-detail.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+/**
+ * ResultDetail — the canonical GIS analysis result inspector (spec §7).
+ *
+ * Composed entirely of reusable semantic sections + shared primitives (no
+ * per-family components). Map actions go through the store (`updateLayer`,
+ * `focusLayer`) — never `setViewport`, never direct MapLibre. Output metadata is
+ * enriched lazily by `useResultDescriptor` (metadata-first, no full GeoJSON).
+ *
+ * Truthfulness: CRS renders "未知" when unknown; feature count renders "未报告"
+ * when not backed by evidence; warnings are always visible (never buried in JSON).
+ */
+import { useCallback, useMemo } from 'react';
+import {
+  ArrowLeft,
+  Eye,
+  EyeOff,
+  MapPinned,
+  Download,
+  Layers as LayersIcon,
+  Sliders,
+  Crosshair,
+  Trash2,
+} from 'lucide-react';
+import clsx from 'clsx';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { useResultDescriptor } from '@/lib/hooks/use-result-descriptor';
+import { deriveSuggestedActions } from '@/lib/results/suggested-actions';
+import { familyLabel } from '@/lib/results/families';
+import type { AnalysisResult, ResultMetric, ResultWarning, SuggestedAction } from '@/lib/results/types';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { InlineNotice } from '@/components/shared/inline-notice';
+import { IconButton } from '@/components/shared/icon-button';
+
+interface ResultDetailProps {
+  result: AnalysisResult;
+  sessionId?: string | null;
+  ownerToken?: string | null;
+  onBack: () => void;
+  onSend: (text: string) => void;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  completed: '已完成',
+  failed: '失败',
+  partial: '部分完成',
+  warning: '完成（含告警）',
+  running: '运行中',
+  unknown: '未知',
+};
+
+const WARNING_VARIANT: Record<string, 'info' | 'warning' | 'error'> = {
+  info: 'info',
+  warning: 'warning',
+  error: 'error',
+};
+
+function formatTime(ms?: number): string {
+  if (!ms) return '';
+  try {
+    return new Date(ms).toLocaleString(undefined, {
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}
+
+function formatBytes(bytes?: number): string {
+  if (bytes === undefined || bytes === null) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function Section({ title, children, action }: { title: string; children: React.ReactNode; action?: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-1.5" aria-label={title}>
+      <div className="flex items-center justify-between">
+        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">{title}</h4>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function MetricItem({ metric }: { metric: ResultMetric }) {
+  return (
+    <div
+      className={clsx(
+        'flex flex-col rounded-md border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-subtle)] px-2 py-1.5',
+        metric.emphasis === 'primary' && 'border-[var(--agent-accent,#16a34a)]/40',
+      )}
+    >
+      <span className="text-[10px] text-[var(--theme-text-muted)]">{metric.label}</span>
+      <span className={clsx('font-mono text-[var(--theme-text-primary)]', metric.emphasis === 'primary' ? 'text-[15px]' : 'text-[13px]')}>
+        {metric.value}
+        {metric.unit ? <span className="ml-0.5 text-[10px] text-[var(--theme-text-muted)]">{metric.unit}</span> : null}
+      </span>
+    </div>
+  );
+}
+
+function WarningItem({ warning }: { warning: ResultWarning }) {
+  return <InlineNotice variant={WARNING_VARIANT[warning.level] ?? 'info'}>{warning.message}</InlineNotice>;
+}
+
+export function ResultDetail({ result, sessionId, ownerToken, onBack, onSend }: ResultDetailProps) {
+  // Lazy metadata-first enrichment (no full GeoJSON). No-op when already enriched.
+  useResultDescriptor(result, sessionId, ownerToken);
+
+  const layers = useHudStore((s) => s.layers);
+  const updateLayer = useHudStore((s) => s.updateLayer);
+  const focusLayer = useHudStore((s) => s.focusLayer);
+  const setActiveLeftTab = useHudStore((s) => s.setActiveLeftTab);
+  const removeResult = useHudStore((s) => s.removeResult);
+
+  const output = result.outputs[0];
+  const ref = output?.ref;
+
+  // Live layer binding (store truth, not the normalizer's static hint).
+  const boundLayer = useMemo(
+    () => (ref ? layers.find((l) => l.id === ref || l._refId === ref) ?? null : null),
+    [layers, ref],
+  );
+  const hasBoundLayer = !!boundLayer;
+  const hasVisibleLayer = !!boundLayer?.visible;
+
+  const actions = useMemo(
+    () => deriveSuggestedActions(result.family, result.outputs, hasVisibleLayer, hasBoundLayer),
+    [result.family, result.outputs, hasVisibleLayer, hasBoundLayer],
+  );
+
+  const handleAction = useCallback(
+    (action: SuggestedAction) => {
+      if (!action.available) return;
+      switch (action.kind) {
+        case 'show_on_map':
+        case 'hide':
+          if (ref) updateLayer(ref, { visible: !hasVisibleLayer });
+          break;
+        case 'zoom':
+          if (ref) focusLayer(ref);
+          break;
+        case 'style':
+          setActiveLeftTab('layers');
+          break;
+        case 'buffer':
+          onSend(`对刚生成的「${result.toolLabel}」结果做缓冲区分析`);
+          break;
+        case 'overlay':
+          onSend(`将「${result.toolLabel}」结果与其他图层进行叠加分析`);
+          break;
+        case 'classify':
+          onSend(`对「${result.toolLabel}」栅格结果进行分类`);
+          break;
+        case 'inspect':
+          onSend(`检查「${result.toolLabel}」结果中的显著要素`);
+          break;
+        case 'export':
+          onSend(`导出「${result.toolLabel}」结果`);
+          break;
+      }
+    },
+    [ref, hasVisibleLayer, updateLayer, focusLayer, setActiveLeftTab, onSend, result.toolLabel],
+  );
+
+  const crsLabel = output?.crs ?? '未知';
+  const featureCountLabel =
+    output?.featureCount !== undefined ? output.featureCount.toLocaleString() : '未报告';
+  const geomLabel = output?.geometryTypes?.length ? output.geometryTypes.join('、') : '未报告';
+  const bboxLabel = output?.bbox ? output.bbox.map((n) => n.toFixed(3)).join(', ') : '未报告';
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-3 py-2.5 text-[13px]">
+      {/* Header */}
+      <div className="flex items-center gap-1.5">
+        <IconButton label="返回结果列表" icon={ArrowLeft} onClick={onBack} />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate font-medium text-[var(--theme-text-primary)]">{result.toolLabel}</span>
+          <span className="truncate text-[11px] text-[var(--theme-text-muted)]">
+            {familyLabel(result.family)} · {formatTime(result.capturedAt)}
+          </span>
+        </div>
+        <StatusBadge status={result.status} label={STATUS_LABEL[result.status] ?? result.status} />
+        <IconButton label="从列表移除" icon={Trash2} variant="ghost" onClick={() => { removeResult(result.id); onBack(); }} />
+      </div>
+
+      {/* Summary */}
+      {result.summary ? (
+        <p className="rounded-md bg-[var(--theme-bg-subtle)] px-2.5 py-2 text-[12.5px] leading-relaxed text-[var(--theme-text-secondary)]">
+          {result.summary}
+        </p>
+      ) : null}
+
+      {/* Warnings — always visible, never buried */}
+      {result.warnings.length > 0 ? (
+        <Section title="告警 / 提示">
+          <div className="flex flex-col gap-1.5">
+            {result.warnings.map((w) => (
+              <WarningItem key={w.code} warning={w} />
+            ))}
+          </div>
+        </Section>
+      ) : null}
+
+      {/* Key metrics */}
+      {result.metrics.length > 0 ? (
+        <Section title="关键指标">
+          <div className="grid grid-cols-2 gap-1.5">
+            {result.metrics.map((m, i) => (
+              <MetricItem key={`${m.label}-${i}`} metric={m} />
+            ))}
+          </div>
+        </Section>
+      ) : null}
+
+      {/* Inputs */}
+      <Section title="输入">
+        {result.inputs.length > 0 ? (
+          <ul className="flex flex-col gap-1">
+            {result.inputs.map((inp, i) => (
+              <li key={i} className="flex items-baseline justify-between gap-2 text-[12.5px]">
+                <span className="text-[var(--theme-text-secondary)]">{inp.label}</span>
+                {inp.ref ? (
+                  <span className="truncate font-mono text-[10.5px] text-[var(--theme-text-muted)]" title={inp.ref}>{inp.ref}</span>
+                ) : (
+                  <span className="text-[10.5px] italic text-[var(--theme-text-muted)]">推断</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-[12px] italic text-[var(--theme-text-muted)]">未捕获输入参数（仅展示操作与输出）。</p>
+        )}
+      </Section>
+
+      {/* Parameters */}
+      {result.parameters.length > 0 ? (
+        <Section title="参数">
+          <dl className="grid grid-cols-[auto_1fr] gap-x-2.5 gap-y-1 text-[12.5px]">
+            {result.parameters.map((p, i) => (
+              <div key={i} className="contents">
+                <dt className="text-[var(--theme-text-muted)]">{p.label}</dt>
+                <dd className="truncate font-mono text-[var(--theme-text-primary)]" title={String(p.value)}>{String(p.value)}</dd>
+              </div>
+            ))}
+          </dl>
+        </Section>
+      ) : null}
+
+      {/* Output + map linkage */}
+      <Section
+        title="输出与地图"
+        action={
+          hasBoundLayer ? (
+            <span className="inline-flex items-center gap-1 text-[10.5px] text-[var(--theme-text-muted)]">
+              <span
+                aria-hidden
+                className={clsx('h-1.5 w-1.5 rounded-full', hasVisibleLayer ? 'bg-emerald-500' : 'bg-slate-400')}
+              />
+              {hasVisibleLayer ? '地图中可见' : '已隐藏'}
+            </span>
+          ) : null
+        }
+      >
+        <div className="flex flex-col gap-1.5 rounded-md border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-subtle)] px-2.5 py-2 text-[12.5px]">
+          <Row label="类型" value={outputKindLabel(output?.kind)} />
+          <Row label="要素数" value={featureCountLabel} />
+          <Row label="几何类型" value={geomLabel} />
+          <Row label="CRS" value={crsLabel} muted={crsLabel === '未知'} />
+          <Row label="范围 (W,S,E,N)" value={bboxLabel} mono />
+          {output?.estimatedBytes ? <Row label="估算大小" value={formatBytes(output.estimatedBytes)} /> : null}
+          {ref ? <Row label="引用" value={ref} mono title={ref} /> : null}
+          {output?.note ? <Row label="备注" value={output.note} /> : null}
+        </div>
+
+        {/* Map actions */}
+        <div className="flex flex-wrap gap-1.5">
+          {actions
+            .filter((a) => ['show_on_map', 'hide', 'zoom'].includes(a.kind))
+            .map((a) => (
+              <ActionButton key={a.kind} action={a} onAction={handleAction} />
+            ))}
+        </div>
+      </Section>
+
+      {/* Suggested next actions (analytical intents) */}
+      {actions.some((a) => !['show_on_map', 'hide', 'zoom'].includes(a.kind)) ? (
+        <Section title="后续操作">
+          <div className="flex flex-wrap gap-1.5">
+            {actions
+              .filter((a) => !['show_on_map', 'hide', 'zoom'].includes(a.kind))
+              .map((a) => (
+                <ActionButton key={a.kind} action={a} onAction={handleAction} />
+              ))}
+          </div>
+        </Section>
+      ) : null}
+
+      {/* Legend (compact; the live legend renders on the map) */}
+      {result.legendSpec ? (
+        <Section title="图例">
+          <span className="text-[12.5px] text-[var(--theme-text-secondary)]">
+            {legendSummary(result.legendSpec)}（完整图例见地图）
+          </span>
+        </Section>
+      ) : null}
+
+      {/* Provenance */}
+      {result.provenance.length > 0 ? (
+        <Section title="数据 lineage">
+          <ol className="flex flex-col gap-1 text-[12px] text-[var(--theme-text-secondary)]">
+            {result.provenance.map((p, i) => (
+              <li key={i} className="flex items-baseline gap-1.5">
+                <span className="text-[var(--theme-text-muted)]">{provenanceLabel(p.kind)}</span>
+                <span className="truncate text-[var(--theme-text-primary)]">{p.label}</span>
+              </li>
+            ))}
+          </ol>
+        </Section>
+      ) : null}
+
+      {/* Raw — progressive disclosure */}
+      <details className="group rounded-md border border-[var(--theme-border-subtle)] text-[12px]">
+        <summary className="cursor-pointer select-none px-2.5 py-1.5 text-[var(--theme-text-muted)] hover:bg-[var(--theme-bg-hover)]">
+          原始结果（高级）
+        </summary>
+        <pre className="max-h-64 overflow-auto px-2.5 py-2 font-mono text-[10.5px] leading-relaxed text-[var(--theme-text-secondary)]">
+          {truncateJson(result.raw)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+function Row({ label, value, mono, muted, title }: { label: string; value: string; mono?: boolean; muted?: boolean; title?: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-[var(--theme-text-muted)]">{label}</span>
+      <span
+        className={clsx('truncate text-right', mono && 'font-mono text-[11.5px]', muted && 'italic text-[var(--theme-text-muted)]')}
+        title={title ?? value}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function ActionButton({ action, onAction }: { action: SuggestedAction; onAction: (a: SuggestedAction) => void }) {
+  const icon = actionIcon(action.kind);
+  return (
+    <button
+      type="button"
+      disabled={!action.available}
+      onClick={() => onAction(action)}
+      aria-label={action.label}
+      className="inline-flex items-center gap-1 rounded-md border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1 text-[12px] text-[var(--theme-text-secondary)] transition-colors hover:bg-[var(--theme-bg-hover)] disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {icon ? <icon.type size={13} aria-hidden /> : null}
+      {action.label}
+    </button>
+  );
+}
+
+function actionIcon(kind: SuggestedAction['kind']): { type: typeof Eye } | null {
+  switch (kind) {
+    case 'show_on_map': return { type: Eye };
+    case 'hide': return { type: EyeOff };
+    case 'zoom': return { type: Crosshair };
+    case 'style': return { type: Sliders };
+    case 'buffer': return { type: MapPinned };
+    case 'overlay': return { type: LayersIcon };
+    case 'classify': return { type: LayersIcon };
+    case 'inspect': return { type: Crosshair };
+    case 'export': return { type: Download };
+    default: return null;
+  }
+}
+
+function outputKindLabel(kind?: string): string {
+  const map: Record<string, string> = {
+    vector: '矢量', raster: '栅格', statistic: '统计', table: '表格', image: '图像', none: '—',
+  };
+  return kind ? map[kind] ?? kind : '—';
+}
+
+function legendSummary(spec: AnalysisResult['legendSpec']): string {
+  if (!spec) return '';
+  const typeMap: Record<string, string> = { graduated: '分级', continuous: '连续', categorical: '分类', divergent: '发散' };
+  const field = (spec as { field?: string }).field;
+  return `${typeMap[spec.type] ?? spec.type}${field ? ` · ${field}` : ''}`;
+}
+
+function provenanceLabel(kind: string): string {
+  const map: Record<string, string> = { input: '输入', operation: '操作', output: '输出', run: '运行' };
+  return map[kind] ?? kind;
+}
+
+function truncateJson(raw: unknown): string {
+  try {
+    const s = JSON.stringify(raw, null, 2);
+    return s.length > 4000 ? `${s.slice(0, 4000)}\n…（已截断）` : s;
+  } catch {
+    return String(raw);
+  }
+}
+
+export default ResultDetail;

--- a/frontend/components/sidebar/results/result-list.tsx
+++ b/frontend/components/sidebar/results/result-list.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+/**
+ * ResultList — bounded, session-scoped list of captured analysis results.
+ * Master half of the Results tab master-detail. Keyboard-navigable (native
+ * buttons), dense, status-forward.
+ */
+import { ClipboardList } from 'lucide-react';
+import clsx from 'clsx';
+import { familyLabel } from '@/lib/results/families';
+import type { AnalysisResult } from '@/lib/results/types';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { EmptyState } from '@/components/shared/empty-state';
+
+interface ResultListProps {
+  results: AnalysisResult[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  completed: '已完成',
+  failed: '失败',
+  partial: '部分完成',
+  warning: '含告警',
+  running: '运行中',
+  unknown: '未知',
+};
+
+function formatTime(ms?: number): string {
+  if (!ms) return '';
+  try {
+    return new Date(ms).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
+export function ResultList({ results, selectedId, onSelect }: ResultListProps) {
+  if (results.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center p-4">
+        <EmptyState
+          icon={ClipboardList}
+          title="暂无分析结果"
+          description="完成一次空间分析后，结果将自动出现在此处，供你查看输入、指标、输出与地图联动。"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <ul aria-label="分析结果列表" className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
+      {results.map((r) => {
+        const selected = r.id === selectedId;
+        const hasLayer = r.outputs[0]?.hasLayer;
+        return (
+          <li key={r.id}>
+            <button
+              type="button"
+              aria-current={selected ? 'true' : undefined}
+              onClick={() => onSelect(r.id)}
+              className={clsx(
+                'flex w-full flex-col gap-1 rounded-md border px-2.5 py-2 text-left transition-colors',
+                selected
+                  ? 'border-[var(--agent-accent,#16a34a)]/50 bg-[var(--theme-bg-hover)]'
+                  : 'border-transparent hover:bg-[var(--theme-bg-hover)]',
+              )}
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="truncate text-[13px] font-medium text-[var(--theme-text-primary)]">{r.toolLabel}</span>
+                <StatusBadge status={r.status} label={STATUS_LABEL[r.status] ?? r.status} />
+                <span className="ml-auto shrink-0 text-[10.5px] text-[var(--theme-text-muted)]">{formatTime(r.capturedAt)}</span>
+              </div>
+              <div className="flex items-center gap-1.5 text-[11px] text-[var(--theme-text-muted)]">
+                <span>{familyLabel(r.family)}</span>
+                {hasLayer ? (
+                  <span className="inline-flex items-center gap-0.5 rounded bg-[var(--theme-bg-subtle)] px-1 py-0.5 text-[10px]">
+                    已挂载图层
+                  </span>
+                ) : null}
+                {r.warnings.length > 0 ? (
+                  <span className="inline-flex items-center gap-0.5 rounded bg-amber-500/10 px-1 py-0.5 text-[10px] text-amber-600 dark:text-amber-300">
+                    {r.warnings.length} 条告警
+                  </span>
+                ) : null}
+              </div>
+              {r.summary ? (
+                <span className="line-clamp-2 text-[12px] text-[var(--theme-text-secondary)]">{r.summary}</span>
+              ) : null}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default ResultList;

--- a/frontend/components/sidebar/tasks-tab.tsx
+++ b/frontend/components/sidebar/tasks-tab.tsx
@@ -13,7 +13,7 @@
  */
 'use client';
 
-import { ListChecks, RefreshCw, RotateCcw, X } from 'lucide-react';
+import { ListChecks, RefreshCw, RotateCcw, X, ClipboardList } from 'lucide-react';
 import { useMemo } from 'react';
 
 import type { JobStatus, JobView } from '@/lib/api/jobs';
@@ -69,6 +69,16 @@ function JobCard({
     isCancelling && job.active && job.status !== 'cancelling' ? 'cancelling' : job.status;
   const showProgress = job.active && job.progress !== null;
   const indeterminate = job.active && job.progress === null;
+
+  // Result Workbench entry point: link a durable job to a captured result by
+  // shared background_job_ids / agent_step_id, and surface an inspector link.
+  const results = useHudStore((s) => s.results);
+  const selectResult = useHudStore((s) => s.selectResult);
+  const setActiveLeftTab = useHudStore((s) => s.setActiveLeftTab);
+  const linkedResult = results.find(
+    (r) => r.backgroundJobIds.includes(job.id) || (!!job.agent_step_id && r.id === job.agent_step_id),
+  );
+  const canOpenResult = !!linkedResult && !job.active;
 
   return (
     /* 任务行与 layers-tab 同款交互配方：hover 底色 + 左侧预留 accent 指示条
@@ -128,9 +138,22 @@ function JobCard({
         <span>已用 {formatElapsed(job, now)}</span>
         <div className="flex items-center gap-2">
           {job.result_ref && !job.active && (
-            <span className="max-w-[10rem] truncate text-ink-muted" title={job.result_ref}>
-              {job.result_ref.split('/').pop()}
-            </span>
+            canOpenResult && linkedResult ? (
+              <button
+                type="button"
+                onClick={() => { selectResult(linkedResult.id); setActiveLeftTab('results'); }}
+                className="inline-flex max-w-[10rem] items-center gap-1 truncate rounded-sm px-1 py-0.5 text-ink-muted transition-colors hover:bg-surface-hover hover:text-ink"
+                title={`在结果工作台查看：${job.result_ref}`}
+                aria-label="在结果工作台查看分析结果"
+              >
+                <ClipboardList className="h-3 w-3" aria-hidden />
+                <span className="truncate">{job.result_ref.split('/').pop()}</span>
+              </button>
+            ) : (
+              <span className="max-w-[10rem] truncate text-ink-muted" title={job.result_ref}>
+                {job.result_ref.split('/').pop()}
+              </span>
+            )
           )}
           {job.cancellable && (
             <button

--- a/frontend/lib/hooks/use-result-descriptor.ts
+++ b/frontend/lib/hooks/use-result-descriptor.ts
@@ -1,0 +1,130 @@
+'use client';
+
+/**
+ * Lazy, metadata-first output descriptor for a result.
+ *
+ * Fetches `GET /layers/descriptor/{ref}` (feature_count / bbox / geometry_types /
+ * estimated_bytes) — NEVER the full GeoJSON payload (spec §16). The fetch is:
+ *  - per-ref deduped (module-level in-flight map + cache),
+ *  - aborted on result/session switch or unmount,
+ *  - guarded by a generation counter so a slow response for result A can never
+ *    overwrite result B (spec §17).
+ *
+ * CRS is intentionally not enriched (the descriptor carries none); it stays
+ * "Unknown" in the UI (spec §9).
+ */
+import { useEffect, useRef } from 'react';
+import { apiFetch, isApiError } from '@/lib/api/transport';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { devOnly } from '@/lib/utils/logger';
+import type { AnalysisResult, LayerDescriptor } from '@/lib/results/types';
+
+interface InFlightEntry {
+  promise: Promise<LayerDescriptor | null>;
+  controller: AbortController;
+}
+
+// Module-level dedup: one in-flight request per ref + a small positive cache so
+// re-mounting the same result detail (e.g. after a tab round-trip) doesn't refetch.
+const inFlight = new Map<string, InFlightEntry>();
+const cache = new Map<string, LayerDescriptor | null>();
+const CACHE_TTL_MS = 30_000;
+
+function cacheKey(ref: string, sessionId: string | null | undefined): string {
+  return `${sessionId ?? '_'}::${ref}`;
+}
+
+async function fetchDescriptor(
+  ref: string,
+  sessionId: string | null | undefined,
+  ownerToken: string | null | undefined,
+  outerSignal: AbortSignal,
+): Promise<LayerDescriptor | null> {
+  const key = cacheKey(ref, sessionId);
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const existing = inFlight.get(key);
+  if (existing) {
+    // Attach abort linkage: if the outer call aborts we still let the shared
+    // request finish for other consumers, but we race-abort our own wait.
+    try {
+      return await existing.promise;
+    } catch {
+      return null;
+    }
+  }
+
+  const controller = new AbortController();
+  const onOuterAbort = () => controller.abort();
+  outerSignal.addEventListener('abort', onOuterAbort, { once: true });
+
+  const params = new URLSearchParams();
+  if (sessionId) params.set('session_id', sessionId);
+  const path = `/api/v1/layers/descriptor/${encodeURIComponent(ref)}${params.toString() ? `?${params}` : ''}`;
+
+  const promise = apiFetch<LayerDescriptor>(path, {
+    signal: controller.signal,
+    ownerToken: ownerToken ?? undefined,
+    label: 'Result descriptor error',
+  })
+    .then((data) => {
+      cache.set(key, data ?? null);
+      scheduleEvict(key);
+      return data ?? null;
+    })
+    .catch((err) => {
+      if (!isApiError(err)) devOnly.warn('[ResultDescriptor] fetch failed', err);
+      // Negative-cache briefly to avoid hammering on 404 (session expired).
+      cache.set(key, null);
+      scheduleEvict(key);
+      return null;
+    })
+    .finally(() => {
+      inFlight.delete(key);
+      outerSignal.removeEventListener('abort', onOuterAbort);
+    });
+
+  inFlight.set(key, { promise, controller });
+  return promise;
+}
+
+function scheduleEvict(key: string): void {
+  setTimeout(() => cache.delete(key), CACHE_TTL_MS);
+}
+
+/**
+ * Enrich the given result's output with descriptor metadata. No-op when the
+ * result has no ref, or is already enriched, or the descriptor is unavailable.
+ */
+export function useResultDescriptor(
+  result: AnalysisResult | null,
+  sessionId: string | null | undefined,
+  ownerToken: string | null | undefined,
+): void {
+  const enrichResultOutput = useHudStore((s) => s.enrichResultOutput);
+  const generationRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const ref = result?.outputs[0]?.ref;
+  const resultId = result?.id;
+  const alreadyEnriched = !!result?.outputs[0]?.featureCount || !!result?.outputs[0]?.estimatedBytes;
+
+  useEffect(() => {
+    if (!resultId || !ref || alreadyEnriched) return;
+    const gen = ++generationRef.current;
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    fetchDescriptor(ref, sessionId, ownerToken, controller.signal).then((descriptor) => {
+      // Generation guard: drop responses that no longer match the current result.
+      if (gen !== generationRef.current || controller.signal.aborted) return;
+      if (descriptor) enrichResultOutput(resultId, ref, descriptor);
+    });
+
+    return () => {
+      controller.abort();
+      if (abortRef.current === controller) abortRef.current = null;
+    };
+  }, [resultId, ref, alreadyEnriched, sessionId, ownerToken, enrichResultOutput]);
+}

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -174,6 +174,8 @@ export function useSSEStream(
       plan?: PlanProposalPayload;
       agentPlan?: AgentPlanState;
       layerAdded?: string;
+      /** Result Workbench linkage (id of the captured AnalysisResult for this step). */
+      resultId?: string;
     }>
   >([
     {
@@ -279,7 +281,20 @@ export function useSSEStream(
           chunk,
           !!(data.is_reasoning || data.type === "reasoning"),
         );
+      } else if (event.event === 'tool_call') {
+        // Result Workbench: stash the tool-call args so the matching step_result
+        // can show truthful input evidence + parameters (best-effort, keyed by
+        // tool name within the turn).
+        if (data.name && typeof data.arguments === 'string') {
+          useHudStore.getState().captureToolCallArgs(data.name, data.arguments);
+        }
       } else if (event.event === "step_result") {
+        // Result Workbench: normalize + record this result into the bounded,
+        // session-scoped registry. Runs before the layer/chart handling so the
+        // result is inspectable even when no layer is mounted. propose_plan and
+        // other non-analysis events are ignored inside the slice. The returned
+        // id lets the chat layer-added chip deep-link to the same result.
+        const workbenchResultId = useHudStore.getState().captureStepResult(data);
         // Plan Mode：propose_plan 返回的 plan 摘要挂到当前消息，由 PlanProposalCard 渲染
         if (data.tool === 'propose_plan' && data.result?.success && data.result?.plan_id) {
           const plan: PlanProposalPayload = {
@@ -384,7 +399,7 @@ export function useSSEStream(
           }
 
           setMessages((prev) =>
-            prev.map((m) => (m.id === thinkingId ? { ...m, layerAdded: layerName } : m))
+            prev.map((m) => (m.id === thinkingId ? { ...m, layerAdded: layerName, resultId: workbenchResultId } : m))
           );
         }
         // Chart data from generate_chart tool — attach to message for rendering in chat

--- a/frontend/lib/hooks/use-workspace-session.test.ts
+++ b/frontend/lib/hooks/use-workspace-session.test.ts
@@ -20,6 +20,7 @@ const hudState = vi.hoisted(() => ({
   setBaseLayer: vi.fn(),
   addLayer: vi.fn(),
   fetchAnalysisAssets: vi.fn().mockResolvedValue(undefined),
+  clearResults: vi.fn(),
 }));
 
 vi.mock('@/lib/store/useHudStore', () => ({

--- a/frontend/lib/hooks/use-workspace-session.ts
+++ b/frontend/lib/hooks/use-workspace-session.ts
@@ -33,6 +33,7 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
   const setSelectedFeature = useHudStore((s) => s.setSelectedFeature);
   const setAiStatus = useHudStore((s) => s.setAiStatus);
   const clearTask = useHudStore((s) => s.clearTask);
+  const clearResults = useHudStore((s) => s.clearResults);
 
   // Sync sessionId state to ref
   useEffect(() => {
@@ -84,6 +85,9 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
       setSelectedFeature(null);
       setAiStatus('idle');
       clearTask();
+      // Result Workbench: results reference session-scoped ref: cursors that are
+      // dead in the new session — clear the registry to avoid stale inspection.
+      clearResults();
       // F4: the viewport seq tracker is per-session (server seqs are
       // session-scoped) — reset before the restore GET so the coalesce below
       // compares against a fresh counter, not the previous session's.
@@ -192,7 +196,7 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
         }
       }
     },
-    [clearLayers, clearAnnotations, clearTask, setSelectedFeature, setAiStatus, dispatchAction]
+    [clearLayers, clearAnnotations, clearTask, clearResults, setSelectedFeature, setAiStatus, dispatchAction]
   );
 
   const startNewSession = useCallback(

--- a/frontend/lib/results/families.ts
+++ b/frontend/lib/results/families.ts
@@ -1,0 +1,243 @@
+/**
+ * Analysis-family classification + metric extraction rules.
+ *
+ * This is the data-driven "matrix": each family declares how to read *scalar*
+ * result fields for metrics. It reads ONLY scalars — it never touches
+ * `result.data.features` (which may be a large array, or already stripped by the
+ * server-side slim_event_result). Missing fields are skipped, never fabricated.
+ */
+import type { OutputKind, ResultFamily, ResultMetric, StepResultEvent } from './types';
+
+/* ─── Tool labels (localized; falls back to humanized name) ─────────────────── */
+
+const TOOL_LABELS: Record<string, string> = {
+  buffer_analysis: '缓冲区分析',
+  multi_ring_buffer: '多环缓冲区',
+  service_area_simple: '服务区域',
+  overlay_analysis: '叠加分析',
+  spatial_stats: '空间统计',
+  moran_i: "Moran's I 空间自相关",
+  standard_deviational_ellipse: '标准差椭圆',
+  hotspot_analysis: '热点分析',
+  spatial_cluster: '空间聚类',
+  st_dbscan: '时空聚类 (ST-DBSCAN)',
+  kde_surface: '核密度表面',
+  kde_contours: '核密度等值线',
+  heatmap_data: '热力图',
+  idw_interpolation: 'IDW 插值',
+  isochrone_network: '等时圈分析',
+  nearest_facility: '最近设施',
+  raster_reclassify: '栅格重分类',
+  raster_calculator: '栅格计算器',
+  raster_resample: '栅格重采样',
+  zonal_stats: '分区统计',
+  h3_binning: 'H3 聚合',
+  h3_lisa: 'H3 LISA',
+  compute_ndvi: 'NDVI 计算',
+  fetch_dem: 'DEM 获取',
+  create_thematic_map: '专题制图',
+  apply_template: '制图模板',
+  display_layer: '图层显示',
+};
+
+const FAMILY_LABELS: Record<ResultFamily, string> = {
+  buffer: '邻近分析',
+  overlay: '叠加分析',
+  spatial_stats: '空间统计',
+  hotspot: '热点分析',
+  cluster: '聚类分析',
+  density: '密度分析',
+  interpolation: '插值分析',
+  network: '网络分析',
+  raster: '栅格分析',
+  h3: '六边形 (H3) 分析',
+  remote_sensing: '遥感分析',
+  cartography: '制图',
+  generic: '空间分析',
+};
+
+const FAMILY_BY_TOOL: Record<string, ResultFamily> = {
+  buffer_analysis: 'buffer',
+  multi_ring_buffer: 'buffer',
+  service_area_simple: 'buffer',
+  overlay_analysis: 'overlay',
+  spatial_stats: 'spatial_stats',
+  moran_i: 'spatial_stats',
+  standard_deviational_ellipse: 'spatial_stats',
+  hotspot_analysis: 'hotspot',
+  spatial_cluster: 'cluster',
+  st_dbscan: 'cluster',
+  kde_surface: 'density',
+  kde_contours: 'density',
+  heatmap_data: 'density',
+  idw_interpolation: 'interpolation',
+  isochrone_network: 'network',
+  nearest_facility: 'network',
+  raster_reclassify: 'raster',
+  raster_calculator: 'raster',
+  raster_resample: 'raster',
+  // zonal_stats outputs a VECTOR FeatureCollection (polygons enriched with raster
+  // stats), so it must NOT be classified as raster (which would force kind=raster).
+  h3_binning: 'h3',
+  h3_lisa: 'h3',
+  compute_ndvi: 'remote_sensing',
+  fetch_dem: 'remote_sensing',
+  create_thematic_map: 'cartography',
+  apply_template: 'cartography',
+};
+
+export function classifyFamily(tool: string): ResultFamily {
+  return FAMILY_BY_TOOL[tool] ?? 'generic';
+}
+
+export function toolLabel(tool: string): string {
+  return TOOL_LABELS[tool] ?? humanize(tool);
+}
+
+export function familyLabel(family: ResultFamily): string {
+  return FAMILY_LABELS[family];
+}
+
+function humanize(tool: string): string {
+  return tool
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
+/* ─── Output kind ───────────────────────────────────────────────────────────── */
+
+export function outputKindFor(
+  family: ResultFamily,
+  result: Record<string, any> | null | undefined,
+  geojsonRef: string | null | undefined,
+): OutputKind {
+  if (result?.image || result?.type === 'heatmap_raster') return 'image';
+  // A session ref means a vector layer is mounted — prefer that over the family
+  // default so vector-producing tools (e.g. zonal_stats) are never mislabeled raster.
+  if (geojsonRef) return 'vector';
+  if (family === 'raster' || family === 'remote_sensing') return 'raster';
+  if (family === 'spatial_stats') return 'statistic';
+  if (family === 'cartography') return 'none';
+  return result?.data ? 'vector' : 'statistic';
+}
+
+/* ─── Metric extraction (scalars only) ──────────────────────────────────────── */
+
+/** Safely read a (possibly nested) scalar path from the slim_event. */
+function readPath(src: Record<string, any> | null | undefined, path: string): any {
+  if (!src) return undefined;
+  const parts = path.split('.');
+  let cur: any = src;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+function num(v: any): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+function round(n: number, digits = 3): number {
+  const f = 10 ** digits;
+  return Math.round(n * f) / f;
+}
+
+function metric(label: string, v: number | undefined, opts: { unit?: string; digits?: number; emphasis?: 'primary' | 'secondary' } = {}): ResultMetric | null {
+  if (v === undefined) return null;
+  return {
+    label,
+    value: opts.digits ? round(v, opts.digits) : v,
+    unit: opts.unit,
+    emphasis: opts.emphasis,
+  };
+}
+
+/**
+ * Extract result metrics from the slim_event. Reads only scalar fields; never
+ * touches feature arrays. Returns [] when no scalar metrics are available
+ * (feature count etc. is then sourced from the descriptor endpoint).
+ */
+export function extractMetrics(
+  family: ResultFamily,
+  step: StepResultEvent,
+): ResultMetric[] {
+  const r = step.result ?? {};
+  const data = r.data;
+  const out: (ResultMetric | null)[] = [];
+
+  switch (family) {
+    case 'spatial_stats': {
+      if (step.tool === 'moran_i') {
+        out.push(metric("Moran's I", num(readPath(data, 'moran_i')), { digits: 4, emphasis: 'primary' }));
+        out.push(metric('期望 I', num(readPath(data, 'expected_i')), { digits: 4 }));
+        out.push(metric('p 值', num(readPath(data, 'p_value')), { digits: 4 }));
+        const pattern = readPath(data, 'pattern');
+        if (typeof pattern === 'string') out.push({ label: '空间模式', value: pattern });
+        out.push(metric('要素数', num(readPath(data, 'n_features'))));
+      } else if (step.tool === 'standard_deviational_ellipse') {
+        out.push(metric('椭圆面积', num(readPath(data, 'area_km2')), { unit: 'km²', digits: 2, emphasis: 'primary' }));
+        out.push(metric('方向角', num(readPath(data, 'angle_deg')), { unit: '°', digits: 1 }));
+        const dir = readPath(data, 'direction');
+        if (typeof dir === 'string') out.push({ label: '方向', value: dir });
+      } else {
+        out.push(metric('要素数', num(readPath(data, 'count')), { emphasis: 'primary' }));
+        out.push(metric('总面积', num(readPath(data, 'total_area_m2')), { unit: 'm²', digits: 1 }));
+        out.push(metric('总长度', num(readPath(data, 'total_length_m')), { unit: 'm', digits: 1 }));
+      }
+      break;
+    }
+    case 'hotspot': {
+      out.push(metric('热点数', num(readPath(data, 'hot_spots_count')), { emphasis: 'primary' }));
+      out.push(metric('冷点数', num(readPath(data, 'cold_spots_count'))));
+      out.push(metric('距离带', num(readPath(data, 'distance_band_m')), { unit: 'm', digits: 1 }));
+      break;
+    }
+    case 'cluster': {
+      const method = readPath(data, 'method');
+      if (typeof method === 'string') out.push({ label: '方法', value: method });
+      out.push(metric('簇数', num(readPath(data, 'n_clusters')), { emphasis: 'primary' }));
+      const stats = readPath(data, 'cluster_stats');
+      if (Array.isArray(stats)) out.push({ label: '簇统计', value: `${stats.length} 组` });
+      break;
+    }
+    case 'density': {
+      if (step.tool === 'heatmap_data') {
+        out.push(metric('总点数', num(r.total_points ?? readPath(r, 'metadata.point_count')), { emphasis: 'primary' }));
+      } else {
+        out.push(metric('单元格数', num(readPath(data, 'count')), { emphasis: 'primary' }));
+        out.push(metric('带宽', num(readPath(data, 'bandwidth_m')), { unit: 'm', digits: 1 }));
+        const grid = readPath(data, 'grid_size');
+        if (Array.isArray(grid)) out.push({ label: '网格尺寸', value: `${grid[0]}×${grid[1]}` });
+        out.push(metric('最小密度', num(readPath(data, 'stats.min')), { digits: 4 }));
+        out.push(metric('最大密度', num(readPath(data, 'stats.max')), { digits: 4 }));
+        out.push(metric('平均密度', num(readPath(data, 'stats.mean_density')), { digits: 4 }));
+      }
+      break;
+    }
+    case 'network': {
+      // isochrone: unreachable count is prose in summary (parsed as warning);
+      // facility count comes from args. Nearest facility has no aggregate scalar.
+      break;
+    }
+    case 'remote_sensing': {
+      if (step.tool === 'compute_ndvi') {
+        out.push(metric('NDVI 最小', num(readPath(r, 'ndvi_stats.min')), { digits: 3 }));
+        out.push(metric('NDVI 最大', num(readPath(r, 'ndvi_stats.max')), { digits: 3, emphasis: 'primary' }));
+        out.push(metric('NDVI 均值', num(readPath(r, 'ndvi_stats.mean')), { digits: 3 }));
+        const cov = readPath(r, 'vegetation_coverage');
+        if (typeof cov === 'number') out.push(metric('植被覆盖度', cov, { unit: '%', digits: 1, emphasis: 'primary' }));
+        else if (typeof cov === 'string') out.push({ label: '植被覆盖度', value: cov });
+      }
+      break;
+    }
+    default:
+      // buffer / overlay / interpolation / raster / h3 / cartography / generic:
+      // no reliable scalar metrics in the slim_event; counts come from descriptor.
+      break;
+  }
+
+  return out.filter((m): m is ResultMetric => m !== null);
+}

--- a/frontend/lib/results/normalize.ts
+++ b/frontend/lib/results/normalize.ts
@@ -1,0 +1,334 @@
+/**
+ * Pure normalizer: SSE `step_result` → shared `AnalysisResult`.
+ *
+ * Deterministic & side-effect-free (safe to memoize). All "live" concerns
+ * (layer visibility, descriptor enrichment, job status) are reconciled later by
+ * the store/hook layer; the normalizer only reflects what the event itself
+ * truthfully carries.
+ */
+import { classifyFamily, extractMetrics, familyLabel, outputKindFor, toolLabel } from './families';
+import { deriveSuggestedActions } from './suggested-actions';
+import type {
+  AnalysisResult,
+  ArgsContext,
+  BBox,
+  InputRef,
+  ResultParam,
+  ResultStatus,
+  ResultWarning,
+  StepResultEvent,
+} from './types';
+import type { LegendSpec } from '@/lib/map-kit/types';
+
+const REF_KEYS = new Set([
+  'geojson',
+  'layer',
+  'layer_a',
+  'layer_b',
+  'network_layer',
+  'source_points',
+  'target_points',
+  'raster_path',
+  'raster_a',
+  'raster_b',
+  'h3_geojson',
+]);
+
+const FIELD_KEYS = new Set(['value_field', 'stat_field', 'timestamp_field', 'field']);
+
+const PARAM_KEYS = new Set([
+  'distance',
+  'distances',
+  'unit',
+  'how',
+  'method',
+  'n_clusters',
+  'eps',
+  'eps1_spatial_meters',
+  'eps2_temporal_seconds',
+  'min_samples',
+  'value_field',
+  'stat_field',
+  'stat_method',
+  'timestamp_field',
+  'resolution',
+  'power',
+  'expression',
+  'constant',
+  'scheme',
+  'travel_time',
+  'travel_time_min',
+  'mode',
+  'levels',
+  'bandwidth',
+  'cell_size',
+  'radius',
+  'render_type',
+  'palette',
+  'target_resolution',
+  'target_crs',
+  'resampling',
+  'distance_band',
+  'merge_rings',
+  'dissolve',
+  'date_from',
+  'date_to',
+  'nodata',
+]);
+
+/* ─── helpers ───────────────────────────────────────────────────────────────── */
+
+export function parseBBox(bbox: unknown): BBox | undefined {
+  if (Array.isArray(bbox) && bbox.length === 4 && bbox.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+    return bbox as BBox;
+  }
+  return undefined;
+}
+
+function extractLegendSpec(result: Record<string, any>): LegendSpec | undefined {
+  const ls = result.legend_spec ?? result.data?.legend_spec;
+  // Light validation: must look like one of the legend variants.
+  if (ls && typeof ls === 'object' && typeof ls.type === 'string') {
+    return ls as LegendSpec;
+  }
+  return undefined;
+}
+
+function extractWarnings(result: Record<string, any>, summary: string | undefined): ResultWarning[] {
+  const warnings: ResultWarning[] = [];
+  const seen = new Set<string>();
+  const add = (w: ResultWarning) => {
+    if (!seen.has(w.code)) {
+      seen.add(w.code);
+      warnings.push(w);
+    }
+  };
+
+  // NOTE: `_streaming_note` is a transport artifact (the server slimmed feature
+  // data out of the SSE event but the full layer IS auto-loaded on the map). It
+  // is NOT a result-quality warning, so we intentionally do not surface it —
+  // otherwise every feature-bearing result would be mislabeled "partial".
+  if (result.correction_hint) {
+    add({ level: 'warning', code: 'correction_hint', message: String(result.correction_hint) });
+  }
+
+  const text = summary ?? '';
+  if (/grid too dense/i.test(text)) {
+    add({ level: 'warning', code: 'grid_too_dense', message: '网格过密，可能影响渲染性能。' });
+  }
+  if (/unreachable|disconnected from the road network/i.test(text)) {
+    add({ level: 'warning', code: 'unreachable_facilities', message: '存在无法到达的设施（与路网不连通）。' });
+  }
+  if (/no significant/i.test(text)) {
+    add({ level: 'info', code: 'no_significance', message: '未发现显著的热点/冷点。' });
+  }
+  // Generic "Warning:" sentences in summary prose.
+  const m = /Warning:\s*([^\n.]+)/i.exec(text);
+  if (m && !seen.has('generic_warning')) {
+    add({ level: 'warning', code: 'generic_warning', message: m[1].trim() });
+  }
+
+  return warnings;
+}
+
+function extractInputs(args: Record<string, any> | undefined): { inputs: InputRef[]; field?: string } {
+  if (!args) return { inputs: [] };
+  const inputs: InputRef[] = [];
+  let field: string | undefined;
+  for (const [k, v] of Object.entries(args)) {
+    if (FIELD_KEYS.has(k) && typeof v === 'string' && v) {
+      field = v;
+      continue;
+    }
+    const isRefVal = typeof v === 'string' && v.startsWith('ref:');
+    if (REF_KEYS.has(k) || isRefVal) {
+      inputs.push({
+        ref: isRefVal ? v : undefined,
+        label: labelForInput(k, v),
+        inferred: !isRefVal && !REF_KEYS.has(k),
+      });
+    }
+  }
+  return { inputs, field };
+}
+
+function labelForInput(key: string, value: any): string {
+  const map: Record<string, string> = {
+    geojson: '输入图层',
+    layer: '输入图层',
+    layer_a: '图层 A',
+    layer_b: '图层 B',
+    network_layer: '路网图层',
+    source_points: '源点',
+    target_points: '目标点',
+    raster_path: '输入栅格',
+    raster_a: '栅格 A',
+    raster_b: '栅格 B',
+    h3_geojson: 'H3 图层',
+  };
+  if (typeof value === 'string' && value.startsWith('ref:')) return map[key] ?? '引用图层';
+  if (typeof value === 'string' && value) return value.length > 40 ? `${value.slice(0, 37)}…` : value;
+  return map[key] ?? key;
+}
+
+function extractParams(args: Record<string, any> | undefined, field?: string): ResultParam[] {
+  if (!args) return [];
+  const params: ResultParam[] = [];
+  for (const [k, v] of Object.entries(args)) {
+    if (PARAM_KEYS.has(k) && v !== undefined && v !== null && v !== '') {
+      params.push({ label: paramLabel(k), value: formatParam(v), source: k });
+    }
+  }
+  if (field && !params.some((p) => p.source === 'value_field')) {
+    params.push({ label: '字段', value: field, source: 'value_field' });
+  }
+  return params;
+}
+
+function paramLabel(key: string): string {
+  const map: Record<string, string> = {
+    distance: '缓冲距离',
+    distances: '缓冲距离',
+    unit: '单位',
+    how: '叠加方式',
+    method: '方法',
+    n_clusters: '簇数',
+    eps: 'eps',
+    min_samples: '最小样本数',
+    value_field: '值字段',
+    stat_field: '统计字段',
+    stat_method: '统计方法',
+    timestamp_field: '时间字段',
+    resolution: '分辨率',
+    power: '幂参数',
+    expression: '表达式',
+    constant: '常量',
+    scheme: '分类方案',
+    travel_time: '通行时间',
+    travel_time_min: '通行时间',
+    mode: '出行方式',
+    levels: '层级',
+    bandwidth: '带宽',
+    cell_size: '像元大小',
+    radius: '半径',
+    render_type: '渲染类型',
+    palette: '配色',
+    target_resolution: '目标分辨率',
+    target_crs: '目标 CRS',
+    resampling: '重采样',
+    distance_band: '距离带',
+    merge_rings: '合并环',
+    dissolve: '融合',
+    date_from: '起始日期',
+    date_to: '结束日期',
+    nodata: 'nodata',
+  };
+  return map[key] ?? key;
+}
+
+function formatParam(v: any): string | number | boolean {
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return v;
+  if (Array.isArray(v)) return v.join(', ');
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+function deriveStatus(
+  result: Record<string, any>,
+  warnings: ResultWarning[],
+  approximate: boolean,
+): ResultStatus {
+  if (result.success === false || result.error || result.error_type) return 'failed';
+  const hasStrong = warnings.some((w) => w.level === 'warning' || w.level === 'error');
+  if (hasStrong) return approximate ? 'partial' : 'warning';
+  if (approximate) return 'partial';
+  return 'completed';
+}
+
+/* ─── entry ─────────────────────────────────────────────────────────────────── */
+
+export function normalizeStepResult(step: StepResultEvent, argsCtx?: ArgsContext): AnalysisResult {
+  const tool = step.tool ?? 'unknown';
+  const family = classifyFamily(tool);
+  const result = step.result ?? {};
+  const geojsonRef = step.geojson_ref ?? null;
+  const summary = typeof result.summary === 'string' ? result.summary : undefined;
+
+  const legendSpec = extractLegendSpec(result);
+  const warnings = extractWarnings(result, summary);
+  // "Approximate/partial" means a genuine quality compromise (filtered geometry,
+  // over-dense grid) — NOT merely the presence of any warning. A plain warning
+  // (e.g. unreachable facilities) stays status `warning`, not `partial`.
+  const approximate = warnings.some((w) => w.code === 'grid_too_dense');
+  const status = deriveStatus(result, warnings, approximate);
+
+  const { inputs, field } = argsCtx?.captured ? extractInputs(argsCtx.args) : { inputs: [], field: undefined };
+  const parameters = argsCtx?.captured ? extractParams(argsCtx.args, field) : [];
+
+  const kind = outputKindFor(family, result, geojsonRef);
+  const hasBoundLayer = !!(geojsonRef || result.image);
+  // Ref layers mount hidden (visible: !geojson_ref); image-only layers mount visible.
+  const hasVisibleLayer = !!(result.image && !geojsonRef);
+
+  const outputs = [
+    {
+      kind,
+      ref: geojsonRef ?? undefined,
+      hasLayer: hasBoundLayer,
+      bbox: parseBBox(result.bbox),
+      note: kind === 'raster' && result.result_path ? '栅格已写入存储' : undefined,
+    },
+  ];
+
+  const suggestedActions = deriveSuggestedActions(family, outputs, hasVisibleLayer, hasBoundLayer);
+
+  const metrics = extractMetrics(family, step);
+
+  const provenance = [
+    { kind: 'operation' as const, label: toolLabel(tool), detail: familyLabel(family) },
+    ...inputs.map((inp) => ({ kind: 'input' as const, label: inp.label, detail: inp.ref })),
+    { kind: 'output' as const, label: outputLabel(kind), detail: geojsonRef ?? undefined },
+    ...(step.background_job_ids?.length ? [{ kind: 'run' as const, label: `后台作业 ×${step.background_job_ids.length}` }] : []),
+  ];
+
+  return {
+    // Prefer the stable step_id. Avoid falling back to task_id when it equals the
+    // session id (Pi-event path stamps task_id = session_id), which would collapse
+    // every result in a turn onto one registry entry.
+    id: step.step_id
+      || (step.task_id && step.task_id !== step.session_id ? step.task_id : `${tool}-${Date.now()}`),
+    tool,
+    toolLabel: toolLabel(tool),
+    family,
+    status,
+    summary,
+    inputs: argsCtx?.captured ? inputs : [],
+    parameters,
+    metrics,
+    warnings,
+    outputs,
+    bbox: parseBBox(result.bbox),
+    legendSpec,
+    layerBindings: [],
+    provenance,
+    suggestedActions,
+    backgroundJobIds: step.background_job_ids ?? [],
+    raw: result,
+    approximate: approximate || undefined,
+  };
+}
+
+function outputLabel(kind: string): string {
+  const map: Record<string, string> = {
+    vector: '矢量输出',
+    raster: '栅格输出',
+    statistic: '统计结果',
+    table: '表格输出',
+    image: '图像输出',
+    none: '无图层输出',
+  };
+  return map[kind] ?? '输出';
+}

--- a/frontend/lib/results/suggested-actions.ts
+++ b/frontend/lib/results/suggested-actions.ts
@@ -1,0 +1,51 @@
+/**
+ * Derive safe "next actions" from a result's capabilities (spec §13).
+ *
+ * Actions never duplicate tool execution logic — map actions (show/hide/zoom) go
+ * through the store, and analytical suggestions (buffer/overlay/classify/export)
+ * are surfaced as chat *intents* the user can send, reusing existing workflows.
+ */
+import type { OutputDescriptor, ResultFamily, SuggestedAction } from './types';
+
+export function deriveSuggestedActions(
+  family: ResultFamily,
+  outputs: OutputDescriptor[],
+  /** Whether the result currently has a visible bound layer. */
+  hasVisibleLayer: boolean,
+  /** Whether any bound layer exists (visible or hidden). */
+  hasBoundLayer: boolean,
+): SuggestedAction[] {
+  const actions: SuggestedAction[] = [];
+  const primary = outputs[0];
+  const kind = primary?.kind;
+
+  // Map actions — only when a layer is actually bound.
+  if (hasBoundLayer) {
+    actions.push({
+      kind: hasVisibleLayer ? 'hide' : 'show_on_map',
+      label: hasVisibleLayer ? '在地图上隐藏' : '在地图上显示',
+      available: true,
+    });
+    actions.push({ kind: 'zoom', label: '缩放至结果', available: !!primary?.bbox || hasBoundLayer });
+  }
+
+  // Capability-driven analytical suggestions (chat intents).
+  if (kind === 'vector' || kind === 'image') {
+    actions.push({ kind: 'style', label: '调整样式', available: hasBoundLayer });
+    if (family === 'hotspot' || family === 'cluster' || family === 'h3') {
+      actions.push({ kind: 'inspect', label: '检查显著要素', available: true });
+    }
+  }
+  if (kind === 'vector') {
+    actions.push({ kind: 'buffer', label: '对结果做缓冲区', available: !!primary?.ref });
+    actions.push({ kind: 'overlay', label: '与其他图层叠加', available: !!primary?.ref });
+  }
+  if (kind === 'raster') {
+    actions.push({ kind: 'classify', label: '分类', available: true });
+  }
+  if (primary) {
+    actions.push({ kind: 'export', label: '导出结果', available: true });
+  }
+
+  return actions;
+}

--- a/frontend/lib/results/types.ts
+++ b/frontend/lib/results/types.ts
@@ -1,0 +1,201 @@
+/**
+ * Analysis Result Workbench — shared result model (semantic primitives).
+ *
+ * Design (see .scratch/analysis-workbench/DESIGN.md): one normalized model fed by
+ * the SSE `step_result` event, rendered by a small set of reusable section
+ * components. Tool families differ only in *metric extraction* (data-driven rules
+ * in families.ts), never in their rendering components.
+ *
+ * Truthfulness contract (spec §9):
+ *  - CRS is never fabricated. `crs` is `undefined` ⇒ render "Unknown".
+ *  - `featureCount`/`geometryTypes` are only set when backed by evidence
+ *    (descriptor endpoint or an echoed scalar). Otherwise omitted ⇒ "not reported".
+ *  - Warnings are inferred from real signals (summary prose, `_streaming_note`,
+ *    `correction_hint`); they are never invented.
+ */
+import type { LegendSpec } from '@/lib/map-kit/types';
+
+/** Bounding box as [west, south, east, north]. */
+export type BBox = [number, number, number, number];
+
+export type ResultFamily =
+  | 'buffer'
+  | 'overlay'
+  | 'spatial_stats'
+  | 'hotspot'
+  | 'cluster'
+  | 'density'
+  | 'interpolation'
+  | 'network'
+  | 'raster'
+  | 'h3'
+  | 'remote_sensing'
+  | 'cartography'
+  | 'generic';
+
+/**
+ * Coarse result status derived from the slim_event. `partial`/`warning` surface
+ * meaningful caveats without marking the run a failure.
+ */
+export type ResultStatus =
+  | 'completed'
+  | 'failed'
+  | 'partial'
+  | 'warning'
+  | 'running'
+  | 'unknown';
+
+export type OutputKind = 'vector' | 'raster' | 'statistic' | 'table' | 'image' | 'none';
+
+export interface InputRef {
+  /** Session ref (ref:geojson-…) or layer id, when inferable from the tool args. */
+  ref?: string;
+  /** Human label — the layer name when resolvable, else the arg key. */
+  label: string;
+  /** Field/column the operation acted on, when stated in the args. */
+  field?: string;
+  /** True when the input was inferred rather than read from a captured arg. */
+  inferred?: boolean;
+}
+
+export interface ResultParam {
+  label: string;
+  value: string | number | boolean;
+  /** Original arg key, for transparency in the "raw parameters" view. */
+  source?: string;
+}
+
+export interface ResultMetric {
+  label: string;
+  value: string | number;
+  emphasis?: 'primary' | 'secondary';
+  unit?: string;
+}
+
+export type WarningLevel = 'info' | 'warning' | 'error';
+
+export interface ResultWarning {
+  level: WarningLevel;
+  /** Stable machine code (e.g. `geometry_dropped`, `unreachable_facilities`). */
+  code: string;
+  message: string;
+}
+
+export interface OutputDescriptor {
+  kind: OutputKind;
+  /** Session ref (ref:geojson-…) when the output backs a fetchable layer. */
+  ref?: string;
+  /** Geometry type(s) — only when backed by descriptor/echoed evidence. */
+  geometryTypes?: string[];
+  /** Feature count — only when truthfully known. */
+  featureCount?: number;
+  /** CRS — only when truthfully known; `undefined` means unknown (never EPSG:4326 fallback). */
+  crs?: string;
+  /** Bounding box [W,S,E,N] when known. */
+  bbox?: BBox;
+  /** Whether a map layer is currently bound to this output in the store. */
+  hasLayer: boolean;
+  /** Estimated bytes (from descriptor) — drives "large output" hints without downloading. */
+  estimatedBytes?: number;
+  /** Truthful note for non-layer outputs (raster path present, image pushed, …). */
+  note?: string;
+}
+
+export interface LayerBinding {
+  /** Store layer id (equals the ref for tool results). */
+  layerId: string;
+  visible: boolean;
+  name: string;
+}
+
+export interface ProvenanceLink {
+  label: string;
+  detail?: string;
+  kind: 'input' | 'operation' | 'output' | 'run';
+}
+
+export type SuggestedActionKind =
+  | 'show_on_map'
+  | 'hide'
+  | 'zoom'
+  | 'style'
+  | 'export'
+  | 'overlay'
+  | 'buffer'
+  | 'classify'
+  | 'inspect';
+
+export interface SuggestedAction {
+  kind: SuggestedActionKind;
+  label: string;
+  /** Whether the action is currently actionable (e.g. requires a bound layer). */
+  available: boolean;
+}
+
+export interface AnalysisResult {
+  /** Stable id — `step_id` when present, else a synthetic fallback. */
+  id: string;
+  tool: string;
+  toolLabel: string;
+  family: ResultFamily;
+  status: ResultStatus;
+  /** A durable background job is still running for this result. */
+  running?: boolean;
+  /** Epoch ms when the result was captured into the registry. */
+  capturedAt?: number;
+  completedAt?: string;
+  durationMs?: number;
+  summary?: string;
+  inputs: InputRef[];
+  parameters: ResultParam[];
+  metrics: ResultMetric[];
+  warnings: ResultWarning[];
+  outputs: OutputDescriptor[];
+  bbox?: BBox;
+  legendSpec?: LegendSpec;
+  layerBindings: LayerBinding[];
+  provenance: ProvenanceLink[];
+  suggestedActions: SuggestedAction[];
+  /** Linked durable job ids (status cross-link via /tasks/jobs). */
+  backgroundJobIds: string[];
+  /** Progressive-disclosure raw slim_event — never auto-rendered. */
+  raw: unknown;
+  /** A meaningful approximation/partial signal was detected. */
+  approximate?: boolean;
+}
+
+/* ─── Inputs to the normalizer ──────────────────────────────────────────────── */
+
+/** Shape of the SSE `step_result` event payload (execution_engine.py:916-932). */
+export interface StepResultEvent {
+  task_id?: string;
+  step_id?: string;
+  tool: string;
+  result?: Record<string, any> | null;
+  geojson_ref?: string | null;
+  session_id?: string;
+  background_job_ids?: string[] | null;
+}
+
+/**
+ * Best-effort tool-call arguments captured from the preceding `tool_call` event,
+ * used for input evidence + meaningful parameters. Correlation is by tool name
+ * within the turn; `captured: false` means args were unavailable and the
+ * normalizer must degrade gracefully (truthful "inferred"/"not reported").
+ */
+export interface ArgsContext {
+  args?: Record<string, any>;
+  captured: boolean;
+}
+
+/** Response of `GET /layers/descriptor/{ref_id}` (layer.py:125-164). */
+export interface LayerDescriptor {
+  ref_id?: string;
+  feature_count?: number;
+  point_count?: number;
+  geometry_types?: string[] | Record<string, number>;
+  bbox?: BBox | number[];
+  mvt_capable?: boolean;
+  raster_capable?: boolean;
+  estimated_bytes?: number;
+}

--- a/frontend/lib/store/hud-types.ts
+++ b/frontend/lib/store/hud-types.ts
@@ -1,6 +1,7 @@
 import type { Layer } from '@/lib/types/layer';
 import type { GeoJSONFeatureCollection } from '@/lib/types';
 import type { ExplorerTask } from '@/lib/types/explorer';
+import type { AnalysisResult, LayerDescriptor, StepResultEvent } from '@/lib/results/types';
 
 export interface SelectedFeatureInfo {
   layerId: string;          // 渲染层 id (含 custom- 前缀)
@@ -70,7 +71,7 @@ export interface CausalEntry {
   mapState?: Record<string, unknown>;
 }
 
-export type LeftTab = 'chat' | 'project' | 'layers' | 'analysis' | 'exports' | 'export_layout' | 'data_sources' | 'tasks';
+export type LeftTab = 'chat' | 'project' | 'layers' | 'analysis' | 'exports' | 'export_layout' | 'data_sources' | 'tasks' | 'results';
 export type SettingsTab = 'llm' | 'skills' | 'rag' | 'layers' | 'map' | 'system';
 
 export interface SkillEntry {
@@ -308,6 +309,19 @@ export interface HudState {
   addExplorerTask: (task: ExplorerTask) => void;
   updateExplorerTask: (taskId: string, updates: Partial<ExplorerTask>) => void;
   removeExplorerTask: (taskId: string) => void;
+
+  /* ─── Analysis Results Workbench (session-scoped, bounded, non-persisted) ─── */
+  results: AnalysisResult[];
+  selectedResultId: string | null;
+  /** Stash preceding tool_call args (best-effort input evidence). */
+  captureToolCallArgs: (tool: string, argsStr: string) => void;
+  /** Normalize + record a step_result event; returns the result id (or undefined if ignored). */
+  captureStepResult: (step: StepResultEvent) => string | undefined;
+  /** Merge lazy /layers/descriptor metadata into a result's output (no CRS fabrication). */
+  enrichResultOutput: (resultId: string, ref: string, descriptor: LayerDescriptor) => void;
+  selectResult: (id: string | null) => void;
+  removeResult: (id: string) => void;
+  clearResults: () => void;
 
   /* ─── Export Layout ─── */
   exportSettings: ExportSettings;

--- a/frontend/lib/store/slices/resultsSlice.ts
+++ b/frontend/lib/store/slices/resultsSlice.ts
@@ -1,0 +1,139 @@
+/**
+ * Results slice — GIS Analysis Result Workbench registry.
+ *
+ * Session-scoped, bounded, NON-persisted (deliberately excluded from the
+ * `geoagent-settings` partialize, exactly like `layers`: results reference
+ * session-only `ref:` cursors that would be dead after reload).
+ *
+ * Fed by the SSE stream: `captureToolCallArgs` stashes the preceding tool_call
+ * args (best-effort, keyed by tool name within the turn), and `captureStepResult`
+ * normalizes a `step_result` event into the shared model. The registry only
+ * mutates on `step_result`/`tool_call` — never on token events — so token
+ * streaming cannot rerender the workbench (spec §16).
+ */
+import type { StateCreator } from 'zustand';
+import type { HudState } from '../hud-types';
+import { normalizeStepResult, parseBBox } from '@/lib/results/normalize';
+import type { AnalysisResult, LayerDescriptor, StepResultEvent } from '@/lib/results/types';
+
+/** Bounded history (spec §16: bounded history, no unbounded growth). */
+export const MAX_RESULTS = 50;
+
+function normalizeGeometryTypes(g: LayerDescriptor['geometry_types']): string[] | undefined {
+  if (!g) return undefined;
+  if (Array.isArray(g)) return g.length ? g.map(String) : undefined;
+  if (typeof g === 'object' && g) {
+    const keys = Object.keys(g);
+    return keys.length ? keys : undefined;
+  }
+  return undefined;
+}
+
+function parseArgs(raw: string): Record<string, any> | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Pure-orchestration / map-action tools that carry no inspectable analysis result. */
+const IGNORED_TOOLS = new Set(['propose_plan', 'display_layer']);
+
+/**
+ * Strip heavy payload keys from the stored `raw` so the bounded registry (up to
+ * MAX_RESULTS entries) cannot hold dozens of multi-MB FeatureCollections in
+ * memory. The slim metadata (summary / stats / legend_spec / echoed scalars) is
+ * retained for the advanced "raw result" disclosure; the feature/image payload
+ * is already loaded on the map and is not actionable in raw JSON.
+ */
+const HEAVY_RAW_KEYS = new Set(['data', 'image', 'geojson', 'features', 'grid', 'data_list']);
+function sanitizeRaw(raw: unknown): unknown {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (!HEAVY_RAW_KEYS.has(k)) out[k] = v;
+    }
+    return out;
+  }
+  return raw;
+}
+
+export const createResultsSlice: StateCreator<HudState, [], [], Partial<HudState>> = (set) => {
+  /** Pending tool_call args, keyed by tool name (best-effort, last-writer per turn). */
+  let pendingArgs: Record<string, Record<string, any>> = {};
+
+  return {
+    /* ─── Analysis Results Workbench ─── */
+    results: [],
+    selectedResultId: null,
+
+    captureToolCallArgs: (tool, argsStr) => {
+      const parsed = parseArgs(argsStr);
+      if (parsed) pendingArgs = { ...pendingArgs, [tool]: parsed };
+    },
+
+    captureStepResult: (stepInput: StepResultEvent) => {
+      // Ignore pure orchestration/map-action events that carry no inspectable result.
+      const step = stepInput as StepResultEvent;
+      if (!step || !step.tool || IGNORED_TOOLS.has(step.tool)) return undefined;
+
+      const args = pendingArgs[step.tool];
+      const base = normalizeStepResult(step, { captured: !!args, args });
+      const normalized: AnalysisResult = {
+        ...base,
+        capturedAt: Date.now(),
+        raw: sanitizeRaw(base.raw),
+      };
+      // Drop stale args for this tool so a later same-name call doesn't reuse them.
+      const { [step.tool]: _used, ...rest } = pendingArgs;
+      pendingArgs = rest;
+
+      set((s) => {
+        // Dedup by id (re-emitted step_result for the same step updates in place).
+        const without = s.results.filter((r) => r.id !== normalized.id);
+        const next = [normalized, ...without].slice(0, MAX_RESULTS);
+        return { results: next };
+      });
+      return normalized.id;
+    },
+
+    enrichResultOutput: (resultId, ref, descriptor) =>
+      set((s) => ({
+        results: s.results.map((r) => {
+          if (r.id !== resultId) return r;
+          const outputs = r.outputs.map((o) => {
+            if (o.ref !== ref) return o;
+            return {
+              ...o,
+              featureCount: descriptor.feature_count ?? o.featureCount,
+              geometryTypes: normalizeGeometryTypes(descriptor.geometry_types) ?? o.geometryTypes,
+              // Prefer the event's bbox (computed server-side from full data); only
+              // fall back to the descriptor's (≤5000-feature sample) bbox when absent.
+              bbox: o.bbox ?? parseBBox(descriptor.bbox),
+              estimatedBytes: descriptor.estimated_bytes ?? o.estimatedBytes,
+              // CRS intentionally NOT derived from the descriptor (it carries none);
+              // it stays `undefined` ⇒ UI renders "Unknown" (spec §9, never fabricated).
+            };
+          });
+          const bbox = r.bbox ?? parseBBox(descriptor.bbox);
+          return { ...r, outputs, bbox };
+        }),
+      })),
+
+    selectResult: (id) => set({ selectedResultId: id }),
+
+    removeResult: (id) =>
+      set((s) => ({
+        results: s.results.filter((r) => r.id !== id),
+        selectedResultId: s.selectedResultId === id ? null : s.selectedResultId,
+      })),
+
+    clearResults: () => {
+      pendingArgs = {};
+      set({ results: [], selectedResultId: null });
+    },
+  };
+};

--- a/frontend/lib/store/useHudStore.ts
+++ b/frontend/lib/store/useHudStore.ts
@@ -24,6 +24,7 @@ import { persist } from 'zustand/middleware';
 
 import type { HudState, LeftTab } from './hud-types';
 import { createLayersSlice } from './slices/layersSlice';
+import { createResultsSlice } from './slices/resultsSlice';
 import { createSettingsSlice } from './slices/settingsSlice';
 import { createTaskSlice } from './slices/taskSlice';
 import { createUiSlice } from './slices/uiSlice';
@@ -59,6 +60,7 @@ export const useHudStore = create<HudState>()(
   persist(
     (...a) => ({
       ...createLayersSlice(...a),
+      ...createResultsSlice(...a),
       ...createTaskSlice(...a),
       ...createSettingsSlice(...a),
       ...createUiSlice(...a),

--- a/frontend/test/results/normalize.test.ts
+++ b/frontend/test/results/normalize.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeStepResult, parseBBox } from '@/lib/results/normalize';
+import type { ArgsContext, StepResultEvent } from '@/lib/results/types';
+
+function step(partial: Partial<StepResultEvent>): StepResultEvent {
+  return { tool: 'unknown', ...partial };
+}
+
+describe('parseBBox', () => {
+  it('accepts a 4-number [W,S,E,N] array', () => {
+    expect(parseBBox([1, 2, 3, 4])).toEqual([1, 2, 3, 4]);
+  });
+  it('rejects non-finite / wrong-length', () => {
+    expect(parseBBox([1, 2, 3])).toBeUndefined();
+    expect(parseBBox([1, 2, 3, NaN])).toBeUndefined();
+    expect(parseBBox('1,2,3,4')).toBeUndefined();
+  });
+});
+
+describe('normalizeStepResult — family + metrics', () => {
+  it('classifies buffer vector output with captured args (inputs + params)', () => {
+    const argsCtx: ArgsContext = {
+      captured: true,
+      args: { geojson: 'ref:geojson-abc123', distance: 500, unit: 'meters' },
+    };
+    const res = normalizeStepResult(
+      step({
+        step_id: 's1',
+        tool: 'buffer_analysis',
+        geojson_ref: 'ref:geojson-abc123',
+        result: { success: true, summary: '已生成缓冲区。', bbox: [116, 39, 117, 40] },
+      }),
+      argsCtx,
+    );
+    expect(res.family).toBe('buffer');
+    expect(res.toolLabel).toBe('缓冲区分析');
+    expect(res.status).toBe('completed');
+    expect(res.outputs[0].kind).toBe('vector');
+    expect(res.outputs[0].ref).toBe('ref:geojson-abc123');
+    expect(res.outputs[0].hasLayer).toBe(true);
+    expect(res.inputs).toHaveLength(1);
+    expect(res.inputs[0].ref).toBe('ref:geojson-abc123');
+    expect(res.parameters).toEqual(expect.arrayContaining([
+      expect.objectContaining({ source: 'distance', value: 500 }),
+      expect.objectContaining({ source: 'unit', value: 'meters' }),
+    ]));
+    expect(res.bbox).toEqual([116, 39, 117, 40]);
+  });
+
+  it('extracts Moran’s I statistical metrics from result.data scalars', () => {
+    const res = normalizeStepResult(
+      step({
+        tool: 'moran_i',
+        result: {
+          success: true,
+          summary: 'Spatial autocorrelation computed.',
+          data: { moran_i: 0.4231, expected_i: -0.01, p_value: 0.001, pattern: 'Clustered', n_features: 88 },
+        },
+      }),
+    );
+    expect(res.family).toBe('spatial_stats');
+    const labels = res.metrics.map((m) => m.label);
+    expect(labels).toEqual(expect.arrayContaining(["Moran's I", 'p 值', '空间模式', '要素数']));
+    const moran = res.metrics.find((m) => m.label === "Moran's I");
+    expect(moran?.value).toBe(0.4231);
+    expect(moran?.emphasis).toBe('primary');
+    // no geojson_ref => statistic output, no bound layer
+    expect(res.outputs[0].kind).toBe('statistic');
+    expect(res.outputs[0].hasLayer).toBe(false);
+  });
+
+  it('extracts hotspot counts from data envelope keys (without touching features)', () => {
+    const res = normalizeStepResult(
+      step({
+        tool: 'hotspot_analysis',
+        geojson_ref: 'ref:geojson-h1',
+        result: {
+          success: true,
+          summary: 'Hot spots found.',
+          // data is a FeatureCollection whose features we must NOT read;
+          // envelope scalars live alongside `features`.
+          data: { type: 'FeatureCollection', features: new Array(120), hot_spots_count: 12, cold_spots_count: 7, distance_band_m: 1000 },
+          bbox: [0, 0, 1, 1],
+        },
+      }),
+    );
+    const byLabel = Object.fromEntries(res.metrics.map((m) => [m.label, m.value]));
+    expect(byLabel['热点数']).toBe(12);
+    expect(byLabel['冷点数']).toBe(7);
+    expect(res.outputs[0].featureCount).toBeUndefined(); // not fabricated; filled by descriptor
+  });
+
+  it('extracts cluster method + n_clusters', () => {
+    const res = normalizeStepResult(
+      step({
+        tool: 'spatial_cluster',
+        geojson_ref: 'ref:geojson-c1',
+        result: { success: true, summary: 'ok', data: { method: 'kmeans', n_clusters: 5, cluster_stats: [{}, {}, {}] } },
+      }),
+    );
+    const byLabel = Object.fromEntries(res.metrics.map((m) => [m.label, m.value]));
+    expect(byLabel['方法']).toBe('kmeans');
+    expect(byLabel['簇数']).toBe(5);
+    expect(byLabel['簇统计']).toBe('3 组');
+  });
+
+  it('classifies raster reclassify as raster output without a layer', () => {
+    const res = normalizeStepResult(
+      step({
+        tool: 'raster_reclassify',
+        result: { success: true, summary: 'done', data: { result_path: '/data/out.tif' }, result_path: '/data/out.tif' },
+      }),
+      { captured: true, args: { raster_path: '/data/in.tif', scheme: [{ min: 0, max: 1, value: 1, label: 'low' }] } },
+    );
+    expect(res.family).toBe('raster');
+    expect(res.outputs[0].kind).toBe('raster');
+    expect(res.outputs[0].hasLayer).toBe(false);
+  });
+
+  it('extracts NDVI remote-sensing metrics', () => {
+    const res = normalizeStepResult(
+      step({
+        tool: 'compute_ndvi',
+        result: { status: 'ok', bbox: [100, 30, 101, 31], ndvi_stats: { min: -0.2, max: 0.8, mean: 0.31 }, vegetation_coverage: 62.5 },
+      }),
+    );
+    expect(res.family).toBe('remote_sensing');
+    const byLabel = Object.fromEntries(res.metrics.map((m) => [m.label, m.value]));
+    expect(byLabel['NDVI 最大']).toBe(0.8);
+    expect(byLabel['植被覆盖度']).toBe(62.5);
+    expect(res.outputs[0].kind).toBe('raster');
+  });
+
+  it('detects unreachable-facilities warning from isochrone summary prose', () => {
+    const res = normalizeStepResult(
+      step({
+        tool: 'isochrone_network',
+        geojson_ref: 'ref:geojson-iso',
+        result: { success: true, summary: 'Isochrone built. 3 facility(ies) unreachable (disconnected from the road network).' },
+      }),
+    );
+    expect(res.warnings.some((w) => w.code === 'unreachable_facilities')).toBe(true);
+    expect(res.status).toBe('warning');
+  });
+
+  it('treats heatmap image output as a visible layer', () => {
+    const res = normalizeStepResult(
+      step({
+        tool: 'heatmap_data',
+        result: { type: 'heatmap_raster', image: 'data:image/png;base64,xxxx', bbox: [0, 0, 1, 1], total_points: 5432, metadata: { render_type: 'raster', point_count: 5432 } },
+      }),
+    );
+    expect(res.outputs[0].kind).toBe('image');
+    expect(res.outputs[0].hasLayer).toBe(true);
+    const byLabel = Object.fromEntries(res.metrics.map((m) => [m.label, m.value]));
+    expect(byLabel['总点数']).toBe(5432);
+  });
+});
+
+describe('normalizeStepResult — truthfulness (CRS / unknown / failed)', () => {
+  it('never fabricates CRS (output.crs stays undefined)', () => {
+    const res = normalizeStepResult(
+      step({ tool: 'buffer_analysis', geojson_ref: 'ref:geojson-x', result: { success: true, summary: 'ok' } }),
+    );
+    expect(res.outputs[0].crs).toBeUndefined();
+  });
+
+  it('handles an unknown / minimal tool gracefully (generic family, no metrics)', () => {
+    const res = normalizeStepResult(
+      step({ tool: 'some_custom_tool', result: { success: true, summary: 'done' } }),
+    );
+    expect(res.family).toBe('generic');
+    expect(res.status).toBe('completed');
+    expect(res.metrics).toEqual([]);
+    expect(res.outputs[0].kind).toBe('statistic');
+  });
+
+  it('classifies zonal_stats as a VECTOR output (regression: was mislabeled raster)', () => {
+    // zonal_stats returns a FeatureCollection (polygons enriched with raster stats),
+    // backed by a geojson_ref — it must render as vector, never raster.
+    const res = normalizeStepResult(
+      step({ tool: 'zonal_stats', geojson_ref: 'ref:geojson-zonal', result: { success: true, summary: 'ok' } }),
+    );
+    expect(res.outputs[0].kind).toBe('vector');
+    expect(res.outputs[0].hasLayer).toBe(true);
+  });
+
+  it('marks a failed result (success=false + error_type)', () => {
+    const res = normalizeStepResult(
+      step({ tool: 'hotspot_analysis', result: { success: false, error_type: 'VALIDATION_ERROR', summary: 'Missing value_field.', correction_hint: 'Provide value_field.' } }),
+    );
+    expect(res.status).toBe('failed');
+    expect(res.warnings.some((w) => w.code === 'correction_hint')).toBe(true);
+  });
+
+  it('does NOT treat the _streaming_note transport artifact as a result warning', () => {
+    const res = normalizeStepResult(
+      step({ tool: 'buffer_analysis', geojson_ref: 'ref:geojson-big', result: { success: true, summary: 'ok', _streaming_note: '大体积要素数据已过滤。' } }),
+    );
+    // _streaming_note is a transport detail (full layer is auto-loaded); it must
+    // NOT mark the result approximate/partial or every vector result would be "partial".
+    expect(res.warnings.some((w) => w.code === 'geometry_dropped')).toBe(false);
+    expect(res.approximate).toBeUndefined();
+    expect(res.status).toBe('completed');
+  });
+});
+
+describe('normalizeStepResult — args context + legend', () => {
+  it('returns no inputs/params when args were not captured', () => {
+    const res = normalizeStepResult(
+      step({ tool: 'buffer_analysis', geojson_ref: 'ref:geojson-y', result: { success: true, summary: 'ok' } }),
+      { captured: false },
+    );
+    expect(res.inputs).toEqual([]);
+    expect(res.parameters).toEqual([]);
+  });
+
+  it('extracts legend_spec from top-level and from data', () => {
+    const top = normalizeStepResult(
+      step({ tool: 'h3_binning', geojson_ref: 'ref:geojson-h3', result: { success: true, summary: 'ok', legend_spec: { type: 'graduated', field: 'val', breaks: [0, 1], palette: 'p', palette_colors: ['#fff', '#000'] } } }),
+    );
+    expect(top.legendSpec?.type).toBe('graduated');
+
+    const nested = normalizeStepResult(
+      step({ tool: 'kde_contours', result: { type: 'FeatureCollection', summary: 'ok', data: { legend_spec: { type: 'continuous', min: 0, max: 1, palette: 'p', palette_colors: ['#000', '#fff'] } } } }),
+    );
+    expect(nested.legendSpec?.type).toBe('continuous');
+  });
+
+  it('records background job linkage in provenance', () => {
+    const res = normalizeStepResult(
+      step({ tool: 'compute_ndvi', background_job_ids: ['101', '102'], result: { status: 'ok', bbox: [0, 0, 1, 1] } }),
+    );
+    expect(res.backgroundJobIds).toEqual(['101', '102']);
+    expect(res.provenance.some((p) => p.kind === 'run')).toBe(true);
+  });
+});

--- a/frontend/test/results/results-ui.test.tsx
+++ b/frontend/test/results/results-ui.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { normalizeStepResult } from '@/lib/results/normalize';
+import { ResultList } from '@/components/sidebar/results/result-list';
+import { ResultDetail } from '@/components/sidebar/results/result-detail';
+import { createMockLayer } from '../test-utils';
+import type { AnalysisResult } from '@/lib/results/types';
+
+beforeEach(() => {
+  useHudStore.getState().clearResults();
+  useHudStore.setState({ layers: [] });
+});
+
+function hotspotResult(summary = '已识别热点。'): AnalysisResult {
+  return normalizeStepResult({
+    step_id: 's1',
+    tool: 'hotspot_analysis',
+    geojson_ref: 'ref:geojson-x1',
+    result: {
+      success: true,
+      summary,
+      bbox: [116, 39, 117, 40],
+      data: { type: 'FeatureCollection', features: [], hot_spots_count: 12, cold_spots_count: 3, distance_band_m: 800 },
+    },
+  });
+}
+
+describe('ResultList', () => {
+  it('shows an empty state when there are no results', () => {
+    render(<ResultList results={[]} selectedId={null} onSelect={() => {}} />);
+    expect(screen.getByText('暂无分析结果')).toBeInTheDocument();
+  });
+
+  it('renders results and selects on click', () => {
+    const r = hotspotResult();
+    const onSelect = vi.fn();
+    render(<ResultList results={[r]} selectedId={null} onSelect={onSelect} />);
+    expect(screen.getByText('已识别热点。')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button'));
+    expect(onSelect).toHaveBeenCalledWith('s1');
+  });
+});
+
+describe('ResultDetail — truthfulness + map linkage', () => {
+  it('shows metrics, keeps CRS unknown, surfaces warnings, and toggles layer visibility', () => {
+    // A genuine warning via correction_hint (separate from the summary, so the
+    // surfaced warning text is unambiguous).
+    const r = normalizeStepResult({
+      step_id: 's1',
+      tool: 'hotspot_analysis',
+      geojson_ref: 'ref:geojson-x1',
+      result: {
+        success: true,
+        summary: '已识别热点。',
+        correction_hint: '请检查输入字段是否完整。',
+        bbox: [116, 39, 117, 40],
+        data: { type: 'FeatureCollection', features: [], hot_spots_count: 12, cold_spots_count: 3, distance_band_m: 800 },
+      },
+    });
+    useHudStore.setState({ results: [r] });
+    useHudStore.setState({
+      layers: [createMockLayer({ id: 'ref:geojson-x1', name: 'Hotspot', visible: false })],
+    });
+
+    render(
+      <ResultDetail result={r} sessionId="sess" ownerToken={null} onBack={() => {}} onSend={() => {}} />,
+    );
+
+    // Metric rendered (hot spot count = 12).
+    expect(screen.getByText('12')).toBeInTheDocument();
+    // CRS kept truthful ("未知"), never fabricated as EPSG:4326.
+    expect(screen.getByText('未知')).toBeInTheDocument();
+    // Warning surfaced (not buried in raw JSON).
+    expect(screen.getByText('请检查输入字段是否完整。')).toBeInTheDocument();
+
+    // Map action: layer is hidden → "在地图上显示" toggles store visibility.
+    const showBtn = screen.getByRole('button', { name: '在地图上显示' });
+    fireEvent.click(showBtn);
+    expect(useHudStore.getState().layers[0].visible).toBe(true);
+  });
+
+  it('renders the failed state and correction hint', () => {
+    const failed = normalizeStepResult({
+      step_id: 's-fail',
+      tool: 'hotspot_analysis',
+      result: { success: false, error_type: 'VALIDATION_ERROR', summary: 'Missing value_field.', correction_hint: '请提供 value_field。' },
+    });
+    useHudStore.setState({ results: [failed] });
+    render(
+      <ResultDetail result={failed} sessionId="sess" ownerToken={null} onBack={() => {}} onSend={() => {}} />,
+    );
+    expect(screen.getByText('失败')).toBeInTheDocument();
+    expect(screen.getByText('请提供 value_field。')).toBeInTheDocument();
+  });
+});

--- a/frontend/test/results/resultsSlice.test.ts
+++ b/frontend/test/results/resultsSlice.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { MAX_RESULTS } from '@/lib/store/slices/resultsSlice';
+import type { LayerDescriptor, StepResultEvent } from '@/lib/results/types';
+
+beforeEach(() => {
+  useHudStore.getState().clearResults();
+});
+
+function hotspotStep(overrides: Partial<StepResultEvent> = {}): StepResultEvent {
+  return {
+    step_id: 'step-1',
+    tool: 'hotspot_analysis',
+    geojson_ref: 'ref:geojson-h1',
+    result: {
+      success: true,
+      summary: 'Hot spots found.',
+      bbox: [0, 0, 1, 1],
+      data: { type: 'FeatureCollection', features: [], hot_spots_count: 5, cold_spots_count: 2, distance_band_m: 800 },
+    },
+    ...overrides,
+  };
+}
+
+describe('resultsSlice — capture + bounded history', () => {
+  it('captures a step_result into the registry and selects nothing by default', () => {
+    const id = useHudStore.getState().captureStepResult(hotspotStep());
+    expect(id).toBe('step-1');
+    const results = useHudStore.getState().results;
+    expect(results).toHaveLength(1);
+    expect(results[0].tool).toBe('hotspot_analysis');
+    expect(results[0].status).toBe('completed');
+    expect(results[0].capturedAt).toBeTypeOf('number');
+  });
+
+  it('bounds the registry to MAX_RESULTS (newest kept, oldest dropped)', () => {
+    for (let i = 0; i < MAX_RESULTS + 5; i++) {
+      useHudStore.getState().captureStepResult(hotspotStep({ step_id: `step-${i}` }));
+    }
+    expect(useHudStore.getState().results).toHaveLength(MAX_RESULTS);
+    // Newest first; the last captured should be at the head.
+    expect(useHudStore.getState().results[0].id).toBe(`step-${MAX_RESULTS + 4}`);
+  });
+
+  it('dedups by id (re-emitted step_result updates in place, no duplicate)', () => {
+    useHudStore.getState().captureStepResult(hotspotStep({ step_id: 'dup' }));
+    useHudStore.getState().captureStepResult(hotspotStep({ step_id: 'dup' }));
+    expect(useHudStore.getState().results).toHaveLength(1);
+  });
+
+  it('ignores propose_plan orchestration events', () => {
+    const id = useHudStore.getState().captureStepResult({ tool: 'propose_plan', result: { success: true, plan_id: 'p1' } });
+    expect(id).toBeUndefined();
+    expect(useHudStore.getState().results).toHaveLength(0);
+  });
+
+  it('filters pure map-action tools (display_layer) that carry no inspectable result', () => {
+    const id = useHudStore.getState().captureStepResult({ tool: 'display_layer', result: { success: true } });
+    expect(id).toBeUndefined();
+    expect(useHudStore.getState().results).toHaveLength(0);
+  });
+
+  it('strips heavy payload keys from the stored raw to bound memory', () => {
+    useHudStore.getState().captureStepResult({
+      step_id: 'heavy',
+      tool: 'hotspot_analysis',
+      geojson_ref: 'ref:geojson-h',
+      result: { success: true, summary: 'ok', data: { type: 'FeatureCollection', features: new Array(1000) }, stats: { n: 1 } },
+    });
+    const raw = useHudStore.getState().results[0].raw as Record<string, unknown>;
+    expect(raw.data).toBeUndefined(); // heavy FC stripped
+    expect(raw.summary).toBe('ok'); // metadata retained
+    expect((raw as any).stats).toEqual({ n: 1 }); // light scalars retained
+  });
+
+  it('captures tool_call args as input evidence for the matching step_result', () => {
+    useHudStore.getState().captureToolCallArgs('buffer_analysis', JSON.stringify({ geojson: 'ref:geojson-in', distance: 300 }));
+    useHudStore.getState().captureStepResult({
+      step_id: 's-buf',
+      tool: 'buffer_analysis',
+      geojson_ref: 'ref:geojson-out',
+      result: { success: true, summary: 'ok' },
+    });
+    const r = useHudStore.getState().results[0];
+    expect(r.inputs[0].ref).toBe('ref:geojson-in');
+    expect(r.parameters).toEqual(expect.arrayContaining([expect.objectContaining({ source: 'distance', value: 300 })]));
+  });
+});
+
+describe('resultsSlice — enrich + select + clear', () => {
+  it('enriches output metadata from the descriptor without fabricating CRS', () => {
+    useHudStore.getState().captureStepResult(hotspotStep());
+    const descriptor: LayerDescriptor = { feature_count: 42, geometry_types: ['Point'], bbox: [0, 0, 1, 1], estimated_bytes: 12345 };
+    useHudStore.getState().enrichResultOutput('step-1', 'ref:geojson-h1', descriptor);
+    const out = useHudStore.getState().results[0].outputs[0];
+    expect(out.featureCount).toBe(42);
+    expect(out.geometryTypes).toEqual(['Point']);
+    expect(out.estimatedBytes).toBe(12345);
+    // CRS must remain undefined (descriptor carries none) — never fabricated.
+    expect(out.crs).toBeUndefined();
+  });
+
+  it('select / remove / clear manage selection + registry', () => {
+    useHudStore.getState().captureStepResult(hotspotStep());
+    useHudStore.getState().selectResult('step-1');
+    expect(useHudStore.getState().selectedResultId).toBe('step-1');
+    useHudStore.getState().removeResult('step-1');
+    expect(useHudStore.getState().results).toHaveLength(0);
+    expect(useHudStore.getState().selectedResultId).toBeNull();
+
+    useHudStore.getState().captureStepResult(hotspotStep());
+    useHudStore.getState().clearResults();
+    expect(useHudStore.getState().results).toHaveLength(0);
+    expect(useHudStore.getState().selectedResultId).toBeNull();
+  });
+});

--- a/frontend/test/results/use-result-descriptor.test.ts
+++ b/frontend/test/results/use-result-descriptor.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Mock the transport so we can assert URL + control promise resolution.
+const pending = new Map<string, (v: any) => void>();
+vi.mock('@/lib/api/transport', () => ({
+  apiFetch: vi.fn((path: string, opts?: { signal?: AbortSignal }) => {
+    return new Promise((resolve, reject) => {
+      pending.set(path, resolve);
+      const onAbort = () => reject(new DOMException('aborted', 'AbortError'));
+      if (opts?.signal?.aborted) return onAbort();
+      opts?.signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }),
+  isApiError: () => false,
+}));
+
+// vi.mock is hoisted, so this resolves to the mocked module.
+import { apiFetch } from '@/lib/api/transport';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { useResultDescriptor } from '@/lib/hooks/use-result-descriptor';
+import type { AnalysisResult } from '@/lib/results/types';
+
+const apiFetchMock = apiFetch as unknown as { mock: { calls: string[][] } };
+
+let refSeq = 0;
+function seedResult(id: string, ref: string): AnalysisResult {
+  useHudStore.getState().captureStepResult({
+    step_id: id,
+    tool: 'hotspot_analysis',
+    geojson_ref: ref,
+    result: { success: true, summary: 'ok', bbox: [0, 0, 1, 1] },
+  });
+  return useHudStore.getState().results.find((r) => r.id === id)!;
+}
+
+const flush = () => Promise.resolve();
+
+describe('useResultDescriptor — metadata-first, no full GeoJSON', () => {
+  beforeEach(() => {
+    useHudStore.getState().clearResults();
+    pending.clear();
+    (apiFetchMock.mock.calls as any).length = 0;
+    refSeq += 1;
+  });
+
+  it('fetches the descriptor endpoint, never the full-data endpoint', async () => {
+    const ref = `ref:geojson-ep-${refSeq}`;
+    const result = seedResult('ep-1', ref);
+    renderHook((p: { r: AnalysisResult }) => useResultDescriptor(p.r, 'sess', null), {
+      initialProps: { r: result },
+    });
+    await vi.waitFor(() => expect(apiFetchMock.mock.calls.length).toBeGreaterThan(0));
+    const path = apiFetchMock.mock.calls[0][0];
+    expect(path).toContain('/layers/descriptor/');
+    expect(path).toContain(encodeURIComponent(ref));
+    expect(path).not.toContain('/layers/data/');
+  });
+
+  it('dedupes: re-mounting the same ref does not trigger a second fetch', async () => {
+    const ref = `ref:geojson-dp-${refSeq}`;
+    const result = seedResult('dp-1', ref);
+    const { unmount } = renderHook((p: { r: AnalysisResult }) => useResultDescriptor(p.r, 'sess', null), {
+      initialProps: { r: result },
+    });
+    await vi.waitFor(() => expect(apiFetchMock.mock.calls.length).toBe(1));
+    // Resolve → caches the descriptor for (sess, ref).
+    pending.get(apiFetchMock.mock.calls[0][0])?.({ feature_count: 10 });
+    await flush();
+    unmount();
+
+    // Remount with a fresh result id but the SAME ref+session → cache hit, no new fetch.
+    const result2 = seedResult('dp-2', ref);
+    renderHook((p: { r: AnalysisResult }) => useResultDescriptor(p.r, 'sess', null), {
+      initialProps: { r: result2 },
+    });
+    await flush();
+    const encRef = encodeURIComponent(ref);
+    const refCalls = apiFetchMock.mock.calls.filter((c) => c[0].includes(encRef));
+    expect(refCalls).toHaveLength(1);
+  });
+
+  it('stale-response protection: a slow result A cannot overwrite result B', async () => {
+    const refA = `ref:geojson-a-${refSeq}`;
+    const refB = `ref:geojson-b-${refSeq}`;
+    const a = seedResult('stale-A', refA);
+    const b = seedResult('stale-B', refB);
+
+    const { rerender } = renderHook((p: { r: AnalysisResult }) => useResultDescriptor(p.r, 'sess', null), {
+      initialProps: { r: a },
+    });
+    await flush(); // A's effect fires apiFetch(refA)
+    rerender({ r: b });
+    await flush(); // B's effect fires apiFetch(refB) + aborts A's controller
+
+    // Resolve B → B is enriched.
+    const bPath = apiFetchMock.mock.calls.find((c) => c[0].includes(encodeURIComponent(refB)))?.[0];
+    expect(bPath).toBeDefined();
+    pending.get(bPath!)?.({ feature_count: 99 });
+
+    // Resolve A late (its controller was aborted on the switch, so this is a no-op).
+    const aPath = apiFetchMock.mock.calls.find((c) => c[0].includes(encodeURIComponent(refA)))?.[0];
+    if (aPath) pending.get(aPath)?.({ feature_count: 7 });
+
+    // B is enriched once the promise chain (apiFetch → fetchDescriptor → hook) settles.
+    await vi.waitFor(() => {
+      expect(useHudStore.getState().results.find((r) => r.id === 'stale-B')!.outputs[0].featureCount).toBe(99);
+    });
+
+    // A must never have been enriched — stale-response protection held.
+    await vi.waitFor(() => {
+      expect(useHudStore.getState().results.find((r) => r.id === 'stale-A')!.outputs[0].featureCount).toBeUndefined();
+    });
+  });
+});

--- a/frontend/test/test-utils.tsx
+++ b/frontend/test/test-utils.tsx
@@ -94,6 +94,15 @@ export function createMockStoreState(overrides?: Partial<HudState>): Record<stri
     annotations: [],
     addAnnotation: vi.fn(),
     clearAnnotations: vi.fn(),
+    // Analysis Results Workbench slice
+    results: [],
+    selectedResultId: null,
+    captureToolCallArgs: vi.fn(),
+    captureStepResult: vi.fn(),
+    enrichResultOutput: vi.fn(),
+    selectResult: vi.fn(),
+    removeResult: vi.fn(),
+    clearResults: vi.fn(),
     ...overrides,
   }
 }


### PR DESCRIPTION
## Problem

Completed GIS analyses are currently surfaced as streamed chat markdown, a "图层已挂载" chip, ad-hoc per-tool result cards (`CartographyResultCard`, `H3LisaResultCard`, `IsochroneResultCard`, …), and loose layers in the Layers tab. There is **no single place** to understand, for a finished analysis: what ran, which inputs were used, what outputs were created, the key quantitative result, where it is on the map, which artifact/ref backs which layer, whether warnings/partial results were involved, and what sensible next actions exist. The chat `toolCalls`/`ToolCallChain` tracker is dormant (ADR-0022) and result cards hard-code colors and diverge from the shared primitives.

This PR adds a **GIS Analysis Result Workbench**: one canonical result-detail experience with multiple entry points, built **frontend-only** on top of the existing map-first V3 workspace and backend contracts — no new GIS framework, no backend changes, no new artifact model.

## Result Contract Audit

Four parallel read-only audits mapped the real contracts (artifacts in `.scratch` at branch start, summarized here):

- **Result flow:** tool dict (envelope-A `{success,summary,data,…}` *or* raw FC/dict) → `ToolDispatchService` → `ToolDispatchResult{status,llm_payload,slim_event,geojson_ref,…}` → SSE `step_result{task_id,step_id,tool,result:slim_event,geojson_ref?,background_job_ids?}`. `slim_event` = tool dict minus `{geojson,features,data_list,grid}` + computed `bbox` + `_streaming_note`.
- **`ToolExecutionResult`** (`tool_pipeline.py:21`) has **no** ref/warnings/summary fields — those live inside `result`/`outcome`. **`ref_descriptor` does not exist** anywhere (grep: 0 hits); the closest is the descriptor endpoint.
- **Artifact** (`project.py:199`): `crs` is **nullable by design** (INV-ART1); no `feature_count`/`bbox` columns — those come from `GET /layers/descriptor/{ref}` (`feature_count, geometry_types, bbox, estimated_bytes`). Warnings are **not unified** (free-text in `summary`; structured `QualityIssue` exists but isn't wired into results). `EPSG:4326` is used as a silent backend fallback in several places but never declared on results.

**Conclusion:** the frontend can normalize from `step_result` + the descriptor endpoint alone → **frontend-only** implementation, additive, no breaking contract change (spec §10).

## Information Architecture

- New left-tab **"结果" (Results)** in the NavRail (8 tabs now) + ContextPanel, master-detail within the panel (280–420px, map stays usable — spec §15).
- **Entry points converge on one detail view:** the Results list; the Tasks `result_ref` (now a link when a result is linked); and the chat "感知图层已挂载" chip ("查看结果"). Deep-linking is by a stable `resultId` captured on the same `step_result` event (no fragile name matching).
- Session-scoped, **non-persisted** registry (`results` is excluded from the `geoagent-settings` partialize like `layers`), cleared on session switch.

## Result Model

A shared `AnalysisResult` + semantic primitives (`InputRef`, `ResultParam`, `ResultMetric`, `ResultWarning`, `OutputDescriptor`, `LayerBinding`, `ProvenanceLink`, `SuggestedAction`) in `frontend/lib/results/`. A **pure** normalizer `normalizeStepResult(step, argsCtx)` maps the event to the model; the "matrix" is data-driven in `families.ts` (each family declares scalar metric reads — **never** feature arrays). A small set of reusable sections renders every family — **no per-tool components** (spec §6).

## Analysis Families Supported

buffer, overlay, spatial_stats (incl. Moran's I, SDE), hotspot, cluster (DBSCAN/kmeans/ST-DBSCAN), density (KDE surface/contours, heatmap), interpolation (IDW/H3), network (isochrone, nearest facility), raster (reclassify/calc/resample), H3 (binning/LISA), remote sensing (NDVI/DEM), cartography, plus a truthful `generic` fallback. Verified by family-specific normalizer tests.

## Map Integration

Map actions go through the **store only** (audited safe paths): show/hide via `updateLayer(ref,{visible})`, zoom via `focusLayer(ref)`. It **never** calls `addLayer` (no duplicate/stale layers — `addLayer` already dedups by id==ref), **never** `setViewport` (broken camera semantics), **never** pokes MapLibre directly (spec §8). Map actions are offered only when a layer is actually bound (honest for statistic-only / image-only results). Compatible with the now-merged #344 metadata-first/tile-native ref layers (rebased cleanly on top).

## Artifact / Provenance Integration

Output inspection uses `GET /layers/descriptor/{ref}` (metadata-first). Provenance is synthesized truthfully from what the event carries (operation = tool, inputs from captured `tool_call` args, output = ref/kind, run linkage via `background_job_ids`). It does **not** fabricate a lineage DAG for ad-hoc chat tool calls (those have no workflow-run lineage); durable workflow lineage (#346/#349) is left to its own surfaces.

## Truthfulness / CRS / Warning Semantics

- **CRS is never fabricated.** `output.crs` is only ever set from evidence; `enrichResultOutput` explicitly refuses to derive CRS from the descriptor. UI renders **"未知"** when unknown — never an `EPSG:4326` fallback (spec §9). Verified by tests.
- **Feature count / geometry types** only set when backed by the descriptor or an echoed scalar; otherwise "未报告".
- **Warnings are always visible** (dedicated section, never buried in raw JSON). Inferred from real signals (`summary` prose patterns, `correction_hint`). The `_streaming_note` transport artifact is intentionally **not** treated as a warning (it would mislabel every vector result "partial").

## Performance

- **Metadata-first:** opening a result fetches `/layers/descriptor/{ref}`, **never** `/layers/data/{ref}` (full GeoJSON). Verified: `use-result-descriptor.test.ts` asserts the URL.
- **No duplicate fetch:** per-ref in-flight dedup + 30s positive cache → re-mounting the same result = 0 extra requests. Verified.
- **Stale-response protection:** generation guard + AbortController — a slow result A cannot overwrite result B. Verified.
- **No token-stream rerender:** the registry mutates only on `step_result`/`tool_call`, never on token events; the workbench is a separate tab that unmounts on switch anyway.
- **Bounded:** registry capped at 50; heavy payload keys (`data/features/image/…`) stripped from the stored `raw` to bound memory. Verified.
- **No polling** of completed results.

## Accessibility / Responsive

- Results list uses native buttons (Tab/Enter/Space) with `aria-current` for selection (correct ARIA — the initial `role=listbox/option` draft was flagged in review and fixed).
- Status announced via `StatusBadge`; warnings via `InlineNotice` (`role=alert`/`status`); map-action buttons have text labels (not icon-only); raw JSON behind a keyboard-accessible `<details>`.
- Lives in the resizable ContextPanel (280–420px), so at 1024px the map remains usable (no full-map takeover).

## Tests

`frontend/test/results/` — **36 new tests**, all green as part of the full suite:
- Normalization (18): vector / raster / statistical (Moran's I, SDE) / hotspot / cluster / density / NDVI / network / unknown / **null-CRS** / warning / partial / failed / args-not-captured / legend / zonal_stats-vector regression.
- Slice (9): bounded history, dedup, ignored tools (`propose_plan`, `display_layer`), input capture, descriptor enrichment (**no CRS fabrication**), raw sanitization, select/remove/clear.
- Descriptor hook (3): descriptor-not-data URL, fetch dedupe, **stale A↛B**.
- UI (6): empty/populated list + selection; detail metrics / truthful CRS / surfaced warning / map-visibility toggle / failed state.

Updated 3 existing tests for the new tab/store fields (nav-rail 7→8 tabs, context-panel + use-workspace-session mocks).

## Visual QA

The full app requires a live GIS backend (DB / redis / tool runtime / LLM) to produce real analysis results, which is out of scope to spin up here. Visual behavior was instead validated **deterministically via the component-test matrix** (asserting the rendered DOM for empty / populated / completed / failed / warning states, truthful CRS, and the map-action effect) plus a successful production build. The gitignored `.scratch/analysis-workbench/` holds the raw audit/review notes.

## Adversarial Review

Independent review found **no P0**, **1 P1** (zonal_stats mislabeled raster → offered raster "classify" on a vector result) and several P2s. All P1 + high-value P2s fixed and locked with regression tests:
- zonal_stats reclassified + `outputKindFor` now prefers `geojsonRef→vector`.
- `_streaming_note` no longer false-positives every result as "partial".
- robust result id (no collapse to session id on the Pi-event path).
- memory-bounded stored `raw`; event bbox preferred over the descriptor's sampled bbox.
- `display_layer` noise filtered; invalid-ARIA list semantics fixed; dead `setResultJobStatus` removed.

## Compatibility

Additive frontend-only. No backend, no migrations, no new artifact model, no changes to tool/SSE/job contracts. Existing chat/Tasks/Layers behavior preserved; new entry points are opt-in links.

## Conflict Boundaries

Scope deliberately avoids #344 (map/MVT data plane), #345 (Data Fabric reliability), #348 (context perf), #349 (workflow recovery/lineage), #350 (LLM pooling) — all of which merged into master during this work. The branch **rebased cleanly** on top of them (only `use-sse-stream.ts` overlapped, no conflicts). The Result Workbench consumes their outputs (descriptor endpoint, tile-native layers, job linkage) without duplicating their internals.

## Deferred Work

- Rich **comparison UX** (input-vs-output / run-A-vs-run-B) — deferred; would build on #349's `compare_runs` and is secondary to single-result inspection (spec §12).
- Workflow-run **lineage DAG** rendering inside the detail — deferred to compose with #346/#349's provenance surfaces rather than duplicate.
- Tool-call args correlation is best-effort by tool name within a turn (documented approximation); a stable `tool_call_id` on `step_result` would make input evidence exact.
- Live visual screenshot matrix (blocked on backend stack; see Visual QA).

## Local Validation

Validation was performed locally. GitHub Actions / CI/CD were not used as completion evidence.

- `npx tsc --noEmit` ✅  `npx tsc -p tsconfig.test.json --noEmit` ✅
- `npm run lint` (--max-warnings 0) ✅
- `npm test` → **934 passed, 3 skipped** (pre-existing) ✅
- `npm run build` → Next.js production build ✅

BASE_SHA `84c73fa` → FINAL_SHA `e1b5ae8` (rebased onto `origin/master` `5a76d79`).
