### PR TITLE
perf(mvt): reuse prepared geometry across tile encoding

### DIFF
--- a/app/api/routes/layer.py
+++ b/app/api/routes/layer.py
@@ -22,7 +22,7 @@ from app.models.db_model import Conversation
 from app.services.mvt import (
     RefDataUnavailableError,
     build_spatial_index_entry,
-    encode_tile,
+    encode_tile_from_index,
     single_flight,
     spatial_index_cache,
     tile_lru_cache,
@@ -102,12 +102,12 @@ def _encode_tile_cached(session_id: str, ref_id: str, z: int, x: int, y: int, da
 
     Runs inside asyncio.to_thread. Raises RefDataUnavailableError when the
     index was evicted between the route's presence check and this build (the
-    route then refetches the ref data once and retries).
+    route then refetches the ref data once and retries). Encoding reuses the
+    index's pre-built geometries (no per-tile GeoJSON→Shapely reconstruction).
     """
     key = (session_id, ref_id)
     entry = spatial_index_cache.get_or_build(key, lambda: build_spatial_index_entry(key, data))
-    features = entry.query_tile(z, x, y)
-    raw = encode_tile(features, z, x, y)
+    raw = encode_tile_from_index(entry, z, x, y)
     body = gzip.compress(raw)
     tile_lru_cache.put((session_id, ref_id, z, x, y), body)
     return body

--- a/app/services/mvt.py
+++ b/app/services/mvt.py
@@ -534,32 +534,87 @@ def _shapely_parts(geom):
             yield from _shapely_parts(g)
 
 
-def _encode_line_polygon_shapely(gtype: str, coords, z: int, x: int, y: int) -> Optional[bytes]:
-    """Line/Polygon encode with shapely: simplify + is_valid gate + exact clip."""
-    geom = _shapely_geom_from_coords(gtype, coords)
-    if geom is None or geom.is_empty:
-        return None
+def _simplify_and_project(gtype: str, geom_lonlat, geom_z0, z: int):
+    """Return the z0 world-px geometry to clip, reusing cached projections.
+
+    The geometry construction and (for high zoom) the z0 projection are the
+    expensive parts of the encode hot path; this function lets an index that
+    already built both reuse them instead of redoing the work per tile.
+
+    ``geom_lonlat`` is the lon/lat shapely geometry (always required: the
+    simplify tolerance is zoom-dependent and applied in lon/lat space, and the
+    is_valid gate runs against it). ``geom_z0`` is the cached z0 projection of
+    the *unsimplified* lon/lat geometry, or None when the caller has no index
+    (then it is rebuilt on demand at z >= _SIMPLIFY_MAX_ZOOM).
+
+    Output is identical regardless of whether geom_z0 is cached or rebuilt:
+    projection is homogeneous in z, so transform(geom_lonlat) is exactly what
+    the z >= threshold path emits. Returns None when the feature must be dropped
+    (empty / invalid polygon / degenerate simplification).
+    """
     is_poly = gtype in _IS_POLY
-    if is_poly and not geom.is_valid:
+    if geom_lonlat is None or geom_lonlat.is_empty:
+        return None
+    if is_poly and not geom_lonlat.is_valid:
         # never emit self-intersecting polygons
         logger.debug("mvt: skipping invalid %s feature", gtype)
         return None
-    if z < _SIMPLIFY_MAX_ZOOM:
-        # half a pixel at zoom z; in degree terms: 360 / (256 * 2^z) / 2,
-        # converted to z0 world px (world = 256): 2 ** -(z + 1)
-        simplified = geom.simplify(2.0 ** -(z + 1), preserve_topology=True)
-        if simplified.is_empty:
-            return None
-        if not is_poly or simplified.is_valid:
-            geom = simplified
-        # else: simplification produced self-intersection → keep the original
-        # (which passed the is_valid gate above)
-    geom = shapely.transform(geom, _transform_z0)
+    if z >= _SIMPLIFY_MAX_ZOOM:
+        # no simplification: reuse the cached z0 geometry (or rebuild it once).
+        # An exception here propagates to ``_encode_geometry``'s guard, which
+        # falls back to the pure-python encoder — matching the pre-refactor
+        # behavior exactly. (Index callers never reach this line: they pass a
+        # cached geom_z0 and return above.)
+        if geom_z0 is not None:
+            return geom_z0
+        return shapely.transform(geom_lonlat, _transform_z0)
+    # z < threshold: simplify in lon/lat space, then project the result.
+    # half a pixel at zoom z; in degree terms: 360 / (256 * 2^z) / 2,
+    # converted to z0 world px (world = 256): 2 ** -(z + 1)
+    simplified = geom_lonlat.simplify(2.0 ** -(z + 1), preserve_topology=True)
+    if simplified.is_empty:
+        return None
+    if not is_poly or simplified.is_valid:
+        geom_lonlat = simplified
+    # else: simplification produced self-intersection → keep the original
+    # (which passed the is_valid gate above)
+    return shapely.transform(geom_lonlat, _transform_z0)
+
+
+def _clip_and_encode(geom, is_poly: bool, z: int, x: int, y: int) -> Optional[bytes]:
+    """Clip a z0 geometry to the tile rect and encode it; None if nothing inside."""
+    if geom is None:
+        return None
     clipped = geom.intersection(shapely.geometry.box(*_tile_rect_z0(z, x, y)))
     if clipped.is_empty:
         return None
-    parts = _shapely_parts(clipped)
-    return _encode_parts(parts, is_poly, z, x, y)
+    return _encode_parts(_shapely_parts(clipped), is_poly, z, x, y)
+
+
+def _encode_line_polygon_shapely(gtype: str, coords, z: int, x: int, y: int) -> Optional[bytes]:
+    """Line/Polygon encode from raw GeoJSON coords (no index to reuse from).
+
+    Constructs the lon/lat shapely geometry and lets ``_simplify_and_project``
+    rebuild the z0 projection on demand. This is the path used by the public
+    ``encode_tile``; the index-aware path uses ``_encode_line_polygon_from_geoms``.
+    """
+    geom_lonlat = _shapely_geom_from_coords(gtype, coords)
+    geom = _simplify_and_project(gtype, geom_lonlat, None, z)
+    return _clip_and_encode(geom, gtype in _IS_POLY, z, x, y)
+
+
+def _encode_line_polygon_from_geoms(
+    gtype: str, geom_lonlat, geom_z0, z: int, x: int, y: int
+) -> Optional[bytes]:
+    """Line/Polygon encode reusing a feature's pre-built shapely geometries.
+
+    ``geom_lonlat`` / ``geom_z0`` come from the spatial index (built once per
+    ref), so no GeoJSON→Shapely construction happens per tile and the z0
+    projection is reused at z >= _SIMPLIFY_MAX_ZOOM. Output is byte-identical to
+    ``_encode_line_polygon_shapely`` for the same input coordinates.
+    """
+    geom = _simplify_and_project(gtype, geom_lonlat, geom_z0, z)
+    return _clip_and_encode(geom, gtype in _IS_POLY, z, x, y)
 
 
 def _encode_line_polygon_pure(gtype: str, coords, z: int, x: int, y: int) -> Optional[bytes]:
@@ -667,15 +722,24 @@ def _to_feature_dicts(features_data) -> List[dict]:
     return []
 
 
-def encode_tile(features_data, z: int, x: int, y: int) -> bytes:
-    """Encode features into a raw (uncompressed) MVT tile for (z, x, y).
+def _type_id_for(gtype: str) -> Optional[int]:
+    if gtype in _IS_POINT:
+        return _GT_POINT
+    if gtype in _IS_LINE:
+        return _GT_LINESTRING
+    if gtype in _IS_POLY:
+        return _GT_POLYGON
+    return None
 
