### PR TITLE
fix(runtime): close out P2 stability follow-ups (post-#352)

### DIFF
--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -699,6 +699,10 @@ class PiBridge:
         await self._lock.acquire()
         cancelled = False
         timed_out = False
+        # G: set True when the pump observes the Pi subprocess dying mid-stream
+        # (see the process_died_event watcher below). Initialized here so the
+        # finally can read it even on the early-return send-failure path.
+        process_died = False
         # F5/F24: publish the active turn's identity + cancellation token while
         # the lock is held — abort() reads the sid for session scoping,
         # dispatch_tool binds the token via use_token. Cleared in the finally.
@@ -726,41 +730,86 @@ class PiBridge:
             # Stream events from Pi
             yield sse_event("task_start", {"task_id": turn_sid, "session_id": turn_sid, "turn_id": turn_id})
 
+            # G: watch the subprocess death signal alongside the event queue so
+            # a mid-stream Pi crash ends the turn promptly (error + done +
+            # no abort) instead of parking on heartbeat silence for the whole
+            # PI_EVENT_STREAM_TIMEOUT=180s stall budget and then retrying with
+            # duplicate side effects. Bare MagicMock rpc fakes (used by other
+            # test suites) auto-create a MagicMock for ``process_died_event``,
+            # which is not awaitable — fall back to a never-set event so those
+            # fakes degrade to the old heartbeat-only behavior.
+            process_died_event = getattr(self._rpc, "process_died_event", None)
+            if not isinstance(process_died_event, asyncio.Event):
+                process_died_event = asyncio.Event()
+
             silence_seconds = 0.0
-            while True:
-                try:
-                    event = await asyncio.wait_for(
-                        self._rpc.events.get(), timeout=PI_HEARTBEAT_INTERVAL
+            get_task = asyncio.ensure_future(self._rpc.events.get())
+            died_task = asyncio.ensure_future(process_died_event.wait())
+            pending = {get_task, died_task}
+            try:
+                while True:
+                    done, pending = await asyncio.wait(
+                        pending, timeout=PI_HEARTBEAT_INTERVAL,
+                        return_when=asyncio.FIRST_COMPLETED,
                     )
-                    silence_seconds = 0.0
-                    sse = map_event_to_sse(event, turn_sid, cache_lookup=get_cached_dispatch_result)
-                    if _harness is not None:
-                        # V3: 给原始 SSE 事件记录补 turn/run correlation（显式透传）。
-                        _harness.record_sse_event({
-                            **event, "run_id": turn_sid, "turn_id": turn_id,
-                        })
-                    if sse:
-                        # V3: step_result 负载加 additive turn_id 字段（前端 ack 时
-                        # 通过 correlation 回传，闭环才完整）。
-                        yield _inject_turn_id(sse, turn_id)
-                    if event.get("type") == "agent_end":
+                    if died_task in done:
+                        # Pi subprocess died mid-stream: the reader's finally
+                        # already failed every pending future; end the turn now
+                        # (error + done below), no abort RPC needed.
+                        process_died = True
                         break
-                except asyncio.TimeoutError:
-                    silence_seconds += PI_HEARTBEAT_INTERVAL
-                    if silence_seconds >= PI_EVENT_STREAM_TIMEOUT:
-                        # True stall: no Pi event for the whole stall budget.
-                        timed_out = True
-                        break
-                    # Keepalive: an SSE comment line (``: ...``) is ignored by
-                    # the client parser and never enters chat history or the
-                    # LLM context, but it produces bytes on the wire so proxies
-                    # and browsers see activity and don't drop the connection.
-                    yield ": keepalive\n\n"
+                    if get_task in done:
+                        event = get_task.result()
+                        silence_seconds = 0.0
+                        sse = map_event_to_sse(event, turn_sid, cache_lookup=get_cached_dispatch_result)
+                        if _harness is not None:
+                            # V3: 给原始 SSE 事件记录补 turn/run correlation（显式透传）。
+                            _harness.record_sse_event({
+                                **event, "run_id": turn_sid, "turn_id": turn_id,
+                            })
+                        if sse:
+                            # V3: step_result 负载加 additive turn_id 字段（前端 ack 时
+                            # 通过 correlation 回传，闭环才完整）。
+                            yield _inject_turn_id(sse, turn_id)
+                        if event.get("type") == "agent_end":
+                            break
+                        # Re-arm the queue waiter for the next event; the
+                        # completed waiter task is dropped from `pending` by
+                        # the next asyncio.wait round.
+                        get_task = asyncio.ensure_future(self._rpc.events.get())
+                        pending.add(get_task)
+                    else:
+                        # Neither an event nor a death within one heartbeat
+                        # interval -> accumulate silence, keepalive.
+                        silence_seconds += PI_HEARTBEAT_INTERVAL
+                        if silence_seconds >= PI_EVENT_STREAM_TIMEOUT:
+                            # True stall: no Pi event for the whole stall budget.
+                            timed_out = True
+                            break
+                        # Keepalive: an SSE comment line (``: ...``) is ignored by
+                        # the client parser and never enters chat history or the
+                        # LLM context, but it produces bytes on the wire so proxies
+                        # and browsers see activity and don't drop the connection.
+                        yield ": keepalive\n\n"
+            finally:
+                # G: cancel the parked wait tasks so no queue-get / death-wait
+                # task outlives the turn; await their completion so nothing
+                # lingers past loop teardown. Also covers generator
+                # cancellation (client disconnect) mid-await.
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
 
             if timed_out:
                 yield sse_event("error", {
                     "session_id": turn_sid,
                     "error": f"Pi agent stalled — no events for {int(PI_EVENT_STREAM_TIMEOUT)}s. The agent may be stuck; please retry.",
+                })
+            if process_died:
+                yield sse_event("error", {
+                    "session_id": turn_sid,
+                    "error": "Pi agent process exited unexpectedly mid-stream. The agent's tools may have run partially; please retry.",
                 })
 
             yield sse_event("done", {"session_id": turn_sid})
@@ -771,7 +820,22 @@ class PiBridge:
             cancelled = True
             raise
         finally:
-            if cancelled or timed_out:
+            if process_died:
+                # G: the Pi subprocess is dead — the reader's finally already
+                # failed every pending future, so an abort RPC would only
+                # raise 'Pi process not started' (duplicate of the fast-fail).
+                # Still ignite the turn's cancellation token so in-flight
+                # HTTP-callback tool dispatches (bound via use_token) stop at
+                # their next checkpoint() instead of running to completion
+                # against a dead turn.
+                logger.error(
+                    "[PiBridge] Pi subprocess exited mid-stream (turn=%s); "
+                    "skipping abort RPC (reader already failed pending futures)",
+                    turn_sid,
+                )
+                if _active_turn_token is not None:
+                    _active_turn_token.cancel("pi process exited unexpectedly")
+            elif cancelled or timed_out:
                 # Tell Pi to stop generating tokens / executing tools. F10:
                 # this now covers the stall-timeout path too — previously a
                 # stalled turn yielded error+done and returned WITHOUT the

--- a/app/core/rate_limiter.py
+++ b/app/core/rate_limiter.py
@@ -126,12 +126,24 @@ class MemoryRateLimiter:
 
 
 _rate_limiter: RateLimiter | None = None
+# P2: 首次探测 Redis 失败会回退到内存版。原实现把该回退永久缓存 —— Redis 恢复后
+# 整个进程生命周期内跨 pod 限流仍然失效（安全上 fail-open 无害，但语义漂移）。
+# 现在记录回退时刻，下次调用时若超过 _FALLBACK_REPROBE_S 则重新探测一次；成功则
+# 切换回 Redis 后端，失败则刷新回退时刻（避免每次调用都打 Redis）。
+_FALLBACK_REPROBE_S = 60.0
+_rate_limiter_fallback_at: float | None = None
 
 
 async def get_rate_limiter() -> RateLimiter:
     """Return a shared rate limiter instance, preferring Redis when available."""
-    global _rate_limiter
-    if _rate_limiter is not None:
+    global _rate_limiter, _rate_limiter_fallback_at
+    if _rate_limiter is not None and not isinstance(_rate_limiter, MemoryRateLimiter):
+        return _rate_limiter
+    if (
+        _rate_limiter is not None
+        and _rate_limiter_fallback_at is not None
+        and (time.monotonic() - _rate_limiter_fallback_at) < _FALLBACK_REPROBE_S
+    ):
         return _rate_limiter
 
     try:
@@ -145,9 +157,11 @@ async def get_rate_limiter() -> RateLimiter:
         )
         await client.ping()
         _rate_limiter = RedisRateLimiter(client)
+        _rate_limiter_fallback_at = None
         logger.info("[RateLimiter] Using Redis backend")
     except Exception as exc:
         logger.warning(f"[RateLimiter] Redis unavailable ({exc}), falling back to in-memory")
         _rate_limiter = MemoryRateLimiter()
+        _rate_limiter_fallback_at = time.monotonic()
 
     return _rate_limiter

--- a/app/services/chat/event_resume.py
+++ b/app/services/chat/event_resume.py
@@ -233,6 +233,12 @@ class TurnResumeRegistry:
         if session_id not in self._buffers:
             self._order.append(session_id)
             self._buffers[session_id] = deque()
+        else:
+            # P2: 重新注册已有 key 时刷新 LRU 序（MRU bump）—— 否则一个活跃
+            # 会话的 buffer 会被 32 个「只注册过一次」的其它会话挤出缓存，
+            # 造成活跃会话的续传不可用。
+            self._order.remove(session_id)
+            self._order.append(session_id)
         buffers = self._buffers[session_id]
         buffers.append(buffer)
         while len(buffers) > self._max_buffers_per_session:

--- a/app/services/chat/pi_rpc_client.py
+++ b/app/services/chat/pi_rpc_client.py
@@ -11,6 +11,11 @@ Interface:
     - :attr:`events` - the raw ``AgentSessionEvent`` queue (consumed by the mapper)
     - :attr:`process_died` - True after the Pi process exits (lets the bridge
       fall back to the legacy path)
+    - :attr:`process_died_event` - public ``asyncio.Event`` set at the same
+      moment ``process_died`` flips True; ``start()`` clears both so a stale
+      death can't fast-fail a healthy respawned turn. Lets a streaming turn
+      park on ``{events.get(), process_died_event.wait()}`` and learn of a
+      mid-stream death promptly instead of via heartbeat silence.
 
 The ADR-0022 dispatch-result cache and the two dispatch adapters stay in
 ``agent_pi_bridge.py`` - this module has no knowledge of tool dispatch.
@@ -99,6 +104,11 @@ class PiRpcClient:
         self._stderr_task: Optional[asyncio.Task] = None
         # 审计 AGENT-05：Pi 进程死亡后标记为 True，让 _use_pi_bridge() 能回退
         self._process_died = False
+        # 与 _process_died 同步翻转的 asyncio.Event：stream_prompt 把它和事件
+        # 队列一起 wait，进程中途死亡时能立刻结束 turn，而不是靠心跳静默等满
+        # PI_EVENT_STREAM_TIMEOUT。start() 里与 flag 一起 clear，防止上一次
+        # 死亡的残留信号误杀重连后的新 turn。
+        self._process_died_event = asyncio.Event()
         # Register an atexit hook so that if the Python process exits for any
         # catchable reason (SIGTERM, unhandled exception, normal shutdown) the
         # Pi child is terminated rather than orphaned. The k8s entrypoint's
@@ -140,10 +150,26 @@ class PiRpcClient:
         """True after the Pi process exits or the reader task crashes."""
         return self._process_died
 
+    @property
+    def process_died_event(self) -> asyncio.Event:
+        """Public death signal: set the moment ``process_died`` flips True.
+
+        Awaitable alongside :attr:`events` so a streaming consumer can fast-fail
+        on a mid-stream subprocess death instead of waiting out the stall
+        budget. Cleared by :meth:`start` so a stale death from a previous
+        process can't fast-fail a healthy respawned turn.
+        """
+        return self._process_died_event
+
     async def start(self) -> None:
         """Start the Pi subprocess."""
         if self._process is not None:
             return
+
+        # 重连/respawn：清掉上一次死亡的残留信号，防止陈旧死亡误杀新 turn
+        # （reader finally 里与 flag 一起 set 的 event，这里与 flag 一起 clear）。
+        self._process_died = False
+        self._process_died_event.clear()
 
         self._session_dir.mkdir(parents=True, exist_ok=True)
 
@@ -298,8 +324,10 @@ class PiRpcClient:
         finally:
             # Pi 进程退出 / reader 异常 -> fail 所有 pending 请求，避免 300s 挂起
             self._fail_all_pending("Pi process exited or reader stopped")
-            # 标记为不可用
+            # 标记为不可用（flag + 可等待的 asyncio.Event 同步翻转，让正在
+            # stream_prompt 里等待的 turn 立刻感知死亡并 fast-fail）
             self._process_died = True
+            self._process_died_event.set()
             # Clear the dead process reference so start() can respawn (its guard
             # is `if self._process is not None: return`). Only clear when the
             # process has actually exited (poll() returns a non-None exit code) -

--- a/app/services/session_data_protocol.py
+++ b/app/services/session_data_protocol.py
@@ -205,9 +205,14 @@ def get_session_store() -> SessionStoreProtocol:
     """
     global _active_store
     if _active_store is None:
-        from app.services.session_data import create_session_data_manager
+        # P2: 与 `session_data_manager`（session_data.py 模块单例）共用同一个
+        # 实例，而不是各建一个 —— 原来两个独立 RedisSessionStore 各自持有 L1
+        # 缓存：引擎经 session_data_manager 的写不会失效 explorer 经
+        # get_session_store() 的 L1（反之亦然），同 id 会话存在 ≤L1_TTL 的
+        # 陈旧读取。共享实例后 L1 写失效对所有消费方可见。
+        from app.services.session_data import session_data_manager
 
-        _active_store = create_session_data_manager()
+        _active_store = session_data_manager
     return _active_store
 
 

--- a/app/services/tool_dispatch_service.py
+++ b/app/services/tool_dispatch_service.py
@@ -388,14 +388,21 @@ class ToolDispatchService:
 
     @staticmethod
     def _mint_one_map_action(command_dict: Dict[str, Any]) -> Optional[dict]:
-        """给单个 command dict 铸 action_id（已存在则复用），返回元数据。"""
+        """给单个 command dict 铸 action_id（每次派发都铸新 id），返回元数据。
+
+        P2 (F25): 不再复用 command dict 里已存在的 action_id。原实现「已存在则
+        复用」在工具返回缓存/持久化的 command 对象跨 turn 重放时会复用旧 id：
+        两次真实执行（如重新飞一次/重新导出）共用一个 action_id，ACK store 的
+        first-terminal-wins 会把第二次执行的真实终态当作重复丢弃 —— 下游遥测
+        无法区分两次真实副作用。每次派发铸新 id 后：同 turn 内去重（
+        `_session_executed_sets`）保证同一 tool_call 不会重复派发；跨 turn 的
+        陈旧 id 不再可能碰撞。前端以 SSE 事件里携带的 action_id 为准，行为不变。
+        """
         cmd_name = command_dict.get("command") or command_dict.get("type") or ""
         if not cmd_name:
             return None
-        action_id = command_dict.get("action_id")
-        if not action_id or not isinstance(action_id, str):
-            action_id = _mint_map_action_id()
-            command_dict["action_id"] = action_id
+        action_id = _mint_map_action_id()
+        command_dict["action_id"] = action_id
         requested = _cap_requested_snapshot(command_dict.get("params") or {})
         return {
             "action_id": action_id,

--- a/frontend/lib/api/chat.test.ts
+++ b/frontend/lib/api/chat.test.ts
@@ -277,5 +277,25 @@ describe('Chat API', () => {
       expect(events[0]).toMatchObject({ event: 'token', id: '3' });
       expect(events[1]).toMatchObject({ event: 'done', id: '4' });
     });
+
+    it('yields step_cancelled with its payload (runtime-chaos P2)', async () => {
+      mockFetch.mockResolvedValueOnce(makeSSEStream([
+        'event: step_cancelled',
+        'data: {"task_id":"t1","step_id":"step-1","tool":"search_poi","session_id":"s1"}',
+        '',
+      ]));
+      const events: SSEEvent[] = [];
+      for await (const e of streamChat('hello')) {
+        events.push(e);
+      }
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe('step_cancelled');
+      expect(events[0].data).toEqual({
+        task_id: 't1',
+        step_id: 'step-1',
+        tool: 'search_poi',
+        session_id: 's1',
+      });
+    });
   });
 });

--- a/frontend/lib/api/chat.ts
+++ b/frontend/lib/api/chat.ts
@@ -42,6 +42,7 @@ export type SSEEventType =
   | 'task_complete'
   | 'task_error'
   | 'task_cancelled'
+  | 'step_cancelled'
   | 'session'
   | 'task_plan'
   | 'token'

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -6,17 +6,29 @@ import {
   resolveParentLayerId,
 } from './use-sse-stream';
 import { useHudStore } from '@/lib/store/useHudStore';
-import type { SelectedFeatureInfo } from '@/lib/store/hud-types';
+import type { SelectedFeatureInfo, ToolCallEntry } from '@/lib/store/hud-types';
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 // use-sse-stream consumes the bridge for aiStatus + send; we spy on send to
-// capture the mapState payload (the FE-4 contract under test).
+// capture the mapState payload (the FE-4 contract under test). The mock also
+// captures the real onEvent callback (useMapBridge's 3rd arg —
+// (sessionId, dispatchAction, onEvent, sessionTokenRef, opts)) so tests can
+// drive SSE events straight into the hook.
 const bridgeMock = vi.hoisted(() => ({
   send: vi.fn().mockResolvedValue(undefined),
   aiStatus: 'idle',
+  onEventCallback: null as ((event: {
+    event: string;
+    data: Record<string, unknown>;
+  }) => void) | null,
 }));
 
-vi.mock('./useMapBridge', () => ({ useMapBridge: () => bridgeMock }));
+vi.mock('./useMapBridge', () => ({
+  useMapBridge: (...args: unknown[]) => {
+    bridgeMock.onEventCallback = args[2] as typeof bridgeMock.onEventCallback;
+    return bridgeMock;
+  },
+}));
 vi.mock('@/lib/utils/logger', () => ({
   devOnly: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
   safeError: vi.fn(),
@@ -215,5 +227,97 @@ describe('useSSEStream mapState snapshot (FE-4 design §7)', () => {
     const mapState = await sendAndGetMapState();
     expect(mapState.selected_feature).toBeNull();
     expect(mapState.focus_layer_id).toBeNull();
+  });
+});
+
+describe('useSSEStream step_cancelled', () => {
+  beforeEach(() => {
+    bridgeMock.send.mockClear();
+    bridgeMock.onEventCallback = null;
+    useHudStore.setState({
+      selectedFeature: null,
+      focusLayerId: null,
+      layers: [],
+      baseLayer: 'OSM 地图',
+      viewport: { center: [0, 0], zoom: 5, bearing: 0, pitch: 0 },
+      is3D: false,
+    });
+  });
+
+  // Render, send once (establishes thinkingMsgIdRef), then attach the seeded
+  // tool-call rows to the turn's thinking message (the last message).
+  async function renderWithToolCalls(toolCalls: ToolCallEntry[]) {
+    const hook = renderStream();
+    await act(async () => {
+      await hook.result.current.handleSend('hi');
+    });
+    act(() => {
+      hook.result.current.setMessages((prev) => {
+        const idx = prev.length - 1;
+        return [...prev.slice(0, idx), { ...prev[idx], toolCalls }];
+      });
+    });
+    return hook;
+  }
+
+  function emitStepCancelled(data: Record<string, unknown>) {
+    act(() => {
+      bridgeMock.onEventCallback?.({ event: 'step_cancelled', data });
+    });
+  }
+
+  it('marks a matching running row failed/已取消, preserving other fields and sibling rows', async () => {
+    const hook = await renderWithToolCalls([
+      { id: 'step-1', tool: 'search_poi', arguments: '{"q":"school"}', status: 'running', startedAt: 1 },
+      { id: 'step-2', tool: 'heatmap_data', status: 'running', startedAt: 2 },
+    ]);
+    emitStepCancelled({
+      task_id: 't1',
+      step_id: 'step-1',
+      tool: 'search_poi',
+      session_id: 'sid-fe4',
+    });
+    const msg = hook.result.current.messages[hook.result.current.messages.length - 1];
+    expect(msg.toolCalls).toEqual([
+      { id: 'step-1', tool: 'search_poi', arguments: '{"q":"school"}', status: 'failed', error: '已取消', startedAt: 1 },
+      { id: 'step-2', tool: 'heatmap_data', status: 'running', startedAt: 2 },
+    ]);
+  });
+
+  it('no-ops on unknown step_id, preserving message object identity', async () => {
+    const hook = await renderWithToolCalls([
+      { id: 'step-1', tool: 'search_poi', status: 'running', startedAt: 1 },
+    ]);
+    const messagesBefore = hook.result.current.messages;
+    const msgBefore = messagesBefore[messagesBefore.length - 1];
+    emitStepCancelled({ task_id: 't1', step_id: 'nope', tool: 'search_poi', session_id: 'sid-fe4' });
+    expect(hook.result.current.messages).toBe(messagesBefore);
+    expect(hook.result.current.messages[hook.result.current.messages.length - 1]).toBe(msgBefore);
+  });
+
+  it('never overwrites an already-terminal row while cancelling a running row in the same batch', async () => {
+    const hook = await renderWithToolCalls([
+      { id: 'step-1', tool: 'search_poi', status: 'completed', result: 'ok', completedAt: 5 },
+      { id: 'step-2', tool: 'heatmap_data', status: 'running', startedAt: 2 },
+    ]);
+    emitStepCancelled({ task_id: 't1', step_id: 'step-1', tool: 'search_poi', session_id: 'sid-fe4' });
+    let calls = hook.result.current.messages[hook.result.current.messages.length - 1].toolCalls!;
+    expect(calls[0].status).toBe('completed');
+    expect(calls[0].result).toBe('ok');
+    expect(calls[0].error).toBeUndefined();
+    expect(calls[1].status).toBe('running');
+    // a later step_cancelled for the running row still lands
+    emitStepCancelled({ task_id: 't1', step_id: 'step-2', tool: 'heatmap_data', session_id: 'sid-fe4' });
+    calls = hook.result.current.messages[hook.result.current.messages.length - 1].toolCalls!;
+    expect(calls[1]).toMatchObject({ id: 'step-2', status: 'failed', error: '已取消' });
+  });
+
+  it('leaves a row running when data.tool mismatches on the same step_id', async () => {
+    const hook = await renderWithToolCalls([
+      { id: 'step-1', tool: 'search_poi', status: 'running', startedAt: 1 },
+    ]);
+    emitStepCancelled({ task_id: 't1', step_id: 'step-1', tool: 'other_tool', session_id: 'sid-fe4' });
+    const calls = hook.result.current.messages[hook.result.current.messages.length - 1].toolCalls!;
+    expect(calls[0]).toMatchObject({ id: 'step-1', status: 'running' });
   });
 });

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -479,6 +479,38 @@ export function useSSEStream(
         } catch (err) {
           devOnly.warn('[plan_finalized] parse failed', err);
         }
+      } else if (event.event === 'step_cancelled') {
+        // B-P2: 步骤被抢占取消时后端下发 step_cancelled
+        // ({task_id, step_id, tool, session_id})。把对应 running 的 tool-call
+        // 行标记为已取消（复用 ToolCallEntry 的 failed 形态），否则该行会一直
+        // 停在 running 直到流结束。已到终态的行绝不覆盖；未匹配时原样返回 prev，
+        // 保持 message 对象身份不变。
+        const stepId = data.step_id;
+        const tool = data.tool;
+        if (typeof stepId === 'string' && stepId) {
+          setMessages((prev) => {
+            const msgIdx = prev.findIndex(
+              (m) => m.id === thinkingId && Array.isArray(m.toolCalls),
+            );
+            if (msgIdx === -1) return prev;
+            const toolCalls = prev[msgIdx].toolCalls;
+            if (!toolCalls || toolCalls.length === 0) return prev;
+            let changed = false;
+            const nextCalls = toolCalls.map((c) => {
+              const matches =
+                c.id === stepId &&
+                (tool === undefined || c.tool === tool) &&
+                c.status === 'running';
+              if (!matches) return c;
+              changed = true;
+              return { ...c, status: 'failed' as const, error: '已取消' };
+            });
+            if (!changed) return prev;
+            const next = [...prev];
+            next[msgIdx] = { ...prev[msgIdx], toolCalls: nextCalls };
+            return next;
+          });
+        }
       } else if (
         event.event === 'error' ||
         event.event === 'step_error' ||

--- a/tests/test_runtime_chaos_pi.py
+++ b/tests/test_runtime_chaos_pi.py
@@ -1,6 +1,6 @@
 """Runtime-chaos hardening tests for the Pi bridge / RPC client (WP-PI).
 
-Covers four defects, one test class each:
+Covers five defects, one test class each:
 
   - F5:  ``PiBridge.abort(session_id=...)`` must not kill a DIFFERENT
     session's in-flight turn on the singleton bridge.
@@ -12,6 +12,10 @@ Covers four defects, one test class each:
   - F24: the Pi HTTP-callback ``dispatch_tool`` must run under the active
     turn's ``CancellationToken`` so checkpoint()-cooperative tools stop when
     the turn is aborted.
+  - G:   a mid-stream Pi subprocess death must fast-fail the turn via the
+    public ``process_died_event`` (error + done, no abort RPC — the reader
+    already failed pending futures), not park on heartbeat silence for the
+    180s stall budget.
 
 Deterministic: fake RPC clients with asyncio.Queue event streams, Event
 barriers, and tiny patched timeout constants (no wall-clock-dependent
@@ -21,7 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -519,3 +523,193 @@ async def test_abort_toctou_sid_flip_logs_warning(caplog):
     ), "sid flip during the abort RPC must log a TOCTOU warning (P1)"
 
     await gen.aclose()
+
+
+# ── G: mid-stream Pi subprocess death fast-fail ─────────────────────
+
+
+def _make_death_rpc(seed_events: list[dict] | None = None) -> MagicMock:
+    """Like _make_rpc but with a REAL asyncio.Event process_died_event so the
+    bridge's death watcher can be driven deterministically (the bare
+    MagicMock attribute auto-created on attribute access is not awaitable).
+    """
+    rpc = _make_rpc(seed_events)
+    rpc.process_died_event = asyncio.Event()
+    return rpc
+
+
+class _EofPipe:
+    """Immediate-EOF stdout stand-in: read(1)/readline() both return b''."""
+
+    def read(self, n: int = -1):
+        return b""
+
+    def readline(self):
+        return b""
+
+
+@pytest.mark.asyncio
+async def test_process_death_mid_stream_fast_fails_turn(monkeypatch):
+    """G: when the Pi subprocess dies mid-stream, stream_prompt must end the
+    turn promptly with a truthful error + done — NOT park on heartbeat silence
+    for the whole 180s stall budget (which would then abort + encourage a
+    retry that duplicates side effects). It must skip the abort RPC (the
+    reader already failed pending futures; abort would only raise 'Pi process
+    not started'), cancel the turn token (in-flight HTTP-callback dispatches
+    stop at their next checkpoint()), drain the queue and release the lock.
+
+    Deterministic: the stall budget is patched to 3600s so ONLY the death
+    signal can end the stream; completion is asserted via an asyncio.Event
+    barrier inside a short wait_for (no wall-clock sleeps).
+    """
+    class _StubRegistry:
+        def list_tools(self):
+            return ["query_map_features"]
+
+        def metadata(self, name):
+            return {"tier": 1}
+
+    monkeypatch.setattr(bridge_mod, "get_tool_registry", lambda: _StubRegistry())
+    monkeypatch.setattr(bridge_mod, "PI_HEARTBEAT_INTERVAL", 0.01)
+    # Only the death signal may end the stream — a stall would take 3600s.
+    monkeypatch.setattr(bridge_mod, "PI_EVENT_STREAM_TIMEOUT", 3600.0)
+
+    observed_tokens: list = []
+
+    async def _fake_dispatch(self, tc, session_id, executed):
+        observed_tokens.append(current_token())
+        return ToolDispatchResult(
+            status="ok", llm_payload="ok", slim_event={}, geojson_ref=None,
+            raw_result={}, error_msg=None,
+        )
+
+    monkeypatch.setattr(bridge_mod.ToolDispatchService, "dispatch", _fake_dispatch)
+
+    rpc = _make_death_rpc([make_token_event("partial")])  # one event, no agent_end
+    bridge = PiBridge(rpc=rpc)
+
+    parked = asyncio.Event()
+    terminal = asyncio.Event()
+    collected: list[str] = []
+
+    async def _consume():
+        async for ev in bridge.stream_prompt("hi", session_id="sess-death"):
+            collected.append(ev)
+            if "partial" in ev:
+                parked.set()  # turn is mid-stream, parked on the next event
+            if ev.startswith("event: done"):
+                terminal.set()
+
+    consumer = asyncio.create_task(_consume())
+    await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+    # A tool dispatch is in flight via the HTTP callback, bound to the turn's
+    # token (F24); it captures the token object for the cancellation assert.
+    dispatch = asyncio.create_task(dispatch_tool(PiToolRequest(
+        name="query_map_features", toolCallId="tc-death", arguments={},
+        sessionId=None,
+    )))
+    await dispatch
+
+    # Mid-turn: the Pi subprocess dies.
+    rpc.process_died_event.set()
+    await asyncio.wait_for(terminal.wait(), timeout=2.0)
+    await consumer
+
+    # Terminal sequence: a truthful error, then done, and NOTHING after done.
+    structured = [e for e in collected if not e.startswith(":")]
+    assert structured[-1].startswith("event: done"), structured
+    assert structured[-2].startswith("event: error"), structured
+    assert "exited unexpectedly" in structured[-2]
+
+    # No abort RPC: the reader already failed pending futures; abort would
+    # only raise 'Pi process not started' (and duplicate the fast-fail).
+    assert "abort" not in _rpc_commands(rpc), (
+        f"death must skip the abort RPC; calls={_rpc_commands(rpc)}"
+    )
+    rpc.fail_all_pending.assert_not_called()
+
+    # The turn token was cancelled so checkpoint()-cooperative tool
+    # dispatches (HTTP callback path) stop against the dead turn.
+    token = observed_tokens[0]
+    assert token is not None, "dispatch must run under the turn's token"
+    assert token.cancelled, "mid-stream death must cancel the turn token"
+
+    # Leftover events drained, lock released.
+    assert rpc.events.empty(), "queue must be drained after death"
+    assert bridge._lock.locked() is False, "turn lock leaked after death"
+
+
+@pytest.mark.asyncio
+async def test_process_died_event_fires_on_reader_eof():
+    """G: the public process_died_event must be set by the reader's finally at
+    the same moment process_died flips True (stdout EOF -> subprocess gone),
+    so a streaming turn can fast-fail on it."""
+    client = PiRpcClient()
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+    mock_proc.stdout = _EofPipe()
+    mock_proc.stderr = _EofPipe()
+    mock_proc.poll.return_value = 1
+
+    client._process = mock_proc
+    assert client.process_died_event.is_set() is False
+
+    await client._read_responses()
+
+    assert client.process_died_event.is_set() is True
+    assert client.process_died is True
+    # The dead process reference is cleared so start() can respawn.
+    assert client._process is None
+
+
+@pytest.mark.asyncio
+async def test_start_clears_death_signal():
+    """G guard: a stale death signal from a previous process must not fast-fail
+    a healthy respawned turn — start() clears both the flag and the event
+    before spawning (mirrors the unit respawn test's Popen mocking)."""
+    import app.api.routes.pi_tools  # noqa: F401 — pre-import so the patch hits the cached module
+
+    client = PiRpcClient()
+    client._process_died = True
+    client._process_died_event.set()
+
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = None
+    mock_proc.stdin = MagicMock()
+
+    with patch.object(PiRpcClient, "_read_responses", new_callable=AsyncMock), \
+         patch.object(PiRpcClient, "_read_stderr", new_callable=AsyncMock), \
+         patch("app.services.chat.pi_rpc_client.subprocess.Popen", return_value=mock_proc), \
+         patch("app.api.routes.pi_tools.get_bridge_secret", return_value="test-secret"), \
+         patch.object(PiRpcClient, "_wait_for_ready", new_callable=AsyncMock):
+        await client.start()
+
+    assert client.process_died is False, "start() must clear the stale death flag"
+    assert client.process_died_event.is_set() is False, (
+        "start() must clear the stale death event so a respawned turn isn't fast-failed"
+    )
+    assert client._process is mock_proc
+
+
+@pytest.mark.asyncio
+async def test_stream_prompt_happy_path_unchanged_with_death_aware_rpc():
+    """G guard: with a death-aware client (real process_died_event that never
+    fires), the happy path is unchanged — task_start -> token -> agent_end ->
+    done, no error, no abort, queue empty, lock released."""
+    rpc = _make_death_rpc([
+        make_token_event("hello"),
+        {"type": "agent_end"},
+    ])
+    bridge = PiBridge(rpc=rpc)
+
+    events = [ev async for ev in bridge.stream_prompt("hi", session_id="sess-ok")]
+
+    structured = [e for e in events if not e.startswith(":")]
+    assert any("task_start" in e for e in structured), structured
+    assert any("hello" in e for e in structured), structured
+    assert structured[-1].startswith("event: done"), structured
+    assert not any(e.startswith("event: error") for e in structured), structured
+    assert "abort" not in _rpc_commands(rpc), _rpc_commands(rpc)
+    assert bridge._lock.locked() is False
+    assert rpc.events.empty()

--- a/tests/test_runtime_p2_followups.py
+++ b/tests/test_runtime_p2_followups.py
@@ -1,0 +1,211 @@
+"""P2 follow-up regression tests (post-PR #352 hardening round).
+
+Covers the deferred P2 items fixed after the first adversarial review:
+
+  A. F29  TaskQueueService._task_owners 无界增长 → LRU 有界化
+  B.      rate limiter Redis 回退永久缓存 → 周期重探测
+  C.      TurnResumeRegistry 重注册不刷新 LRU 序（MRU bump）
+  D.      get_session_store() 与 session_data_manager 双单例 → 共享实例
+  E.      _mint_one_map_action 复用陈旧 action_id（F25）→ 每次派发铸新 id
+
+All deterministic — no wall-clock sleeps (injectable time / module-state reset).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services.task_queue import TaskQueueService
+from app.services.chat.event_resume import TurnEventBuffer, TurnResumeRegistry
+from app.services.tool_dispatch_service import ToolDispatchService
+
+
+# ─── A. F29: _task_owners bounded LRU ────────────────────────────────────────
+
+
+class TestTaskOwnersBounded:
+    @pytest.fixture
+    def small_owners(self, monkeypatch):
+        monkeypatch.setattr(TaskQueueService, "_OWNERS_MAX_ENTRIES", 3)
+        TaskQueueService._task_owners.clear()
+        yield
+        TaskQueueService._task_owners.clear()
+
+    def test_evicts_oldest_beyond_cap(self, small_owners):
+        TaskQueueService.register_owner("t1", "u1")
+        TaskQueueService.register_owner("t2", "u2")
+        TaskQueueService.register_owner("t3", "u3")
+        TaskQueueService.register_owner("t4", "u4")  # 超上限 → 逐出 t1
+        assert TaskQueueService.verify_owner("t1", "u1") is False
+        assert TaskQueueService.verify_owner("t2", "u2") is True
+        assert TaskQueueService.verify_owner("t3", "u3") is True
+        assert TaskQueueService.verify_owner("t4", "u4") is True
+
+    def test_verify_refreshes_recency(self, small_owners):
+        TaskQueueService.register_owner("a", "u")
+        TaskQueueService.register_owner("b", "u")
+        TaskQueueService.register_owner("c", "u")
+        # b 命中刷新 recency；再注册 d 逐出最旧的 a（而不是刚命中的 b）
+        assert TaskQueueService.verify_owner("b", "u") is True
+        TaskQueueService.register_owner("d", "u")
+        assert TaskQueueService.verify_owner("a", "u") is False
+        assert TaskQueueService.verify_owner("b", "u") is True
+        assert TaskQueueService.verify_owner("d", "u") is True
+
+    def test_register_ignores_empty_user(self, small_owners):
+        TaskQueueService.register_owner("t1", "")
+        assert TaskQueueService.verify_owner("t1", "") is False
+
+
+# ─── B. rate limiter: fallback re-probe ──────────────────────────────────────
+
+
+class TestRateLimiterReprobe:
+    @pytest.fixture
+    def reset_module_state(self):
+        import app.core.rate_limiter as rl
+
+        saved = (rl._rate_limiter, rl._rate_limiter_fallback_at)
+        rl._rate_limiter = None
+        rl._rate_limiter_fallback_at = None
+        yield rl
+        rl._rate_limiter, rl._rate_limiter_fallback_at = saved
+
+    @pytest.mark.asyncio
+    async def test_fallback_then_reprobe_after_interval(self, monkeypatch, reset_module_state):
+        import app.core.rate_limiter as rl
+        from app.core.rate_limiter import MemoryRateLimiter, RedisRateLimiter
+
+        calls = {"n": 0}
+
+        class _FakeClient:
+            def __init__(self, url, **kw):
+                self.url = url
+
+            async def ping(self):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise RuntimeError("redis down")
+                return True
+
+        monkeypatch.setattr("redis.asyncio.from_url", _FakeClient)
+        monkeypatch.setattr(rl, "_FALLBACK_REPROBE_S", 60.0)
+
+        limiter1 = await rl.get_rate_limiter()
+        assert isinstance(limiter1, MemoryRateLimiter)
+        assert rl._rate_limiter_fallback_at is not None
+
+        # 间隔内不重探测（仍内存版）
+        monkeypatch.setattr("app.core.rate_limiter.time.monotonic", lambda: 100.0)
+        rl._rate_limiter_fallback_at = 60.0  # 40s 前回退，< 60s 间隔
+        limiter_same = await rl.get_rate_limiter()
+        assert limiter_same is limiter1
+
+        # 超过间隔 → 重探测成功 → 切回 Redis 后端
+        rl._rate_limiter_fallback_at = 30.0  # 70s 前回退
+        limiter2 = await rl.get_rate_limiter()
+        assert isinstance(limiter2, RedisRateLimiter)
+        assert rl._rate_limiter_fallback_at is None
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_reprobe_failure_refreshes_fallback(self, monkeypatch, reset_module_state):
+        import app.core.rate_limiter as rl
+        from app.core.rate_limiter import MemoryRateLimiter
+
+        calls = {"n": 0}
+
+        class _AlwaysDown:
+            async def ping(self):
+                calls["n"] += 1
+                raise RuntimeError("redis down")
+
+        monkeypatch.setattr("redis.asyncio.from_url", lambda url, **kw: _AlwaysDown())
+        monkeypatch.setattr(
+            "app.core.rate_limiter.time.monotonic", lambda: 1000.0
+        )
+        rl._rate_limiter_fallback_at = 0.0  # 早已超过间隔
+        limiter = await rl.get_rate_limiter()
+        assert isinstance(limiter, MemoryRateLimiter)
+        assert rl._rate_limiter_fallback_at == 1000.0  # 刷新回退时刻，不每次打 Redis
+        await rl.get_rate_limiter()
+        assert calls["n"] == 1  # 间隔内不再探测
+
+
+# ─── C. TurnResumeRegistry MRU bump ──────────────────────────────────────────
+
+
+class TestResumeRegistryMRU:
+    def _buffer(self, sid: str, n_events: int = 0) -> TurnEventBuffer:
+        b = TurnEventBuffer(session_id=sid, message=f"msg-{sid}", max_events=8)
+        for i in range(n_events):
+            b.record(f"data: x{i}\n\n")
+        return b
+
+    def test_re_register_refreshes_lru_recency(self):
+        reg = TurnResumeRegistry(max_sessions=3, max_buffers_per_session=2)
+        reg.register("A", self._buffer("A"))
+        reg.register("B", self._buffer("B"))
+        reg.register("C", self._buffer("C"))
+        # 重注册 A → A 变为最新；再注册 D 应逐出 B（最旧），而不是 A
+        reg.register("A", self._buffer("A", 1))
+        reg.register("D", self._buffer("D"))
+        assert reg.get("A") is not None
+        assert reg.get("D") is not None
+        assert reg.get("B") is None
+        assert reg.get("C") is not None
+
+
+# ─── D. get_session_store() shares the canonical singleton ───────────────────
+
+
+class TestSessionStoreSingleton:
+    def test_get_session_store_is_session_data_manager(self):
+        from app.services import session_data
+        from app.services.session_data_protocol import (
+            get_session_store,
+            set_active_session_store,
+        )
+
+        try:
+            set_active_session_store(None)
+            store = get_session_store()
+            assert store is session_data.session_data_manager
+        finally:
+            set_active_session_store(None)
+
+    def test_set_active_store_still_overrides(self):
+        from app.services.session_data import MemorySessionStore
+        from app.services.session_data_protocol import (
+            get_session_store,
+            set_active_session_store,
+        )
+
+        custom = MemorySessionStore()
+        try:
+            set_active_session_store(custom)
+            assert get_session_store() is custom
+        finally:
+            set_active_session_store(None)
+
+
+# ─── E. F25: _mint_one_map_action always mints a fresh id ────────────────────
+
+
+class TestMintMapActionFreshId:
+    def test_reuse_scenario_mints_distinct_ids(self):
+        cmd: dict[str, Any] = {
+            "command": "fly_to",
+            "params": {"longitude": 116.3, "latitude": 39.9},
+            "action_id": "stale-from-previous-turn",  # 跨 turn 陈旧 id
+        }
+        e1 = ToolDispatchService._mint_one_map_action(cmd)
+        e2 = ToolDispatchService._mint_one_map_action(cmd)
+        assert e1 is not None and e2 is not None
+        assert e1["action_id"] != e2["action_id"]
+        assert e1["action_id"] != "stale-from-previous-turn"
+        assert cmd["action_id"] == e2["action_id"]
+
+    def test_missing_command_returns_none(self):
+        assert ToolDispatchService._mint_one_map_action({"params": {}}) is None

--- a/tests/unit/test_harness_interaction_v3.py
+++ b/tests/unit/test_harness_interaction_v3.py
@@ -141,18 +141,24 @@ async def test_dispatch_no_command_no_minting(fake_registry, clean_session):
 
 
 @pytest.mark.asyncio
-async def test_dispatch_minting_preserves_preexisting_action_id(fake_registry, clean_session):
-    """已铸过 action_id 的 command dict → 复用，不重复铸造。"""
+async def test_dispatch_minting_mints_fresh_id_over_preexisting(fake_registry, clean_session):
+    """F25: 已带 action_id 的 command dict（跨 turn 缓存/持久化对象）→ 仍铸新 id。
+
+    复用陈旧 id 会让 ACK store 的 first-terminal-wins 把第二次真实执行的终态
+    当作重复丢弃（重复副作用不可区分）。每次派发必须铸新 id；同 turn 去重由
+    `_session_executed_sets` 保证，前端以 SSE 事件携带的 action_id 为准。
+    """
     fake_registry.dispatch.return_value = {
         "success": True,
         "command": "fly_to",
         "params": {"center": [116.0, 39.0], "zoom": 12},
-        "action_id": "ma-preexisting1234",
+        "action_id": "ma-preexisting1234",  # 陈旧 id（来自之前某次执行）
     }
     svc = ToolDispatchService(registry=fake_registry)
     result = await svc.dispatch(_tc("webgis_view_set", {}), clean_session, set())
-    assert result.map_actions[0]["action_id"] == "ma-preexisting1234"
-    assert result.raw_result["action_id"] == "ma-preexisting1234"
+    assert result.map_actions[0]["action_id"] != "ma-preexisting1234"
+    assert result.map_actions[0]["action_id"].startswith("ma-")
+    assert result.raw_result["action_id"] == result.map_actions[0]["action_id"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_store_contract.py
+++ b/tests/unit/test_session_store_contract.py
@@ -184,50 +184,55 @@ async def test_factory_get_session_store():
     assert get_session_store() is custom
 
 
-def test_factory_selects_backend_from_settings_use_redis(monkeypatch):
-    """REVIEW-P1-6: the seam used to gate on settings.REDIS_ENABLED (which
-    does not exist) and then try to import a name the redis module doesn't
-    export, so the `except Exception` fallback always returned memory even
-    when USE_REDIS=True. Verify the seam now honors the real config flag.
+def test_get_session_store_returns_canonical_singleton(monkeypatch):
+    """P2: `get_session_store()` 必须返回规范单例 `session_data_manager`，
+    而不是每次新建一个实例 —— 两个独立 RedisSessionStore 各持一份 L1 缓存，
+    引擎经 session_data_manager 的写不会失效 explorer 经 get_session_store()
+    的 L1（反之亦然），同 id 会话存在 ≤L1_TTL 的陈旧读取。共享实例后 L1
+    写失效对所有消费方可见。
+
+    `set_active_session_store()` 仍可显式覆盖（测试/替代 provider）；重置为
+    None 后回到规范单例。后端选择（USE_REDIS）由 import 期工厂
+    `create_session_data_manager()` 决定，其行为由 tests/unit/test_session_factory.py
+    单独覆盖（这里不再重复 mock 工厂）。
     """
     import fakeredis.aioredis
 
-    from app.services import session_data_protocol
+    from app.services import session_data, session_data_protocol
+    from app.services.session_data import MemorySessionStore
     from app.services.session_data_redis import RedisSessionDataManager
 
-    # Wire the factory to an injected fakeredis so USE_REDIS=True doesn't
-    # try to reach a real Redis server.
     fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=False)
