### PR TITLE
fix(map): harden map-action ACK delivery under transient failures

### DIFF
--- a/frontend/lib/api/map-action-acks.test.ts
+++ b/frontend/lib/api/map-action-acks.test.ts
@@ -1,11 +1,71 @@
-import { describe, expect, it, vi } from 'vitest';
-import { createMapActionAckSender } from './map-action-acks';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  classifyAckDelivery,
+  createMapActionAckSender,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_MAX_QUEUE,
+} from './map-action-acks';
+import type { MapActionAck } from './map-action-acks';
+import { devOnly } from '@/lib/utils/logger';
+
+function ack(actionId: string, extras: Partial<MapActionAck> = {}): MapActionAck {
+  return { action_id: actionId, command: 'fly_to', status: 'succeeded', ...extras };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('classifyAckDelivery', () => {
+  it('treats network errors, timeouts, 408, 429, 5xx, and dropped>0 as transient', () => {
+    expect(classifyAckDelivery({ error: new TypeError('Failed to fetch') })).toEqual({
+      kind: 'transient',
+      reason: 'network',
+    });
+    expect(classifyAckDelivery({ error: Object.assign(new Error('aborted'), { name: 'AbortError' }) })).toEqual({
+      kind: 'transient',
+      reason: 'timeout',
+    });
+    expect(classifyAckDelivery({ status: 408 })).toEqual({ kind: 'transient', reason: 'http_408' });
+    expect(classifyAckDelivery({ status: 429 })).toEqual({ kind: 'transient', reason: 'http_429' });
+    expect(classifyAckDelivery({ status: 503 })).toEqual({ kind: 'transient', reason: 'http_5xx' });
+    expect(classifyAckDelivery({ status: 200, dropped: 2 })).toEqual({
+      kind: 'transient',
+      reason: 'backend_dropped',
+    });
+  });
+
+  it('treats auth, deleted session, and validation 4xx as permanent', () => {
+    expect(classifyAckDelivery({ status: 401 })).toEqual({ kind: 'permanent', reason: 'http_401' });
+    expect(classifyAckDelivery({ status: 403 })).toEqual({ kind: 'permanent', reason: 'http_403' });
+    expect(classifyAckDelivery({ status: 404 })).toEqual({ kind: 'permanent', reason: 'http_404' });
+    expect(classifyAckDelivery({ status: 410 })).toEqual({ kind: 'permanent', reason: 'http_410' });
+    expect(classifyAckDelivery({ status: 400 })).toEqual({ kind: 'permanent', reason: 'http_4xx' });
+    expect(classifyAckDelivery({ status: 422 })).toEqual({ kind: 'permanent', reason: 'validation' });
+  });
+
+  it('treats HTTP 200 without dropped as success', () => {
+    expect(classifyAckDelivery({ status: 200 })).toEqual({ kind: 'success', reason: 'ok' });
+    expect(classifyAckDelivery({ status: 200, dropped: 0 })).toEqual({ kind: 'success', reason: 'ok' });
+  });
+});
 
 describe('map action ACK follow-up', () => {
   it('delivers a server-issued cartographic repair action to the current session', async () => {
     const body = { repair_action: { action_id: 'ma-carto-1' } };
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,
+      status: 200,
       json: () => Promise.resolve(body),
     });
     const onResponse = vi.fn();
@@ -21,8 +81,7 @@ describe('map action ACK follow-up', () => {
     sender.sink({ action_id: 'ma-original', command: 'add_layer', status: 'succeeded' });
     token = 'owner-b';
     sender.flush();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushMicrotasks();
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl.mock.calls[0][1].headers['X-Session-Token']).toBe('owner-a');
@@ -31,7 +90,7 @@ describe('map action ACK follow-up', () => {
   });
 
   it('uses the token belonging to the ACK correlation session after a switch', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
     const tokens = new Map([
       ['session-a', 'owner-a'],
       ['session-b', 'owner-b'],
@@ -50,10 +109,472 @@ describe('map action ACK follow-up', () => {
       correlation: { session_id: 'session-a' },
     });
     sender.flush();
-    await Promise.resolve();
+    await flushMicrotasks();
 
     expect(fetchImpl.mock.calls[0][0]).toContain('/sessions/session-a/map-action-ack');
     expect(fetchImpl.mock.calls[0][1].headers['X-Session-Token']).toBe('owner-a');
+    sender.dispose();
+  });
+});
+
+describe('map action ACK delivery (fault matrix)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeSender(
+    fetchImpl: ReturnType<typeof vi.fn>,
+    overrides: Partial<Parameters<typeof createMapActionAckSender>[0]> = {},
+  ) {
+    return createMapActionAckSender({
+      getSessionId: () => 'session-a',
+      getToken: () => 'owner-a',
+      debounceMs: 10,
+      retryBaseMs: 100,
+      retryMaxMs: 400,
+      random: () => 0.5,
+      requestTimeoutMs: 0,
+      maxAttempts: 3,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      ...overrides,
+    });
+  }
+
+  it('1. first POST network failure retries with the same action_id and then succeeds', async () => {
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue(jsonResponse({ accepted: 1, duplicates: 0 }));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-1'));
+    sender.flush();
+    await flushMicrotasks();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(fetchImpl.mock.calls[0][1].body as string);
+    const retryBody = JSON.parse(fetchImpl.mock.calls[1][1].body as string);
+    expect(retryBody.acks[0].action_id).toBe('ma-1');
+    expect(retryBody.acks[0].action_id).toBe(firstBody.acks[0].action_id);
+    sender.dispose();
+  });
+
+  it('2b. HTTP 200 with dropped>0 retries the same action_id and then succeeds', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ accepted: 0, duplicates: 0, dropped: 1 }))
+      .mockResolvedValue(jsonResponse({ accepted: 1, duplicates: 0 }));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-dropped'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetchImpl.mock.calls[1][1].body as string).acks[0].action_id).toBe('ma-dropped');
+    sender.dispose();
+  });
+
+  it('2. HTTP 503 retries and then succeeds', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ detail: 'unavailable' }, 503))
+      .mockResolvedValue(jsonResponse({ accepted: 1, duplicates: 0 }));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-503'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    sender.dispose();
+  });
+
+  it('3. HTTP 429 is retried only within the attempt bound', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ detail: 'Too many map action acks' }, 429));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-429'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(200);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(DEFAULT_MAX_ATTEMPTS);
+    sender.dispose();
+  });
+
+  it('4. HTTP 401/403 are not retried', async () => {
+    for (const status of [401, 403]) {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ detail: 'no' }, status));
+      const sender = makeSender(fetchImpl);
+      sender.sink(ack(`ma-${status}`));
+      sender.flush();
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(1000);
+      await flushMicrotasks();
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      sender.dispose();
+    }
+  });
+
+  it('5. HTTP 400 validation errors are not retried', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ detail: 'bad ack' }, 400));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-400'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    sender.dispose();
+  });
+
+  it('6. exhausted retries settle the queue and do not loop', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError('offline'));
+    const warnSpy = vi.spyOn(devOnly, 'warn');
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-ex'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(200);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(5000);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('exhausted retry'))).toBe(true);
+    warnSpy.mockRestore();
+    sender.dispose();
+  });
+
+  it('7. a retried POST keeps the same action_id so backend first-terminal-wins sees one identity', async () => {
+    const stored = new Set<string>();
+    const terminals: string[] = [];
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new TypeError('net'))
+      .mockImplementation(async (_url: string, init: RequestInit) => {
+        const acks = JSON.parse(String(init.body)).acks as Array<{ action_id: string; status: string }>;
+        let accepted = 0;
+        let duplicates = 0;
+        for (const item of acks) {
+          if (stored.has(item.action_id)) {
+            duplicates += 1;
+          } else {
+            stored.add(item.action_id);
+            terminals.push(item.status);
+            accepted += 1;
+          }
+        }
+        return jsonResponse({ accepted, duplicates });
+      });
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-dup', { status: 'succeeded' }));
+    sender.flush();
+    await flushMicrotasks();
+    sender.sink(ack('ma-dup', { status: 'failed', error: 'late' }));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(stored.size).toBe(1);
+    expect(terminals).toEqual(['succeeded']);
+    sender.dispose();
+  });
+
+  it('8. more than 50 ACKs stay chunked at 50', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ accepted: 50, duplicates: 0 }));
+    const sender = makeSender(fetchImpl);
+
+    for (let i = 0; i < 51; i += 1) {
+      sender.sink(ack(`ma-${i}`));
+    }
+    sender.flush();
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const sizes = fetchImpl.mock.calls.map((call) => JSON.parse(call[1].body as string).acks.length);
+    expect(sizes).toEqual([50, 1]);
+    sender.dispose();
+  });
+
+  it('9. session A items still POST only to A after a switch to B', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ accepted: 1, duplicates: 0 }));
+    let session = 'session-a';
+    const tokens: Record<string, string> = { 'session-a': 'owner-a', 'session-b': 'owner-b' };
+    const sender = createMapActionAckSender({
+      getSessionId: () => session,
+      getToken: (sid) => tokens[sid ?? session] ?? null,
+      debounceMs: 10,
+      requestTimeoutMs: 0,
+      random: () => 0.5,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    sender.sink(ack('ma-a'));
+    session = 'session-b';
+    sender.sink(ack('ma-b'));
+    sender.flush();
+    await flushMicrotasks();
+
+    const urls = fetchImpl.mock.calls.map((call) => String(call[0]));
+    const headers = fetchImpl.mock.calls.map((call) => call[1].headers['X-Session-Token']);
+    const bodies = fetchImpl.mock.calls.map((call) => JSON.parse(call[1].body as string).acks[0].action_id);
+    expect(urls.some((u) => u.includes('/sessions/session-a/map-action-ack'))).toBe(true);
+    expect(urls.some((u) => u.includes('/sessions/session-b/map-action-ack'))).toBe(true);
+    expect(headers).toContain('owner-a');
+    expect(headers).toContain('owner-b');
+    const aCall = fetchImpl.mock.calls.find((call) => String(call[0]).includes('/sessions/session-a/'));
+    expect(aCall?.[1].headers['X-Session-Token']).toBe('owner-a');
+    expect(JSON.parse(aCall?.[1].body as string).acks[0].action_id).toBe('ma-a');
+    expect(bodies).toEqual(expect.arrayContaining(['ma-a', 'ma-b']));
+    expect(String(aCall?.[0])).not.toMatch(/owner-a|token=/i);
+    sender.dispose();
+  });
+
+  it('10. dispose cancels retry timers so advancing time does not POST again', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError('offline'));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-unmount'));
+    sender.flush();
+    await flushMicrotasks();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    sender.dispose();
+    await vi.advanceTimersByTimeAsync(10_000);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispose then a new sink still delivers (Strict Mode remount)', async () => {
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new TypeError('offline'))
+      .mockResolvedValue(jsonResponse({ accepted: 1, duplicates: 0 }));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-old'));
+    sender.flush();
+    await flushMicrotasks();
+    sender.dispose();
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    sender.sink(ack('ma-new'));
+    sender.flush();
+    await flushMicrotasks();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetchImpl.mock.calls[1][1].body as string).acks[0].action_id).toBe('ma-new');
+    sender.dispose();
+  });
+
+  it('HTTP 200 with an unreadable JSON body is transient and retries', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new SyntaxError('not json')),
+      })
+      .mockResolvedValue(jsonResponse({ accepted: 1, duplicates: 0 }));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-html'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    sender.dispose();
+  });
+
+  it('a hung response body is aborted by the request timeout and leaves inFlight', async () => {
+    const fetchImpl = vi.fn()
+      .mockImplementationOnce((_url: string, init: RequestInit) => Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+          });
+        }),
+      }))
+      .mockResolvedValue(jsonResponse({ accepted: 1, duplicates: 0 }));
+    const sender = makeSender(fetchImpl, { requestTimeoutMs: 50 });
+
+    sender.sink(ack('ma-hang-body'));
+    sender.flush();
+    await flushMicrotasks();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(100);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    sender.dispose();
+  });
+
+  it('a skipped stale-session repair does not burn the repair id', async () => {
+    const repair = { action_id: 'ma-carto-1', command: 'cartographic_runtime_repair', params: {} };
+    const onResponse = vi.fn(() => false);
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({
+      accepted: 1,
+      duplicates: 0,
+      repair_action: repair,
+    }));
+    const sender = makeSender(fetchImpl, { onResponse });
+
+    sender.sink(ack('ma-orig-1'));
+    sender.flush();
+    await flushMicrotasks();
+    sender.sink(ack('ma-orig-2'));
+    sender.flush();
+    await flushMicrotasks();
+
+    expect(onResponse).toHaveBeenCalledTimes(2);
+    sender.dispose();
+  });
+
+  it('onResponse throw after HTTP 200 does not retry the settled batch', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({
+      accepted: 1,
+      duplicates: 0,
+      repair_action: { action_id: 'ma-carto-boom', command: 'cartographic_runtime_repair', params: {} },
+    }));
+    const sender = makeSender(fetchImpl, {
+      onResponse: () => {
+        throw new Error('dispatch exploded');
+      },
+    });
+
+    sender.sink(ack('ma-ok'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    sender.dispose();
+  });
+
+  it('11. a duplicate successful repair_action is delivered to onResponse only once', async () => {
+    const repair = { action_id: 'ma-carto-1', command: 'cartographic_runtime_repair', params: {} };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({
+      accepted: 1,
+      duplicates: 0,
+      repair_action: repair,
+    }));
+    const onResponse = vi.fn();
+    const sender = makeSender(fetchImpl, { onResponse });
+
+    sender.sink(ack('ma-orig-1'));
+    sender.flush();
+    await flushMicrotasks();
+    sender.sink(ack('ma-orig-2'));
+    sender.flush();
+    await flushMicrotasks();
+
+    const repairCalls = onResponse.mock.calls.filter((c) => {
+      const body = c[1] as { repair_action?: { action_id?: string } };
+      return body?.repair_action?.action_id === 'ma-carto-1';
+    });
+    expect(repairCalls).toHaveLength(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    sender.dispose();
+  });
+
+  it('12. a slow in-flight retry does not block a new ACK batch from enqueueing and POSTing', async () => {
+    let releaseFirst: ((value: unknown) => void) | undefined;
+    const fetchImpl = vi.fn()
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        releaseFirst = resolve;
+      }))
+      .mockResolvedValue(jsonResponse({ accepted: 1, duplicates: 0 }));
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-slow'));
+    sender.flush();
+    await flushMicrotasks();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    sender.sink(ack('ma-new'));
+    sender.flush();
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const secondIds = JSON.parse(fetchImpl.mock.calls[1][1].body as string).acks.map(
+      (item: { action_id: string }) => item.action_id,
+    );
+    expect(secondIds).toEqual(['ma-new']);
+    releaseFirst?.(jsonResponse({ accepted: 1, duplicates: 0 }));
+    sender.dispose();
+  });
+
+  it('13. the in-memory queue stays bounded under a sustained outage', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError('offline'));
+    const warnSpy = vi.spyOn(devOnly, 'warn');
+    const sender = makeSender(fetchImpl, { maxQueue: 8, maxAttempts: 2, debounceMs: 0 });
+
+    for (let i = 0; i < 20; i += 1) {
+      sender.sink(ack(`ma-flood-${i}`));
+    }
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(500);
+    await flushMicrotasks();
+
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes('queue overflow'))).toBe(true);
+    const posted = fetchImpl.mock.calls.reduce((sum, call) => {
+      return sum + JSON.parse(call[1].body as string).acks.length;
+    }, 0);
+    expect(posted).toBeLessThanOrEqual(8 * 2);
+    expect(DEFAULT_MAX_QUEUE).toBeGreaterThan(50);
+    warnSpy.mockRestore();
+    sender.dispose();
+  });
+
+  it('does not put the owner token in the URL, and logs never include it or the body', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError('offline'));
+    const warnSpy = vi.spyOn(devOnly, 'warn');
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-sec', {
+      requested: { geojson: { type: 'FeatureCollection', features: [] } },
+    }));
+    sender.flush();
+    await flushMicrotasks();
+
+    expect(String(fetchImpl.mock.calls[0][0])).not.toMatch(/owner-a|X-Session-Token/i);
+    const logText = JSON.stringify(warnSpy.mock.calls);
+    expect(logText).not.toContain('owner-a');
+    expect(logText).not.toMatch(/FeatureCollection|geojson/i);
+    warnSpy.mockRestore();
     sender.dispose();
   });
 });

