### PR TITLE
perf(layer): keep descriptor authorization metadata-only

### DIFF
--- a/app/api/routes/layer.py
+++ b/app/api/routes/layer.py
@@ -198,16 +198,12 @@ async def get_layer_descriptor(
     if not ref_id or len(ref_id) > 128 or any(c.isspace() for c in ref_id):
         raise HTTPException(status_code=400, detail="非法 ref_id")
 
-    # V3: Try pre-computed descriptor first
-    descriptor = await session_data_manager.get_ref_descriptor(session_id, ref_id)
-    if descriptor:
-        # Auth check: verify ownership via the existing get_ref_data path
-        # (descriptor itself doesn't contain sensitive data, but access control must match)
-        res = await session_data_manager.get_ref_data(session_id, ref_id, owner_token=owner_token)
-        if not res.success:
-            status_code = 403 if res.error_type == "PermissionDenied" else 404
-            raise HTTPException(status_code=status_code, detail=res.error or "数据不可用")
-        # Descriptor found and access granted
+    # V3: metadata-only auth + descriptor read — never hydrates the full payload.
+    res = await session_data_manager.get_ref_descriptor_authorized(
+        session_id, ref_id, owner_token=owner_token
+    )
+    if res.success:
+        descriptor = res.data
         return {
             "ref_id": descriptor["ref_id"],
             "session_id": session_id,
@@ -219,7 +215,12 @@ async def get_layer_descriptor(
             "raster_capable": False,  # descriptor doesn't store raster flag yet
             "estimated_bytes": descriptor["estimated_bytes"],
         }
-    
+    if res.error_type == "PermissionDenied":
+        raise HTTPException(status_code=403, detail=res.error or "数据不可用")
+    # NotFound: pre-V3 ref without descriptor, or payload evicted — 走现有 fallback
+    # （fallback 里 get_ref_data 会对 pre-V3 ref 现算 descriptor、对已 evicted ref
+    #   返回 404，语义与现状一致）
+
     # Fallback: compute on-the-fly for refs without stored descriptor (pre-V3 refs)
     res = await session_data_manager.get_ref_data(session_id, ref_id, owner_token=owner_token)
     if not res.success or not res.data:

--- a/app/services/session_data.py
+++ b/app/services/session_data.py
@@ -274,6 +274,22 @@ class MemorySessionStore(BaseSessionStore):
         """V3 Performance: return pre-computed descriptor (O(1)); None if not found."""
         return self._descriptors.get(session_id, {}).get(ref_id)
 
+    async def ref_exists(self, session_id: str, ref_id: str) -> bool:
+        """O(1) existence check; mirrors ``get()``'s LRU recency side-effect.
+
+        On a hit, moves the ref to the MRU end of the session's LRU order
+        (``move_to_end``, O(1)) so a metadata-only descriptor poll keeps the
+        payload alive under capacity eviction — same recency semantics as a
+        payload ``get()``. Unlike ``get()`` it does NOT read or re-store the
+        payload data itself (no pop/re-insert), so nothing is copied or
+        deserialized. Returns False on a miss (no reordering).
+        """
+        session_cache = self._store.get(session_id)
+        if not session_cache or ref_id not in session_cache:
+            return False
+        session_cache.move_to_end(ref_id)
+        return True
+
     async def clear_session(self, session_id: str) -> None:
         """清理会话数据"""
         self._store.pop(session_id, None)

--- a/app/services/session_data_protocol.py
+++ b/app/services/session_data_protocol.py
@@ -127,6 +127,37 @@ class SessionStoreProtocol(Protocol):
         reading or scanning the full data payload. None if ref not found."""
         ...
 
+    async def get_ref_descriptor_authorized(
+        self,
+        session_id: str,
+        ref_id: str,
+        owner_token: Optional[str] = None,
+    ) -> SessionRefDataResult:
+        """Metadata-only variant of get_ref_data for the descriptor fast path.
+
+        Validates the owner token and ref existence and returns the pre-computed
+        descriptor WITHOUT reading or deserializing the full data payload
+        (no get() call). error_type semantics match get_ref_data:
+        PermissionDenied on token mismatch, NotFound when there is no descriptor
+        or the underlying ref payload is gone.
+
+        Descriptors are keyed by canonical ref_id — this method does NOT resolve
+        aliases; an alias input is treated as a plain ref_id and NotFound (the
+        caller's fallback then handles it, matching master's behaviour).
+
+        Caveat: the "never hydrates" promise assumes the descriptor key exists.
+        RedisSessionStore.get_ref_descriptor has a pre-existing on-the-fly
+        fallback — when the descriptor/meta key is missing (pre-V3 ref, or the
+        meta key's TTL expired before the data key's) it reads the full payload,
+        recomputes and caches the descriptor, so this method hydrates in that
+        case. This is pre-existing behaviour affecting only legacy refs.
+        """
+        ...
+
+    async def ref_exists(self, session_id: str, ref_id: str) -> bool:
+        """O(1) existence check for a ref payload — does not read or deserialize it."""
+        ...
+
     async def cleanup_idle_sessions(self, max_sessions: int = 100) -> None:
         ...
 
@@ -142,6 +173,20 @@ class BaseSessionStore:
         """Default fallback alias resolution. Overridden by subclasses if alias map is separate."""
         return ref_or_alias
 
+    def _validate_owner_token(self, meta: Optional[Dict[str, Any]], owner_token: Optional[str]) -> Optional[SessionRefDataResult]:
+        """Shared owner-token check for get_ref_data / get_ref_descriptor_authorized.
+        Returns a PermissionDenied result if the token mismatches, else None."""
+        meta = meta or {}
+        map_state = meta.get("map_state", {})
+        expected_token = meta.get("owner_token") or map_state.get("owner_token")
+        if expected_token and owner_token != expected_token:
+            return SessionRefDataResult(
+                success=False,
+                error="Security token mismatch",
+                error_type="PermissionDenied",
+            )
+        return None
+
     async def get_ref_data(
         self,
         session_id: str,
@@ -150,14 +195,9 @@ class BaseSessionStore:
     ) -> SessionRefDataResult:
         """Deep interface method: resolves alias, validates owner token if present, and returns deserialized data."""
         meta = await self.get_session_metadata(session_id)
-        map_state = meta.get("map_state", {}) if meta else {}
-        expected_token = (meta.get("owner_token") if meta else None) or map_state.get("owner_token")
-        if expected_token and owner_token != expected_token:
-            return SessionRefDataResult(
-                success=False,
-                error="Security token mismatch",
-                error_type="PermissionDenied",
-            )
+        denied = self._validate_owner_token(meta, owner_token)
+        if denied is not None:
+            return denied
 
         raw_data = await self.get(session_id, ref_or_alias)
         if raw_data is None:
@@ -176,6 +216,54 @@ class BaseSessionStore:
                 return SessionRefDataResult(success=True, data=raw_data)
 
         return SessionRefDataResult(success=True, data=raw_data)
+
+    async def get_ref_descriptor_authorized(
+        self,
+        session_id: str,
+        ref_id: str,
+        owner_token: Optional[str] = None,
+    ) -> SessionRefDataResult:
+        """Metadata-only variant of get_ref_data for the descriptor fast path.
+
+        Validates the owner token and ref existence and returns the pre-computed
+        descriptor WITHOUT reading or deserializing the full data payload
+        (no get() call). error_type semantics match get_ref_data:
+        PermissionDenied on token mismatch, NotFound when there is no descriptor
+        or the underlying ref payload is gone.
+
+        Descriptors are keyed by canonical ref_id — this method does NOT resolve
+        aliases; an alias input is treated as a plain ref_id and NotFound (the
+        caller's fallback then handles it, matching master's behaviour).
+
+        Caveat: the "never hydrates" promise assumes the descriptor key exists.
+        RedisSessionStore.get_ref_descriptor has a pre-existing on-the-fly
+        fallback — when the descriptor/meta key is missing (pre-V3 ref, or the
+        meta key's TTL expired before the data key's) it reads the full payload,
+        recomputes and caches the descriptor, so this method hydrates in that
+        case. This is pre-existing behaviour affecting only legacy refs.
+        """
+        meta = await self.get_session_metadata(session_id)
+        denied = self._validate_owner_token(meta, owner_token)
+        if denied is not None:
+            return denied
+
+        descriptor = await self.get_ref_descriptor(session_id, ref_id)
+        if not descriptor:
+            return SessionRefDataResult(
+                success=False,
+                error="Referenced data expired or not found",
+                error_type="NotFound",
+            )
+
+        exists = await self.ref_exists(session_id, ref_id)
+        if not exists:
+            return SessionRefDataResult(
+                success=False,
+                error="Referenced data expired or not found",
+                error_type="NotFound",
+            )
+
+        return SessionRefDataResult(success=True, data=descriptor)
 
 
 # Backward compatibility aliases

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -920,6 +920,34 @@ class RedisSessionStore(BaseSessionStore):
             logger.error("Redis get_ref_descriptor failed for %s/%s: %s", session_id, ref_id, e)
             return None
 
+    async def ref_exists(self, session_id: str, ref_id: str) -> bool:
+        """EXISTS on the data key with ``get()``'s recency side-effects.
+
+        Checks the data key without reading/deserializing the payload. On a hit,
+        renews the same three recency markers as ``get()``'s hit branch —
+        ``expire(data_key, DATA_TTL)``, ``zadd(refs_order, {ref_id: now})`` and
+        ``_refresh_session_ttl`` — so a metadata-only descriptor poll keeps the
+        payload alive under TTL/LRU eviction, preserving master's "descriptor
+        read keeps payload alive" semantics (master went through
+        get_ref_data → get()). A miss performs no writes.
+        Redis 不可达时返回 False（与 get() 的 cache-miss 语义一致：上层走
+        fallback 后得到 NotFound，和现状 Redis 抖动时的行为相同）。
+        """
+        await self._ensure_connected()
+        data_key = self._data_key(session_id, ref_id)
+        try:
+            if not await self._r.exists(data_key):
+                return False
+            async with self._r.pipeline() as pipe:
+                pipe.expire(data_key, DATA_TTL)
+                pipe.zadd(self._refs_order_key(session_id), {ref_id: time.time()})
+                self._refresh_session_ttl(pipe, session_id)
+                await pipe.execute()
+            return True
+        except aioredis.RedisError as e:
+            logger.warning("Redis ref_exists failed for session %s ref %s: %s", session_id, ref_id, e)
+            return False
+
     def _refresh_session_ttl(self, pipe, session_id: str) -> None:
         for key in [
             self._aliases_key(session_id),

--- a/tests/test_layer_descriptor_api.py
+++ b/tests/test_layer_descriptor_api.py
@@ -1,0 +1,288 @@
+"""
+HTTP-level tests for ``GET /api/v1/layers/descriptor/{ref_id}``
+(app/api/routes/layer.py ``get_layer_descriptor``) — the V3 metadata fast path.
+
+Route behaviour under test:
+- seam success → 200 with the descriptor fields, no payload hydration
+  (store.get / store.get_ref_data never called)
+- PermissionDenied → 403, WITHOUT falling back to get_ref_data
+- NotFound → existing fallback via get_ref_data(): pre-V3 refs are recomputed
+  into a 200 with correct feature_count; genuinely missing refs → 404
+
+Memory backend plus one Redis-on-fakeredis case: store-level dual-backend
+parity is covered by tests/unit/test_descriptor_auth_fastpath.py. A fresh
+MemorySessionStore is injected as the route module's ``session_data_manager``
+per test (module-level import, so the ``app.api.routes.layer`` attribute is
+patched); the Redis case injects a fakeredis-backed RedisSessionStore the same
+way to lock in the seam-internal on-the-fly recompute path unique to Redis.
+"""
+import pytest
+from httpx import AsyncClient, ASGITransport
+from unittest.mock import patch
+from fastapi import FastAPI
+
+from app.api.routes import layer as _mod
+from app.core.auth import require_owned_session
+from app.models.db_model import Conversation
+from app.services.session_data import MemorySessionStore
+
+_VALID_SID = "session-aaaaaaaaaaaaaaaa"  # >= min_length=8
+
+
+def _point_fc(n=1000):
+    """n-Point FeatureCollection; minimal payload (see store-level twin)."""
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [116.0 + i * 0.001, 39.9],
+                },
+                "properties": {"id": i},
+            }
+            for i in range(n)
+        ],
+    }
+
+
+@pytest.fixture
+def store():
+    return MemorySessionStore()
+
+
+@pytest.fixture
+def app(monkeypatch, store):
+    """Inject a fresh MemorySessionStore into the route module's
+    ``session_data_manager`` name (layer.py imports it at module top, so the
+    attribute on the module is patched). Cross-tenant guard stubbed to
+    always-pass like tests/test_layer_api.py (isolation covered elsewhere)."""
+    async def _noop_verify(session_id, user_id, owner_token=None):
+        return None
+
+    monkeypatch.setattr(_mod, "_verify_session_owner", _noop_verify)
+    monkeypatch.setattr(_mod, "session_data_manager", store)
+
+    app = FastAPI()
+    app.dependency_overrides[require_owned_session] = lambda: Conversation(id=_VALID_SID)
+    app.include_router(_mod.router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_descriptor_fastpath_success_no_hydration(client, store):
+    """Fast path: 200 with correct descriptor fields, zero payload reads."""
+    ref_id = await store.store(_VALID_SID, _point_fc(1000), prefix="data")
+
+    with patch.object(store, "get", wraps=store.get) as spy_get, patch.object(
+        store, "get_ref_data", wraps=store.get_ref_data
+    ) as spy_grd:
+        resp = await client.get(
+            f"/api/v1/layers/descriptor/{ref_id}",
+            params={"session_id": _VALID_SID},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ref_id"] == ref_id
+    assert body["session_id"] == _VALID_SID
+    assert body["feature_count"] == 1000
+    assert body["point_count"] == 1000
+    assert body["geometry_types"] == ["Point"]
+    assert body["bbox"] == [116.0, 39.9, 116.999, 39.9]
+    assert body["mvt_capable"] is True
+    assert body["raster_capable"] is False
+    assert body["estimated_bytes"] == 1000 * 100 + 1024
+    assert spy_get.call_count == 0
+    assert spy_grd.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_descriptor_anonymous_correct_token_success(client, store):
+    """Anonymous session guarded by an owner_token: correct X-Session-Token → 200."""
+    await store.set_map_state(_VALID_SID, "owner_token", "secret-token")
+    ref_id = await store.store(_VALID_SID, _point_fc(10), prefix="data")
+
+    resp = await client.get(
+        f"/api/v1/layers/descriptor/{ref_id}",
+        params={"session_id": _VALID_SID},
+        headers={"X-Session-Token": "secret-token"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["feature_count"] == 10
+
+
+@pytest.mark.asyncio
+async def test_descriptor_wrong_token_403(client, store):
+    """Wrong token → 403 (no fallback hydration attempted)."""
+    await store.set_map_state(_VALID_SID, "owner_token", "secret-token")
+    ref_id = await store.store(_VALID_SID, _point_fc(10), prefix="data")
+
+    with patch.object(store, "get", wraps=store.get) as spy_get:
+        resp = await client.get(
+            f"/api/v1/layers/descriptor/{ref_id}",
+            params={"session_id": _VALID_SID},
+            headers={"X-Session-Token": "wrong-token"},
+        )
+
+    assert resp.status_code == 403
+    assert spy_get.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_descriptor_missing_ref_404(client):
+    """Never-stored ref → seam NotFound → fallback NotFound → 404."""
+    resp = await client.get(
+        "/api/v1/layers/descriptor/ref:missing",
+        params={"session_id": _VALID_SID},
+    )
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_descriptor_cross_session_404(client, store):
+    """Ref stored in another session → 404."""
+    ref_id = await store.store("session-bbbbbbbbbbbbbbbb", _point_fc(10), prefix="data")
+
+    resp = await client.get(
+        f"/api/v1/layers/descriptor/{ref_id}",
+        params={"session_id": _VALID_SID},
+    )
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_descriptor_orphaned_descriptor_404(client, store):
+    """Descriptor residue with payload gone → seam NotFound → fallback
+    get_ref_data also NotFound → 404 (stale descriptor must NOT be served)."""
+    ref_id = await store.store(_VALID_SID, _point_fc(10), prefix="data")
+    del store._store[_VALID_SID][ref_id]
+
+    resp = await client.get(
+        f"/api/v1/layers/descriptor/{ref_id}",
+        params={"session_id": _VALID_SID},
+    )
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_pre_v3_ref_fallback_still_works(client, store):
+    """Pre-V3 ref (no stored descriptor): seam NotFound → route-level fallback
+    get_ref_data() hydrates and recomputes → 200 with correct feature_count.
+    get_ref_data IS legitimately called this time."""
+    ref_id = await store.store(_VALID_SID, _point_fc(25), prefix="data")
+    store._descriptors[_VALID_SID].pop(ref_id)
+
+    with patch.object(store, "get_ref_data", wraps=store.get_ref_data) as spy_grd:
+        resp = await client.get(
+            f"/api/v1/layers/descriptor/{ref_id}",
+            params={"session_id": _VALID_SID},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["feature_count"] == 25
+    assert body["point_count"] == 25
+    assert spy_grd.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_descriptor_invalid_ref_id_400(client, store):
+    """Existing guard: ref_id containing whitespace or exceeding 128 chars → 400."""
+    for bad_ref in ("ref with space", "r" * 129):
+        resp = await client.get(
+            f"/api/v1/layers/descriptor/{bad_ref}",
+            params={"session_id": _VALID_SID},
+        )
+        assert resp.status_code == 400, f"expected 400 for ref_id {bad_ref!r}"
+
+
+# ─────────────────────────────────────────────── Redis end-to-end path ────
+# Locking in the seam-internal on-the-fly recompute that only exists on Redis:
+# when the descriptor/meta key is missing (pre-V3 ref, or its TTL expired first)
+# RedisSessionStore.get_ref_descriptor reads the full payload, recomputes and
+# caches the descriptor — the seam then returns success (Memory instead returns
+# NotFound here and the route falls back to get_ref_data). End-user outcome is
+# a 200 with correct fields on both backends; this case pins the Redis one.
+
+
+def _redis_store_factory():
+    """RedisSessionStore backed by in-process fakeredis (same injection as
+    tests/unit/test_descriptor_auth_fastpath.py). The injected client is wired
+    via the ``redis=`` test seam so `store._r` is already the FakeRedis."""
+    import fakeredis.aioredis
+    from app.services.session_data_redis import RedisSessionStore
+
+    return RedisSessionStore(
+        redis_url="redis://unused",
+        redis=fakeredis.aioredis.FakeRedis(decode_responses=False),
+    )
+
+
+@pytest.fixture
+def redis_store():
+    return _redis_store_factory()
+
+
+@pytest.fixture
+def redis_app(monkeypatch, redis_store):
+    """Route app with the fakeredis-backed RedisSessionStore injected as
+    ``session_data_manager`` (same patching as the memory ``app`` fixture)."""
+    async def _noop_verify(session_id, user_id, owner_token=None):
+        return None
+
+    monkeypatch.setattr(_mod, "_verify_session_owner", _noop_verify)
+    monkeypatch.setattr(_mod, "session_data_manager", redis_store)
+
+    app = FastAPI()
+    app.dependency_overrides[require_owned_session] = lambda: Conversation(id=_VALID_SID)
+    app.include_router(_mod.router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture
+async def redis_client(redis_app):
+    transport = ASGITransport(app=redis_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_descriptor_redis_meta_key_missing_recomputes_200(redis_client, redis_store):
+    """Redis only: meta key deleted (pre-V3 ref / early meta TTL expiry) →
+    the seam's get_ref_descriptor recomputes from the payload on the fly →
+    200 with correct descriptor fields. Asserts the exact same response
+    contract as the memory fast-path success test."""
+    sid = _VALID_SID
+    ref_id = await redis_store.store(sid, _point_fc(1000), prefix="data")
+    await redis_store._ensure_connected()
+    await redis_store._r.delete(redis_store._descriptor_key(sid, ref_id))
+
+    resp = await redis_client.get(
+        f"/api/v1/layers/descriptor/{ref_id}",
+        params={"session_id": sid},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ref_id"] == ref_id
+    assert body["session_id"] == sid
+    assert body["feature_count"] == 1000
+    assert body["point_count"] == 1000
+    assert body["geometry_types"] == ["Point"]
+    assert body["bbox"] == [116.0, 39.9, 116.999, 39.9]
+    assert body["mvt_capable"] is True
+    assert body["raster_capable"] is False
+    assert body["estimated_bytes"] == 1000 * 100 + 1024

--- a/tests/unit/test_descriptor_auth_fastpath.py
+++ b/tests/unit/test_descriptor_auth_fastpath.py
@@ -1,0 +1,463 @@
+"""
+Store-level contract tests for the descriptor fast-path authorization seam
+``BaseSessionStore.get_ref_descriptor_authorized`` (V3 perf work, route
+``GET /api/v1/layers/descriptor/{ref_id}`` in app/api/routes/layer.py).
+
+What this seam promises:
+- returns ``SessionRefDataResult``; ``success=True`` → ``data`` is the
+  pre-computed descriptor dict, WITHOUT reading the full payload
+  (no ``get()`` / ``get_ref_data()`` call)
+- owner-token mismatch → ``error_type="PermissionDenied"``
+- descriptor missing (pre-V3 ref) OR payload gone (``ref_exists`` False)
+  → ``error_type="NotFound"``
+
+Every test here runs against BOTH backends (MemorySessionStore +
+RedisSessionStore over fakeredis) so protocol parity is enforced, mirroring
+tests/unit/test_session_store_contract.py.
+
+KNOWN CONTRACT DEVIATION (Redis, pre-existing — NOT introduced by this branch):
+``RedisSessionStore.get_ref_descriptor`` (session_data_redis.py:895) has an
+on-the-fly fallback: when the descriptor/meta key is missing but the data key
+exists, it reads the full payload, recomputes and caches the descriptor, and
+returns it. Consequently the seam's "descriptor missing → NotFound" promise
+does NOT hold on Redis for pre-V3 refs — the seam returns success with the
+recomputed descriptor. End-user behaviour (200 with a correct descriptor) is
+identical through either path; test_pre_v3_ref_without_descriptor_falls_back
+asserts each backend's actual behaviour and documents this. App source was
+NOT modified per task constraints.
+"""
+import time
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+
+from app.services.session_data import MemorySessionStore
+from app.services.session_data_redis import RedisSessionStore
+
+STORE_FACTORIES = [MemorySessionStore]
+
+
+def _redis_store_factory():
+    """RedisSessionStore backed by in-process fakeredis (same pattern as
+    tests/unit/test_session_store_contract.py). The injected client is wired
+    in via the ``redis=`` test seam so the production code path runs unchanged
+    and `store._r` is already the FakeRedis (no lazy-connect step to trigger)."""
+    import fakeredis.aioredis
+
+    return RedisSessionStore(
+        redis_url="redis://unused",
+        redis=fakeredis.aioredis.FakeRedis(decode_responses=False),
+    )
+
+
+if RedisSessionStore is not None:
+    STORE_FACTORIES.append(_redis_store_factory)
+
+
+def _point_fc(n=1000):
+    """n-Point FeatureCollection; minimal payload (short coords, single int
+    property) so building/store()ing the 100k variant stays fast."""
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [116.0 + i * 0.001, 39.9],
+                },
+                "properties": {"id": i},
+            }
+            for i in range(n)
+        ],
+    }
+
+
+def _spy_store_methods(store, stack: ExitStack) -> dict:
+    """Wrap the seam's callable surface with counting mocks (wraps= keeps the
+    real implementation live while call_count tracks actual invocations).
+
+    Patches are entered on the caller's ExitStack (caller controls lifetime)
+    and the mocks are returned keyed by method name."""
+    spies = {}
+    for name in (
+        "get",
+        "get_ref_data",
+        "get_session_metadata",
+        "get_ref_descriptor",
+        "ref_exists",
+    ):
+        spies[name] = stack.enter_context(
+            patch.object(store, name, wraps=getattr(store, name))
+        )
+    return spies
+
+
+# ───────────────────────────────────────────── A. deterministic work-count ──
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_descriptor_auth_never_hydrates_payload(store_factory):
+    """Core acceptance: the seam serves the descriptor without hydrating the
+    payload — zero get() and zero get_ref_data() calls."""
+    store = store_factory()
+    sid = "fastpath_sid_1"
+    ref_id = await store.store(sid, _point_fc(1000), prefix="data")
+
+    with ExitStack() as stack:
+        spies = _spy_store_methods(store, stack)
+        res = await store.get_ref_descriptor_authorized(sid, ref_id)
+
+    assert res.success is True
+    assert res.data is not None
+    assert res.data["feature_count"] == 1000
+    assert spies["get"].call_count == 0, "fast path must never call get()"
+    assert spies["get_ref_data"].call_count == 0, "fast path must never call get_ref_data()"
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_descriptor_auth_work_count_independent_of_feature_count(store_factory):
+    """Deterministic work-count acceptance (no wall-clock / sleep).
+
+    Run the seam once per payload size (1k and 100k features) and snapshot the
+    call count of every seam-relevant store method. Both sizes must yield
+    byte-identical counts — the fast path's work is independent of feature
+    count / payload bytes. (100k kept: FC build ~0.14s, Redis store ~0.5s —
+    far under the 30s budget.)
+    """
+    counts = {}
+    for n in (1000, 100000):
+        store = store_factory()
+        sid = f"fastpath_sid_{n}"
+        ref_id = await store.store(sid, _point_fc(n), prefix="data")
+
+        with ExitStack() as stack:
+            spies = _spy_store_methods(store, stack)
+            res = await store.get_ref_descriptor_authorized(sid, ref_id)
+            assert res.success is True
+            counts[n] = {name: spies[name].call_count for name in spies}
+
+    assert counts[1000] == counts[100000], (
+        f"seam work count must be independent of payload size; got {counts}"
+    )
+    # Sanity: the profile is exactly the metadata-only path (no payload reads).
+    assert counts[1000] == {
+        "get": 0,
+        "get_ref_data": 0,
+        "get_session_metadata": 1,
+        "get_ref_descriptor": 1,
+        "ref_exists": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_descriptor_auth_redis_never_gets_data_key():
+    """Redis backend only: the seam must never issue a GET against a data key.
+
+    Both the descriptor read (get_ref_descriptor) and the payload read (get)
+    funnel through the same ``store._r.get`` command — only the KEY
+    distinguishes them: ``session:{sid}:data:{ref_id}`` (payload) vs
+    ``session:{sid}:meta:{ref_id}`` (descriptor, see _data_key/_descriptor_key
+    in app/services/session_data_redis.py). Spy on ``_r.get`` and assert no
+    argument carries the data-key prefix. ``store._r`` is already the injected
+    FakeRedis here, so no _ensure_connected step to sequence.
+    """
+    store = _redis_store_factory()
+    sid = "fastpath_sid_redis"
+    ref_id = await store.store(sid, _point_fc(1000), prefix="data")
+    data_key = store._data_key(sid, ref_id)
+    assert data_key.startswith(f"session:{sid}:data:")
+
+    calls = []
+    original_get = store._r.get
+
+    async def _spy(key, *args, **kwargs):
+        calls.append(key)
+        return await original_get(key, *args, **kwargs)
+
+    store._r.get = _spy
+    try:
+        res = await store.get_ref_descriptor_authorized(sid, ref_id)
+    finally:
+        store._r.get = original_get
+
+    assert res.success is True
+    assert calls, "expected at least the descriptor-key GET"
+    data_hits = [
+        (k.decode() if isinstance(k, bytes) else k)
+        for k in calls
+        if (k.decode() if isinstance(k, bytes) else k).startswith(data_key)
+    ]
+    assert not data_hits, (
+        f"fast path must never GET the payload data key; hit on {data_hits}"
+    )
+
+
+# ─────────────────────────────────────────────── B. security regression matrix ──
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_owner_session_no_token_required(store_factory):
+    """Session without an owner_token: no token needed → success."""
+    store = store_factory()
+    sid = "fastpath_sid_b1"
+    ref_id = await store.store(sid, _point_fc(10), prefix="data")
+
+    res = await store.get_ref_descriptor_authorized(sid, ref_id)
+
+    assert res.success is True
+    assert res.data["ref_id"] == ref_id
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_anonymous_correct_owner_token_success(store_factory):
+    """Anonymous session guarded by an owner_token: correct token → success,
+    still zero payload reads."""
+    store = store_factory()
+    sid = "fastpath_sid_b2"
+    await store.set_map_state(sid, "owner_token", "secret-token")
+    ref_id = await store.store(sid, _point_fc(10), prefix="data")
+
+    with ExitStack() as stack:
+        spies = _spy_store_methods(store, stack)
+        res = await store.get_ref_descriptor_authorized(
+            sid, ref_id, owner_token="secret-token"
+        )
+
+    assert res.success is True
+    assert res.data["feature_count"] == 10
+    assert spies["get"].call_count == 0
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_anonymous_wrong_token_denied(store_factory):
+    """Wrong owner token → PermissionDenied, and the token is validated BEFORE
+    the descriptor is read: an unauthorized caller must not learn whether a
+    descriptor exists (get_ref_descriptor not called) nor read payloads
+    (get not called)."""
+    store = store_factory()
+    sid = "fastpath_sid_b3"
+    await store.set_map_state(sid, "owner_token", "secret-token")
+    ref_id = await store.store(sid, _point_fc(10), prefix="data")
+
+    with ExitStack() as stack:
+        spies = _spy_store_methods(store, stack)
+        res = await store.get_ref_descriptor_authorized(
+            sid, ref_id, owner_token="wrong-token"
+        )
+
+    assert res.success is False
+    assert res.error_type == "PermissionDenied"
+    assert spies["get"].call_count == 0
+    assert spies["get_ref_descriptor"].call_count == 0, (
+        "token check must precede descriptor read — unauthenticated callers "
+        "get no existence oracle"
+    )
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_missing_ref_not_found(store_factory):
+    """Never-stored ref → NotFound."""
+    store = store_factory()
+    sid = "fastpath_sid_b4"
+
+    res = await store.get_ref_descriptor_authorized(sid, "ref:does-not-exist")
+
+    assert res.success is False
+    assert res.error_type == "NotFound"
+
+
+@pytest.mark.asyncio
+async def test_evicted_ref_not_found_memory():
+    """Memory LRU: capacity=1 evicts the first ref (payload + descriptor) →
+    the seam must report NotFound for it while the surviving ref still works."""
+    store = MemorySessionStore(capacity=1)
+    sid = "fastpath_sid_b5"
+    ref1 = await store.store(sid, {"payload": 1}, prefix="data")
+    ref2 = await store.store(sid, {"payload": 2}, prefix="data")
+    assert ref1 != ref2
+
+    res1 = await store.get_ref_descriptor_authorized(sid, ref1)
+    assert res1.success is False
+    assert res1.error_type == "NotFound"
+
+    res2 = await store.get_ref_descriptor_authorized(sid, ref2)
+    assert res2.success is True
+    assert res2.data["ref_id"] == ref2
+
+
+@pytest.mark.asyncio
+async def test_evicted_ref_not_found_redis():
+    """Redis has no capacity=1 analogue in this simulation; model an
+    evicted/expired ref by deleting BOTH the descriptor key and the data key
+    (real eviction in session_data_redis.py `_evict_ref` deletes both) →
+    NotFound."""
+    store = _redis_store_factory()
+    sid = "fastpath_sid_b5r"
+    ref1 = await store.store(sid, {"payload": 1}, prefix="data")
+
+    await store._r.delete(store._descriptor_key(sid, ref1))
+    await store._r.delete(store._data_key(sid, ref1))
+
+    res = await store.get_ref_descriptor_authorized(sid, ref1)
+    assert res.success is False
+    assert res.error_type == "NotFound"
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_cross_session_ref_not_found(store_factory):
+    """A ref stored in session A is invisible to session B → NotFound."""
+    store = store_factory()
+    sid_a, sid_b = "fastpath_sid_b6a", "fastpath_sid_b6b"
+    ref_id = await store.store(sid_a, _point_fc(10), prefix="data")
+
+    res = await store.get_ref_descriptor_authorized(sid_b, ref_id)
+
+    assert res.success is False
+    assert res.error_type == "NotFound"
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_descriptor_orphaned_but_data_gone_not_found(store_factory):
+    """Descriptor residue with the payload gone must NOT yield success.
+
+    Memory: ``del store._store[sid][ref_id]`` keeps the descriptor entry.
+    Redis: delete only the data key, keep the descriptor key. The seam's
+    ref_exists check must catch the orphaned state → NotFound (never success),
+    and must not hydrate (get call count 0)."""
+    store = store_factory()
+    sid = "fastpath_sid_b7"
+    ref_id = await store.store(sid, _point_fc(10), prefix="data")
+    if isinstance(store, RedisSessionStore):
+        await store._r.delete(store._data_key(sid, ref_id))
+    else:
+        del store._store[sid][ref_id]
+
+    with ExitStack() as stack:
+        spies = _spy_store_methods(store, stack)
+        res = await store.get_ref_descriptor_authorized(sid, ref_id)
+
+    assert res.success is False
+    assert res.error_type == "NotFound"
+    assert spies["get"].call_count == 0
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_pre_v3_ref_without_descriptor_falls_back(store_factory):
+    """Pre-V3 ref (no stored descriptor) must remain servable.
+
+    Memory: remove the descriptor entry → the seam reports NotFound and the
+    ROUTE-level fallback (get_ref_data) recomputes the descriptor; store-level
+    assertion is NotFound. get_ref_data must still return the payload intact
+    (fallback path not broken).
+
+    Redis: deleting the meta key does NOT surface NotFound —
+    RedisSessionStore.get_ref_descriptor's pre-existing on-the-fly fallback
+    reads the data key, recomputes and caches the descriptor, so the seam
+    returns success. This deviates from the seam's documented contract (see
+    module docstring) and is asserted here as the ACTUAL behavior; end-user
+    outcome (200 with a correct descriptor) is identical through either path.
+    """
+    store = store_factory()
+    sid = "fastpath_sid_b8"
+    ref_id = await store.store(sid, _point_fc(10), prefix="data")
+
+    if isinstance(store, RedisSessionStore):
+        await store._r.delete(store._descriptor_key(sid, ref_id))
+        res = await store.get_ref_descriptor_authorized(sid, ref_id)
+        assert res.success is True, (
+            "Redis get_ref_descriptor recomputes a missing descriptor on the "
+            "fly (pre-existing fallback) — see module docstring; flip this to "
+            "expect NotFound if that fallback is ever removed"
+        )
+        assert res.data["feature_count"] == 10
+    else:
+        store._descriptors[sid].pop(ref_id)
+        res = await store.get_ref_descriptor_authorized(sid, ref_id)
+        assert res.success is False
+        assert res.error_type == "NotFound"
+
+    # Deep read path (route-level fallback) is intact on both backends.
+    deep = await store.get_ref_data(sid, ref_id)
+    assert deep.success is True
+    assert deep.data is not None
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_ref_exists_parity(store_factory):
+    """ref_exists primitive parity: present / missing / cross-session."""
+    store = store_factory()
+    sid_a, sid_b = "fastpath_sid_b9a", "fastpath_sid_b9b"
+    ref_id = await store.store(sid_a, {"payload": 1}, prefix="data")
+
+    assert await store.ref_exists(sid_a, ref_id) is True
+    assert await store.ref_exists(sid_a, "ref:does-not-exist") is False
+    assert await store.ref_exists(sid_b, ref_id) is False
+
+
+# ─────────────────────────────────────── C. recency side-effect regression ──
+
+
+@pytest.mark.parametrize("store_factory", STORE_FACTORIES)
+@pytest.mark.asyncio
+async def test_descriptor_access_refreshes_payload_recency(store_factory):
+    """Fix 1 regression (both backends): a descriptor fast-path hit must carry
+    the same recency side-effects as a payload get() — Memory LRU bump, Redis
+    data-key TTL + refs_order score refresh — so an actively-polled descriptor
+    keeps its payload alive under LRU/TTL eviction (master's
+    get_ref_data → get() semantics).
+
+    Memory: capacity=2 — accessing refA's descriptor, then storing refC must
+    evict the unaccessed refB, not the just-accessed refA.
+    Redis: shrinking the data key's TTL to 1s, then accessing the descriptor
+    must renew it back to ~DATA_TTL (7200s) and re-stamp the refs_order score.
+    """
+    sid = "fastpath_sid_fix1"
+    if store_factory is MemorySessionStore:
+        store = MemorySessionStore(capacity=2)
+        ref_a = await store.store(sid, _point_fc(10), prefix="data")
+        ref_b = await store.store(sid, _point_fc(10), prefix="data")
+
+        res = await store.get_ref_descriptor_authorized(sid, ref_a)
+        assert res.success is True
+
+        ref_c = await store.store(sid, _point_fc(10), prefix="data")
+        assert ref_c not in (ref_a, ref_b)
+        assert await store.ref_exists(sid, ref_a) is True, (
+            "descriptor access must refresh LRU recency so refA survives eviction"
+        )
+        assert await store.ref_exists(sid, ref_b) is False, (
+            "unaccessed refB must be the evicted ref"
+        )
+    else:
+        store = store_factory()
+        ref_id = await store.store(sid, _point_fc(10), prefix="data")
+        data_key = store._data_key(sid, ref_id)
+        # Simulate a payload about to expire (meta key TTL still intact).
+        await store._r.pexpire(data_key, 1000)
+
+        res = await store.get_ref_descriptor_authorized(sid, ref_id)
+        assert res.success is True
+
+        # DATA_TTL = 7200; the hit branch must restore the near-full TTL.
+        ttl = await store._r.ttl(data_key)
+        assert ttl > 7000, (
+            f"descriptor access must renew data-key TTL near DATA_TTL; got ttl={ttl}"
+        )
+
+        # refs_order zset score re-stamped by the hit branch (optional check).
+        score = await store._r.zscore(store._refs_order_key(sid), ref_id)
+        assert score is not None and abs(score - time.time()) < 30, (
+            f"descriptor access must refresh refs_order score; got {score}"
+        )


### PR DESCRIPTION
## Root cause

`GET /layers/descriptor/{ref_id}` 的 V3 metadata-first fast path 命中预计算 descriptor 后，为做 owner-token 鉴权又调用 `session_data_manager.get_ref_data()`。而 `BaseSessionStore.get_ref_data()` 会 `get()` 读取完整 payload 并 JSON 反序列化——对 100k feature / 数 MB 的 GeoJSON，一个本应只有几百 bytes 的 descriptor 请求重新进入 full-data path。

## Original full-payload path

```
get_ref_descriptor() 命中 → get_ref_data(owner_token) 鉴权
  → get_session_metadata() → get(session_id, ref_id) 读完整 payload
  → json.loads(payload) 反序列化 → 只为拿 success/error_type
```

## New auth seam

新增 `BaseSessionStore.get_ref_descriptor_authorized(session_id, ref_id, owner_token)`（`app/services/session_data_protocol.py`）：

1. `get_session_metadata()` → `_validate_owner_token()`（与 `get_ref_data` 共享同一 helper，鉴权逻辑零分歧；**先鉴权再读 descriptor**，未授权调用者连 descriptor 存在性都拿不到——比 master 更好：master 在未鉴权时就调用 `get_ref_descriptor`，Redis 上 pre-V3 ref 会触发全量 payload 现算）
2. `get_ref_descriptor()` 取预计算 descriptor（O(1)，metadata 大小）
3. `ref_exists()` O(1) 存在性检查（Memory: dict 键查询 + LRU move_to_end；Redis: `EXISTS data_key`，命中时镜像 `get()` 的 `EXPIRE`/`ZADD refs_order`/session TTL 续期副作用，保持 master "descriptor 轮询保活 payload" 语义）
4. 全程**不调用 `get()`、不反序列化 payload**

路由映射保持 master contract：`PermissionDenied` → 403（直接抛出，不落 fallback）；`NotFound` → 落现有 pre-V3 fallback（`get_ref_data` 现算 descriptor / 真缺失 404）。

## Work-count evidence（确定性，非 wall-clock）

`tests/unit/test_descriptor_auth_fastpath.py`（Memory + fakeredis Redis 双后端参数化）：

- descriptor 命中时 `get()` 与 `get_ref_data()` 调用次数**均为 0**（spy 断言）；Redis 后端另有 key 级断言：对 `session:{sid}:data:*` 前缀的 `GET` 命令为 0 次
- 1k vs 100k feature 的逐方法调用 profile 完全相等：`{get:0, get_ref_data:0, get_session_metadata:1, get_ref_descriptor:1, ref_exists:1}`——工作量只与 metadata 大小相关，与 feature 数/payload bytes 无关
- 路由级 `tests/test_layer_descriptor_api.py`：1000-feature fast path 200 且 `get`/`get_ref_data` 零调用

## Security matrix（全部覆盖，双后端 parity）

| 场景 | 结果 |
|---|---|
| authenticated owner（无 store token） | 200 success |
| anonymous + 正确 owner token | 200，且 `get` 零调用 |
| anonymous + 错误 token | 403 PermissionDenied，且 `get`/`get_ref_descriptor` 均零调用（无存在性 oracle） |
| missing ref | 404 |
| expired/evicted ref（Memory 真实 LRU 淘汰 / Redis 删 key） | 404 |
| cross-session ref | 404 |
| descriptor 残留但 data 已失效（orphan 异常） | 404（`ref_exists` 兜底），不返回陈旧 descriptor |
| Redis/memory parity | store 级全矩阵双后端参数化通过 |
| pre-V3 ref（无 descriptor） | 走现有 fallback 正常 200（Memory：路由 fallback 现算；Redis：seam 内经既有 on-the-fly fallback 现算，端到端语义一致） |

## Redis/memory 行为

- eviction 生命周期一致：Memory 数据+descriptor 同一原子步淘汰；Redis 同 TTL 同 pipeline 写入、`_evict_ref`/`clear_session` 双删；orphan 由 `ref_exists` 兜为 404（与 master contract 一致）
- Redis 不可达时 `ref_exists` → False → fallback → 404，与 master 抖动期行为一致
- 已知既有偏差（非本分支引入，未扩大）：Redis `get_ref_descriptor` 的 on-the-fly fallback 在 meta key 缺失时会读全量 payload 现算（影响 pre-V3 legacy ref；meta key TTL 不续期的漂移问题为既有问题），docstring 已如实标注

## Tests

- 新增 `tests/unit/test_descriptor_auth_fastpath.py`（25 用例，双后端）+ `tests/test_layer_descriptor_api.py`（9 用例，Memory + Redis HTTP 级）
- 相关套件共 **256 passed**（descriptor / session store contract / protocol / parity / layer route / auth hardening / cross-tenant isolation / L1 cache / chaos store / 100k performance）
- `ruff check app/ tests/` 全绿；`git diff --check` 干净

## BASE_SHA

`81d32e49486a74c9109f85a9be4e3a3534552614`（origin/master）

## Scope boundaries

只动 protocol / 两个 store / descriptor 路由 / 测试。未触碰：MVT encoder、tile cache、frontend、Data Fabric、cartography、LLM/Agent、SessionStore 整体结构、CI/CD。`get_ref_data()` 保留且外部行为不变（仅抽出共享 token 校验 helper）。

## Review

security self-review + 三方并行 review（安全对抗 / spec 符合性 / 双后端正确性），无 Blocker/Major；Minor 发现（TTL/LRU 续期副作用、falsy descriptor 防御、参数命名、docstring caveat、Redis HTTP 级覆盖）已全部修复并补回归测试。