-    use_redis = {"value": False}  # mutable so the factory closure reads it
+    use_redis = {"value": False}
 
     def _factory_with_fake():
-        from app.services.session_data import MemorySessionStore
+        from app.services.session_data import MemorySessionStore as MemStore
 
         if use_redis["value"]:
             return RedisSessionDataManager(
                 redis_url="redis://unused", redis=fake_redis
             )
-        return MemorySessionStore()
+        return MemStore()
 
     monkeypatch.setattr(
         "app.services.session_data.create_session_data_manager",
         _factory_with_fake,
     )
 
-    # Force a fresh singleton so the factory re-runs.
-    session_data_protocol._active_store = None
-    use_redis["value"] = False
-    store = get_session_store()
-    assert not isinstance(store, RedisSessionDataManager), (
-        f"USE_REDIS=False must not yield a Redis store, got {type(store).__name__}"
-    )
-
-    session_data_protocol._active_store = None
-    use_redis["value"] = True
-    store = get_session_store()
-    assert isinstance(store, RedisSessionDataManager), (
-        f"USE_REDIS=True should yield RedisSessionDataManager, got {type(store).__name__}"
-    )
-
-    # Reset for following tests.
-    session_data_protocol._active_store = None
+    try:
+        session_data_protocol._active_store = None
+        # 规范单例：与模块级 session_data_manager 同一实例
+        assert session_data_protocol.get_session_store() is session_data.session_data_manager
+        # 工厂（直接调用）仍遵循 USE_REDIS 选择后端
+        use_redis["value"] = False
+        assert isinstance(_factory_with_fake(), MemorySessionStore)
+        use_redis["value"] = True
+        assert isinstance(_factory_with_fake(), RedisSessionDataManager)
+        # 显式覆盖仍生效，重置后回到规范单例
+        custom = MemorySessionStore()
+        session_data_protocol.set_active_session_store(custom)
+        assert session_data_protocol.get_session_store() is custom
+        session_data_protocol.set_active_session_store(None)
+        assert session_data_protocol.get_session_store() is session_data.session_data_manager
+    finally:
+        session_data_protocol._active_store = None


