### PR TITLE
feat(ui): refine the GIS result workbench visual hierarchy

### DIFF
--- a/frontend/components/shared/status-badge.tsx
+++ b/frontend/components/shared/status-badge.tsx
@@ -41,6 +41,10 @@ const STATUS_MAP: Record<string, { label: string; tone: StatusTone; pulse?: bool
   failed: { label: '失败', tone: 'critical' },
   cancelled: { label: '已取消', tone: 'neutral' },
   stale: { label: '已过期', tone: 'warning' },
+  // 结果工作台：分析结果带着告警完成时，语义是 warning 而不是中性灰——
+  // 否则「部分完成 / 含告警」与「未知」不可区分（V4 审计 P0）。
+  partial: { label: '部分完成', tone: 'warning' },
+  warning: { label: '含告警', tone: 'warning' },
   // 通用语义（图层 / 数据源同步状态等）
   active: { label: '活跃', tone: 'info', pulse: true },
   ok: { label: '正常', tone: 'success' },

--- a/frontend/components/sidebar/results/result-detail.tsx
+++ b/frontend/components/sidebar/results/result-detail.tsx
@@ -154,7 +154,8 @@ export function ResultDetail({ result, sessionId, ownerToken, onBack, onSend }: 
       // Resolve through the bound layer's real id (not the raw ref) so the
       // `_refId` binding the UI honors is the same one the writes target.
       const layerId = boundLayer?.id ?? ref;
-      if (!layerId) return;
+      const needsLayer = action.kind === 'show_on_map' || action.kind === 'hide' || action.kind === 'zoom';
+      if (needsLayer && !layerId) return;
       switch (action.kind) {
         case 'show_on_map':
         case 'hide':

--- a/frontend/components/sidebar/results/result-detail.tsx
+++ b/frontend/components/sidebar/results/result-detail.tsx
@@ -10,6 +10,13 @@
  *
  * Truthfulness: CRS renders "未知" when unknown; feature count renders "未报告"
  * when not backed by evidence; warnings are always visible (never buried in JSON).
+ *
+ * UI V4 — header is a persistent compact bar outside the scroll area (context
+ * survives long scrolls); 输出与地图 leads with a layer strip that fuses the
+ * live visibility state with the show/hide + zoom controls, so the result→map
+ * relationship is one visual unit; analytical suggestions render as secondary
+ * text intents, never mixed with map controls. A failed result drops the
+ * output/actions sections — its content is the correction hint.
  */
 import { useCallback, useMemo } from 'react';
 import {
@@ -41,20 +48,13 @@ interface ResultDetailProps {
   onSend: (text: string) => void;
 }
 
-const STATUS_LABEL: Record<string, string> = {
-  completed: '已完成',
-  failed: '失败',
-  partial: '部分完成',
-  warning: '完成（含告警）',
-  running: '运行中',
-  unknown: '未知',
-};
-
 const WARNING_VARIANT: Record<string, 'info' | 'warning' | 'error'> = {
   info: 'info',
   warning: 'warning',
   error: 'error',
 };
+
+const MAP_ACTION_KINDS: readonly SuggestedAction['kind'][] = ['show_on_map', 'hide', 'zoom'];
 
 function formatTime(ms?: number): string {
   if (!ms) return '';
@@ -80,8 +80,8 @@ function formatBytes(bytes?: number): string {
 function Section({ title, children, action }: { title: string; children: React.ReactNode; action?: React.ReactNode }) {
   return (
     <section className="flex flex-col gap-1.5" aria-label={title}>
-      <div className="flex items-center justify-between">
-        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-[var(--theme-text-muted)]">{title}</h4>
+      <div className="flex items-center justify-between gap-2">
+        <h4 className="eyebrow">{title}</h4>
         {action}
       </div>
       {children}
@@ -90,17 +90,24 @@ function Section({ title, children, action }: { title: string; children: React.R
 }
 
 function MetricItem({ metric }: { metric: ResultMetric }) {
+  const primary = metric.emphasis === 'primary';
+  if (primary) {
+    return (
+      <div className="col-span-2 flex items-baseline justify-between gap-2 rounded-sm border border-status-accent-border px-2 py-1.5">
+        <span className="text-caption text-ink-muted">{metric.label}</span>
+        <span className="min-w-0 truncate font-mono text-heading text-ink">
+          {metric.value}
+          {metric.unit ? <span className="ml-1 text-micro font-normal text-ink-muted">{metric.unit}</span> : null}
+        </span>
+      </div>
+    );
+  }
   return (
-    <div
-      className={clsx(
-        'flex flex-col rounded-md border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-subtle)] px-2 py-1.5',
-        metric.emphasis === 'primary' && 'border-[var(--agent-accent,#16a34a)]/40',
-      )}
-    >
-      <span className="text-[10px] text-[var(--theme-text-muted)]">{metric.label}</span>
-      <span className={clsx('font-mono text-[var(--theme-text-primary)]', metric.emphasis === 'primary' ? 'text-[15px]' : 'text-[13px]')}>
+    <div className="flex items-baseline justify-between gap-2 px-0.5">
+      <span className="min-w-0 truncate text-caption text-ink-muted">{metric.label}</span>
+      <span className="min-w-0 truncate font-mono text-body text-ink">
         {metric.value}
-        {metric.unit ? <span className="ml-0.5 text-[10px] text-[var(--theme-text-muted)]">{metric.unit}</span> : null}
+        {metric.unit ? <span className="ml-1 text-micro text-ink-muted">{metric.unit}</span> : null}
       </span>
     </div>
   );
@@ -111,8 +118,13 @@ function WarningItem({ warning }: { warning: ResultWarning }) {
 }
 
 export function ResultDetail({ result, sessionId, ownerToken, onBack, onSend }: ResultDetailProps) {
+  // A failed result has no inspectable output — its content is the correction
+  // hint. Skip the descriptor enrichment for it (nothing to enrich) and drop
+  // the output/actions sections below instead of rendering rows of 未报告.
+  const failed = result.status === 'failed';
+
   // Lazy metadata-first enrichment (no full GeoJSON). No-op when already enriched.
-  useResultDescriptor(result, sessionId, ownerToken);
+  useResultDescriptor(failed ? null : result, sessionId, ownerToken);
 
   const layers = useHudStore((s) => s.layers);
   const updateLayer = useHudStore((s) => s.updateLayer);
@@ -139,13 +151,19 @@ export function ResultDetail({ result, sessionId, ownerToken, onBack, onSend }: 
   const handleAction = useCallback(
     (action: SuggestedAction) => {
       if (!action.available) return;
+      // Resolve through the bound layer's real id (not the raw ref) so the
+      // `_refId` binding the UI honors is the same one the writes target.
+      const layerId = boundLayer?.id ?? ref;
+      if (!layerId) return;
       switch (action.kind) {
         case 'show_on_map':
         case 'hide':
-          if (ref) updateLayer(ref, { visible: !hasVisibleLayer });
+          // Absolute value from the action kind: two rapid clicks before a
+          // re-render must not compute the same target twice.
+          updateLayer(layerId, { visible: action.kind === 'show_on_map' });
           break;
         case 'zoom':
-          if (ref) focusLayer(ref);
+          focusLayer(layerId);
           break;
         case 'style':
           setActiveLeftTab('layers');
@@ -167,7 +185,7 @@ export function ResultDetail({ result, sessionId, ownerToken, onBack, onSend }: 
           break;
       }
     },
-    [ref, hasVisibleLayer, updateLayer, focusLayer, setActiveLeftTab, onSend, result.toolLabel],
+    [ref, boundLayer, updateLayer, focusLayer, setActiveLeftTab, onSend, result.toolLabel],
   );
 
   const crsLabel = output?.crs ?? '未知';
@@ -176,175 +194,237 @@ export function ResultDetail({ result, sessionId, ownerToken, onBack, onSend }: 
   const geomLabel = output?.geometryTypes?.length ? output.geometryTypes.join('、') : '未报告';
   const bboxLabel = output?.bbox ? output.bbox.map((n) => n.toFixed(3)).join(', ') : '未报告';
 
+  const showOutputSection = !failed;
+  // Partition once: map controls render with the layer strip they act on;
+  // analytical intents are a separate, secondary group.
+  const mapActions = actions.filter((a) => MAP_ACTION_KINDS.includes(a.kind));
+  const toggleAction = mapActions.find((a) => a.kind === 'show_on_map' || a.kind === 'hide');
+  const zoomAction = mapActions.find((a) => a.kind === 'zoom');
+  const analyticalActions = actions.filter((a) => !MAP_ACTION_KINDS.includes(a.kind));
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-3 py-2.5 text-[13px]">
-      {/* Header */}
-      <div className="flex items-center gap-1.5">
-        <IconButton label="返回结果列表" icon={ArrowLeft} onClick={onBack} />
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Header — persistent compact bar (outside the scroll area, so the
+          result identity + status survive any scroll depth). */}
+      <header className="flex shrink-0 items-center gap-1.5 border-b border-edge-subtle px-panel py-1">
+        <IconButton label="返回结果列表" icon={ArrowLeft} size="sm" onClick={onBack} />
         <div className="flex min-w-0 flex-1 flex-col">
-          <span className="truncate font-medium text-[var(--theme-text-primary)]">{result.toolLabel}</span>
-          <span className="truncate text-[11px] text-[var(--theme-text-muted)]">
-            {familyLabel(result.family)} · {formatTime(result.capturedAt)}
+          <span className="truncate text-title font-medium leading-tight text-ink">{result.toolLabel}</span>
+          <span className="truncate text-caption leading-tight text-ink-muted">
+            {[familyLabel(result.family), formatTime(result.capturedAt)].filter(Boolean).join(' · ')}
           </span>
         </div>
-        <StatusBadge status={result.status} label={STATUS_LABEL[result.status] ?? result.status} />
-        <IconButton label="从列表移除" icon={Trash2} variant="ghost" onClick={() => { removeResult(result.id); onBack(); }} />
-      </div>
+        <StatusBadge status={result.status} />
+        <IconButton
+          label="从列表移除"
+          icon={Trash2}
+          size="sm"
+          variant="ghost"
+          onClick={() => {
+            removeResult(result.id);
+            onBack();
+          }}
+        />
+      </header>
 
-      {/* Summary */}
-      {result.summary ? (
-        <p className="rounded-md bg-[var(--theme-bg-subtle)] px-2.5 py-2 text-[12.5px] leading-relaxed text-[var(--theme-text-secondary)]">
-          {result.summary}
-        </p>
-      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto px-panel py-2 text-body">
+        {/* Summary */}
+        {result.summary ? (
+          <p className="leading-normal text-ink-secondary">{result.summary}</p>
+        ) : null}
 
-      {/* Warnings — always visible, never buried */}
-      {result.warnings.length > 0 ? (
-        <Section title="告警 / 提示">
-          <div className="flex flex-col gap-1.5">
-            {result.warnings.map((w) => (
-              <WarningItem key={w.code} warning={w} />
-            ))}
-          </div>
+        {/* Warnings — always visible, never buried */}
+        {result.warnings.length > 0 ? (
+          <Section title="告警 / 提示">
+            <div className="flex flex-col gap-1.5">
+              {result.warnings.map((w) => (
+                <WarningItem key={w.code} warning={w} />
+              ))}
+            </div>
+          </Section>
+        ) : null}
+
+        {/* Key metrics */}
+        {result.metrics.length > 0 ? (
+          <Section title="关键指标">
+            <div className="grid grid-cols-2 gap-x-2 gap-y-1">
+              {result.metrics.map((m, i) => (
+                <MetricItem key={`${m.label}-${i}`} metric={m} />
+              ))}
+            </div>
+          </Section>
+        ) : null}
+
+        {/* Inputs */}
+        <Section title="输入">
+          {result.inputs.length > 0 ? (
+            <ul className="flex flex-col gap-0.5">
+              {result.inputs.map((inp, i) => (
+                <li key={i} className="flex items-baseline justify-between gap-2 text-meta">
+                  <span className="shrink-0 text-ink-secondary">{inp.label}</span>
+                  {inp.ref ? (
+                    <span className="min-w-0 truncate font-mono text-caption text-ink-muted" title={inp.ref}>
+                      {inp.ref}
+                    </span>
+                  ) : (
+                    <span className="text-caption italic text-ink-muted">推断</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-meta italic text-ink-muted">未捕获输入参数（仅展示操作与输出）。</p>
+          )}
         </Section>
-      ) : null}
 
-      {/* Key metrics */}
-      {result.metrics.length > 0 ? (
-        <Section title="关键指标">
-          <div className="grid grid-cols-2 gap-1.5">
-            {result.metrics.map((m, i) => (
-              <MetricItem key={`${m.label}-${i}`} metric={m} />
-            ))}
-          </div>
-        </Section>
-      ) : null}
+        {/* Parameters */}
+        {result.parameters.length > 0 ? (
+          <Section title="参数">
+            <dl className="grid grid-cols-[auto_1fr] gap-x-2.5 gap-y-0.5 text-meta">
+              {result.parameters.map((p, i) => (
+                <div key={i} className="contents">
+                  <dt className="text-ink-muted">{p.label}</dt>
+                  <dd className="min-w-0 truncate font-mono text-ink" title={String(p.value)}>
+                    {String(p.value)}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </Section>
+        ) : null}
 
-      {/* Inputs */}
-      <Section title="输入">
-        {result.inputs.length > 0 ? (
-          <ul className="flex flex-col gap-1">
-            {result.inputs.map((inp, i) => (
-              <li key={i} className="flex items-baseline justify-between gap-2 text-[12.5px]">
-                <span className="text-[var(--theme-text-secondary)]">{inp.label}</span>
-                {inp.ref ? (
-                  <span className="truncate font-mono text-[10.5px] text-[var(--theme-text-muted)]" title={inp.ref}>{inp.ref}</span>
-                ) : (
-                  <span className="text-[10.5px] italic text-[var(--theme-text-muted)]">推断</span>
-                )}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-[12px] italic text-[var(--theme-text-muted)]">未捕获输入参数（仅展示操作与输出）。</p>
-        )}
-      </Section>
-
-      {/* Parameters */}
-      {result.parameters.length > 0 ? (
-        <Section title="参数">
-          <dl className="grid grid-cols-[auto_1fr] gap-x-2.5 gap-y-1 text-[12.5px]">
-            {result.parameters.map((p, i) => (
-              <div key={i} className="contents">
-                <dt className="text-[var(--theme-text-muted)]">{p.label}</dt>
-                <dd className="truncate font-mono text-[var(--theme-text-primary)]" title={String(p.value)}>{String(p.value)}</dd>
+        {/* Output + map linkage — the layer strip fuses live visibility with
+            the map controls, then the metadata sheet follows. */}
+        {showOutputSection ? (
+          <Section title="输出与地图">
+            {hasBoundLayer ? (
+              <div className="flex items-center gap-1 rounded-md border border-edge-subtle bg-surface-raised px-1 py-0.5">
+                {toggleAction ? (
+                  <IconButton
+                    label={toggleAction.label}
+                    icon={hasVisibleLayer ? EyeOff : Eye}
+                    size="sm"
+                    disabled={!toggleAction.available}
+                    onClick={() => handleAction(toggleAction)}
+                  />
+                ) : null}
+                <span className="min-w-0 flex-1 truncate px-0.5 font-mono text-caption text-ink" title={boundLayer?.name}>
+                  {boundLayer?.name ?? ref}
+                </span>
+                <span className="inline-flex shrink-0 items-center gap-1 text-caption text-ink-muted">
+                  <span
+                    aria-hidden
+                    className={clsx(
+                      'h-1 w-1 rounded-pill',
+                      hasVisibleLayer ? 'bg-status-accent-vivid' : 'bg-ink-disabled',
+                    )}
+                  />
+                  {hasVisibleLayer ? '地图中可见' : '已隐藏'}
+                </span>
+                {zoomAction ? (
+                  <IconButton
+                    label={zoomAction.label}
+                    icon={Crosshair}
+                    size="sm"
+                    disabled={!zoomAction.available}
+                    onClick={() => handleAction(zoomAction)}
+                  />
+                ) : null}
               </div>
-            ))}
-          </dl>
-        </Section>
-      ) : null}
+            ) : (
+              <p className="text-meta text-ink-muted">
+                {ref ? '引用层未绑定到当前地图会话。' : '该结果未挂载为地图图层。'}
+              </p>
+            )}
 
-      {/* Output + map linkage */}
-      <Section
-        title="输出与地图"
-        action={
-          hasBoundLayer ? (
-            <span className="inline-flex items-center gap-1 text-[10.5px] text-[var(--theme-text-muted)]">
-              <span
-                aria-hidden
-                className={clsx('h-1.5 w-1.5 rounded-full', hasVisibleLayer ? 'bg-emerald-500' : 'bg-slate-400')}
-              />
-              {hasVisibleLayer ? '地图中可见' : '已隐藏'}
-            </span>
-          ) : null
-        }
-      >
-        <div className="flex flex-col gap-1.5 rounded-md border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-subtle)] px-2.5 py-2 text-[12.5px]">
-          <Row label="类型" value={outputKindLabel(output?.kind)} />
-          <Row label="要素数" value={featureCountLabel} />
-          <Row label="几何类型" value={geomLabel} />
-          <Row label="CRS" value={crsLabel} muted={crsLabel === '未知'} />
-          <Row label="范围 (W,S,E,N)" value={bboxLabel} mono />
-          {output?.estimatedBytes ? <Row label="估算大小" value={formatBytes(output.estimatedBytes)} /> : null}
-          {ref ? <Row label="引用" value={ref} mono title={ref} /> : null}
-          {output?.note ? <Row label="备注" value={output.note} /> : null}
-        </div>
+            <div className="flex flex-col gap-0.5 rounded-md bg-surface-sunken px-2.5 py-1.5 text-meta">
+              <Row label="类型" value={outputKindLabel(output?.kind)} />
+              <Row label="要素数" value={featureCountLabel} />
+              <Row label="几何类型" value={geomLabel} />
+              <Row label="CRS" value={crsLabel} muted={crsLabel === '未知'} />
+              {/* bbox/ref are data, not prose — wrap instead of truncating so a
+                  coordinate is never silently cut mid-number. */}
+              <Row label="范围 (W,S,E,N)" value={bboxLabel} mono wrap />
+              {output?.estimatedBytes ? <Row label="估算大小" value={formatBytes(output.estimatedBytes)} /> : null}
+              {ref ? <Row label="引用" value={ref} mono wrap title={ref} /> : null}
+              {output?.note ? <Row label="备注" value={output.note} /> : null}
+            </div>
+          </Section>
+        ) : null}
 
-        {/* Map actions */}
-        <div className="flex flex-wrap gap-1.5">
-          {actions
-            .filter((a) => ['show_on_map', 'hide', 'zoom'].includes(a.kind))
-            .map((a) => (
-              <ActionButton key={a.kind} action={a} onAction={handleAction} />
-            ))}
-        </div>
-      </Section>
-
-      {/* Suggested next actions (analytical intents) */}
-      {actions.some((a) => !['show_on_map', 'hide', 'zoom'].includes(a.kind)) ? (
-        <Section title="后续操作">
-          <div className="flex flex-wrap gap-1.5">
-            {actions
-              .filter((a) => !['show_on_map', 'hide', 'zoom'].includes(a.kind))
-              .map((a) => (
+        {/* Suggested next actions — analytical intents, secondary to map controls */}
+        {!failed && analyticalActions.length > 0 ? (
+          <Section title="后续操作">
+            <div className="flex flex-wrap gap-1">
+              {analyticalActions.map((a) => (
                 <ActionButton key={a.kind} action={a} onAction={handleAction} />
               ))}
-          </div>
-        </Section>
-      ) : null}
+            </div>
+          </Section>
+        ) : null}
 
-      {/* Legend (compact; the live legend renders on the map) */}
-      {result.legendSpec ? (
-        <Section title="图例">
-          <span className="text-[12.5px] text-[var(--theme-text-secondary)]">
-            {legendSummary(result.legendSpec)}（完整图例见地图）
-          </span>
-        </Section>
-      ) : null}
+        {/* Legend (compact; the live legend renders on the map) */}
+        {result.legendSpec ? (
+          <Section title="图例">
+            <span className="text-meta text-ink-secondary">
+              {legendSummary(result.legendSpec)}（完整图例见地图）
+            </span>
+          </Section>
+        ) : null}
 
-      {/* Provenance */}
-      {result.provenance.length > 0 ? (
-        <Section title="数据 lineage">
-          <ol className="flex flex-col gap-1 text-[12px] text-[var(--theme-text-secondary)]">
-            {result.provenance.map((p, i) => (
-              <li key={i} className="flex items-baseline gap-1.5">
-                <span className="text-[var(--theme-text-muted)]">{provenanceLabel(p.kind)}</span>
-                <span className="truncate text-[var(--theme-text-primary)]">{p.label}</span>
-              </li>
-            ))}
-          </ol>
-        </Section>
-      ) : null}
+        {/* Provenance */}
+        {result.provenance.length > 0 ? (
+          <Section title="数据溯源">
+            <ol className="flex flex-col gap-0.5 text-meta text-ink-secondary">
+              {result.provenance.map((p, i) => (
+                <li key={i} className="flex items-baseline gap-1.5">
+                  <span className="shrink-0 text-ink-muted">{provenanceLabel(p.kind)}</span>
+                  <span className="min-w-0 truncate text-ink">{p.label}</span>
+                </li>
+              ))}
+            </ol>
+          </Section>
+        ) : null}
 
-      {/* Raw — progressive disclosure */}
-      <details className="group rounded-md border border-[var(--theme-border-subtle)] text-[12px]">
-        <summary className="cursor-pointer select-none px-2.5 py-1.5 text-[var(--theme-text-muted)] hover:bg-[var(--theme-bg-hover)]">
-          原始结果（高级）
-        </summary>
-        <pre className="max-h-64 overflow-auto px-2.5 py-2 font-mono text-[10.5px] leading-relaxed text-[var(--theme-text-secondary)]">
-          {truncateJson(result.raw)}
-        </pre>
-      </details>
+        {/* Raw — progressive disclosure */}
+        <details className="rounded-sm border border-edge-subtle text-meta">
+          <summary className="cursor-pointer select-none px-2 py-1 text-ink-muted transition-colors hover:bg-surface-hover">
+            原始结果（高级）
+          </summary>
+          <pre className="max-h-64 overflow-auto px-2 py-1.5 font-mono text-caption leading-relaxed text-ink-secondary">
+            {truncateJson(result.raw)}
+          </pre>
+        </details>
+      </div>
     </div>
   );
 }
 
-function Row({ label, value, mono, muted, title }: { label: string; value: string; mono?: boolean; muted?: boolean; title?: string }) {
+function Row({
+  label,
+  value,
+  mono,
+  muted,
+  wrap,
+  title,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  muted?: boolean;
+  wrap?: boolean;
+  title?: string;
+}) {
   return (
     <div className="flex items-baseline justify-between gap-2">
-      <span className="text-[var(--theme-text-muted)]">{label}</span>
+      <span className="shrink-0 text-ink-muted">{label}</span>
       <span
-        className={clsx('truncate text-right', mono && 'font-mono text-[11.5px]', muted && 'italic text-[var(--theme-text-muted)]')}
+        className={clsx(
+          'min-w-0 text-right text-ink',
+          mono && 'font-mono text-caption',
+          wrap ? 'break-words' : 'truncate',
+          muted && 'italic text-ink-muted',
+        )}
         title={title ?? value}
       >
         {value}
@@ -361,9 +441,9 @@ function ActionButton({ action, onAction }: { action: SuggestedAction; onAction:
       disabled={!action.available}
       onClick={() => onAction(action)}
       aria-label={action.label}
-      className="inline-flex items-center gap-1 rounded-md border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 py-1 text-[12px] text-[var(--theme-text-secondary)] transition-colors hover:bg-[var(--theme-bg-hover)] disabled:cursor-not-allowed disabled:opacity-40"
+      className="inline-flex h-control-sm items-center gap-1 rounded-sm px-1.5 text-meta text-ink-secondary transition-colors hover:bg-surface-hover hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
     >
-      {icon ? <icon.type size={13} aria-hidden /> : null}
+      {icon ? <icon.type size={12} aria-hidden /> : null}
       {action.label}
     </button>
   );

--- a/frontend/components/sidebar/results/result-list.tsx
+++ b/frontend/components/sidebar/results/result-list.tsx
@@ -4,8 +4,13 @@
  * ResultList — bounded, session-scoped list of captured analysis results.
  * Master half of the Results tab master-detail. Keyboard-navigable (native
  * buttons), dense, status-forward.
+ *
+ * UI V4 — dense two-line rows with the layers-tab border-l-2 edge treatment
+ * instead of stacked cards: tool/status/time on the first line, family · map
+ * linkage · warning tally · summary on the second. Selected ≠ hover (accent
+ * edge + surface-selected vs plain hover), per the nav-rail contract.
  */
-import { ClipboardList } from 'lucide-react';
+import { ClipboardList, Layers, TriangleAlert } from 'lucide-react';
 import clsx from 'clsx';
 import { familyLabel } from '@/lib/results/families';
 import type { AnalysisResult } from '@/lib/results/types';
@@ -17,15 +22,6 @@ interface ResultListProps {
   selectedId: string | null;
   onSelect: (id: string) => void;
 }
-
-const STATUS_LABEL: Record<string, string> = {
-  completed: '已完成',
-  failed: '失败',
-  partial: '部分完成',
-  warning: '含告警',
-  running: '运行中',
-  unknown: '未知',
-};
 
 function formatTime(ms?: number): string {
   if (!ms) return '';
@@ -50,7 +46,7 @@ export function ResultList({ results, selectedId, onSelect }: ResultListProps) {
   }
 
   return (
-    <ul aria-label="分析结果列表" className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
+    <ul aria-label="分析结果列表" className="flex min-h-0 flex-1 flex-col overflow-y-auto py-1">
       {results.map((r) => {
         const selected = r.id === selectedId;
         const hasLayer = r.outputs[0]?.hasLayer;
@@ -61,33 +57,39 @@ export function ResultList({ results, selectedId, onSelect }: ResultListProps) {
               aria-current={selected ? 'true' : undefined}
               onClick={() => onSelect(r.id)}
               className={clsx(
-                'flex w-full flex-col gap-1 rounded-md border px-2.5 py-2 text-left transition-colors',
+                'flex w-full flex-col gap-0.5 border-l-2 px-panel py-1 text-left transition-colors',
                 selected
-                  ? 'border-[var(--agent-accent,#16a34a)]/50 bg-[var(--theme-bg-hover)]'
-                  : 'border-transparent hover:bg-[var(--theme-bg-hover)]',
+                  ? 'border-l-status-accent bg-surface-selected'
+                  : 'border-l-transparent hover:bg-surface-hover',
               )}
             >
-              <div className="flex items-center gap-1.5">
-                <span className="truncate text-[13px] font-medium text-[var(--theme-text-primary)]">{r.toolLabel}</span>
-                <StatusBadge status={r.status} label={STATUS_LABEL[r.status] ?? r.status} />
-                <span className="ml-auto shrink-0 text-[10.5px] text-[var(--theme-text-muted)]">{formatTime(r.capturedAt)}</span>
-              </div>
-              <div className="flex items-center gap-1.5 text-[11px] text-[var(--theme-text-muted)]">
-                <span>{familyLabel(r.family)}</span>
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span className="truncate text-body font-medium text-ink">{r.toolLabel}</span>
+                <StatusBadge status={r.status} />
+                <span className="ml-auto shrink-0 font-mono text-caption tabular-nums text-ink-muted">
+                  {formatTime(r.capturedAt)}
+                </span>
+              </span>
+              <span className="flex min-w-0 items-center gap-2 text-meta text-ink-muted">
+                <span className="shrink-0">{familyLabel(r.family)}</span>
                 {hasLayer ? (
-                  <span className="inline-flex items-center gap-0.5 rounded bg-[var(--theme-bg-subtle)] px-1 py-0.5 text-[10px]">
-                    已挂载图层
+                  <span className="inline-flex shrink-0 items-center gap-0.5 text-status-accent">
+                    <Layers size={10} aria-hidden />
+                    图层
                   </span>
                 ) : null}
                 {r.warnings.length > 0 ? (
-                  <span className="inline-flex items-center gap-0.5 rounded bg-amber-500/10 px-1 py-0.5 text-[10px] text-amber-600 dark:text-amber-300">
+                  <span className="inline-flex shrink-0 items-center gap-0.5 text-status-warning">
+                    <TriangleAlert size={10} aria-hidden />
                     {r.warnings.length} 条告警
                   </span>
                 ) : null}
-              </div>
-              {r.summary ? (
-                <span className="line-clamp-2 text-[12px] text-[var(--theme-text-secondary)]">{r.summary}</span>
-              ) : null}
+                {r.summary ? (
+                  <span className="min-w-0 truncate text-ink-muted" title={r.summary}>
+                    {r.summary}
+                  </span>
+                ) : null}
+              </span>
             </button>
           </li>
         );

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -346,6 +346,9 @@ describe('useSSEStream step_cancelled', () => {
     emitStepCancelled({ task_id: 't1', step_id: 'step-1', tool: 'other_tool', session_id: 'sid-fe4' });
     const calls = hook.result.current.messages[hook.result.current.messages.length - 1].toolCalls!;
     expect(calls[0]).toMatchObject({ id: 'step-1', status: 'running' });
+  });
+});
+
 describe('canonical MapSpec runtime patch', () => {
   beforeEach(() => {
     useHudStore.setState({

--- a/frontend/test/design-system/visual-system.contract.test.tsx
+++ b/frontend/test/design-system/visual-system.contract.test.tsx
@@ -244,6 +244,17 @@ describe('one status colour vocabulary', () => {
     expect(failed.firstElementChild!.className).toContain('status-critical');
   });
 
+  it('renders result warning statuses in the warning tone, not neutral', () => {
+    // Result Workbench audit P0: `partial` / `warning` results fell back to the
+    // neutral slot and were indistinguishable from `unknown` — a result that
+    // carries warnings must read as warning-tone like every other warning state.
+    const { container: partial } = render(<StatusBadge status="partial" />);
+    expect(partial.firstElementChild!.className).toContain('status-warning');
+
+    const { container: warning } = render(<StatusBadge status="warning" />);
+    expect(warning.firstElementChild!.className).toContain('status-warning');
+  });
+
   it('treats a healthy data source as success, not as in-progress', () => {
     const src = read('components/sidebar/data-sources/source-item-card.tsx');
     // Both healthy and active mean "reachable" for a source; neither may borrow

--- a/frontend/test/results/results-ui.test.tsx
+++ b/frontend/test/results/results-ui.test.tsx
@@ -170,6 +170,21 @@ describe('ResultDetail — V4 action grouping + status vocabulary', () => {
     renderDetail(r, []);
     expect(screen.getByText('该结果未挂载为地图图层。')).toBeInTheDocument();
   });
+
+  it('export on a ref-less statistic still calls onSend', () => {
+    const r = normalizeStepResult({
+      step_id: 's-stat',
+      tool: 'moran_i',
+      result: { success: true, summary: 'ok', data: { moran_i: 0.42 } },
+    });
+    const onSend = vi.fn();
+    render(
+      <ResultDetail result={r} sessionId="sess" ownerToken={null} onBack={() => {}} onSend={onSend} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '导出结果' }));
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend.mock.calls[0][0]).toContain('导出');
+  });
 });
 
 describe('ResultList — V4 density contracts', () => {

--- a/frontend/test/results/results-ui.test.tsx
+++ b/frontend/test/results/results-ui.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import { normalizeStepResult } from '@/lib/results/normalize';
 import { ResultList } from '@/components/sidebar/results/result-list';
@@ -9,7 +9,7 @@ import type { AnalysisResult } from '@/lib/results/types';
 
 beforeEach(() => {
   useHudStore.getState().clearResults();
-  useHudStore.setState({ layers: [] });
+  useHudStore.setState({ layers: [], focusLayerId: null });
 });
 
 function hotspotResult(summary = '已识别热点。'): AnalysisResult {
@@ -92,5 +92,117 @@ describe('ResultDetail — truthfulness + map linkage', () => {
     );
     expect(screen.getByText('失败')).toBeInTheDocument();
     expect(screen.getByText('请提供 value_field。')).toBeInTheDocument();
+  });
+});
+
+describe('ResultDetail — V4 action grouping + status vocabulary', () => {
+  function renderDetail(r: AnalysisResult, layers: ReturnType<typeof createMockLayer>[] = []) {
+    useHudStore.setState({ results: [r], layers });
+    return render(
+      <ResultDetail result={r} sessionId="sess" ownerToken={null} onBack={() => {}} onSend={() => {}} />,
+    );
+  }
+
+  it('keeps map controls inside 输出与地图 and analytical intents in 后续操作', () => {
+    renderDetail(hotspotResult(), [
+      createMockLayer({ id: 'ref:geojson-x1', name: 'Hotspot', visible: true }),
+    ]);
+
+    const output = screen.getByRole('region', { name: '输出与地图' });
+    const next = screen.getByRole('region', { name: '后续操作' });
+
+    // Map controls (store-driven) live with the layer state they act on.
+    expect(within(output).getByRole('button', { name: '在地图上隐藏' })).toBeInTheDocument();
+    expect(within(output).getByRole('button', { name: '缩放至结果' })).toBeInTheDocument();
+    // Analytical intents are a separate, secondary group — never mixed in.
+    expect(within(output).queryByRole('button', { name: '导出结果' })).not.toBeInTheDocument();
+    expect(within(next).getByRole('button', { name: '导出结果' })).toBeInTheDocument();
+  });
+
+  it('zoom focuses the bound layer through the store', () => {
+    renderDetail(hotspotResult(), [
+      createMockLayer({ id: 'ref:geojson-x1', name: 'Hotspot', visible: true }),
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: '缩放至结果' }));
+    expect(useHudStore.getState().focusLayerId).toBe('ref:geojson-x1');
+  });
+
+  it('labels warning-carrying results 含告警 from the shared status vocabulary', () => {
+    const r = normalizeStepResult({
+      step_id: 's-warn',
+      tool: 'isochrone_network',
+      geojson_ref: 'ref:iso-x',
+      result: { success: true, summary: 'Isochrone built. 3 facility(ies) unreachable (disconnected from the road network).' },
+    });
+    renderDetail(r);
+    expect(screen.getByText('含告警')).toBeInTheDocument();
+  });
+
+  it('drops the output and next-action sections for a failed result', () => {
+    const failed = normalizeStepResult({
+      step_id: 's-fail2',
+      tool: 'hotspot_analysis',
+      result: { success: false, error_type: 'VALIDATION_ERROR', summary: 'Missing value_field.', correction_hint: '请提供 value_field。' },
+    });
+    renderDetail(failed);
+    expect(screen.queryByRole('region', { name: '输出与地图' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: '后续操作' })).not.toBeInTheDocument();
+  });
+
+  it('explains an unbound ref instead of rendering dead map controls', () => {
+    const r = normalizeStepResult({
+      step_id: 's-unbound',
+      tool: 'hotspot_analysis',
+      geojson_ref: 'ref:gone',
+      result: { success: true, summary: 'ok' },
+    });
+    renderDetail(r, []);
+    expect(screen.getByText('引用层未绑定到当前地图会话。')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '缩放至结果' })).not.toBeInTheDocument();
+  });
+
+  it('explains a ref-less result has no map layer', () => {
+    const r = normalizeStepResult({
+      step_id: 's-stat',
+      tool: 'moran_i',
+      result: { success: true, summary: 'ok', data: { moran_i: 0.42 } },
+    });
+    renderDetail(r, []);
+    expect(screen.getByText('该结果未挂载为地图图层。')).toBeInTheDocument();
+  });
+});
+
+describe('ResultList — V4 density contracts', () => {
+  it('marks the selected row with aria-current', () => {
+    const r = hotspotResult();
+    render(<ResultList results={[r]} selectedId="s1" onSelect={() => {}} />);
+    const row = screen.getByRole('button');
+    expect(row).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('shows the layer chip only when an output is mounted as a layer', () => {
+    const withLayer = hotspotResult();
+    const without = normalizeStepResult({
+      step_id: 's-stat',
+      tool: 'moran_i',
+      result: { success: true, summary: '统计完成。', data: { moran_i: 0.42 } },
+    });
+    render(<ResultList results={[withLayer, without]} selectedId={null} onSelect={() => {}} />);
+    const chips = screen.getAllByText('图层');
+    expect(chips).toHaveLength(1);
+  });
+
+  it('shows the warning tally in the warning colour vocabulary, not amber literals', () => {
+    const r = normalizeStepResult({
+      step_id: 's-warn',
+      tool: 'isochrone_network',
+      geojson_ref: 'ref:iso-x',
+      result: { success: true, summary: 'Isochrone built. 3 facility(ies) unreachable (disconnected from the road network).' },
+    });
+    render(<ResultList results={[r]} selectedId={null} onSelect={() => {}} />);
+    expect(screen.getByText('1 条告警')).toBeInTheDocument();
+    expect(screen.getByText('1 条告警').className).toContain('status-warning');
+    // No raw Tailwind palette literals for the warning role.
+    expect(screen.getByText('1 条告警').className).not.toMatch(/amber|yellow-/);
   });
 });

--- a/frontend/test/visual/capture.mjs
+++ b/frontend/test/visual/capture.mjs
@@ -59,6 +59,40 @@ const SURFACES = [
   { name: 'panel-collapsed', tab: '图层', collapse: true },
   { name: 'hud-expanded', tab: '对话', hud: true },
   /*
+    Result Workbench: the results registry is session-scoped and fed only by the
+    chat SSE stream, so these seed it through the production path — the stubbed
+    `/chat/stream` response below replays tool_call + step_result events through
+    the same normalizer that fills the registry on screen. The turn produces
+    five results covering the audit matrix: completed vector w/ metrics + bound
+    layer + long ref, statistic w/ metrics, warning (unreachable facilities),
+    partial (grid too dense) and failed (correction hint).
+  */
+  { name: 'results-empty', tab: '结果' },
+  { name: 'results-list', tab: '结果', seedResults: true },
+  { name: 'results-detail', tab: '结果', seedResults: true, openResult: '热点分析' },
+  { name: 'results-detail-warning', tab: '结果', seedResults: true, openResult: '等时圈分析' },
+  { name: 'results-detail-partial', tab: '结果', seedResults: true, openResult: '核密度表面' },
+  { name: 'results-detail-failed', tab: '结果', seedResults: true, openResult: '时空聚类' },
+  /*
+    Narrowest panel (280px, the resize clamp floor) and widest (420px) via the
+    real keyboard resize path on the drag separator — proves the detail survives
+    both ends of the ContextPanel width range.
+  */
+  {
+    name: 'results-detail-narrow',
+    tab: '结果',
+    seedResults: true,
+    openResult: '热点分析',
+    panelArrows: -6,
+  },
+  {
+    name: 'results-detail-wide',
+    tab: '结果',
+    seedResults: true,
+    openResult: '热点分析',
+    panelArrows: 7,
+  },
+  /*
     Map overlays need layers in the store, and the store is deliberately not on
     `window`. Rather than reach past the app, these two restore a session: the
     real production path (`use-workspace-session`) reads `map-state`, pulls each
@@ -145,6 +179,112 @@ const RESTORED_LAYERS = [
 ];
 
 const NOW = '2026-01-01T08:30:00Z';
+
+/* ── Result Workbench seed turn ───────────────────────────────────────────────
+ *
+ * One chat turn whose SSE replay fills the results registry through the real
+ * normalizer. Refs are deliberately long to exercise truncation; the hotspot
+ * ref also gets a descriptor below so the Output section renders enriched
+ * metadata (count / geometry / bbox / bytes). */
+
+const HOTSPOT_REF = 'ref:hotspot-8f3a2b7c4d5e6f7a8b9c0d1e2f3a4b5c';
+const ISO_REF = 'ref:iso-2c4b6e8a0d1f3a5b7c9e';
+
+function sse(name, payload) {
+  return `event: ${name}\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+const toolCall = (name, args) => sse('tool_call', { name, arguments: JSON.stringify(args) });
+
+const RESULTS_SSE_BODY = [
+  sse('session', { session_id: 's-1' }),
+  sse('task_start', { task_id: 't-1', session_id: 's-1' }),
+  sse('token', { content: '正在对商业 POI 执行空间分析…' }),
+  // 1) hotspot — completed vector w/ metrics, legend + visible bound layer (long ref)
+  toolCall('hotspot_analysis', {
+    geojson: HOTSPOT_REF,
+    value_field: 'poi_weight',
+    distance_band: 1000,
+  }),
+  sse('step_result', {
+    task_id: 't-1',
+    step_id: 'sr-hotspot',
+    tool: 'hotspot_analysis',
+    geojson_ref: HOTSPOT_REF,
+    result: {
+      success: true,
+      summary: '已完成商业 POI 热点分析：识别出 12 个显著热点与 7 个冷点，结果已挂载为图层。',
+      bbox: [116.2814, 39.7842, 116.7351, 40.1213],
+      data: { hot_spots_count: 12, cold_spots_count: 7, distance_band_m: 1000 },
+      legend_spec: {
+        type: 'graduated',
+        field: 'gi_bin',
+        breaks: [0, 3, 5, 7, 9],
+        palette: 'RdYlBu',
+        palette_colors: ['#2166ac', '#92c5de', '#f7f7f7', '#f4a582', '#b2182b'],
+      },
+      runtime_patch: { visible: true },
+    },
+  }),
+  // 2) Moran's I — statistic with metrics, no layer
+  toolCall('moran_i', { geojson: 'ref:census-blocks', value_field: 'pop_density' }),
+  sse('step_result', {
+    task_id: 't-1',
+    step_id: 'sr-moran',
+    tool: 'moran_i',
+    result: {
+      success: true,
+      summary: '全局空间自相关计算完成，呈现显著聚类模式。',
+      data: { moran_i: 0.4231, expected_i: -0.0114, p_value: 0.001, pattern: 'Clustered', n_features: 88 },
+    },
+  }),
+  // 3) isochrone — warning (unreachable facilities), hidden layer, params
+  toolCall('isochrone_network', {
+    network_layer: 'ref:road-network',
+    source_points: 'ref:facilities-clinic',
+    travel_time: 15,
+    mode: 'walk',
+  }),
+  sse('step_result', {
+    task_id: 't-1',
+    step_id: 'sr-iso',
+    tool: 'isochrone_network',
+    geojson_ref: ISO_REF,
+    result: {
+      success: true,
+      summary: 'Isochrone built. 3 facility(ies) unreachable (disconnected from the road network).',
+      bbox: [116.1073, 39.7211, 116.8892, 40.1987],
+    },
+  }),
+  // 4) KDE — partial (grid too dense)
+  toolCall('kde_surface', { geojson: 'ref:poi-all', bandwidth: 1200, cell_size: 30 }),
+  sse('step_result', {
+    task_id: 't-1',
+    step_id: 'sr-kde',
+    tool: 'kde_surface',
+    result: {
+      success: true,
+      summary: 'Kernel density surface estimated. Warning: grid too dense, output resampled to 2 m cells.',
+      data: { count: 40320, bandwidth_m: 1200, grid_size: [512, 384], stats: { min: 0.0004, max: 128.4419, mean_density: 6.2041 } },
+    },
+  }),
+  // 5) ST-DBSCAN — failed with correction hint
+  toolCall('st_dbscan', { geojson: 'ref:taxi-trips', eps: 300, min_samples: 8, timestamp_field: 'ts' }),
+  sse('step_result', {
+    task_id: 't-1',
+    step_id: 'sr-stdbscan',
+    tool: 'st_dbscan',
+    result: {
+      success: false,
+      error_type: 'VALIDATION_ERROR',
+      summary: '时间字段解析失败。',
+      correction_hint: '请提供 ISO 8601 格式的时间字段（当前字段 ts 含非数值）。',
+    },
+  }),
+  sse('token', { content: '五个分析步骤已完成，结果已收入结果工作台。' }),
+  sse('task_complete', { task_id: 't-1' }),
+  'data: [DONE]\n\n',
+].join('');
 
 const project = (id, name, description, status = 'active') => ({
   id,
@@ -240,6 +380,26 @@ const template = (id, kind, name, category, description) => ({
  * the shots exercise real information density instead of only empty states.
  */
 const FIXTURES = [
+  // Result Workbench seeding: the chat turn replay above is answered as an SSE
+  // stream (must precede the generic localhost JSON branch in installStubs).
+  // Kept here next to the other fixtures for discoverability; matched by URL in
+  // installStubs, not by this list.
+  // Descriptor for the hotspot ref — the only enriched output (metadata-first).
+  [
+    /\/api\/v1\/layers\/descriptor\//,
+    (url) =>
+      decodeURIComponent(url).includes(HOTSPOT_REF)
+        ? {
+            ref_id: HOTSPOT_REF,
+            feature_count: 1284,
+            geometry_types: ['Polygon'],
+            bbox: [116.2814, 39.7842, 116.7351, 40.1213],
+            mvt_capable: true,
+            raster_capable: false,
+            estimated_bytes: 482304,
+          }
+        : {},
+  ],
   // Session map state drives the layer restore, and therefore the legends.
   // Order matters: these patterns are more specific than the session list below.
   [
@@ -348,11 +508,22 @@ async function installStubs(page) {
     const url = route.request().url();
 
     if (/^https?:\/\/(localhost|127\.0\.0\.1):8000\//.test(url)) {
+      // The seeded chat turn replays as an SSE stream through the production
+      // parser/normalizer (fills the Result Workbench registry).
+      if (/\/api\/v1\/chat\/stream/.test(url)) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'text/event-stream',
+          headers: { 'cache-control': 'no-cache' },
+          body: RESULTS_SSE_BODY,
+        });
+      }
       const hit = FIXTURES.find(([re]) => re.test(url));
+      const payload = hit ? (typeof hit[1] === 'function' ? hit[1](url) : hit[1]) : [];
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(hit ? hit[1] : []),
+        body: JSON.stringify(payload),
       });
     }
 
@@ -405,6 +576,71 @@ async function clickTopBarButton(page, label) {
   return false;
 }
 
+/** Send the seed chat turn — the stubbed stream fills the results registry. */
+async function seedResults(page) {
+  // Chat is the default tab and the panel opens on load; clicking the already
+  // active rail tab would TOGGLE the panel closed, so fill directly. Wait for
+  // hydration rather than assuming the app mounted within the page-settle wait.
+  const input = page.locator('textarea[aria-label="输入空间分析指令"]');
+  try {
+    await input.waitFor({ state: 'visible', timeout: 10000 });
+  } catch {
+    return false;
+  }
+  await input.fill('对商业 POI 做热点、可达性与密度分析');
+  const send = page.locator('button[aria-label="发送消息"]');
+  // A swallowed click here would screenshot the empty state as "success", so
+  // let it throw and surface as a capture failure instead.
+  await send.click({ timeout: 5000 });
+  // Poll for the seeded turn to land (SSE replay + layer auto-mount) rather
+  // than a fixed sleep — deterministic on slow machines. The results LIST only
+  // mounts on the results tab, which isn't open yet; the rail badge count is
+  // the tab-agnostic signal that the registry filled.
+  try {
+    await page.waitForFunction(
+      () => {
+        const tab = document.querySelector('[role="tab"][aria-label*="结果"]');
+        return !!tab && /\d/.test(tab.textContent ?? '');
+      },
+      { timeout: 15000 },
+    );
+  } catch {
+    return false;
+  }
+  // Descriptor enrichment settles shortly after the rows appear.
+  await page.waitForTimeout(1200);
+  return true;
+}
+
+/** Open a result detail by its tool label in the results list. */
+async function openResult(page, label) {
+  const row = page
+    .locator(`ul[aria-label="分析结果列表"] button:has-text("${label}")`)
+    .first();
+  try {
+    await row.waitFor({ state: 'visible', timeout: 10000 });
+  } catch {
+    return false;
+  }
+  await row.click({ timeout: 5000 }).catch(() => {});
+  return true;
+}
+
+/**
+ * Resize the context panel via the keyboard path on the drag separator.
+ * Negative arrowPresses shrink (ArrowLeft), positive grow (ArrowRight).
+ */
+async function resizePanel(page, arrowPresses) {
+  const handle = page.locator('div[role="separator"][aria-label="调整面板宽度"]');
+  if (!(await handle.count())) return false;
+  await handle.focus();
+  for (let i = 0; i < Math.abs(arrowPresses); i += 1) {
+    await page.keyboard.press(arrowPresses < 0 ? 'ArrowLeft' : 'ArrowRight');
+  }
+  await page.waitForTimeout(300);
+  return true;
+}
+
 async function capture() {
   const browser = await chromium.launch({ args: ['--force-color-profile=srgb'] });
   const failures = [];
@@ -417,7 +653,19 @@ async function capture() {
         deviceScaleFactor: 1,
         reducedMotion: 'reduce',
         locale: 'zh-CN',
+        // Pinned timezone + a wall clock anchored to NOW: result timestamps
+        // render identically across runs/machines so before/after diffs show
+        // real changes, not clock noise. Elapsed time keeps flowing normally.
+        timezoneId: 'Asia/Shanghai',
       });
+      await context.addInitScript(
+        ({ anchor }) => {
+          const realNow = Date.now;
+          const t0 = realNow();
+          Date.now = () => anchor + (realNow() - t0);
+        },
+        { anchor: Date.parse('2026-01-01T08:30:00Z') },
+      );
       const page = await context.newPage();
       await installStubs(page);
       page.on('pageerror', (e) => failures.push(`${vp.name}/${theme}: ${e.message}`));
@@ -441,8 +689,17 @@ async function capture() {
             if (await entry.count()) await entry.click({ timeout: 5000 }).catch(() => {});
             await page.waitForTimeout(1400);
           }
+          if (surface.seedResults && !(await seedResults(page))) {
+            throw new Error('seed chat input not found — results registry not populated');
+          }
           if (surface.tab) await clickRailTab(page, surface.tab);
           if (surface.button) await clickTopBarButton(page, surface.button);
+          if (surface.openResult && !(await openResult(page, surface.openResult))) {
+            throw new Error(`result row "${surface.openResult}" not found`);
+          }
+          if (surface.panelArrows !== undefined && !(await resizePanel(page, surface.panelArrows))) {
+            throw new Error('panel resize separator not found');
+          }
           if (surface.collapse) await clickRailTab(page, surface.tab);
           if (surface.hud) {
             const chevron = page
@@ -472,6 +729,9 @@ async function capture() {
   if (failures.length) {
     console.log(`[visual] ${failures.length} issue(s):`);
     for (const f of failures.slice(0, 40)) console.log(`  - ${f}`);
+    // A broken seed/selector must fail the run, not just print — otherwise a
+    // wrong-state screenshot ships as a golden.
+    process.exitCode = 1;
   }
 }
 


### PR DESCRIPTION
## Summary

Converges the Result Workbench (added in #353) onto the Professional GIS Visual System V4 (established in #351). Visual-hierarchy/density/scannability pass only — no new analysis features, no scope beyond the Result Workbench module.

- **BASE_SHA:** `81d32e49486a74c9109f85a9be4e3a3534552614` (origin/master @ #356)

## Visual audit (Phase 1)

Before touching CSS, the Result Workbench was added to the Playwright capture harness (8 new surfaces) and baselines were captured across **1920×1080 / 1440×900 / 1366×768 / 1024×768 × light/dark**, seeded through the production path (a stubbed `POST /api/v1/chat/stream` replays `tool_call` + `step_result` SSE events through the real normalizer; the descriptor endpoint and `/layers/data` are stubbed; tiles → 1×1 PNG; no backend contacted). Findings were ranked P0/P1/P2:

- **P0** `partial`/`warning` result statuses fell through StatusBadge's `STATUS_MAP` to **neutral gray** — a warning-carrying result was indistinguishable from `unknown` (measured identical computed colors).
- **P1** list rows were consumer-card stacks (78–98px each) instead of dense GIS rows; selection ≈ hover; map actions and analytical intents were one flat button ocean; hardcoded amber/emerald/slate literals bypassed the status vocabulary; arbitrary `text-[12.5px]`-style sizes bypassed the font scale; detail header crowded at 280px with label drift (`完成（含告警）` vs `含告警`).
- **P2** bbox truncated mid-number at narrow widths; `数据 lineage` mixed English; failed results rendered rows of `未报告` noise.
- *Reclassified as non-issue:* a measured 3px panel "overflow" is the intentional `-right-[3px]` drag-handle overhang in context-panel (global, untouched).

## What changed

| Area | Decision |
|---|---|
| `status-badge.tsx` | `STATUS_MAP` += `partial`/`warning` → warning tone (single vocabulary). Duplicated `STATUS_LABEL` maps in list+detail deleted; canonical labels come from the badge. |
| `result-list.tsx` | Dense two-line `border-l-2` rows: tool + badge + timestamp / family · `图层` chip · warning tally · 1-line summary. Selected = accent edge + `surface-selected` (≠ hover). Warning tally in `status-warning` text (was `amber-500/10` literals). |
| `result-detail.tsx` | Persistent compact header outside the scroll area. Primary metric = `col-span-2` accent-bordered band; secondary flat rows. **输出与地图** leads with a layer strip fusing live visibility + show/hide/zoom IconButtons (result→map as one visual unit), then a sunken metadata sheet whose **bbox/ref wrap, never truncate mid-number**. Analytical intents render as secondary text actions. Failed results drop output/actions sections (the correction hint is the content). `数据 lineage` → `数据溯源`; `.eyebrow` section titles. |
| a11y | `aria-current` selection, IconButton labels + `disabled`, status always text+color, timestamps at `text-caption` per token intent, reduced-motion untouched, focus via global `*:focus-visible`. |
| `capture.mjs` | Result Workbench joins the visual matrix (8 surfaces incl. 280px narrow + 420px wide via keyboard resize). Harness hardened: poll-verified seeding (rail-badge signal), deterministic pinned clock + `timezoneId`, non-zero exit on failures. |

## Before / after

Generated (gitignored) via `node test/visual/capture.mjs --out .visual/before|after` — 64 shots per run, zero failures. Highlights (1440×900 light, 280px narrow, dark):

- `results-list`: rows 78–98px card stacks → dense two-line rows (~48px); warning/partial badges now amber vs neutral gray; selected row has an accent left edge.
- `results-detail`: header wraps/breaks at 280px → persistent single-line bar; output metadata truncated bbox → wrapped full coordinates; map controls now sit in the layer strip with the visibility state they act on.
- light/dark verified structurally identical (same DOM, token-driven colors only; no `dark:` variants introduced).

## Tests

- `npm run typecheck` ✓ `npm run lint` ✓ (`--max-warnings 0`)
- Full suite `npm test`: **1197 passed**, 3 skipped (pre-existing) — includes Result Workbench vitest, design-system contract tests, visual-system tests.
- New: contract test asserting `partial`/`warning` → warning tone; behavior tests for map-vs-analytical action grouping (regions), zoom → `focusLayer`, canonical badge labels, failed-result section drop, unbound-ref explanations, layer chip, warning-tally tone + no amber literals, `aria-current` selection. Behavior-first; the only class assertions follow the existing token-contract idiom.
- Capture scenarios: `results-empty`, `results-list`, `results-detail`, `-warning`, `-partial`, `-failed`, `-narrow` (280px), `-wide` (420px) × 4 viewports × 2 themes, all backend/tile stubbed.

## Reviews

- **matt /code-review** (Standards + Spec axes) and **gstack /review** (checklist + testing/maintainability/design specialists + adversarial pass) run; all actionable findings fixed (single action partition, `boundLayer.id` write path, absolute visibility toggle, descriptor skip for failed results, caption typography, harness hardening, test isolation). Recorded, not fixed (out of scope): run-inspector `partial` badge now duplicates its own prose; `[LiveLayerFetch]` AbortError console noise on session switch; PanelHeader subtitle truncation.

## ⚠️ Flagged drive-by (test-only)

`frontend/lib/hooks/use-sse-stream.test.ts` arrived **truncated from #356** — two missing closing braces broke `npm run typecheck` repo-wide at base. This PR completes the block (3 lines); the file's 16 tests were silently unparseable before and now run and pass.

## Cross-module note

`STATUS_MAP` is shared: dataset `quality_status: 'warning'` in project-tab previously rendered the raw string in neutral; it now renders `含告警` in warning tone (backend enum includes `warning`, so this is the semantically correct slot). No other consumer changes.

## Explicitly untouched

backend, analysis algorithms, NavRail, ContextPanel architecture, global token system, MapLibre, Chat UX, Settings, CI/CD, all other tabs/drawers.