### PR TITLE
fix: typecheck AbortSignal assignment in ACK tail-POST test

### DIFF
--- a/frontend/lib/api/map-action-acks.test.ts
+++ b/frontend/lib/api/map-action-acks.test.ts
@@ -392,7 +392,7 @@ describe('map action ACK delivery (fault matrix)', () => {
     let capturedSignal: AbortSignal | undefined;
     let release: ((value: unknown) => void) | undefined;
     const fetchImpl = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
-      capturedSignal = init.signal;
+      capturedSignal = init.signal ?? undefined;
       return new Promise((resolve) => {
         release = resolve;
       });


### PR DESCRIPTION
Post-merge: tsconfig.test.json rejected assigning RequestInit.signal (AbortSignal | null) to AbortSignal | undefined. Normalize with ?? undefined. No production change.