### PR DESCRIPTION
# PR body — fix(runtime): close out P2 stability follow-ups (post-#352)

## Summary
Follow-up hardening round after #352 (merged as `2c39bbd`). Closes the deferred P2 items from the fault-injection campaign with deterministic regression tests. All items reproduce on current master; each fix has a failing-first regression test.

- **BASE:** `7cc51f7` (master at branch point)
- **Branch:** `stability/runtime-chaos-p2-followups-kimi`

## Changes

### Backend
1. **F29 — `TaskQueueService._task_owners` unbounded growth → bounded LRU** (`app/services/task_queue.py`). The celery task_id→user mapping grew forever (every Celery submit). Now an `OrderedDict` capped at 20k with recency refresh on `verify_owner`. Tests: cap eviction, recency refresh, empty-user no-op.
2. **Rate limiter Redis fallback re-probe** (`app/core/rate_limiter.py`). A first-call Redis outage cached the in-memory limiter for the process lifetime (cross-pod rate limiting silently lost after recovery). Now re-probes after 60s. Tests: fallback→re-probe→Redis switch; failure refreshes the fallback timestamp.
3. **`TurnResumeRegistry` MRU bump on re-register** (`app/services/chat/event_resume.py`). A re-registering hot session could be LRU-evicted by 32 one-shot sessions, breaking resume. Re-registration now refreshes recency. Test: A,B,C → re-register A → D evicts B, not A.
4. **`get_session_store()` now returns the canonical `session_data_manager` singleton** (`app/services/session_data_protocol.py`). Two independent RedisSessionStore instances each kept their own L1 cache (engine writes didn't invalidate the explorer path's L1 and vice versa, ≤2s stale reads on id reuse). Tests: identity with the canonical singleton; `set_active_session_store` override still works.
5. **F25 — `_mint_one_map_action` always mints a fresh `action_id` per dispatch** (`app/services/tool_dispatch_service.py`). Reusing a stale id from a cached/persisted command dict made the ACK store's first-terminal-wins discard a genuinely re-executed tool's terminal (duplicate side effects indistinguishable). Tests: two mints on one dict → distinct ids; the dict's stale id is replaced.
6. **Pi subprocess death fast-fail mid-stream** (`app/agent_pi_bridge.py`, `app/services/chat/pi_rpc_client.py`). A mid-stream Pi death previously stalled the turn until the 180s heartbeat timeout. `PiRpcClient` now exposes `process_died_event`; `stream_prompt` waits on {queue, death} and terminates with a truthful error+done promptly, cancels the turn token, releases the lock, and skips the abort RPC when the subprocess is already dead. Tests: death mid-stream → prompt terminal without stall, no abort, lock released, token cancelled; event fires on reader EOF; `start()` clears the death signal; happy path unchanged.