-    ``features_data`` may be a list of GeoJSON feature dicts, a bare
-    FeatureCollection, a wrapped ref-data shape ({"geojson": ...}) or the
-    legacy point list [((lon, lat), props), ...]. Returns a valid (possibly
-    empty) tile: b"" when nothing falls inside the tile.
+
+def _assemble_mvt(records: List[Tuple[int, bytes, Dict[str, Any]]]) -> bytes:
+    """Assemble the final MVT tile bytes from encoded feature records.
+
+    Each record is ``(type_id, geometry_bytes, properties)``. Property keys and
+    values are deduplicated in first-seen order, exactly as the wire format
+    requires. Returns b"" when no feature produced geometry (a valid empty tile
+    message with no layer).
     """
-    features = _to_feature_dicts(features_data)
     keys: List[str] = []
     key_idx: Dict[str, int] = {}
     values: List[bytes] = []
@@ -694,29 +758,9 @@ def encode_tile(features_data, z: int, x: int, y: int) -> bytes:
         return value_idx[encoded]
 
     feature_msgs: List[bytes] = []
-    for f in features:
-        geometry = f.get("geometry")
-        if not isinstance(geometry, dict):
-            continue
-        gtype = geometry.get("type")
-        coords = geometry.get("coordinates")
-        if gtype == "GeometryCollection":
-            logger.warning("mvt: GeometryCollection features are not encoded, skipping")
-            continue
-        if gtype not in _SUPPORTED_TYPES:
-            continue
-        geom_bytes = _encode_geometry(gtype, coords, z, x, y)
-        if geom_bytes is None:
-            continue
-        if gtype in _IS_POINT:
-            type_id = _GT_POINT
-        elif gtype in _IS_LINE:
-            type_id = _GT_LINESTRING
-        else:
-            type_id = _GT_POLYGON
+    for type_id, geom_bytes, props in records:
         tags: List[int] = []
-        props = f.get("properties") or {}
-        for k, v in props.items():
+        for k, v in (props or {}).items():
             encoded = _encode_value(v)
             if encoded is None:
                 continue
@@ -742,6 +786,42 @@ def encode_tile(features_data, z: int, x: int, y: int) -> bytes:
     return bytes(tile)
 
 
