### PR TITLE
fix(cartography): make runtime repair generation-safe

### DIFF
--- a/frontend/components/map/map-panel.cartography-race.test.tsx
+++ b/frontend/components/map/map-panel.cartography-race.test.tsx
@@ -1,0 +1,544 @@
+/* eslint-disable @typescript-eslint/no-require-imports --
+ * vi.mock factories are hoisted above top-level imports by vitest; referencing
+ * module-scope variables would TDZ, so factories require() instead (vitest
+ * official pattern). Scoped to this test file. */
+import { render, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MapPanel } from './map-panel';
+import type { Layer } from '@/lib/types/layer';
+import { makeMockMaplibreMap } from '../../test/__mocks__/maplibre-map';
+
+/**
+ * Cartographic observation→repair generation-safety (latest-generation-wins).
+ *
+ * The repair loop fires one client_generation-stamped POST per meaningful
+ * MapSpec reconcile. These tests drive the real component through real
+ * reconciles with a CONTROLLABLE fetch (deferred per call) so response arrival
+ * order is fully deterministic. They pin the invariants:
+ *   INV-1 latest generation wins (out-of-order same-session response)
+ *   INV-2 session switch drops the in-flight response
+ *   INV-3 duplicate repair applied at most once
+ *   INV-4 stale mapspec_fingerprint repair ignored
+ *   INV-5 a failed observation may be retried by the next meaningful reconcile
+ *   INV-6 unmount with an outstanding request produces no side effect
+ *   INV-7 a valid latest-generation repair is still applied
+ */
+
+// ─── hoisted registries (bridge mock factories ↔ assertions) ────────────────
+
+const rmg = vi.hoisted(() => ({
+  renderCount: 0,
+  lastOnLoad: null as null | (() => void),
+  map: null as any,
+}));
+
+const hud = vi.hoisted(() => {
+  const initialState = () => ({
+    is3D: false,
+    processLayers: {} as Record<string, unknown>,
+    cartographyTitle: null as string | null,
+    viewport: { center: [116.4, 39.9], zoom: 4, bearing: 0, pitch: 0, bounds: undefined },
+    focusLayerId: null as string | null,
+    aiStatus: 'idle',
+    selectedFeature: null as any,
+    mapLoaded: false,
+    baseLayer: 'Carto 深色',
+  });
+  const actions = {
+    setMapLoaded: (v: boolean) => hud.setState({ mapLoaded: v }),
+    setSelectedFeature: (f: any) => hud.setState({ selectedFeature: f }),
+    setViewport: (c: any, z: number, b: number, p: number, bounds?: any) =>
+      hud.setState({ viewport: { center: c, zoom: z, bearing: b, pitch: p, bounds } }),
+    focusLayer: (id: string | null) => hud.setState({ focusLayerId: id }),
+  };
+  const state: Record<string, unknown> = { ...initialState(), ...actions };
+  const listeners = new Set<() => void>();
+  return {
+    state,
+    listeners,
+    getState: () => state,
+    setState: (partial: Record<string, unknown>) => {
+      Object.assign(state, partial);
+      listeners.forEach((l) => l());
+    },
+    reset: () => {
+      Object.keys(state).forEach((k) => delete state[k]);
+      Object.assign(state, initialState(), actions);
+    },
+  };
+});
+
+// Stable dispatch + logger spies the assertions read.
+const dispatch = vi.hoisted(() => vi.fn());
+const logger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('react-map-gl/maplibre', () => {
+  const React = require('react');
+  const MapMock = React.forwardRef(function MapMock(props: any, ref: any) {
+    React.useImperativeHandle(ref, () => ({ getMap: () => rmg.map }), []);
+    rmg.renderCount += 1;
+    rmg.lastOnLoad = props.onLoad ?? null;
+    React.useEffect(() => {
+      // Fire onLoad inside the mount effect (RTL wraps it in act) so mapReady
+      // flips synchronously and the runtime is created before we proceed.
+      props.onLoad?.();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return React.createElement('div', { 'data-testid': 'map-mock' }, props.children);
+  });
+  const PopupMock = (props: any) =>
+    React.createElement('div', { 'data-testid': 'popup' }, props.children);
+  return { default: MapMock, Popup: PopupMock };
+});
+
+vi.mock('@/lib/store/useHudStore', () => {
+  const React = require('react');
+  const { useSyncExternalStore } = React;
+  const subscribe = (cb: () => void) => {
+    hud.listeners.add(cb);
+    return () => hud.listeners.delete(cb);
+  };
+  const useHudStore = (selector: (s: any) => unknown) =>
+    useSyncExternalStore(subscribe, () => selector(hud.state), () => selector(hud.state));
+  useHudStore.getState = () => hud.state;
+  useHudStore.setState = (partial: any) => hud.setState(partial);
+  useHudStore.subscribe = subscribe;
+  return { useHudStore };
+});
+
+vi.mock('@/lib/contexts/map-action-context', () => ({
+  useMapAction: () => ({
+    actions: [],
+    dispatchAction: dispatch,
+    popAction: vi.fn(),
+    selectedBaseLayer: 1,
+    setSelectedBaseLayer: vi.fn(),
+    registerSnapshotFn: vi.fn(),
+    getMapSnapshot: vi.fn(() => null),
+    registerAckSink: vi.fn(() => () => {}),
+    reportTerminal: vi.fn(),
+    clearActions: vi.fn(),
+    droppedCount: 0,
+    completedActions: [],
+    runningActionId: null,
+  }),
+}));
+
+vi.mock('./map-action-handler', () => ({ MapActionHandler: () => null }));
+vi.mock('./thematic-legend', () => {
+  const React = require('react');
+  return { ThematicLegend: () => React.createElement('div', { 'data-testid': 'legend-mock' }) };
+});
+vi.mock('./map-decorations', () => {
+  const React = require('react');
+  return { MapDecorations: () => React.createElement('div', { 'data-testid': 'decor-mock' }) };
+});
+vi.mock('@/lib/utils/logger', () => ({
+  devOnly: logger,
+  logger: logger,
+}));
+
+// ─── controllable fetch ────────────────────────────────────────────────────
+
+interface PendingCall {
+  resolve: (r: Response) => void;
+  reject: (e: unknown) => void;
+  settled: boolean;
+}
+
+function makeAbortError(): Error {
+  const err = new Error('The user aborted a request.');
+  err.name = 'AbortError';
+  return err;
+}
+
+function makeControllableFetch(opts: { respectSignal?: boolean } = {}) {
+  const respectSignal = opts.respectSignal ?? false;
+  const calls: Array<{ url: string; init: RequestInit; body: any }> = [];
+  const pending: PendingCall[] = [];
+  const fetchMock = vi.fn((url: string, init: RequestInit) => {
+    let body: any = undefined;
+    try {
+      body = init.body ? JSON.parse(String(init.body)) : undefined;
+    } catch {
+      body = undefined;
+    }
+    calls.push({ url, init, body });
+    return new Promise<Response>((resolve, reject) => {
+      const entry: PendingCall = { resolve, reject, settled: false };
+      pending.push(entry);
+      // When respectSignal is set, the mock behaves like real fetch: an aborted
+      // signal rejects with AbortError, exercising the production
+      // timedFetch → AbortError → catch path.
+      if (respectSignal) {
+        const signal = init.signal as AbortSignal | undefined;
+        if (signal) {
+          if (signal.aborted) {
+            entry.settled = true;
+            reject(makeAbortError());
+          } else {
+            signal.addEventListener('abort', () => {
+              if (!entry.settled) {
+                entry.settled = true;
+                reject(makeAbortError());
+              }
+            });
+          }
+        }
+      }
+    });
+  });
+  return {
+    fetchMock,
+    calls,
+    callBody: (i: number) => calls[i]?.body,
+    resolveJson(i: number, json: unknown) {
+      const entry = pending[i];
+      if (entry && !entry.settled) {
+        entry.settled = true;
+        entry.resolve(
+          new Response(JSON.stringify(json), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+    },
+    rejectError(i: number, err: unknown) {
+      const entry = pending[i];
+      if (entry && !entry.settled) {
+        entry.settled = true;
+        entry.reject(err);
+      }
+    },
+  };
+}
+
+/** A repair_action the backend would mint for one MapSpec generation. */
+function repairAction(
+  actionId: string,
+  mapspecFingerprint: string,
+  patchFingerprint = `repair-sha256:${actionId}`,
+) {
+  return {
+    observation_accepted: true,
+    repair_action: {
+      action_id: actionId,
+      command: 'cartographic_runtime_repair',
+      correlation: { session_id: 's', step_id: '' },
+      params: {
+        mapspec_fingerprint: mapspecFingerprint,
+        observation_sequence: 1,
+        patch_fingerprint: patchFingerprint,
+        repair_patches: [],
+      },
+    },
+  };
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const noop = () => {};
+
+function freshMockMap() {
+  const map = makeMockMaplibreMap();
+  map.isStyleLoaded = vi.fn(() => true);
+  map.setTerrain = vi.fn();
+  map.getBounds = vi.fn(() => ({
+    getWest: () => 116.3, getSouth: () => 39.8, getEast: () => 116.5, getNorth: () => 40.0,
+  }));
+  return map;
+}
+
+/** A layer that triggers exactly one cartographic observation per fingerprint. */
+function fingerprintLayer(id: string, fingerprint: string): Layer {
+  return {
+    id,
+    name: id,
+    type: 'vector',
+    visible: true,
+    opacity: 1,
+    source: {
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', properties: { v: 1 }, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
+      ],
+    },
+    style: { color: '#16a34a' },
+    _refId: id,
+    _mapspecLayerId: id,
+    _mapspecFingerprint: fingerprint,
+    _mapspecGenerationAt: 1,
+  } as Layer;
+}
+
+const FP_A = 'carto-sha256:aaaa1111bbbb2222cccc3333dddd4444';
+const FP_B = 'carto-sha256:zzzz9999yyyy8888xxxx7777wwww6666';
+const FP_C = 'carto-sha256:qqqq5555rrrr4444ssss3333tttt2222';
+
+function panelProps(layers: Layer[], sessionId = 'session-A', ownerToken = 'owner-token') {
+  return {
+    layers,
+    onRemoveLayer: noop,
+    onToggleLayer: noop,
+    onViewportChange: noop,
+    sessionId,
+    ownerToken,
+  };
+}
+
+async function mountPanel(layers: Layer[], sessionId = 'session-A') {
+  const view = render(<MapPanel {...panelProps(layers, sessionId)} />);
+  // onLoad fires inside the mount effect → mapReady → runtime created + first
+  // reconcile enqueued; drain the debounced apply chain so the observation POST
+  // has been issued before we touch the controllable fetch.
+  await waitFor(() => expect(rmg.renderCount).toBeGreaterThan(1));
+  await act(async () => { await new Promise((r) => setTimeout(r, 120)); });
+  return view;
+}
+
+async function rerenderPanel(view: ReturnType<typeof render>, layers: Layer[], sessionId = 'session-A') {
+  view.rerender(<MapPanel {...panelProps(layers, sessionId)} />);
+  await act(async () => { await new Promise((r) => setTimeout(r, 120)); });
+}
+
+/** Flush microtasks so a resolved fetch's .then dispatch runs inside act. */
+async function flush() {
+  await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+}
+
+const dispatchedIds = () => dispatch.mock.calls.map((c) => (c[0] as any)?.action_id);
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+describe('MapPanel — cartographic repair generation safety', () => {
+  let fetchCtl: ReturnType<typeof makeControllableFetch>;
+
+  beforeEach(() => {
+    hud.reset();
+    rmg.map = freshMockMap();
+    rmg.renderCount = 0;
+    rmg.lastOnLoad = null;
+    dispatch.mockClear();
+    logger.warn.mockClear();
+    logger.error.mockClear();
+    fetchCtl = makeControllableFetch();
+    vi.stubGlobal('fetch', fetchCtl.fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // TEST-1 — out-of-order same-session response: only the newest applies.
+  it('applies only the newer repair when B responds before A (INV-1)', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    // A second meaningful reconcile (new fingerprint) issues B while A is pending.
+    await rerenderPanel(view, [fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(2));
+
+    // Network returns B first, then the stale A.
+    fetchCtl.resolveJson(1, repairAction('r-B', FP_B));
+    await flush();
+    fetchCtl.resolveJson(0, repairAction('r-A', FP_A));
+    await flush();
+
+    expect(dispatchedIds()).toEqual(['r-B']);
+  });
+
+  // TEST-2 — a response from session A must not touch session B.
+  it('drops the in-flight response after a session switch (INV-2)', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)], 'session-A');
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    // Switch session (and drop the fingerprint layer so no new observation fires).
+    await rerenderPanel(view, [], 'session-B');
+    expect(fetchCtl.calls).toHaveLength(1);
+
+    fetchCtl.resolveJson(0, repairAction('r-A', FP_A));
+    await flush();
+
+    expect(dispatchedIds()).toEqual([]);
+  });
+
+  // TEST-3 — duplicate repair_action (same action_id) applied at most once.
+  it('applies a duplicate repair at most once even across generations (INV-3)', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    fetchCtl.resolveJson(0, repairAction('r-A', FP_A));
+    await flush();
+    expect(dispatchedIds()).toEqual(['r-A']);
+
+    // A newer generation legitimately returns the SAME repair (e.g. a retried /
+    // cached repair re-echoed). Generation gate would let it through; dedup must
+    // not re-apply it.
+    await rerenderPanel(view, [fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(2));
+    fetchCtl.resolveJson(1, repairAction('r-A', FP_B, 'repair-sha256:r-A'));
+    await flush();
+
+    expect(dispatchedIds()).toEqual(['r-A']);
+  });
+
+  // TEST-4 — a failed observation is retried by the next meaningful reconcile.
+  it('recovers from a failed observation without a retry storm (INV-5)', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    // Network failure → catch resets the observation key so a later reconcile
+    // may retry. No new request is spawned by the failure itself.
+    fetchCtl.rejectError(0, new TypeError('network down'));
+    await flush();
+    expect(fetchCtl.calls).toHaveLength(1);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+
+    // Next meaningful reconcile (new fingerprint) re-issues and succeeds.
+    await rerenderPanel(view, [fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(2));
+    fetchCtl.resolveJson(1, repairAction('r-B', FP_B));
+    await flush();
+
+    expect(dispatchedIds()).toEqual(['r-B']);
+    expect(fetchCtl.calls).toHaveLength(2); // exactly one retry — no storm
+  });
+
+  // TEST-5 — a repair targeting a stale fingerprint is ignored (fp gate, INV-4).
+  it('ignores a repair whose mapspec_fingerprint is no longer current (INV-4)', async () => {
+    await mountPanel([fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    // Backend (bug/cache) echoes a repair for an OLD fingerprint although the
+    // latest issued observation targets FP_B. The fp gate must drop it.
+    fetchCtl.resolveJson(0, repairAction('r-stale', FP_A));
+    await flush();
+
+    expect(dispatchedIds()).toEqual([]);
+  });
+
+  // TEST-6 — a valid latest-generation repair is still applied (INV-7).
+  it('applies a valid latest-generation repair (INV-7)', async () => {
+    await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    fetchCtl.resolveJson(0, repairAction('r-A', FP_A));
+    await flush();
+
+    expect(dispatchedIds()).toEqual(['r-A']);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  // TEST-7 — unmount with an outstanding request produces no side effect.
+  it('dispatches nothing when unmounted with an outstanding request (INV-6)', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+
+    view.unmount();
+    // The late response resolves after unmount.
+    fetchCtl.resolveJson(0, repairAction('r-A', FP_A));
+    await flush();
+
+    expect(dispatchedIds()).toEqual([]);
+  });
+
+  // Bonus — issuing a newer observation aborts the prior in-flight request's
+  // signal (the AbortController wiring the generation gate backs up).
+  it('aborts the previous in-flight request signal when a newer observation issues', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    const priorSignal = fetchCtl.calls[0].init.signal as AbortSignal;
+
+    await rerenderPanel(view, [fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(2));
+
+    // AbortController.abort() flips signal.aborted synchronously.
+    expect(priorSignal.aborted).toBe(true);
+    // The newer request is unaffected.
+    expect((fetchCtl.calls[1].init.signal as AbortSignal).aborted).toBe(false);
+  });
+
+  // End-to-end abort path: with a signal-respecting fetch, a supersede rejects
+  // the prior request with AbortError; the catch must swallow it SILENTLY (no
+  // warn, no observation-key reset) so no redundant retry re-POSTs (INV-5).
+  it('silently swallows a supersede AbortError (no warn, no retry re-POST)', async () => {
+    fetchCtl = makeControllableFetch({ respectSignal: true });
+    vi.stubGlobal('fetch', fetchCtl.fetchMock);
+
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    // Issuing B aborts A → A's fetch rejects with AbortError → catch swallows it.
+    await rerenderPanel(view, [fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(2));
+    await flush();
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    // B still resolves and dispatches normally.
+    fetchCtl.resolveJson(1, repairAction('r-B', FP_B));
+    await flush();
+
+    expect(dispatchedIds()).toEqual(['r-B']);
+    expect(fetchCtl.calls).toHaveLength(2); // no extra retry POST of B
+  });
+
+  // Timeout (ApiTimeoutError) must NOT be swallowed as an abort — the key resets
+  // so the next meaningful reconcile retries (INV-5). This pins the error-name
+  // classification in the catch (the most likely regression target).
+  it('retries after a timeout error without classifying it as an abort (INV-5)', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    const timeout = new Error('timed out after 30000ms');
+    timeout.name = 'ApiTimeoutError';
+    fetchCtl.rejectError(0, timeout);
+    await flush();
+    // Not an AbortError ⇒ surfaced (warn) and the key reset for retry.
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+
+    // Next meaningful reconcile re-issues and succeeds.
+    await rerenderPanel(view, [fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(2));
+    fetchCtl.resolveJson(1, repairAction('r-B', FP_B));
+    await flush();
+
+    expect(dispatchedIds()).toEqual(['r-B']);
+  });
+
+  // Two distinct valid repairs in sequence must BOTH apply — guards against an
+  // over-aggressive dedup that would drop every other repair.
+  it('applies two distinct repairs across two generations', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    fetchCtl.resolveJson(0, repairAction('r-A', FP_A));
+    await flush();
+
+    await rerenderPanel(view, [fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(2));
+    fetchCtl.resolveJson(1, repairAction('r-B', FP_B));
+    await flush();
+
+    expect(dispatchedIds()).toEqual(['r-A', 'r-B']);
+  });
+
+  // A,B,A′: a duplicate action_id re-echoed at a NEWER (non-adjacent) generation
+  // is applied at most once. Distinguishes the bounded-Set dedup from a single
+  // last-key (which would re-apply A′ after B). (INV-3)
+  it('does not re-apply an action_id seen in a non-adjacent generation (INV-3)', async () => {
+    const view = await mountPanel([fingerprintLayer('L', FP_A)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(1));
+    fetchCtl.resolveJson(0, repairAction('r-A', FP_A));
+    await flush();
+
+    await rerenderPanel(view, [fingerprintLayer('L', FP_B)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(2));
+    fetchCtl.resolveJson(1, repairAction('r-B', FP_B));
+    await flush();
+
+    // Third generation re-echoes the FIRST action_id at the latest generation.
+    await rerenderPanel(view, [fingerprintLayer('L', FP_C)]);
+    await waitFor(() => expect(fetchCtl.calls).toHaveLength(3));
+    fetchCtl.resolveJson(2, repairAction('r-A', FP_C));
+    await flush();
+
+    expect(dispatchedIds()).toEqual(['r-A', 'r-B']);
+  });
+});

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -70,6 +70,10 @@ const DEFAULT_VIEW_STATE = {
   zoom: 4,
 }
 
+// Cap on remembered applied repair action_ids (bounded memory; older ids are
+// stale generations that the generation gate already drops, so eviction is safe).
+const MAX_APPLIED_REPAIR_IDS = 16;
+
 export function MapPanel({
   layers,
   onRemoveLayer: _onRemoveLayer,
@@ -179,6 +183,30 @@ export function MapPanel({
   const cartographicObservationGenerationRef = useRef(Date.now() * 1000)
   const cartographicSessionIdRef = useRef(sessionId)
   cartographicSessionIdRef.current = sessionId
+  // Cartographic observation→repair generation safety (latest-generation-wins).
+  // The backend already rejects stale observations server-side and strips
+  // repair_action from stale responses, but HTTP responses within ONE session
+  // can still arrive out of order. These refs make the client self-protecting:
+  // only the newest issued generation/fingerprint may dispatch a repair.
+  const latestIssuedCartographicFingerprintRef = useRef<string>('')
+  // Bounded ring of recently-applied repair action_ids so a re-echoed (duplicate)
+  // response is applied at most once. Keyed on action_id ONLY — patch_fingerprint
+  // can legitimately recur for a different mapspec fingerprint and would wrongly
+  // block a valid re-issue, so it is intentionally not used as a dedup key.
+  const appliedRepairIdsRef = useRef<Set<string>>(new Set())
+  const mountedRef = useRef(true)
+  const observationAbortRef = useRef<AbortController | null>(null)
+
+  // Cancel any in-flight observation on unmount so a late response can never
+  // setState / dispatch a map action after the panel is gone (INV-6).
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      observationAbortRef.current?.abort()
+      observationAbortRef.current = null
+    }
+  }, [])
 
   // FE-3 (design §7): derive interactiveLayerIds from the runtime's APPLIED
   // spec — the authoritative registry of what the map currently reflects
@@ -306,24 +334,66 @@ export function MapPanel({
           Date.now() * 1000,
         )
         cartographicObservationGenerationRef.current = clientGeneration
+        // Capture THIS request's correlation in the closure so a late response
+        // compares against the newest issued values, not its own stale view.
+        const requestGeneration = clientGeneration
+        latestIssuedCartographicFingerprintRef.current = generation._mapspecFingerprint
+        // A newer observation supersedes any still in flight: abort it so its
+        // late response cannot dispatch a stale repair. The generation gate in
+        // the handler below is the authoritative guard; the abort just reclaims
+        // the round-trip and makes unmount deterministic.
+        observationAbortRef.current?.abort()
+        const controller = new AbortController()
+        observationAbortRef.current = controller
         void apiFetch<{ repair_action?: import('@/lib/types').MapActionPayload }>(
           `/api/v1/chat/sessions/${encodeURIComponent(sessionId)}/cartographic-observation`,
           {
             method: 'POST',
             body: { ...observation, client_generation: clientGeneration },
             ownerToken,
+            signal: controller.signal,
             label: 'Cartographic observation error',
           },
         ).then((response) => {
+          const repair = response.repair_action
+          if (!repair) return
+          // Generation-safe dispatch — latest generation/fingerprint wins.
+          if (!mountedRef.current) return // unmounted: no side effects (INV-6)
+          if (cartographicSessionIdRef.current !== sessionId) return // session switch (INV-2)
+          if (cartographicObservationGenerationRef.current !== requestGeneration) {
+            return // a newer observation was issued → this response is stale (INV-1/INV-7)
+          }
+          const repairParams = repair.params as
+            | { mapspec_fingerprint?: string }
+            | undefined
+          // A repair targeting an older mapspec fingerprint must not mutate a
+          // map that has since advanced (INV-4). Only enforced when the backend
+          // echoes a fingerprint, so a future field change can't block a valid
+          // repair (INV-7).
           if (
-            cartographicSessionIdRef.current === sessionId
-            && response.repair_action
-          ) {
-            dispatchAction(response.repair_action)
+            repairParams?.mapspec_fingerprint
+            && latestIssuedCartographicFingerprintRef.current !== repairParams.mapspec_fingerprint
+          ) return
+          // Duplicate response / retry must not re-apply the same repair (INV-3).
+          const repairId = repair.action_id
+          if (repairId && appliedRepairIdsRef.current.has(repairId)) return
+          dispatchAction(repair)
+          // Record AFTER dispatch so a dispatch throw leaves the repair re-issuable.
+          if (repairId) {
+            const seen = appliedRepairIdsRef.current
+            seen.add(repairId)
+            if (seen.size > MAX_APPLIED_REPAIR_IDS) {
+              seen.delete(seen.keys().next().value as string)
+            }
           }
         }).catch((error) => {
-          // Allow the next meaningful reconcile to retry; token/pan events do
-          // not enter this effect and therefore cannot create a retry storm.
+          // A supersede/unmount abort is expected: the newer request (or the
+          // unmount) owns the state, so stay quiet and leave the key alone.
+          if (!mountedRef.current || error?.name === "AbortError") return
+          // Only the LATEST request may reset the observation key for retry — a
+          // superseded request failing must not force a redundant re-POST of the
+          // newer observation (INV-5: retry without a storm).
+          if (cartographicObservationGenerationRef.current !== requestGeneration) return
           lastCartographicObservationKeyRef.current = ''
           devOnly.warn('[map] cartographic observation failed:', error)
         })


### PR DESCRIPTION
## Summary

Makes the cartographic **observation → `repair_action`** loop (added in #356) generation-safe on the client. Scope is strictly the observation/repair stale-response / ordering / generation consistency — no harness, MapSpec, quality-scoring, rendering, ACK, Data Fabric, UI, or CI changes.

`BASE_SHA`: `81d32e49486a74c9109f85a9be4e3a3534552614` (origin/master, #356 head)

## Discovered race

`frontend/components/map/map-panel.tsx` mints a `client_generation` per meaningful MapSpec reconcile and POSTs `cartographic-observation`. The response gate, however, checked **only `sessionId`**:

```ts
if (cartographicSessionIdRef.current === sessionId && response.repair_action)
  dispatchAction(response.repair_action)
```

Within one session, HTTP responses can arrive **out of order**. `dispatchAction` does not dedup `cartographic_runtime_repair` (only camera commands coalesce), so:

**Before sequence (the bug):**
1. Reconcile A → observation A issued, `client_generation = N`
2. Reconcile B → observation B issued, `client_generation = N+1`
3. B's response lands → `repair_action` B dispatched/applied
4. A's response lands **later** → still same session → `repair_action` A dispatched → **overwrites the newer N+1 state**

The backend already rejects stale observations server-side (`stale_mapspec_fingerprint` / `stale_client_generation`) and **strips `repair_action`** from stale responses (`app/api/routes/chat.py` `push_cartographic_runtime_observation`). That covers the case where requests are reordered *at the backend*, but not the network-reordering window where both responses carry a repair. This PR is defense-in-depth at the client.

## After invariant (latest-generation-wins)

The dispatch gate now reads, in order:
1. `mountedRef` — unmounted ⇒ no side effect (INV-6)
2. `cartographicSessionIdRef === sessionId` — session switch (INV-2)
3. `cartographicObservationGenerationRef === requestGeneration` — a newer observation was issued ⇒ stale (INV-1, INV-7)
4. repair `params.mapspec_fingerprint` (when echoed) must equal the latest issued fingerprint ⇒ stale fingerprint (INV-4)
5. `action_id` not in the bounded applied-id ring ⇒ duplicate (INV-3)

Error path: a supersede/unmount `AbortError` is swallowed silently; only a real failure resets the observation key — and **only when this request is still the latest generation** (INV-5 retry without a storm; a superseded request failing cannot force a redundant re-POST of the newer one).

## Generation / fingerprint semantics

- `client_generation` is monotonically minted client-side (`Math.max(prev+1, Date.now()*1000)`) and stored in `cartographicObservationGenerationRef` **at issue time** = the latest issued generation. Each request captures its own `requestGeneration` in the closure, so a late response compares against the newest value, not its own stale view.
- `latestIssuedCartographicFingerprintRef` tracks the newest issued `mapspec_fingerprint`. The repair's `params.mapspec_fingerprint` (minted by `app/agent_pi_bridge.py` `_advance_runtime_cartographic_repair` from the fingerprint evaluated under the session lock) is compared against it. The check is **presence-guarded** so a missing field can never block a valid repair (INV-7).
- Dedup keys on **`action_id` only** (bounded ring, cap 16). `patch_fingerprint` is intentionally NOT used: it can legitimately recur across different mapspec fingerprints and would wrongly drop a valid re-issue.
- An `AbortController` per in-flight request cancels superseded requests (reclaims the round-trip, makes unmount deterministic). It is a **liveness optimization**; the generation gate is the authoritative guard, kept as defense-in-depth for the post-headers window where abort can no longer reject an already-resolved promise.

No second state machine; public map-action semantics unchanged; the repair loop stays in `map-panel.tsx`.

## Tests — deterministic race suite

New file `frontend/components/map/map-panel.cartography-race.test.tsx` (12 tests) drives the real component through real reconciles with a **controllable fetch** (deferred per call, optionally signal-respecting), so response arrival order is fully deterministic.

| Test | Scenario | Invariant |
|---|---|---|
| TEST-1 | A issued, B issued, B responds then A ⇒ only B applied | INV-1 |
| TEST-2 | session switch mid-flight ⇒ no dispatch | INV-2 |
| TEST-3 | duplicate `action_id` across generations ⇒ applied once | INV-3 |
| TEST-4 | failure ⇒ next meaningful reconcile retries, no storm | INV-5 |
| TEST-5 | repair with stale `mapspec_fingerprint` ⇒ ignored | INV-4 |
| TEST-6 | latest-generation valid repair ⇒ applied | INV-7 |
| TEST-7 | unmount with outstanding request ⇒ no side effect | INV-6 |
| + | supersede aborts the prior in-flight signal | abort wiring |
| + | supersede `AbortError` swallowed silently (signal-respecting fetch) | INV-5 abort path |
| + | `ApiTimeoutError` is NOT swallowed as abort ⇒ retry | INV-5 error class |
| + | two distinct repairs in sequence ⇒ both applied | dedup scope |
| + | A,B,A′ non-adjacent duplicate `action_id` ⇒ at most once | INV-3 ring |

**Before/after evidence:** against the pre-fix `map-panel.tsx` (this PR's tests applied to `BASE_SHA`), **5/8 core tests fail** — the race (TEST-1), dedup (TEST-3), stale fingerprint (TEST-5), unmount (TEST-7), and the abort-wiring test. All pass after the fix.

## Local verification (offline / deterministic)

Frontend (`cd frontend`):
- `npx vitest run components/map/ lib/mapspec-runtime/ lib/api/` → **green** (incl. 12 new race tests; 14 existing map-panel tests unchanged)
- `npx tsc --noEmit` (src config) → **clean**
- `eslint` on changed files (`--max-warnings 0`) → **clean**

Backend (unchanged by this PR — verified for regression + contract):
- `pytest tests/cartography/test_cartography_closed_loop.py tests/cartography/test_concurrency_closed_loop.py -m "cartography or concurrency"` → **20 passed**
- `pytest ...::test_safe_opacity_repair_is_bounded... tests/integration/test_session_api.py` → **6 passed**
- contract: `test_out_of_order_runtime_observation_cannot_overwrite_newer_state` + `test_obsolete_fingerprint_cannot_poison_observation_generation` → **2 passed** (the backend's own latest-generation-wins guard: gen 200 accepted, gen 100 rejected with `repair_action` stripped; stale fingerprint rejected)
- `ruff check app/agent_pi_bridge.py app/api/routes/chat.py app/lib/cartography/` → **All checks passed**

> Note 1 — Pre-existing baseline failure (not introduced here, out of scope): `tsc -p tsconfig.test.json` reports `lib/hooks/use-sse-stream.test.ts(457,1): TS1005: '}' expected`, which reproduces at `BASE_SHA` before any of these changes.
> Note 2 — Backend contract: the route's stale-guard (strip `repair_action` on `stale_*`) already covers the backend half; the frontend gates above are a strict superset of that contract, so the two sides cannot disagree in a direction that double-applies or wrongly drops a valid repair.

## Review

Two independent reviewer passes (async/lifecycle focus + stale/idempotency/error-path focus) found **no P0/P1**. Their convergent P2 hardening items were applied here:
- bounded-Set `action_id` dedup (closes an A,B,A′ slip the single-key would have; removes the `patch_fingerprint` footgun),
- `.catch` key-reset guarded to the latest generation (no redundant re-POST),
- dedup id recorded after a successful dispatch.

## Scope boundaries

This PR only touches observation/repair generation consistency. It does **not**: rewrite the harness, MapSpec, or quality scoring; change map rendering performance; redo the ACK subsystem; touch Data Fabric; change UI appearance; or modify CI/CD.

Do not merge — awaiting review.