### Frontend (contract alignment, no styling change)
7. **`step_cancelled` SSE event handled** (`frontend/lib/api/chat.ts`, `frontend/lib/hooks/use-sse-stream.ts`). The backend's new additive step-terminal event was ignored by the frontend (step rows stayed unresolved until stream end). Added to the `SSEEventType` union and handled: the matching running `ToolCallEntry` row is marked cancelled (`status: 'failed'` + `'已取消'`, existing shape), never overwriting terminal rows, no-op on unknown step_id, identity-preserving. Tests: row marking, unknown-id no-op, terminal-row protection, tool-mismatch guard, SSE parser round-trip.

## Validation
- New regression tests: `tests/test_runtime_p2_followups.py` (10) + `tests/test_runtime_chaos_pi.py` G-section (4) + frontend vitest (5).
- Backend: chaos + adjacent suites **422 passed**; broad backend suite (`-m "not perf and not cartography"`) result below; `ruff check` clean on all changed files.
- Frontend: `vitest run` (affected files), `tsc --noEmit`, `tsc -p tsconfig.test.json --noEmit`, `eslint --max-warnings 0` all green.

## Notes
- Work originally developed in a dedicated worktree; the branch `stability/runtime-chaos-recovery-kimi` was merged as #352 and deleted, so this follow-up is a fresh branch from master.
- Known limits from #352 remain documented there (anonymous `""`-key namespace, abort TOCTOU, queued-turn edge).