--- a/frontend/lib/api/map-action-acks.test.ts
+++ b/frontend/lib/api/map-action-acks.test.ts
@@ -231,11 +231,47 @@ describe('map action ACK delivery (fault matrix)', () => {
     }
   });
 
+  it('4b. HTTP 401 with a rejected json() body is not retried', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.reject(new SyntaxError('<html>unauthorized</html>')),
+    });
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-401-html'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    sender.dispose();
+  });
+
   it('5. HTTP 400 validation errors are not retried', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ detail: 'bad ack' }, 400));
     const sender = makeSender(fetchImpl);
 
     sender.sink(ack('ma-400'));
+    sender.flush();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    sender.dispose();
+  });
+
+  it('5b. HTTP 400 with a rejected json() body is not retried', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () => Promise.reject(new SyntaxError('<html>bad request</html>')),
+    });
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-400-html'));
     sender.flush();
     await flushMicrotasks();
     await vi.advanceTimersByTimeAsync(1000);
@@ -350,6 +386,35 @@ describe('map action ACK delivery (fault matrix)', () => {
     expect(bodies).toEqual(expect.arrayContaining(['ma-a', 'ma-b']));
     expect(String(aCall?.[0])).not.toMatch(/owner-a|token=/i);
     sender.dispose();
+  });
+
+  it('dispose does not abort an in-flight flush (unmount tail POST)', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let release: ((value: unknown) => void) | undefined;
+    const fetchImpl = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      capturedSignal = init.signal;
+      return new Promise((resolve) => {
+        release = resolve;
+      });
+    });
+    const sender = makeSender(fetchImpl);
+
+    sender.sink(ack('ma-tail'));
+    sender.flush();
+    await flushMicrotasks();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(capturedSignal?.aborted).toBe(false);
+
+    sender.dispose();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    release?.(jsonResponse({ accepted: 1, duplicates: 0 }));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(capturedSignal?.aborted).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it('10. dispose cancels retry timers so advancing time does not POST again', async () => {

--- a/frontend/lib/api/map-action-acks.ts
+++ b/frontend/lib/api/map-action-acks.ts
@@ -12,7 +12,9 @@
  * - auth / validation 4xx / 410 are permanent drops;
  * - queue and attempt counts are bounded; POSTs stay chunked at max 50;
  * - retry never blocks map rendering or chat streaming;
- * - dispose() cancels debounce, retry, and request-timeout timers.
+ * - dispose() cancels debounce and retry timers and bumps generation so
+ *   late notify/retry no-op; in-flight POSTs are not aborted (unmount flush
+ *   must complete). Request-timeout timers stay armed.
  *
  * sendBeacon / fetch keepalive are not used: sendBeacon cannot set
  * X-Session-Token, and keepalive's 64KB cap can silently fail a legal batch.
@@ -94,7 +96,7 @@ export interface MapActionAckSender {
   sink: MapActionAckSink;
   /** POST everything queued right now (session switch / unmount). */
   flush: () => void;
-  /** Drop the queue and cancel pending debounce / retry / request timers. */
+  /** Drop the queue and cancel pending debounce / retry timers. In-flight POSTs are not aborted. */
   dispose: () => void;
 }
 
@@ -197,7 +199,6 @@ export function createMapActionAckSender(options: MapActionAckSenderOptions): Ma
   const deliveredRepairs = new Set<string>();
   const deliveredRepairOrder: string[] = [];
   const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
-  const liveControllers = new Set<AbortController>();
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
   let generation = 0;
@@ -328,7 +329,6 @@ export function createMapActionAckSender(options: MapActionAckSenderOptions): Ma
     const doFetch = fetchImpl ?? fetch;
     const acks = items.map((item) => item.ack);
     const controller = new AbortController();
-    liveControllers.add(controller);
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     if (requestTimeoutMs > 0) {
       timeoutId = trackTimer(setTimeout(() => {
@@ -338,7 +338,6 @@ export function createMapActionAckSender(options: MapActionAckSenderOptions): Ma
     const finishRequest = (): void => {
       untrackTimer(timeoutId);
       timeoutId = null;
-      liveControllers.delete(controller);
     };
 
     doFetch(
@@ -361,6 +360,15 @@ export function createMapActionAckSender(options: MapActionAckSenderOptions): Ma
           finishRequest();
           if (isTimeoutError(error)) {
             settleBatch(sessionId, items, classifyAckDelivery({ error }), gen);
+            return;
+          }
+          if (!response.ok) {
+            settleBatch(
+              sessionId,
+              items,
+              classifyAckDelivery({ status: response.status }),
+              gen,
+            );
             return;
           }
           settleBatch(sessionId, items, { kind: 'transient', reason: 'invalid_body' }, gen);
@@ -456,16 +464,9 @@ export function createMapActionAckSender(options: MapActionAckSenderOptions): Ma
 
   const dispose = (): void => {
     generation += 1;
-    pendingTimers.forEach((id) => {
-      clearTimeout(id);
-    });
-    pendingTimers.clear();
-    liveControllers.forEach((controller) => {
-      controller.abort();
-    });
-    liveControllers.clear();
-    inFlight.clear();
+    untrackTimer(debounceTimer);
     debounceTimer = null;
+    untrackTimer(retryTimer);
     retryTimer = null;
     queue = [];
   };

--- a/frontend/lib/api/map-action-acks.ts
+++ b/frontend/lib/api/map-action-acks.ts
@@ -1,20 +1,21 @@
 /**
  * Batched map-action ACK sender (V3 harness–map closed loop, design §6).
  *
- * The MapActionContext reports every terminal action (succeeded / failed /
- * cancelled / superseded) through a `registerAckSink(fn)` DI seam. useMapBridge
- * registers the sink created here, which batches acks and POSTs them to
- * `POST /api/v1/chat/sessions/{sid}/map-action-ack`.
+ * After #356 the ACK endpoint may return `repair_action`, which useMapBridge
+ * dispatches onto the map. Delivery is therefore control-plane, not a pure
+ * metrics channel: bounded, idempotent, transient-resilient — not exactly-once.
  *
- * Delivery guarantees are deliberately weak — this is a metrics channel, not
- * map state:
- * - fire-and-forget: a failed POST drops the batch (devOnly log), the map must
- *   never break because an ACK failed;
- * - 500ms debounce: a burst of terminal events coalesces into one POST;
- * - flush() on session switch / unmount so the tail of a session is not lost.
+ * - session id + owner token are captured per ACK at enqueue;
+ * - retries reuse the same action_id (backend first-terminal-wins);
+ * - only classified transients are retried (network, timeout, 408, 429, 5xx,
+ *   HTTP 200 with `dropped > 0`);
+ * - auth / validation 4xx / 410 are permanent drops;
+ * - queue and attempt counts are bounded; POSTs stay chunked at max 50;
+ * - retry never blocks map rendering or chat streaming;
+ * - dispose() cancels debounce, retry, and request-timeout timers.
  *
- * Auth + transport mirror the map-state push in useMapBridge.ts exactly
- * (X-Session-Token header, API_BASE, plain fetch with .catch).
+ * sendBeacon / fetch keepalive are not used: sendBeacon cannot set
+ * X-Session-Token, and keepalive's 64KB cap can silently fail a legal batch.
  */
 
 import { API_BASE } from '@/lib/api/config';
@@ -38,6 +39,23 @@ export interface MapActionAck {
 /** registerAckSink-compatible callback shape. */
 export type MapActionAckSink = (ack: MapActionAck) => void;
 
+export type AckDeliveryKind = 'success' | 'transient' | 'permanent';
+export type AckDeliveryReason =
+  | 'ok'
+  | 'network'
+  | 'timeout'
+  | 'http_408'
+  | 'http_429'
+  | 'http_5xx'
+  | 'backend_dropped'
+  | 'http_401'
+  | 'http_403'
+  | 'http_404'
+  | 'http_410'
+  | 'http_4xx'
+  | 'validation'
+  | 'invalid_body';
+
 export interface MapActionAckSenderOptions {
   /** Current session at enqueue time (acks without correlation.session_id). */
   getSessionId: () => string | undefined;
@@ -47,10 +65,28 @@ export interface MapActionAckSenderOptions {
   debounceMs?: number;
   /** Backend accepts at most 50 acks per POST (design §4) — larger flushes are chunked. */
   maxAcksPerPost?: number;
+  /** Max POST attempts per ACK (initial + retries). */
+  maxAttempts?: number;
+  /** Max in-memory queued ACKs; overflow drops oldest. */
+  maxQueue?: number;
+  /** Base delay for exponential backoff (ms). */
+  retryBaseMs?: number;
+  /** Cap for exponential backoff (ms). */
+  retryMaxMs?: number;
+  /** Per-request abort timeout (ms). 0 disables. */
+  requestTimeoutMs?: number;
+  /** Test seam for jitter in [0, 1). */
+  random?: () => number;
+  /** Test seam for "now" (ms). */
+  now?: () => number;
   /** Test seam; defaults to global fetch. */
   fetchImpl?: typeof fetch;
-  /** Receives a typed backend follow-up such as an AUTO_SAFE repair action. */
-  onResponse?: (sessionId: string, body: unknown) => void;
+  /**
+   * Receives a typed backend follow-up such as an AUTO_SAFE repair action.
+   * Return `false` when the follow-up was not applied (stale session) so the
+   * sender does not burn the repair id.
+   */
+  onResponse?: (sessionId: string, body: unknown) => boolean | void;
 }
 
 export interface MapActionAckSender {
@@ -58,12 +94,86 @@ export interface MapActionAckSender {
   sink: MapActionAckSink;
   /** POST everything queued right now (session switch / unmount). */
   flush: () => void;
-  /** Drop the queue and cancel the pending debounce timer. */
+  /** Drop the queue and cancel pending debounce / retry / request timers. */
   dispose: () => void;
 }
 
 const DEFAULT_DEBOUNCE_MS = 500;
 const MAX_ACKS_PER_POST = 50;
+export const DEFAULT_MAX_ATTEMPTS = 3;
+export const DEFAULT_MAX_QUEUE = 200;
+export const DEFAULT_RETRY_BASE_MS = 250;
+export const DEFAULT_RETRY_MAX_MS = 4000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DELIVERED_REPAIR_CAP = 256;
+
+interface QueuedAck {
+  sessionId: string | undefined;
+  token: string | null;
+  ack: MapActionAck;
+  attempts: number;
+  readyAt: number;
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const name = (error as { name?: string }).name;
+  return name === 'AbortError' || name === 'TimeoutError' || name === 'ApiTimeoutError';
+}
+
+function droppedCount(body: unknown): number {
+  if (!body || typeof body !== 'object') return 0;
+  const value = (body as { dropped?: unknown }).dropped;
+  return typeof value === 'number' && value > 0 ? value : 0;
+}
+
+function repairActionId(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const repair = (body as { repair_action?: { action_id?: unknown } }).repair_action;
+  return typeof repair?.action_id === 'string' && repair.action_id
+    ? repair.action_id
+    : undefined;
+}
+
+/** Pure classifier: transient vs permanent vs success. No I/O. */
+export function classifyAckDelivery(input: {
+  error?: unknown;
+  status?: number;
+  dropped?: number;
+}): { kind: AckDeliveryKind; reason: AckDeliveryReason } {
+  if (input.error !== undefined) {
+    if (isTimeoutError(input.error)) return { kind: 'transient', reason: 'timeout' };
+    return { kind: 'transient', reason: 'network' };
+  }
+  const status = input.status;
+  if (status === 408) return { kind: 'transient', reason: 'http_408' };
+  if (status === 429) return { kind: 'transient', reason: 'http_429' };
+  if (typeof status === 'number' && status >= 500) return { kind: 'transient', reason: 'http_5xx' };
+  if (status === 401) return { kind: 'permanent', reason: 'http_401' };
+  if (status === 403) return { kind: 'permanent', reason: 'http_403' };
+  if (status === 404) return { kind: 'permanent', reason: 'http_404' };
+  if (status === 410) return { kind: 'permanent', reason: 'http_410' };
+  if (status === 422) return { kind: 'permanent', reason: 'validation' };
+  if (typeof status === 'number' && status >= 400 && status < 500) {
+    return { kind: 'permanent', reason: 'http_4xx' };
+  }
+  if ((input.dropped ?? 0) > 0) return { kind: 'transient', reason: 'backend_dropped' };
+  return { kind: 'success', reason: 'ok' };
+}
+
+function retryDelayMs(
+  attemptsAfterFail: number,
+  retryBaseMs: number,
+  retryMaxMs: number,
+  random: () => number,
+): number {
+  const exp = Math.min(retryBaseMs * (2 ** Math.max(0, attemptsAfterFail - 1)), retryMaxMs);
+  return Math.floor(exp * (0.5 + random()));
+}
+
+function itemKey(sessionId: string | undefined, actionId: string): string {
+  return `${sessionId ?? ''}::${actionId}`;
+}
 
 export function createMapActionAckSender(options: MapActionAckSenderOptions): MapActionAckSender {
   const {
@@ -71,21 +181,166 @@ export function createMapActionAckSender(options: MapActionAckSenderOptions): Ma
     getToken,
     debounceMs = DEFAULT_DEBOUNCE_MS,
     maxAcksPerPost = MAX_ACKS_PER_POST,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    maxQueue = DEFAULT_MAX_QUEUE,
+    retryBaseMs = DEFAULT_RETRY_BASE_MS,
+    retryMaxMs = DEFAULT_RETRY_MAX_MS,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+    random = Math.random,
+    now = () => Date.now(),
     fetchImpl,
     onResponse,
   } = options;
 
-  // Session id is captured per ack at enqueue time: acks produced just before a
-  // session switch still POST to the session that issued the action.
-  let queue: Array<{
-    sessionId: string | undefined;
-    token: string | null;
-    ack: MapActionAck;
-  }> = [];
-  let timer: ReturnType<typeof setTimeout> | null = null;
+  let queue: QueuedAck[] = [];
+  const inFlight = new Set<string>();
+  const deliveredRepairs = new Set<string>();
+  const deliveredRepairOrder: string[] = [];
+  const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
+  const liveControllers = new Set<AbortController>();
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let generation = 0;
 
-  const postBatch = (sessionId: string, token: string | null, acks: MapActionAck[]): void => {
+  const trackTimer = (id: ReturnType<typeof setTimeout>): ReturnType<typeof setTimeout> => {
+    pendingTimers.add(id);
+    return id;
+  };
+
+  const untrackTimer = (id: ReturnType<typeof setTimeout> | null): void => {
+    if (id === null) return;
+    clearTimeout(id);
+    pendingTimers.delete(id);
+  };
+
+  const logEvent = (event: string, fields: Record<string, unknown>): void => {
+    devOnly.warn(`[map-action-acks] ${event}`, fields);
+  };
+
+  const hasItem = (sessionId: string | undefined, actionId: string): boolean => {
+    const key = itemKey(sessionId, actionId);
+    if (inFlight.has(key)) return true;
+    for (let i = 0; i < queue.length; i += 1) {
+      if (itemKey(queue[i].sessionId, queue[i].ack.action_id) === key) return true;
+    }
+    return false;
+  };
+
+  const enqueueItem = (item: QueuedAck, evictOldest: boolean): boolean => {
+    if (queue.length >= maxQueue) {
+      if (!evictOldest) {
+        logEvent('queue overflow', { dropped: 1, queueSize: queue.length });
+        return false;
+      }
+      queue.shift();
+      logEvent('queue overflow', { dropped: 1, queueSize: queue.length });
+    }
+    queue.push(item);
+    return true;
+  };
+
+  const rememberRepair = (sessionId: string, repairId: string): void => {
+    const key = `${sessionId}:${repairId}`;
+    if (deliveredRepairs.has(key)) return;
+    deliveredRepairs.add(key);
+    deliveredRepairOrder.push(key);
+    if (deliveredRepairOrder.length > DELIVERED_REPAIR_CAP) {
+      const old = deliveredRepairOrder.shift();
+      if (old) deliveredRepairs.delete(old);
+    }
+  };
+
+  const notify = (sessionId: string, body: unknown, gen: number): void => {
+    if (gen !== generation) return;
+    const repairId = repairActionId(body);
+    if (repairId && deliveredRepairs.has(`${sessionId}:${repairId}`)) return;
+    const applied = onResponse?.(sessionId, body);
+    if (repairId && applied !== false) rememberRepair(sessionId, repairId);
+  };
+
+  const scheduleRetry = (): void => {
+    if (retryTimer !== null) return;
+    const nowTs = now();
+    let nextAt = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < queue.length; i += 1) {
+      if (queue[i].readyAt > nowTs && queue[i].readyAt < nextAt) {
+        nextAt = queue[i].readyAt;
+      }
+    }
+    if (nextAt === Number.POSITIVE_INFINITY) return;
+    retryTimer = trackTimer(setTimeout(() => {
+      retryTimer = null;
+      flushInternal(false);
+    }, Math.max(0, nextAt - now())));
+  };
+
+  const scheduleDebounce = (): void => {
+    untrackTimer(debounceTimer);
+    debounceTimer = trackTimer(setTimeout(() => {
+      debounceTimer = null;
+      flushInternal(false);
+    }, debounceMs));
+  };
+
+  const settleBatch = (
+    sessionId: string,
+    items: QueuedAck[],
+    classified: { kind: AckDeliveryKind; reason: AckDeliveryReason },
+    gen: number,
+  ): void => {
+    for (let i = 0; i < items.length; i += 1) {
+      inFlight.delete(itemKey(items[i].sessionId, items[i].ack.action_id));
+    }
+    if (gen !== generation) return;
+    if (classified.kind === 'success') return;
+    if (classified.kind === 'permanent') {
+      logEvent('permanent drop', { reason: classified.reason, count: items.length });
+      return;
+    }
+    const retryable: QueuedAck[] = [];
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i];
+      item.attempts += 1;
+      if (item.attempts >= maxAttempts) {
+        logEvent('exhausted retry', { attempts: item.attempts, count: 1 });
+      } else {
+        item.readyAt = now() + retryDelayMs(item.attempts, retryBaseMs, retryMaxMs, random);
+        retryable.push(item);
+      }
+    }
+    if (retryable.length === 0) return;
+    logEvent('transient retry', {
+      reason: classified.reason,
+      attempt: retryable[0].attempts,
+      count: retryable.length,
+    });
+    for (let i = 0; i < retryable.length; i += 1) {
+      enqueueItem(retryable[i], false);
+    }
+    scheduleRetry();
+  };
+
+  const postBatch = (sessionId: string, token: string | null, items: QueuedAck[]): void => {
+    const gen = generation;
+    for (let i = 0; i < items.length; i += 1) {
+      inFlight.add(itemKey(items[i].sessionId, items[i].ack.action_id));
+    }
     const doFetch = fetchImpl ?? fetch;
+    const acks = items.map((item) => item.ack);
+    const controller = new AbortController();
+    liveControllers.add(controller);
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    if (requestTimeoutMs > 0) {
+      timeoutId = trackTimer(setTimeout(() => {
+        controller.abort();
+      }, requestTimeoutMs));
+    }
+    const finishRequest = (): void => {
+      untrackTimer(timeoutId);
+      timeoutId = null;
+      liveControllers.delete(controller);
+    };
+
     doFetch(
       `${API_BASE}/api/v1/chat/sessions/${encodeURIComponent(sessionId)}/map-action-ack`,
       {
@@ -95,71 +350,123 @@ export function createMapActionAckSender(options: MapActionAckSenderOptions): Ma
           ...(token ? { 'X-Session-Token': token } : {}),
         },
         body: JSON.stringify({ acks }),
+        signal: controller.signal,
       },
     ).then(async (response) => {
-      if (!response.ok || typeof response.json !== 'function') return;
-      try {
-        onResponse?.(sessionId, await response.json());
-      } catch {
-        // ACK storage already succeeded; an absent/malformed optional response
-        // body must not affect map interaction.
+      let body: unknown;
+      if (typeof response.json === 'function') {
+        try {
+          body = await response.json();
+        } catch (error: unknown) {
+          finishRequest();
+          if (isTimeoutError(error)) {
+            settleBatch(sessionId, items, classifyAckDelivery({ error }), gen);
+            return;
+          }
+          settleBatch(sessionId, items, { kind: 'transient', reason: 'invalid_body' }, gen);
+          return;
+        }
       }
-    }).catch((e) => {
-      // Fire-and-forget: a failed ACK POST must never degrade the map or stream.
-      devOnly.warn('[map-action-acks] ACK POST failed, dropping batch:', e);
+      finishRequest();
+      if (response.ok && (body === undefined || typeof body !== 'object' || body === null)) {
+        settleBatch(sessionId, items, { kind: 'transient', reason: 'invalid_body' }, gen);
+        return;
+      }
+      const classified = classifyAckDelivery({
+        status: response.status,
+        dropped: response.ok ? droppedCount(body) : undefined,
+      });
+      try {
+        if (response.ok && body !== undefined) {
+          notify(sessionId, body, gen);
+        }
+      } catch {
+        // Repair dispatch is optional closed-loop control. It must not
+        // reclassify a settled POST as a transport failure.
+      }
+      settleBatch(sessionId, items, classified, gen);
+    }).catch((error: unknown) => {
+      finishRequest();
+      settleBatch(sessionId, items, classifyAckDelivery({ error }), gen);
     });
   };
 
-  const flush = (): void => {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
+  const flushInternal = (force: boolean): void => {
+    untrackTimer(debounceTimer);
+    debounceTimer = null;
+    untrackTimer(retryTimer);
+    retryTimer = null;
     if (queue.length === 0) return;
-    const pending = queue;
-    queue = [];
-    // Group by session, preserving insertion order. A plain array of pairs is
-    // used instead of Map iteration: the repo tsconfig has no ES2015+ target,
-    // so `for...of` over a Map would fail tsc (TS2802).
+
+    const nowTs = now();
+    const pending: QueuedAck[] = [];
+    const kept: QueuedAck[] = [];
+    for (let i = 0; i < queue.length; i += 1) {
+      if (force || queue[i].readyAt <= nowTs) pending.push(queue[i]);
+      else kept.push(queue[i]);
+    }
+    queue = kept;
+    if (pending.length === 0) {
+      if (queue.length > 0) scheduleRetry();
+      return;
+    }
+
     const groups: Array<{
       sessionId: string | undefined;
       token: string | null;
-      acks: MapActionAck[];
+      items: QueuedAck[];
     }> = [];
-    for (const item of pending) {
+    for (let i = 0; i < pending.length; i += 1) {
+      const item = pending[i];
       const group = groups.find(
         (g) => g.sessionId === item.sessionId && g.token === item.token,
       );
-      if (group) group.acks.push(item.ack);
-      else groups.push({ sessionId: item.sessionId, token: item.token, acks: [item.ack] });
+      if (group) group.items.push(item);
+      else groups.push({ sessionId: item.sessionId, token: item.token, items: [item] });
     }
-    for (const { sessionId, token, acks } of groups) {
+    for (let g = 0; g < groups.length; g += 1) {
+      const { sessionId, token, items } = groups[g];
       if (!sessionId) {
-        devOnly.warn('[map-action-acks] dropping acks with no session:', acks.length);
+        logEvent('permanent drop', { reason: 'no_session', count: items.length });
         continue;
       }
-      for (let i = 0; i < acks.length; i += maxAcksPerPost) {
-        postBatch(sessionId, token, acks.slice(i, i + maxAcksPerPost));
+      for (let i = 0; i < items.length; i += maxAcksPerPost) {
+        postBatch(sessionId, token, items.slice(i, i + maxAcksPerPost));
       }
     }
+    if (queue.length > 0) scheduleRetry();
   };
 
   const sink: MapActionAckSink = (ack) => {
     const sessionId = ack.correlation?.session_id ?? getSessionId();
-    queue.push({
+    if (hasItem(sessionId, ack.action_id)) return;
+    enqueueItem({
       sessionId,
       token: getToken(sessionId),
       ack,
-    });
-    if (timer) clearTimeout(timer);
-    timer = setTimeout(flush, debounceMs);
+      attempts: 0,
+      readyAt: now(),
+    }, true);
+    scheduleDebounce();
+  };
+
+  const flush = (): void => {
+    flushInternal(true);
   };
 
   const dispose = (): void => {
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
+    generation += 1;
+    pendingTimers.forEach((id) => {
+      clearTimeout(id);
+    });
+    pendingTimers.clear();
+    liveControllers.forEach((controller) => {
+      controller.abort();
+    });
+    liveControllers.clear();
+    inFlight.clear();
+    debounceTimer = null;
+    retryTimer = null;
     queue = [];
   };
 

--- a/frontend/lib/hooks/useMapBridge.test.ts
+++ b/frontend/lib/hooks/useMapBridge.test.ts
@@ -42,11 +42,12 @@ function makeAsyncGen(events: SSEEvent[]): AsyncGenerator<SSEEvent> {
 function makeAckWrapper(
   sinkHolder: { current: MapActionAckSink | null },
   clearActions: () => void,
+  ctxDispatch: (action: MapActionPayload) => void = vi.fn(),
 ) {
   return function AckWrapper({ children }: { children: React.ReactNode }) {
     const value = {
       actions: [],
-      dispatchAction: vi.fn(),
+      dispatchAction: ctxDispatch,
       popAction: vi.fn(),
       selectedBaseLayer: 0,
       setSelectedBaseLayer: vi.fn(),
@@ -763,8 +764,10 @@ describe('useMapBridge', () => {
     vi.unstubAllGlobals();
   });
 
-  it('ACK POST failure is fire-and-forget: devOnly log, batch dropped, stream unaffected (V3)', async () => {
-    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+  it('ACK POST transient failure retries without blocking the stream or map (V3)', async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new TypeError('network down'))
+      .mockResolvedValue({ ok: true, status: 200, json: async () => ({ accepted: 1, duplicates: 0 }) });
     vi.stubGlobal('fetch', fetchMock);
     const warnSpy = vi.spyOn(devOnly, 'warn');
     const sinkHolder: { current: MapActionAckSink | null } = { current: null };
@@ -785,7 +788,8 @@ describe('useMapBridge', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalled();
 
-    // The map/stream loop is unaffected: a fresh turn still dispatches actions.
+    // The map/stream loop is unaffected: a fresh turn still dispatches actions
+    // while the ACK retry timer is still pending.
     mockStreamChat.mockReturnValue(makeAsyncGen([{
       event: 'step_result',
       data: { result: { command: 'fly_to', params: { center: [1, 2], zoom: 10 } }, step_id: 's9', turn_id: 't9' },
@@ -794,7 +798,107 @@ describe('useMapBridge', () => {
     await act(async () => { await result.current.send('q2', {}); });
     expect(dispatchAction).toHaveBeenCalledTimes(1);
 
+    await act(async () => { vi.advanceTimersByTime(400); });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryBody = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    expect(retryBody.acks[0].action_id).toBe('ma-1');
+
     warnSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('ACK sink still POSTs after React Strict Mode remount', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ accepted: 1, duplicates: 0 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const sinkHolder: { current: MapActionAckSink | null } = { current: null };
+    const Inner = makeAckWrapper(sinkHolder, vi.fn());
+    function StrictWrap({ children }: { children: React.ReactNode }) {
+      return React.createElement(React.StrictMode, null, React.createElement(Inner, null, children));
+    }
+
+    mockStreamChat.mockReturnValue(makeAsyncGen([{ event: 'done', data: {} }]));
+    const { result } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent),
+      { wrapper: StrictWrap }
+    );
+    await act(async () => { await result.current.send('q', {}); });
+
+    expect(sinkHolder.current).toBeTruthy();
+    act(() => {
+      sinkHolder.current!({ action_id: 'ma-strict', command: 'fly_to', status: 'succeeded' });
+    });
+    await act(async () => { vi.advanceTimersByTime(500); });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.acks[0].action_id).toBe('ma-strict');
+    vi.unstubAllGlobals();
+  });
+
+  it('unmount flushes once and does not leak a retry timer (fault 10)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('offline'));
+    vi.stubGlobal('fetch', fetchMock);
+    const sinkHolder: { current: MapActionAckSink | null } = { current: null };
+    const wrapper = makeAckWrapper(sinkHolder, vi.fn());
+
+    mockStreamChat.mockReturnValue(makeAsyncGen([{ event: 'done', data: {} }]));
+    const { result, unmount } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent),
+      { wrapper }
+    );
+    await act(async () => { await result.current.send('q', {}); });
+
+    act(() => {
+      sinkHolder.current!({ action_id: 'ma-unmount', command: 'fly_to', status: 'succeeded' });
+    });
+    act(() => { unmount(); });
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await act(async () => { vi.advanceTimersByTime(10_000); });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it('duplicate ACK repair_action responses do not dispatch twice (fault 11)', async () => {
+    const repair = {
+      action_id: 'ma-carto-1',
+      command: 'cartographic_runtime_repair' as const,
+      params: { id: 'layer-1' },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ accepted: 1, duplicates: 0, repair_action: repair }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const ctxDispatch = vi.fn();
+    const sinkHolder: { current: MapActionAckSink | null } = { current: null };
+    const wrapper = makeAckWrapper(sinkHolder, vi.fn(), ctxDispatch);
+
+    mockStreamChat.mockReturnValue(makeAsyncGen([{ event: 'done', data: {} }]));
+    const { result } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent),
+      { wrapper }
+    );
+    await act(async () => { await result.current.send('q', {}); });
+
+    act(() => {
+      sinkHolder.current!({ action_id: 'ma-orig-1', command: 'add_layer', status: 'succeeded' });
+    });
+    await act(async () => { vi.advanceTimersByTime(500); });
+    act(() => {
+      sinkHolder.current!({ action_id: 'ma-orig-2', command: 'add_layer', status: 'succeeded' });
+    });
+    await act(async () => { vi.advanceTimersByTime(500); });
+
+    expect(ctxDispatch).toHaveBeenCalledTimes(1);
+    expect(ctxDispatch).toHaveBeenCalledWith(repair);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     vi.unstubAllGlobals();
   });
 

--- a/frontend/lib/hooks/useMapBridge.test.ts
+++ b/frontend/lib/hooks/useMapBridge.test.ts
@@ -839,6 +839,48 @@ describe('useMapBridge', () => {
     vi.unstubAllGlobals();
   });
 
+  it('unmount flush is not aborted so the tail ACK POST can finish', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let release: ((value: unknown) => void) | undefined;
+    const fetchMock = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      capturedSignal = init.signal as AbortSignal | undefined;
+      return new Promise((resolve) => {
+        release = resolve;
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const sinkHolder: { current: MapActionAckSink | null } = { current: null };
+    const wrapper = makeAckWrapper(sinkHolder, vi.fn());
+
+    mockStreamChat.mockReturnValue(makeAsyncGen([{ event: 'done', data: {} }]));
+    const { result, unmount } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent),
+      { wrapper }
+    );
+    await act(async () => { await result.current.send('q', {}); });
+
+    act(() => {
+      sinkHolder.current!({ action_id: 'ma-tail', command: 'fly_to', status: 'succeeded' });
+    });
+    act(() => { unmount(); });
+    await act(async () => {});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(capturedSignal?.aborted).toBe(false);
+
+    await act(async () => {
+      release?.({
+        ok: true,
+        status: 200,
+        json: async () => ({ accepted: 1, duplicates: 0 }),
+      });
+    });
+
+    expect(capturedSignal?.aborted).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
   it('unmount flushes once and does not leak a retry timer (fault 10)', async () => {
     const fetchMock = vi.fn().mockRejectedValue(new TypeError('offline'));
     vi.stubGlobal('fetch', fetchMock);

--- a/frontend/lib/hooks/useMapBridge.ts
+++ b/frontend/lib/hooks/useMapBridge.ts
@@ -139,6 +139,8 @@ export function useMapBridge(
   const getSessionTokenRef = useRef(getSessionToken);
   getSessionTokenRef.current = getSessionToken;
   const streamEpochRef = useRef(0);
+  const deliveredRepairIdsRef = useRef<Set<string>>(new Set());
+  const deliveredRepairOrderRef = useRef<string[]>([]);
 
   // V3 ACK sender: created once per hook instance. Session + token are read
   // through refs so a session switch re-routes acks without recreating the
@@ -154,12 +156,21 @@ export function useMapBridge(
       ),
       onResponse: (responseSessionId, body) => {
         const response = body as { repair_action?: MapActionPayload } | null;
-        if (
-          responseSessionId === sessionIdRef.current
-          && response?.repair_action
-        ) {
-          mapActionCtxRef.current?.dispatchAction(response.repair_action);
+        const repair = response?.repair_action;
+        if (responseSessionId !== sessionIdRef.current || !repair) return false;
+        const repairId = repair.action_id;
+        if (repairId) {
+          const key = `${responseSessionId}:${repairId}`;
+          if (deliveredRepairIdsRef.current.has(key)) return false;
+          deliveredRepairIdsRef.current.add(key);
+          deliveredRepairOrderRef.current.push(key);
+          if (deliveredRepairOrderRef.current.length > 256) {
+            const old = deliveredRepairOrderRef.current.shift();
+            if (old) deliveredRepairIdsRef.current.delete(old);
+          }
         }
+        mapActionCtxRef.current?.dispatchAction(repair);
+        return true;
       },
     });
   }


### PR DESCRIPTION
## Why ACK semantics changed after closed-loop repair

After #356, `POST /map-action-ack` can return `repair_action`, and `useMapBridge` dispatches it onto the map. ACK transport is no longer a fire-and-forget metrics channel: it participates in the harness–map closed loop. Dropping a batch on the first failed POST loses both telemetry and cartographic control. This PR does **not** implement exactly-once messaging. It adds bounded, idempotent, transient-resilient delivery on the existing `action_id` + first-terminal-wins contract.

## Failure model

| Outcome | Meaning |
|---|---|
| Network / TypeError / abort timeout | Request never settled |
| HTTP 408 / 429 / 5xx | Transient server / limiter |
| HTTP 200 + `dropped > 0` | F26: store did not persist (retry the same ids) |
| HTTP 200 + unreadable / non-object body | Treat as unset, retry |
| 401 / 403 / 404 | Auth / ownership — permanent |
| 410 | Deleted cartographic session — permanent |
| 400 / 422 / other 4xx | Validation / malformed — permanent |

## Retry classifier

Pure `classifyAckDelivery()` in `frontend/lib/api/map-action-acks.ts`. Retry stays **sender-local**. `apiFetch` still refuses to retry POST.

Retries reuse the captured `(sessionId, token, action_id, payload)`. No new ACK identity.

## Bounds

- Max 3 POST attempts per ACK (1 initial + 2 retries)
- Max queue 200; overflow drops oldest on new enqueue, and **drops the retry** (does not evict newer ACKs) when requeuing failures
- Exponential backoff + jitter: `min(250 * 2^(attempt-1), 4000) * (0.5 + random())` ms
- Chunk size remains **50** (backend `max_length=50`)
- Request timeout 10s, held through body read; `dispose()` aborts live controllers
- Retry never blocks map rendering or chat streaming

## Idempotency

- Backend `append_map_action_event` is first-terminal-wins on `(session, action_id)` — duplicate retry POSTs become `duplicates`
- Sender ignores a second `sink()` of an `action_id` already queued or in-flight
- `repair_action` is delivered at most once per `(session, repair.action_id)`
- `onResponse` returning `false` (stale session) does **not** burn the repair id
- `onResponse` throw cannot reclassify a settled 200 as a network failure

## Session isolation

- Session id and owner token are captured at enqueue
- After A→B, A items still POST only to A with A's token
- Stale-session `onResponse` does not dispatch onto B
- Token is header-only (`X-Session-Token`). Never in URL, logs, or beacon payload

## Unload / sendBeacon

**Not used.** `navigator.sendBeacon` cannot set `X-Session-Token`. `fetch` keepalive has a ~64KB cap and can silently fail a legal 50×16KB batch. Live-page bounded retry is the resilience mechanism. `dispose()` cancels debounce/retry/timeout timers and ignores stale in-flight generations (Strict Mode remount stays live).

## Fault matrix (deterministic, fake timers, no real sleep)

1. First POST network failure → retry → success (same `action_id`)
2. 503 → retry → success
2b. 200 + `dropped > 0` → retry → success
3. 429 → bounded retry (max attempts)
4. 401/403 → no retry
5. 400 validation → no retry
6. Max attempts exhausted → queue settles
7. Same `action_id` retry → one terminal identity (frontend + existing backend first-terminal-wins)
8. >50 ACKs still chunked at 50
9. Session A queued → switch B → A still sent only to A
10. Unmount / dispose → no leaked retry timer
11. Duplicate successful `repair_action` → applied once
12. Slow in-flight POST does not block new enqueue
13. Queue bound under sustained outage

Plus: invalid 200 body retry, hung-body timeout, stale-session repair not burned, `onResponse` throw isolation, Strict Mode remount still POSTs.

## Tests

- `frontend`: `npx vitest run lib/api/map-action-acks.test.ts lib/hooks/useMapBridge.test.ts` — **64 passed ×2**
- `frontend`: `npx tsc --noEmit` — exit 0; `eslint` on the four changed files — exit 0
- Pre-existing on BASE_SHA (unchanged): `use-sse-stream.test.ts:457` `'}' expected` under `tsc -p tsconfig.test.json` / repo-wide eslint
- `backend`: `python3 -m pytest tests/unit/test_map_action_acks.py tests/test_runtime_chaos_store.py tests/test_runtime_chaos_resume.py -q --no-cov -k "map_action or ack or first_terminal or dropped"` — **41 passed ×2**
- No new backend store semantics. Contract already covers first-terminal-wins, batch=50, dropped vs duplicates, 404/410/422/429

## Security considerations

- Owner token only as `X-Session-Token`
- Logs are low-cardinality (`transient retry` / `permanent drop` / `exhausted retry` / `queue overflow`) with reason + counts only — no token, no GeoJSON, no request body
- Session switch cannot send A's ACK with B's token
- Stale ACK response cannot mutate the new session
- Repair dispatch cannot be amplified by duplicate 200s

## BASE_SHA

`81d32e49486a74c9109f85a9be4e3a3534552614` (`feat(harness): close the cartographic intelligence evaluation loop (#356)`)

## Scope exclusions

- No SSE reconnect rewrite
- No cartographic observation generation rewrite
- No MapSpec / MVT / Data Fabric / UI / CI changes
- No message-queue service or new large dependencies
- Not merged; do not wait on CI