+def encode_tile(features_data, z: int, x: int, y: int) -> bytes:
+    """Encode features into a raw (uncompressed) MVT tile for (z, x, y).
+
+    ``features_data`` may be a list of GeoJSON feature dicts, a bare
+    FeatureCollection, a wrapped ref-data shape ({"geojson": ...}) or the
+    legacy point list [((lon, lat), props), ...]. Returns a valid (possibly
+    empty) tile: b"" when nothing falls inside the tile.
+
+    This is the coordinate-based path: it parses GeoJSON coordinates into
+    shapely geometries on each call. The index-aware path
+    (``encode_tile_from_index``) reuses geometries already built by the spatial
+    index and produces byte-identical output.
+    """
+    features = _to_feature_dicts(features_data)
+    records: List[Tuple[int, bytes, Dict[str, Any]]] = []
+    for f in features:
+        geometry = f.get("geometry")
+        if not isinstance(geometry, dict):
+            continue
+        gtype = geometry.get("type")
+        coords = geometry.get("coordinates")
+        if gtype == "GeometryCollection":
+            logger.warning("mvt: GeometryCollection features are not encoded, skipping")
+            continue
+        if gtype not in _SUPPORTED_TYPES:
+            continue
+        geom_bytes = _encode_geometry(gtype, coords, z, x, y)
+        if geom_bytes is None:
+            continue
+        type_id = _type_id_for(gtype)
+        if type_id is None:
+            continue
+        records.append((type_id, geom_bytes, f.get("properties") or {}))
+    return _assemble_mvt(records)
+
+
 def encode_point_tile(
     features: List[Tuple[Tuple[float, float], Dict[str, Any]]],
     z: int,
@@ -756,6 +836,54 @@ def encode_point_tile(
     return encode_tile(features, z, x, y)
 
 
+def encode_tile_from_index(entry: "SpatialIndexEntry", z: int, x: int, y: int) -> bytes:
+    """Encode a tile reusing a spatial index's pre-built geometries.
+
+    This is the Data Plane hot path: STRtree candidates come with their already
+    projected shapely geometries, so the per-tile GeoJSON→Shapely construction
+    and (at z >= _SIMPLIFY_MAX_ZOOM) the z0 projection are eliminated — that
+    work happens once at index-build time. Output is byte-identical to
+    ``encode_tile(entry.query_tile(z, x, y), z, x, y)``.
+
+    Points still read their coordinates from the feature dict (their projection
+    is cheap scalar math, no shapely construction). Falls back to the raw
+    ``encode_tile`` path when the index has no prepared shapely geometries
+    (shapely unavailable).
+    """
+    if not _SHAPELY or entry.geoms is None:
+        return encode_tile(entry.query_tile(z, x, y), z, x, y)
+    records: List[Tuple[int, bytes, Dict[str, Any]]] = []
+    for feature, geom_lonlat, geom_z0 in entry.query_candidates(z, x, y):
+        geometry = feature.get("geometry")
+        gtype = geometry.get("type") if isinstance(geometry, dict) else None
+        # GeometryCollections and unsupported types are excluded at index-build
+        # time, so this guard is defensive only (no warning, unlike encode_tile
+        # which receives arbitrary user input).
+        if gtype == "GeometryCollection" or gtype not in _SUPPORTED_TYPES:
+            continue
+        if gtype in _IS_POINT:
+            coords = geometry.get("coordinates")
+            pts = coords if gtype == "MultiPoint" else [coords]
+            geom_bytes = _encode_points(pts, z, x, y)
+        else:
+            try:
+                geom_bytes = _encode_line_polygon_from_geoms(gtype, geom_lonlat, geom_z0, z, x, y)
+            except Exception:
+                # Mirror _encode_geometry's resilience: a pathological geometry
+                # that survives index build but fails shapely simplify/intersect
+                # falls back to the coordinate path (which itself degrades to the
+                # pure-python encoder) rather than failing the whole tile.
+                logger.warning("mvt: shapely encode failed, using pure-python fallback", exc_info=True)
+                geom_bytes = _encode_geometry(gtype, geometry.get("coordinates"), z, x, y)
+        if geom_bytes is None:
+            continue
+        type_id = _type_id_for(gtype)
+        if type_id is None:
+            continue
+        records.append((type_id, geom_bytes, feature.get("properties") or {}))
+    return _assemble_mvt(records)
+
+
 # ─── spatial index ──────────────────────────────────────────────────────────
 
 
@@ -764,18 +892,37 @@ class SpatialIndexEntry:
 
     ``geoms`` are shapely geometries in z0 world pixels (world = 256); the
     query box is the tile rect in the same space, so one index serves every
-    zoom (projection is homogeneous in z). ``bounds`` are plain z0-px bboxes
-    used by the no-shapely full-scan fallback.
+    zoom (projection is homogeneous in z). ``geoms_lonlat`` are the matching
+    lon/lat shapely geometries (retained so tile encoding can apply the
+    zoom-dependent simplification in lon/lat space without re-parsing the
+    GeoJSON coordinates). Retaining both arrays roughly doubles the index's
+    per-ref geometry memory vs. the z0-only design; this is the deliberate
+    trade-off for eliminating per-tile reconstruction, and stays bounded by the
+    per-(session, ref) LRU. ``bounds`` are plain z0-px bboxes used by the
+    no-shapely full-scan fallback. ``geoms`` / ``geoms_lonlat`` are None when
+    shapely is unavailable.
     """
 
-    __slots__ = ("key", "features", "geoms", "tree", "bounds")
+    __slots__ = ("key", "features", "geoms", "geoms_lonlat", "tree", "bounds")
 
-    def __init__(self, key, features, geoms, tree, bounds):
+    def __init__(self, key, features, geoms, geoms_lonlat, tree, bounds):
         self.key = key
         self.features = features
         self.geoms = geoms
+        self.geoms_lonlat = geoms_lonlat
         self.tree = tree
         self.bounds = bounds
+
+    def _candidate_indices(self, z: int, x: int, y: int) -> List[int]:
+        """Insertion-ordered feature indices whose bbox intersects the tile."""
+        x0, y0, x1, y1 = _tile_rect_z0(z, x, y)
+        if self.tree is not None:
+            return [int(i) for i in np.sort(np.atleast_1d(
+                self.tree.query(shapely.geometry.box(x0, y0, x1, y1))))]
+        return [
+            i for i, b in enumerate(self.bounds)
+            if b[0] <= x1 and b[2] >= x0 and b[1] <= y1 and b[3] >= y0
+        ]
 
     def query_tile(self, z: int, x: int, y: int) -> List[dict]:
         """Features whose bbox intersects the tile (exact filter at encode).
@@ -783,15 +930,18 @@ class SpatialIndexEntry:
         Results keep the original feature order (STRtree returns spatially
         sorted indices; re-sorting restores insertion order).
         """
-        x0, y0, x1, y1 = _tile_rect_z0(z, x, y)
-        if self.tree is not None:
-            idx = np.sort(np.atleast_1d(self.tree.query(shapely.geometry.box(x0, y0, x1, y1))))
-            return [self.features[int(i)] for i in idx]
-        hits = []
-        for i, b in enumerate(self.bounds):
-            if b[0] <= x1 and b[2] >= x0 and b[1] <= y1 and b[3] >= y0:
-                hits.append(self.features[i])
-        return hits
+        return [self.features[i] for i in self._candidate_indices(z, x, y)]
+
+    def query_candidates(self, z: int, x: int, y: int):
+        """Prepared ``(feature, geom_lonlat, geom_z0)`` for each bbox-hit candidate.
+
+        Insertion-ordered (parallel to ``query_tile``). Only valid when
+        ``geoms`` is set (shapely available); callers gate on that.
+        """
+        return [
+            (self.features[i], self.geoms_lonlat[i], self.geoms[i])
+            for i in self._candidate_indices(z, x, y)
+        ]
 
 
 def _pure_bounds(gtype: str, coords) -> Optional[Tuple[float, float, float, float]]:
@@ -820,11 +970,17 @@ def _pure_bounds(gtype: str, coords) -> Optional[Tuple[float, float, float, floa
 
 
 def build_spatial_index_entry(key, data) -> SpatialIndexEntry:
-    """Build a spatial index entry for (session_id, ref_id) from raw ref data."""
+    """Build a spatial index entry for (session_id, ref_id) from raw ref data.
+
+    Each kept feature's lon/lat shapely geometry and its z0 projection are
+    retained (parallel to ``features``) so that tile encoding can reuse them
+    instead of re-parsing coordinates and re-projecting per tile request.
+    """
     if data is None:
         raise RefDataUnavailableError(f"ref data unavailable for index build: {key}")
     features = extract_features(data)
     geoms: List[Any] = []
+    geoms_lonlat: List[Any] = []
     bounds: List[Tuple[float, float, float, float]] = []
     kept: List[dict] = []
     for f in features:
@@ -844,6 +1000,7 @@ def build_spatial_index_entry(key, data) -> SpatialIndexEntry:
                     continue
             except Exception:
                 continue
+            geoms_lonlat.append(geom)
             geoms.append(geom_z0)
             bounds.append(tuple(b))
         else:  # pragma: no cover - no-shapely environments
@@ -858,7 +1015,14 @@ def build_spatial_index_entry(key, data) -> SpatialIndexEntry:
             tree = shapely.STRtree(geoms)
         except Exception:  # pragma: no cover - defensive
             tree = None
-    return SpatialIndexEntry(key, kept, geoms if _SHAPELY else None, tree, bounds)
+    return SpatialIndexEntry(
+        key,
+        kept,
+        geoms if _SHAPELY else None,
+        geoms_lonlat if _SHAPELY else None,
+        tree,
+        bounds,
+    )
 
 
 class SpatialIndexCache:

--- a/tests/unit/test_mvt_prepared_geometry.py
+++ b/tests/unit/test_mvt_prepared_geometry.py
@@ -1,0 +1,419 @@
+"""Regression + performance tests for MVT prepared-geometry reuse.
+
+Guards the optimization that makes the spatial index → tile candidate → geometry
+encode hot path reuse geometries already built at index time, instead of
+re-parsing GeoJSON coordinates and re-projecting to z0 on every tile request.
+
+The tests are deterministic (work-counters, not wall-clock) and assert:
+
+  A. After an index build, encoding adjacent tiles does NOT repeat the
+     GeoJSON→Shapely construction / z0 projection per candidate.
+  B. The expensive projection work converges to O(features) at build time plus
+     O(candidate clipping/encoding) at tile time.
+  C. Output is byte-identical to the coordinate-based ``encode_tile`` for every
+     supported geometry type (Point / MultiPoint / LineString / MultiLineString
+     / Polygon + holes / MultiPolygon), at z < 14 and z >= 14.
+  D. A warm tile LRU cache hit performs no geometry work.
+  E. Index eviction + rebuild still encodes correctly.
+  F. The index path is deterministic (the basis for single-flight sharing).
+  G. The index geometry arrays stay bounded and parallel to the feature list.
+"""
+import math
+
+import pytest
+
+from app.services.mvt import (
+    SpatialIndexCache,
+    TileLRUCache,
+    _transform_z0,
+    build_spatial_index_entry,
+    encode_tile,
+    encode_tile_from_index,
+)
+import app.services.mvt as mvt_mod
+
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _feature(gtype, coords, props=None):
+    return {
+        "type": "Feature",
+        "geometry": {"type": gtype, "coordinates": coords},
+        "properties": props or {},
+    }
+
+
+def _fc(*features):
+    return {"type": "FeatureCollection", "features": list(features)}
+
+
+def _tile_of(z, lon, lat):
+    """Tile (z,x,y) containing lon/lat — mirrors mvt._project."""
+    world = 256.0 * (1 << z)
+    px = (lon + 180.0) / 360.0 * world
+    lat_rad = math.radians(lat)
+    py = (1.0 - math.log(math.tan(lat_rad) + 1.0 / math.cos(lat_rad)) / math.pi) / 2.0 * world
+    return (z, int(px // 256), int(py // 256))
+
+
+def _first_lonlat(coords):
+    cur = coords
+    while isinstance(cur, list) and len(cur) and isinstance(cur[0], list):
+        cur = cur[0]
+    return cur[0], cur[1]
+
+
+class _WorkCounter:
+    """Count _shapely_geom_from_coords and z0-transform calls on the mvt module."""
+
+    def __init__(self, monkeypatch):
+        self.construct = 0
+        self.transform_z0 = 0
+        orig_construct = mvt_mod._shapely_geom_from_coords
+        orig_transform = mvt_mod.shapely.transform
+
+        def c_construct(gtype, coords):
+            self.construct += 1
+            return orig_construct(gtype, coords)
+
+        def c_transform(geom, func):
+            if func is _transform_z0:
+                self.transform_z0 += 1
+            return orig_transform(geom, func)
+
+        monkeypatch.setattr(mvt_mod, "_shapely_geom_from_coords", c_construct)
+        monkeypatch.setattr(mvt_mod.shapely, "transform", c_transform)
+
+    def snapshot(self):
+        return self.construct, self.transform_z0
+
+
+# ─── fixtures per geometry type (criterion C) ────────────────────────────────
+
+BEIJING = (116.40, 39.92)
+
+
+def _line(n=24, span=0.05):
+    bx, by = BEIJING
+    return [[bx + span * j / n, by + span * j / (n * 2)] for j in range(n)]
+
+
+GEOMETRY_FIXTURES = {
+    "Point": _feature("Point", [BEIJING[0], BEIJING[1]], {"id": "pt"}),
+    "MultiPoint": _feature("MultiPoint", [[BEIJING[0], BEIJING[1]],
+                                          [BEIJING[0] + 0.01, BEIJING[1] + 0.01]], {"id": "mpt"}),
+    "LineString": _feature("LineString", _line(), {"id": "ln", "cat": 1}),
+    "MultiLineString": _feature("MultiLineString", [_line(), _line(span=0.03)], {"id": "mln"}),
+    "Polygon": _feature(
+        "Polygon",
+        [
+            # exterior ring (CCW in geographic terms)
+            [[116.30, 39.85], [116.50, 39.85], [116.50, 40.00], [116.30, 40.00], [116.30, 39.85]],
+            # hole
+            [[116.35, 39.90], [116.40, 39.90], [116.40, 39.95], [116.35, 39.95], [116.35, 39.90]],
+        ],
+        {"id": "poly"},
+    ),
+    "MultiPolygon": _feature(
+        "MultiPolygon",
+        [
+            [[[116.30, 39.85], [116.40, 39.85], [116.40, 39.95], [116.30, 39.95], [116.30, 39.85]]],
+            [[[116.45, 39.85], [116.55, 39.85], [116.55, 39.95], [116.45, 39.95], [116.45, 39.85]]],
+        ],
+        {"id": "mpoly"},
+    ),
+}
+
+
+# ─── C. byte-identical output per geometry type ─────────────────────────────
+
+
+@pytest.mark.parametrize("gtype", list(GEOMETRY_FIXTURES))
+@pytest.mark.parametrize("z", [3, 12, 14, 16])  # spans simplify (z<14) and no-simplify (z>=14)
+def test_index_path_byte_identical_to_coordinate_path(gtype, z):
+    """encode_tile_from_index must equal encode_tile(query_tile) byte-for-byte."""
+    feat = GEOMETRY_FIXTURES[gtype]
+    fc = _fc(feat)
+    entry = build_spatial_index_entry(("s", "r"), fc)
+    assert len(entry.features) == 1
+    tile = _tile_of(z, *_first_lonlat(feat["geometry"]["coordinates"]))
+    via_index = encode_tile_from_index(entry, *tile)
+    via_coords = encode_tile(entry.query_tile(*tile), *tile)
+    assert via_index == via_coords, f"{gtype} z={z} diverged"
+    assert via_index != b"", f"{gtype} z={z} produced an empty tile"
+
+
+def test_mixed_collection_byte_identical_across_adjacent_tiles():
+    """A mixed collection encodes identically on both paths for many tiles."""
+    fc = _fc(*GEOMETRY_FIXTURES.values())
+    entry = build_spatial_index_entry(("s", "r2"), fc)
+    for z in (4, 11, 13, 15):
+        seen = set()
+        for feat in fc["features"]:
+            t = _tile_of(z, *_first_lonlat(feat["geometry"]["coordinates"]))
+            if t in seen:
+                continue
+            seen.add(t)
+            assert encode_tile_from_index(entry, *t) == encode_tile(entry.query_tile(*t), *t)
+
+
+# ─── C-extras: tricky correctness invariants ─────────────────────────────────
+
+
+@pytest.mark.parametrize("z", [12, 15])  # simplify and no-simplify regimes
+def test_invalid_polygon_dropped_identically_on_both_paths(z):
+    """A self-intersecting (bowtie) polygon is dropped by the is_valid gate on
+    both the coordinate path and the index path — never emitted."""
+    bx, by = BEIJING
+    # bowtie: edges cross at the center → invalid
+    bowtie = _feature(
+        "Polygon",
+        [[[bx, by], [bx + 0.02, by + 0.02], [bx + 0.02, by],
+          [bx, by + 0.02], [bx, by]]],
+        {"id": "bowtie"},
+    )
+    fc = _fc(bowtie)
+    entry = build_spatial_index_entry(("s", "rbow"), fc)
+    assert len(entry.features) == 1  # kept in the index (non-empty)...
+    tile = _tile_of(z, bx, by)
+    via_index = encode_tile_from_index(entry, *tile)
+    via_coords = encode_tile(entry.query_tile(*tile), *tile)
+    assert via_index == via_coords == b""  # ...but dropped at encode on both paths
+
+
+def test_multipolygon_with_hole_byte_identical():
+    """A MultiPolygon whose member carries an interior ring encodes identically."""
+    bx, by = BEIJING
+    mpoly_hole = _feature(
+        "MultiPolygon",
+        [
+            # member 0: square with a hole
+            [
+                [[bx, by], [bx + 0.04, by], [bx + 0.04, by + 0.04], [bx, by + 0.04], [bx, by]],
+                [[bx + 0.01, by + 0.01], [bx + 0.02, by + 0.01], [bx + 0.02, by + 0.02],
+                 [bx + 0.01, by + 0.02], [bx + 0.01, by + 0.01]],
+            ],
+            # member 1: simple square (disjoint)
+            [[[bx + 0.06, by], [bx + 0.08, by], [bx + 0.08, by + 0.02], [bx + 0.06, by + 0.02], [bx + 0.06, by]]],
+        ],
+        {"id": "mpoly_hole"},
+    )
+    fc = _fc(mpoly_hole)
+    entry = build_spatial_index_entry(("s", "rmh"), fc)
+    for z in (11, 14, 16):
+        t = _tile_of(z, bx, by)
+        assert encode_tile_from_index(entry, *t) == encode_tile(entry.query_tile(*t), *t)
+        assert encode_tile_from_index(entry, *t) != b""
+
+
+def test_polygon_straddling_tile_boundary_byte_identical():
+    """A polygon clipped to a tile that catches only a slice must match exactly."""
+    bx, by = BEIJING
+    # a large polygon spanning several z=15 tiles
+    big = _feature(
+        "Polygon",
+        [[[bx, by], [bx + 0.5, by], [bx + 0.5, by + 0.5], [bx, by + 0.5], [bx, by]]],
+        {"id": "big"},
+    )
+    fc = _fc(big)
+    entry = build_spatial_index_entry(("s", "rbig"), fc)
+    origin_tile = _tile_of(15, bx, by)
+    # encode the origin tile and three neighbors — each intersects a different slice
+    for dx, dy in [(0, 0), (1, 0), (0, 1), (1, 1)]:
+        t = (15, origin_tile[1] + dx, origin_tile[2] + dy)
+        via_index = encode_tile_from_index(entry, *t)
+        via_coords = encode_tile(entry.query_tile(*t), *t)
+        assert via_index == via_coords
+
+
+# ─── A + B. no per-candidate rebuild; projection converges to build time ─────
+
+
+def test_index_path_eliminates_geometry_construction_per_tile(monkeypatch):
+    """After build, encoding adjacent tiles does zero GeoJSON→Shapely builds."""
+    counter = _WorkCounter(monkeypatch)
+    # many multi-vertex line/poly features so construction cost is real
+    feats = [_feature("LineString", _line(n=30, span=0.02 * (i + 1)), {"id": i}) for i in range(50)]
+    feats += [_feature("Polygon", [
+        [[116.0 + i * 0.01, 39.9], [116.05 + i * 0.01, 39.9],
+         [116.05 + i * 0.01, 40.0], [116.0 + i * 0.01, 40.0], [116.0 + i * 0.01, 39.9]]]
+    ) for i in range(50)]
+    fc = _fc(*feats)
+    entry = build_spatial_index_entry(("s", "r3"), fc)
+    build_construct, build_transform = counter.snapshot()
+    assert build_construct == len(feats)          # built once per feature
+    assert build_transform == len(feats)          # projected once per feature
+
+    # encode a cluster of adjacent tiles at z<14 (simplify) and z>=14 (no simplify)
+    tiles = [_tile_of(12, 116.1 + d * 0.02, 39.95) for d in range(4)]
+    for t in tiles:
+        encode_tile_from_index(entry, *t)
+    tile_construct, _ = counter.snapshot()
+    # construction must NOT grow with the number of tiles (criterion A/B)
+    assert tile_construct == build_construct, "construction repeated per tile candidate"
+
+    # z>=14 must also avoid the z0 projection per tile
+    build_transform2 = counter.transform_z0
+    hi_tiles = [_tile_of(15, 116.1 + d * 0.02, 39.95) for d in range(3)]
+    for t in hi_tiles:
+        encode_tile_from_index(entry, *t)
+    _, hi_transform = counter.snapshot()
+    assert hi_transform == build_transform2, "z>=14 z0 projection repeated per tile"
+
+
+def test_projection_work_is_o_features_at_build_plus_o_candidates_at_tiles(monkeypatch):
+    """The expensive projection is paid at build; tile work is clipping/encoding only."""
+    counter = _WorkCounter(monkeypatch)
+    fc = _fc(*[_feature("LineString", _line(n=20, span=0.01 * i), {"id": i}) for i in range(30)])
+    entry = build_spatial_index_entry(("s", "r4"), fc)
+    n_features = len(entry.features)
+    base_construct, base_transform = counter.snapshot()
+    assert base_construct == n_features
+    assert base_transform == n_features
+
+    # repeated tiles: total construction stays flat regardless of request count
+    tile = _tile_of(13, *_first_lonlat(fc["features"][0]["geometry"]["coordinates"]))
+    for _ in range(5):
+        encode_tile_from_index(entry, *tile)
+    final_construct, _ = counter.snapshot()
+    assert final_construct == n_features  # 5 requests → still 0 extra constructions
+
+
+# ─── D. warm tile LRU hit performs no geometry work ──────────────────────────
+
+
+def test_warm_tile_cache_hit_does_no_geometry_work(monkeypatch):
+    """A warm tile LRU hit must not invoke the encode path at all."""
+    fc = _fc(*GEOMETRY_FIXTURES.values())
+    entry = build_spatial_index_entry(("s", "r5"), fc)
+    tile = _tile_of(12, *_first_lonlat(GEOMETRY_FIXTURES["Point"]["geometry"]["coordinates"]))
+    cache = TileLRUCache(max_tiles=8, max_bytes=1 << 20)
+
+    calls = {"encode": 0}
+
+    def encode_spy(ent, z, x, y):
+        calls["encode"] += 1
+        return encode_tile_from_index(ent, z, x, y)
+
+    # mirrors the route: cache hit short-circuits before encode
+    def serve(t):
+        cached = cache.get(("s", "r5", *t))
+        if cached is not None:
+            return cached
+        import gzip
+        body = gzip.compress(encode_spy(entry, *t))
+        cache.put(("s", "r5", *t), body)
+        return body
+
+    serve(tile)              # cold: encodes once
+    assert calls["encode"] == 1
+    serve(tile)              # warm: cache hit, no encode
+    serve(tile)              # warm again
+    assert calls["encode"] == 1, "warm cache hit performed geometry work"
+
+
+# ─── E. eviction / rebuild ───────────────────────────────────────────────────
+
+
+def test_index_eviction_and_rebuild_still_encodes():
+    fc = _fc(*GEOMETRY_FIXTURES.values())
+    cache = SpatialIndexCache(max_refs=1)
+    key = ("s", "r6")
+    e1 = cache.get_or_build(key, lambda: build_spatial_index_entry(key, fc))
+    tile = _tile_of(13, *_first_lonlat(GEOMETRY_FIXTURES["LineString"]["geometry"]["coordinates"]))
+    first = encode_tile_from_index(e1, *tile)
+    # evict by inserting another ref (max_refs=1)
+    cache.get_or_build(("s", "other"), lambda: build_spatial_index_entry(("s", "other"), _fc(GEOMETRY_FIXTURES["Point"])))
+    assert cache.get(key) is None
+    # rebuild from scratch
+    e2 = cache.get_or_build(key, lambda: build_spatial_index_entry(key, fc))
+    assert e2 is not e1
+    rebuilt = encode_tile_from_index(e2, *tile)
+    assert rebuilt == first  # deterministic after rebuild
+
+
+# ─── F. determinism (basis for single-flight sharing) ────────────────────────
+
+
+def test_index_path_is_deterministic():
+    """Same index + tile always yields identical bytes (single-flight correctness)."""
+    fc = _fc(*GEOMETRY_FIXTURES.values())
+    entry = build_spatial_index_entry(("s", "r7"), fc)
+    tile = _tile_of(10, *_first_lonlat(GEOMETRY_FIXTURES["Polygon"]["geometry"]["coordinates"]))
+    a = encode_tile_from_index(entry, *tile)
+    b = encode_tile_from_index(entry, *tile)
+    c = encode_tile(entry.query_tile(*tile), *tile)
+    assert a == b == c
+
+
+# ─── G. bounded, parallel geometry arrays ────────────────────────────────────
+
+
+def test_index_geometry_arrays_are_bounded_and_parallel():
+    fc = _fc(*GEOMETRY_FIXTURES.values())
+    entry = build_spatial_index_entry(("s", "r8"), fc)
+    n = len(entry.features)
+    assert n == len(GEOMETRY_FIXTURES)
+    # z0 and lon/lat arrays are plain lists, parallel to features, not unbounded
+    assert isinstance(entry.geoms, list) and len(entry.geoms) == n
+    assert isinstance(entry.geoms_lonlat, list) and len(entry.geoms_lonlat) == n
+    assert isinstance(entry.bounds, list) and len(entry.bounds) == n
+    # each entry carries a non-None prepared geometry
+    assert all(g is not None for g in entry.geoms)
+    assert all(g is not None for g in entry.geoms_lonlat)
+
+
+def test_geometry_collection_not_in_index_but_skipped_in_encode():
+    """GeometryCollections are excluded from the index and never encoded."""
+    gc = _feature("GeometryCollection", None, {"id": "gc"})
+    fc = _fc(GEOMETRY_FIXTURES["Point"], gc)
+    entry = build_spatial_index_entry(("s", "r9"), fc)
+    assert len(entry.features) == 1  # GC dropped at index time
+    tile = _tile_of(13, *_first_lonlat(GEOMETRY_FIXTURES["Point"]["geometry"]["coordinates"]))
+    assert encode_tile_from_index(entry, *tile) != b""
+
+
+# ─── no-shapely fallback still works through the index path ──────────────────
+
+
+def test_index_path_falls_back_when_shapely_unavailable(monkeypatch):
+    """encode_tile_from_index delegates to encode_tile(query_tile) without shapely,
+    and still produces a non-empty tile for an in-bounds feature."""
+    monkeypatch.setattr(mvt_mod, "_SHAPELY", False)
+    fc = _fc(GEOMETRY_FIXTURES["Point"], GEOMETRY_FIXTURES["LineString"])
+    entry = build_spatial_index_entry(("s", "r10"), fc)
+    assert entry.geoms is None and entry.geoms_lonlat is None
+    tile = _tile_of(13, *_first_lonlat(GEOMETRY_FIXTURES["Point"]["geometry"]["coordinates"]))
+    out = encode_tile_from_index(entry, *tile)
+    # fallback runs without error AND actually encodes the in-bounds point
+    assert out == encode_tile(entry.query_tile(*tile), *tile)
+    assert out != b""
+
+
+def test_index_path_line_poly_degrades_to_pure_python_on_shapely_failure(monkeypatch, caplog):
+    """A GEOS failure on the index line/poly path falls back to the coordinate
+    path (→ pure-python) instead of failing the whole tile. Preserves the
+    resilience invariant the scope requires."""
+    import logging
+
+    fc = _fc(GEOMETRY_FIXTURES["LineString"])
+    entry = build_spatial_index_entry(("s", "r11"), fc)
+    tile = _tile_of(13, *_first_lonlat(fc["features"][0]["geometry"]["coordinates"]))
+
+    def _raising(gtype, geom_lonlat, geom_z0, z, x, y):
+        raise RuntimeError("simulated GEOS failure")
+
+    # the fallback in encode_tile_from_index routes through _encode_geometry,
+    # which retries shapely (raising again) then uses the pure-python encoder.
+    # Make the *coordinate* shapely path also raise so the pure fallback is hit.
+    def _raising_shapely(gtype, coords, z, x, y):
+        raise RuntimeError("simulated GEOS failure")
+
+    monkeypatch.setattr(mvt_mod, "_encode_line_polygon_from_geoms", _raising)
+    monkeypatch.setattr(mvt_mod, "_encode_line_polygon_shapely", _raising_shapely)
+    with caplog.at_level(logging.WARNING, logger="app.services.mvt"):
+        out = encode_tile_from_index(entry, *tile)
+    # did not raise; pure-python encoder produced the line geometry
+    assert out != b""
+    assert any("pure-python fallback" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem
The WebGIS MVT Data Plane hot path (`spatial index → tile candidate → geometry encode`) repeated the most expensive geometry work on **every tile request**, scaling as `O(candidate features × requested tiles)`.

## Root cause
`build_spatial_index_entry` already builds, once per feature, a lon/lat shapely geometry and projects it to z0 world pixels (`app/services/mvt.py`). But the encode path threw that work away:
- `SpatialIndexEntry.query_tile()` returned **raw feature dicts**;
- `_encode_line_polygon_shapely()` then re-parsed GeoJSON coordinates into shapely (`_shapely_geom_from_coords`) and re-projected to z0 (`shapely.transform(..., _transform_z0)`) on **each tile**.

Confirmed deterministically (not wall-clock) by instrumenting the module at `BASE_SHA`:

```
BEFORE (2600 mixed features, encode_tile(query_tile))
  z12 (simplify),  4 tiles, 256 candidate-visits: 36 dup GeoJSON→Shapely, 36 dup z0 transforms
  z15 (no simplify), 2 tiles, 16 candidate-visits: 6 dup GeoJSON→Shapely, 6 dup z0 transforms
```

## Architecture before / after
**Before:** `query_tile → [raw feature dicts] → encode_tile → from-coords shapely build + z0 transform + simplify + clip + encode` (per tile, per candidate).

**After:** `query_candidates → [(feature, geom_lonlat, geom_z0)] → encode_tile_from_index → reuse cached geoms + simplify + clip + encode`.

New building blocks (all in `app/services/mvt.py`):
- `_simplify_and_project(gtype, geom_lonlat, geom_z0, z)` — the core. Reuses cached `geom_z0` at `z ≥ 14`; at `z < 14` simplifies the cached `geom_lonlat` (zoom-dependent tolerance, **lon/lat space — unchanged**) then projects. The is_valid gate runs on the canonical lon/lat form before either branch.
- `_clip_and_encode`, `_assemble_mvt`, `_type_id_for` — shared tail/assembly factored out of `encode_tile` so both paths produce **byte-identical** output.
- `_encode_line_polygon_from_geoms` — index-aware line/poly encode.
- `SpatialIndexEntry` gains `geoms_lonlat` (parallel to `geoms`/`features`) and `query_candidates()`; `_candidate_indices()` factored from `query_tile`.
- `encode_tile_from_index(entry, z, x, y)` — the new route entrypoint. Falls back to `encode_tile(query_tile)` when shapely is unavailable; line/poly branch keeps the GEOS-exception → pure-python fallback via `_encode_geometry`.

`app/api/routes/layer.py`: `_encode_tile_cached` now calls `encode_tile_from_index(entry, ...)` instead of `encode_tile(query_tile, ...)`.

## Why output is byte-identical
Projection is homogeneous in z, so `transform(geom_lonlat)` is *exactly* what the `z ≥ 14` path emits — the cached `geom_z0` is that transform computed once at build time. At `z < 14` both paths simplify the same lon/lat geometry with the same tolerance then transform. Verified across 38 tiles (z 0–16) plus parametrized per-type tests.

## Deterministic work-count evidence (the core acceptance)
```
AFTER (encode_tile_from_index, same fixture)
  construction IN tiles: 0   for ALL zooms   (was 36 / 6)  ← GeoJSON→Shapely fully moved to build
  transform_z0 IN tiles: 0   at z ≥ 14        (was 6)        ← z0 projection reused
  transform_z0 IN tiles: >0  at z < 14        (on the *simplified* geom — part of clip/encode)
```
So the expensive projection converges to **O(features) at build + O(candidate clip/encode) at tile time**. Construction (the dominant Python-level coord iteration) is eliminated for every zoom; the z0 transform is additionally eliminated at z ≥ 14 (the case where large vector data is most painful — many high-zoom tiles).

## Correctness (criterion C — no semantic regression)
Byte-equivalence to the coordinate path asserted for **Point, MultiPoint, LineString, MultiLineString, Polygon + holes, MultiPolygon** at z ∈ {3,12,14,16}, plus extra tests for: invalid (bowtie) polygon dropped identically by the is_valid gate, MultiPolygon *with a hole*, and a polygon straddling a tile boundary (partial clip).

## Other acceptance
- **D** warm tile LRU hit → no geometry work (route short-circuits before encode).
- **E** index eviction + rebuild still encodes correctly (deterministic).
- **F** index path is deterministic → basis for single-flight sharing.
- **G** geometry arrays bounded & parallel to features; per-ref LRU unchanged.
- Pure-python fallback and GEOS-exception resilience preserved.
- Tile LRU / ETag / single-flight API unchanged (ETag = sha256(gzip); byte-identical raw → identical gzip → identical ETag).

## Memory impact
Each index entry now retains two geometry arrays (`geoms` z0 + `geoms_lonlat`) instead of one — ~2× per-ref geometry memory. This is the deliberate trade-off for eliminating per-tile reconstruction (the lon/lat geom is required to redo zoom-dependent simplify at z < 14 without re-parsing). Memory stays bounded by the existing per-(session, ref) LRU (`max_refs=256`). Feature dicts are kept intact (no coordinate stripping) to preserve the `query_tile` contract.

## Tests
New: `tests/unit/test_mvt_prepared_geometry.py` (36 tests, criteria A–G + fallback/invalid/boundary/multipolygon-hole). Existing `test_mvt_encoder.py`, `test_performance_100k.py`, `test_perf_optimizations.py`, `test_ref_descriptor_dispatch.py`, `test_layer_manager_phase2.py` all green (102 passed in the targeted run). Full unit suite: no new failures (11 pre-existing failures in data-fabric / pi-bridge / plan-mode suites reproduced identically at `BASE_SHA`; none import `mvt`/`layer`).

## Scope boundaries
Only `app/services/mvt.py`, `app/api/routes/layer.py`, and the new test touched. No LLM/Agent/Data Fabric/UI/MapSpec/Harness/CI changes; no unrelated cleanup. `ruff check` clean; `git diff --check` clean.

## Review
- **matt** (Python correctness/perf/test design): APPROVE; P1s (z≥14 exception parity; invalid-polygon / multipolygon-hole / boundary-straddle test coverage) addressed.
- **gstack** (regression/quality/scope): FIX FIRST → P1 (restore GEOS-exception → pure-python fallback on the route's index path) addressed with a regression test; scope/artifact/API-compat confirmed clean.

## BASE_SHA
`81d32e49486a74c9109f85a9be4e3a3534552614`

## Remaining limitations
- At `z < 14` one z0 transform per line/poly candidate still occurs (on the simplified geometry). Fully eliminating it would require changing the simplify space (output-changing) or caching per-zoom simplified geometries (unbounded) — both rejected to preserve exact output and bounded memory.
- Invalid polygons are retained in the index and dropped at encode (preserves the existing `query_tile` "truthful" behavior); pre-filtering at build is a safe byte-equivalent follow-up not taken here, to avoid changing `query_tile` semantics.
- Point features still read coordinates from the feature dict per tile (scalar projection is cheap; not worth caching).