### PR TITLE
fix: narrow map-action layerId after export-without-layer change

### DIFF
--- a/frontend/components/sidebar/results/result-detail.tsx
+++ b/frontend/components/sidebar/results/result-detail.tsx
@@ -154,18 +154,20 @@ export function ResultDetail({ result, sessionId, ownerToken, onBack, onSend }: 
       // Resolve through the bound layer's real id (not the raw ref) so the
       // `_refId` binding the UI honors is the same one the writes target.
       const layerId = boundLayer?.id ?? ref;
-      const needsLayer = action.kind === 'show_on_map' || action.kind === 'hide' || action.kind === 'zoom';
-      if (needsLayer && !layerId) return;
       switch (action.kind) {
         case 'show_on_map':
-        case 'hide':
+        case 'hide': {
+          if (!layerId) return;
           // Absolute value from the action kind: two rapid clicks before a
           // re-render must not compute the same target twice.
           updateLayer(layerId, { visible: action.kind === 'show_on_map' });
           break;
-        case 'zoom':
+        }
+        case 'zoom': {
+          if (!layerId) return;
           focusLayer(layerId);
           break;
+        }
         case 'style':
           setActiveLeftTab('layers');
           break;


### PR DESCRIPTION
## Why

Post-merge integration: #361 allowed `export`/`onSend` without a layer id, but TypeScript still treated `layerId` as `string | undefined` on `updateLayer`/`focusLayer`. `tsc --noEmit` failed on master.

## Change

Guard `layerId` inside the map-action cases so TS narrows it. Analytical intents (`export`, buffer, etc.) stay available without a layer.

## Tests

- `npx tsc --noEmit` exit 0
- `npx vitest run test/results/results-ui.test.tsx` 14 passed (includes ref-less Moran export → onSend)