### PR TITLE
fix: leftover zero-review authz, rate-limit, and session-lifetime holes

### DIFF
--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -335,63 +335,9 @@ async def dispatch_tool(request: PiToolRequest) -> PiToolResponse:
                 ))
             raise
 
-        duration_ms = int((time.monotonic() - t0) * 1000)
-
-        harness = _get_session_harness(
-            session_id,
-            create=tool_name == "webgis_layer_upsert",
-        )
-        if harness is not None:
-            if result.status == "ok":
-                for ma in result.map_actions:
-                    if rt_ev is not None:
-                        rt_ev.record_map_action_issued(ma["action_id"])
-                    harness.record_map_action_issued(
-                        session_id=session_id,
-                        tool_call_id=request.toolCallId,
-                        turn_id=turn_id or "",
-                        action_id=ma["action_id"],
-                        command=ma["command"],
-                        requested=ma["requested"],
-                        mapspec_fingerprint=ma.get("mapspec_fingerprint"),
-                    )
-            is_error = result.status == "error"
-            ev = {"status": result.status, "llm_payload_len": len(result.llm_payload)}
-            raw = result.raw_result if isinstance(result.raw_result, dict) else {}
-            for k in (
-                "success",
-                "is_compiled",
-                "warnings",
-                "checkpoint_id",
-                "message",
-                "correction_hint",
-                "cartography_findings",
-                "cartographic_review",
-                "mapspec_fingerprint",
-                "runtime_observation_seq",
-                "runtime_projection_fingerprint",
-            ):
-                if k in raw:
-                    ev[k] = raw[k]
-            harness.record_event(ToolCallEvent(
-                tool_call_id=request.toolCallId,
-                tool_name=request.name,
-                arguments=request.arguments or {},
-                duration_ms=duration_ms,
-                is_error=is_error,
-                error_msg=(result.llm_payload[:200] if is_error else ""),
-                result=ev,
-                session_id=session_id,
-            ))
-            if tool_name == "webgis_layer_upsert":
-                try:
-                    await evaluate_cartographic_session(session_id)
-                except Exception as review_error:  # noqa: BLE001 - GIS success is immutable
-                    logger.warning(
-                        "[PiBridge] cartographic evaluation unavailable for %s: %s",
-                        session_id,
-                        review_error,
-                    )
+        if result.status == "ok" and rt_ev is not None:
+            for ma in result.map_actions:
+                rt_ev.record_map_action_issued(ma["action_id"])
 
     duration_ms = int((time.monotonic() - t0) * 1000)
 

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -53,10 +53,20 @@ def _allow_public_register() -> bool:
 
 
 def _get_client_ip(request: Request) -> str:
-    """从请求中提取客户端 IP，优先尝试 X-Forwarded-For 头（代理感知）。"""
+    """Client IP for auth rate limits.
+
+    Production nginx sets ``X-Real-IP $remote_addr`` and appends the real peer
+    as the last ``X-Forwarded-For`` hop (``$proxy_add_x_forwarded_for``).
+    The leftmost XFF value is attacker-controlled and must not key the limiter.
+    """
+    real_ip = (request.headers.get("x-real-ip") or "").strip()
+    if real_ip:
+        return real_ip
     forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
-        return forwarded.split(",")[0].strip()
+        hops = [hop.strip() for hop in forwarded.split(",") if hop.strip()]
+        if hops:
+            return hops[-1]
     return request.client.host if request.client else "unknown"
 
 
@@ -102,6 +112,8 @@ def _user_to_dict(u: User) -> dict:
 def _issue_token_pair(user: User) -> TokenResponse:
     """为给定 user 签发 access + refresh token 对。"""
     token_data = {"sub": user.id, "username": user.username, "role": user.role}
+    if getattr(user, "org_id", None) is not None:
+        token_data["org_id"] = user.org_id
     access = create_access_token(
         data=token_data,
         expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -9,7 +9,13 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, model_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import get_current_user_optional, get_owner_token, require_admin, require_owned_session
+from app.core.auth import (
+    authorize_session_write,
+    get_current_user_optional,
+    get_owner_token,
+    require_admin,
+    require_owned_session,
+)
 from app.core.database import get_async_db
 from app.core.rate_limiter import get_rate_limiter
 from app.models.db_model import Conversation
@@ -525,6 +531,27 @@ async def _guard_body_session(
         raise HTTPException(status_code=404, detail="Session not found")
 
 
+def _pi_stream_capability(
+    conversation,
+    created: bool,
+    user_id: Optional[str],
+    owner_token: Optional[str],
+) -> Optional[str]:
+    """SSE ``owner_token`` for a Pi stream, or 404 if the caller must stop.
+
+    A newly created row mints a token the caller does not yet have — emit it
+    once. An existing row is a TOCTOU against ``_guard_body_session`` (absent
+    at guard time, present at get-or-create): require the same ownership
+    rules as ``authorize_session_write`` and never emit a token the caller
+    did not already present.
+    """
+    if created:
+        return getattr(conversation, "owner_token", None)
+    if not authorize_session_write(conversation, user_id, owner_token):
+        raise HTTPException(status_code=404, detail="Session not found")
+    return None
+
+
 @router.post("/completions", response_model=ChatResponse)
 async def chat_completions(
     req: ChatRequest,
@@ -622,10 +649,14 @@ async def chat_stream(
             # Direct route tests use a minimal close-only DB stand-in. Real
             # requests always carry AsyncSession and persist the capability.
             if db is not None and hasattr(db, "execute"):
-                conversation = await AsyncHistoryService(db).get_or_create_conversation(
+                conversation, created = await AsyncHistoryService(
+                    db
+                ).get_or_create_conversation_with_created(
                     pi_session_id, user_id=user_id
                 )
-                pi_owner_token = conversation.owner_token
+                pi_owner_token = _pi_stream_capability(
+                    conversation, created, user_id, owner_token
+                )
     finally:
         # Release the connection NOW, not when the stream ends. The guard is
         # the only consumer; nothing downstream uses ``db``.

--- a/app/api/routes/templates.py
+++ b/app/api/routes/templates.py
@@ -6,10 +6,10 @@ import logging
 from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, TypeAdapter
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import get_current_user, get_current_user_optional
+from app.core.auth import actor_ids, get_current_user, get_current_user_optional
 from app.core.database import get_async_db
 from app.models.db_model import CartographyTemplate
 from app.schemas.template_schema import (
@@ -56,6 +56,32 @@ def _validate_payload(kind: str, payload: Dict[str, Any]):
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Invalid payload for kind '{kind}'"
         )
+
+
+def _template_scope_clause(user_id: Optional[str], org_id, role: Optional[str]):
+    """Built-ins + own creator_id + matching org. Never treat org_id IS NULL
+    user rows as public — JWT historically omitted org_id, so that predicate
+    leaked every tenant's saved templates.
+    """
+    if role == "admin":
+        return None
+    if user_id is None:
+        return CartographyTemplate.is_builtin.is_(True)
+    clauses = [
+        CartographyTemplate.is_builtin.is_(True),
+        CartographyTemplate.creator_id == user_id,
+    ]
+    if org_id is not None:
+        clauses.append(CartographyTemplate.org_id == org_id)
+    return or_(*clauses)
+
+
+def _template_visible(tmpl: CartographyTemplate, user_id: Optional[str], org_id, role: Optional[str]) -> bool:
+    if tmpl.is_builtin or role == "admin":
+        return True
+    if org_id is not None and tmpl.org_id == org_id:
+        return True
+    return user_id is not None and tmpl.creator_id == user_id
 
 
 def _template_to_dict(tmpl: CartographyTemplate) -> dict:
@@ -108,20 +134,18 @@ async def list_templates(
     from app.schemas.pagination import Page, clamp_pagination
 
     limit, offset = clamp_pagination(limit, offset)
-    user_org_id = _user.get("org_id") if isinstance(_user, dict) else None
+    user_id, user_org_id = actor_ids(_user if isinstance(_user, dict) else None)
+    role = _user.get("role") if isinstance(_user, dict) else None
 
-    # DB-stored templates: scope to caller's org (built-ins + their own).
+    # DB-stored templates: builtins + caller's own (and org, when the JWT
+    # actually carries org_id). Do not use org_id IS NULL as "public".
     stmt = select(CartographyTemplate)
     if kind:
         stmt = stmt.where(CartographyTemplate.kind == kind)
 
-    if user_org_id is not None:
-        # Built-ins (org_id IS NULL) are always visible. User templates are
-        # scoped to the caller's org.
-        stmt = stmt.where(
-            (CartographyTemplate.org_id.is_(None)) | (CartographyTemplate.org_id == user_org_id)
-        )
-    # Unauthenticated callers see only built-in seeds (defense in depth).
+    scope = _template_scope_clause(user_id, user_org_id, role)
+    if scope is not None:
+        stmt = stmt.where(scope)
 
     if source == "builtin":
         stmt = stmt.where(CartographyTemplate.is_builtin.is_(True))
@@ -207,10 +231,17 @@ async def get_template(
     Gallery V2 在用户点击模板卡时调用；列表路径不再下发 payload。
     Built-in seed 也走这条 — 找不到时回退到 SEED_TEMPLATES。
     """
+    user_id, user_org_id = actor_ids(_user if isinstance(_user, dict) else None)
+    role = _user.get("role") if isinstance(_user, dict) else None
     stmt = select(CartographyTemplate).where(CartographyTemplate.id == template_id)
     result = await db.execute(stmt)
     tmpl = result.scalar_one_or_none()
     if tmpl is not None:
+        if not _template_visible(tmpl, user_id, user_org_id, role):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Template '{template_id}' not found",
+            )
         return _template_to_dict(tmpl)
 
     # Fall back to built-in seed.
@@ -235,8 +266,7 @@ async def create_template(
     """
     _validate_payload(req.kind, req.payload)
 
-    user_id = _user.get("user_id") if isinstance(_user, dict) else None
-    user_org_id = _user.get("org_id") if isinstance(_user, dict) else None
+    user_id, user_org_id = actor_ids(_user if isinstance(_user, dict) else None)
     template_id = f"tmpl_user_{uuid.uuid4().hex[:8]}"
     tmpl = CartographyTemplate(
         id=template_id,

--- a/app/services/history_service_async.py
+++ b/app/services/history_service_async.py
@@ -137,6 +137,22 @@ class AsyncHistoryService(HistoryStoreProtocol):
         session_id: str,
         user_id: Optional[str] = None,
     ) -> Conversation:
+        conv, _created = await self.get_or_create_conversation_with_created(
+            session_id, user_id=user_id
+        )
+        return conv
+
+    async def get_or_create_conversation_with_created(
+        self,
+        session_id: str,
+        user_id: Optional[str] = None,
+    ) -> tuple[Conversation, bool]:
+        """Return ``(conversation, created)``.
+
+        ``created`` is True only when this call inserted the row. A concurrent
+        first-message loser re-SELECTs the winner and must treat that as
+        existing (do not emit the winner's ``owner_token``).
+        """
         import anyio
         owner = None if _is_anonymous(user_id) else user_id
         # SEC-08：新建匿名会话时生成 owner_token。认证会话（owner 非空）不需要。
@@ -148,7 +164,7 @@ class AsyncHistoryService(HistoryStoreProtocol):
                 result = await self.db.execute(stmt)
                 conv = result.scalar_one_or_none()
                 if conv:
-                    return conv
+                    return conv, False
 
                 conv = Conversation(
                     id=session_id,
@@ -164,7 +180,7 @@ class AsyncHistoryService(HistoryStoreProtocol):
                 await self.db.commit()
                 # 重新查询以确保加载了关系
                 result = await self.db.execute(stmt)
-                return result.scalar_one()
+                return result.scalar_one(), True
             except Exception as e:
                 # SEC-10 (deep-audit round 3): two concurrent first-messages for
                 # the same session both see "absent", both INSERT, and the loser

--- a/app/services/session_data.py
+++ b/app/services/session_data.py
@@ -40,6 +40,14 @@ class MemorySessionStore(BaseSessionStore):
         # section (see its docstring). Kept separate from `self._lock` so ACK
         # appends don't serialize against layer mutations.
         self._map_action_lock = asyncio.Lock()
+        # Session last-touch order for cleanup_idle_sessions (not first-insert).
+        self._session_order: OrderedDict[str, None] = OrderedDict()
+
+    def _touch_session(self, session_id: str) -> None:
+        if session_id in self._session_order:
+            self._session_order.move_to_end(session_id)
+        else:
+            self._session_order[session_id] = None
 
     async def store(self, session_id: str, data: Any, prefix: str = "data") -> str:
         """存储数据并返回生成的游标 ID"""
@@ -62,6 +70,7 @@ class MemorySessionStore(BaseSessionStore):
             logger.debug(f"Session {session_id}: evicted {oldest_ref} (capacity={self.capacity})")
 
         session_cache[ref_id] = data
+        self._touch_session(session_id)
 
         # V3 Performance: compute descriptor once at store time so every subsequent
         # descriptor read is O(1) instead of O(features).
@@ -92,6 +101,7 @@ class MemorySessionStore(BaseSessionStore):
         # overwrite is the durability path for plans/checkpoints — bump LRU
         # recency so a just-updated plan is not the next eviction victim.
         session_cache.move_to_end(ref_id)
+        self._touch_session(session_id)
         return True
 
     async def set_alias(self, session_id: str, ref_id: str, alias: str) -> None:
@@ -99,6 +109,7 @@ class MemorySessionStore(BaseSessionStore):
         if session_id not in self._aliases:
             self._aliases[session_id] = {}
         self._aliases[session_id][alias] = ref_id
+        self._touch_session(session_id)
 
     async def resolve_alias(self, session_id: str, ref_or_alias: str) -> str:
         """Resolve a ref or alias to its canonical ref_id.
@@ -133,6 +144,7 @@ class MemorySessionStore(BaseSessionStore):
         # 移动到末尾 (LRU)
         data = session_cache.pop(ref_id)
         session_cache[ref_id] = data
+        self._touch_session(session_id)
         return data
 
     # P2-1: get_ref_data was a byte-identical override of
@@ -182,6 +194,7 @@ class MemorySessionStore(BaseSessionStore):
             state[f"_{key}_seq"] = seq
         state[key] = value
         state[f"_{key}_updated_at"] = datetime.now(timezone.utc).isoformat()
+        self._touch_session(session_id)
         return True
 
     async def get_started_at(self, session_id: str) -> Optional[str]:
@@ -231,6 +244,7 @@ class MemorySessionStore(BaseSessionStore):
             "data": data,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         })
+        self._touch_session(session_id)
 
     async def get_event_log(self, session_id: str) -> list[dict]:
         """获取近期用户操作日志"""
@@ -291,6 +305,7 @@ class MemorySessionStore(BaseSessionStore):
         if not session_cache or ref_id not in session_cache:
             return False
         session_cache.move_to_end(ref_id)
+        self._touch_session(session_id)
         return True
 
     async def clear_session(self, session_id: str) -> None:
@@ -301,13 +316,16 @@ class MemorySessionStore(BaseSessionStore):
         self._event_log.pop(session_id, None)
         self._map_action_events.pop(session_id, None)
         self._descriptors.pop(session_id, None)
+        self._session_order.pop(session_id, None)
 
     async def cleanup_idle_sessions(self, max_sessions: int = 100) -> None:
-        """Evict oldest sessions when total exceeds max_sessions."""
-        if len(self._store) <= max_sessions:
+        """Evict least-recently-touched sessions when total exceeds max_sessions."""
+        order = self._session_order
+        if not order:
+            order = OrderedDict((sid, None) for sid in self._store)
+        if len(order) <= max_sessions:
             return
-        # Remove oldest sessions (first inserted in OrderedDict-like fashion)
-        to_remove = list(self._store.keys())[:len(self._store) - max_sessions + 10]
+        to_remove = list(order.keys())[:len(order) - max_sessions + 10]
         for sid in to_remove:
             await self.clear_session(sid)
         logger.info(f"Cleaned up {len(to_remove)} idle sessions")

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -12,10 +12,12 @@ from app.services.session_data_protocol import BaseSessionStore, UNAVAILABLE_REF
 
 logger = logging.getLogger(__name__)
 
-DATA_TTL = 2 * 60 * 60
-STATE_TTL = 4 * 60 * 60
-EVENTS_TTL = 4 * 60 * 60
 SESSION_TTL = 4 * 60 * 60
+# Payload keys used to expire at 2h while session index keys lived 4h and
+# were renewed by viewport writes. Keep data alive for the session lifetime.
+DATA_TTL = SESSION_TTL
+STATE_TTL = SESSION_TTL
+EVENTS_TTL = SESSION_TTL
 MAX_EVENTS = 20
 # V3 闭环：每 session 地图动作 ACK 上限（与 session_data.MAX_MAP_ACTION_EVENTS 保持一致）
 MAX_MAP_ACTION_EVENTS = 200
@@ -214,6 +216,10 @@ class RedisSessionStore(BaseSessionStore):
     def _active_key() -> str:
         return "sessions:active"
 
+    @staticmethod
+    def _activity_key() -> str:
+        return "sessions:activity"
+
     async def store(self, session_id: str, data: Any, prefix: str = "data") -> str:
         """存数据；Redis 不可达时降级返回伪 ref_id 而非抛错。
 
@@ -319,10 +325,11 @@ class RedisSessionStore(BaseSessionStore):
         """
         await self._ensure_connected()
         try:
+            ref_ids = await self._session_ref_ids(session_id)
             async with self._r.pipeline() as pipe:
                 pipe.hset(self._aliases_key(session_id), alias, ref_id)
                 pipe.hset(self._refs_key(session_id), ref_id, alias)
-                self._refresh_session_ttl(pipe, session_id)
+                self._refresh_session_ttl(pipe, session_id, ref_ids)
                 await pipe.execute()
         except aioredis.RedisError as e:
             logger.warning(
@@ -395,6 +402,7 @@ class RedisSessionStore(BaseSessionStore):
 
             async with self._r.pipeline() as pipe:
                 pipe.expire(data_key, DATA_TTL)
+                pipe.expire(self._descriptor_key(session_id, ref_id), DATA_TTL)
                 pipe.zadd(self._refs_order_key(session_id), {ref_id: time.time()})
                 self._refresh_session_ttl(pipe, session_id)
                 await pipe.execute()
@@ -445,6 +453,7 @@ class RedisSessionStore(BaseSessionStore):
         # update_layer_in_state) — otherwise two in-flight POSTs could both pass
         # the check and the older one land last.
         state_key = self._state_key(session_id)
+        ref_ids = await self._session_ref_ids(session_id)
         for attempt in range(3):
             try:
                 async with self._r.pipeline(transaction=True) as pipe:
@@ -468,7 +477,7 @@ class RedisSessionStore(BaseSessionStore):
                     pipe.hset(state_key, f"_{key}_updated_at", datetime.now(timezone.utc).isoformat())
                     pipe.expire(state_key, STATE_TTL)
                     pipe.sadd(self._active_key(), session_id)
-                    self._refresh_session_ttl(pipe, session_id)
+                    self._refresh_session_ttl(pipe, session_id, ref_ids)
                     await pipe.execute()
                 # Write-through invalidation: drop L1 so next read refetches from Redis.
                 self._l1_invalidate_session(session_id)
@@ -654,6 +663,7 @@ class RedisSessionStore(BaseSessionStore):
             ensure_ascii=False,
         )
         try:
+            ref_ids = await self._session_ref_ids(session_id)
             async with self._r.pipeline() as pipe:
                 key = self._events_key(session_id)
                 # rpush 保持与 memory (deque.append) 相同的"最旧在前"时序。
@@ -663,7 +673,7 @@ class RedisSessionStore(BaseSessionStore):
                 pipe.ltrim(key, -MAX_EVENTS, -1)
                 pipe.expire(key, EVENTS_TTL)
                 pipe.sadd(self._active_key(), session_id)
-                self._refresh_session_ttl(pipe, session_id)
+                self._refresh_session_ttl(pipe, session_id, ref_ids)
                 await pipe.execute()
         except aioredis.RedisError as e:
             logger.warning(
@@ -866,6 +876,7 @@ class RedisSessionStore(BaseSessionStore):
                 self._map_actions_order_key(session_id),
             )
             pipe.srem(self._active_key(), session_id)
+            pipe.zrem(self._activity_key(), session_id)
             await pipe.execute()
         # F13: write-through invalidation, like every other writer — otherwise a
         # session recreated with the same id within L1_TTL_SECONDS reads the
@@ -880,9 +891,11 @@ class RedisSessionStore(BaseSessionStore):
         scored = []
         for sid_bytes in active:
             sid = sid_bytes.decode() if isinstance(sid_bytes, bytes) else sid_bytes
-            earliest = await self._r.zrange(self._refs_order_key(sid), 0, 0, withscores=True)
-            score = earliest[0][1] if earliest else 0
-            scored.append((sid, score))
+            raw_score = await self._r.zscore(self._activity_key(), sid)
+            if raw_score is None:
+                earliest = await self._r.zrange(self._refs_order_key(sid), 0, 0, withscores=True)
+                raw_score = earliest[0][1] if earliest else 0
+            scored.append((sid, float(raw_score)))
         scored.sort(key=lambda x: x[1])
         to_remove = len(scored) - max_sessions + 10
         for sid, _ in scored[:to_remove]:
@@ -951,6 +964,7 @@ class RedisSessionStore(BaseSessionStore):
                 return False
             async with self._r.pipeline() as pipe:
                 pipe.expire(data_key, DATA_TTL)
+                pipe.expire(self._descriptor_key(session_id, ref_id), DATA_TTL)
                 pipe.zadd(self._refs_order_key(session_id), {ref_id: time.time()})
                 self._refresh_session_ttl(pipe, session_id)
                 await pipe.execute()
@@ -959,7 +973,21 @@ class RedisSessionStore(BaseSessionStore):
             logger.warning("Redis ref_exists failed for session %s ref %s: %s", session_id, ref_id, e)
             return False
 
-    def _refresh_session_ttl(self, pipe, session_id: str) -> None:
+    async def _session_ref_ids(self, session_id: str) -> list:
+        try:
+            raw = await self._r.smembers(self._index_key(session_id))
+        except aioredis.RedisError:
+            return []
+        return list(raw or [])
+
+    def _refresh_payload_ttls(self, pipe, session_id: str, ref_ids) -> None:
+        for ref_id in ref_ids:
+            if isinstance(ref_id, bytes):
+                ref_id = ref_id.decode()
+            pipe.expire(self._data_key(session_id, ref_id), DATA_TTL)
+            pipe.expire(self._descriptor_key(session_id, ref_id), DATA_TTL)
+
+    def _refresh_session_ttl(self, pipe, session_id: str, ref_ids=None) -> None:
         for key in [
             self._aliases_key(session_id),
             self._refs_key(session_id),
@@ -967,6 +995,10 @@ class RedisSessionStore(BaseSessionStore):
             self._index_key(session_id),
         ]:
             pipe.expire(key, SESSION_TTL)
+        pipe.zadd(self._activity_key(), {session_id: time.time()})
+        pipe.expire(self._activity_key(), SESSION_TTL)
+        if ref_ids:
+            self._refresh_payload_ttls(pipe, session_id, ref_ids)
 
 
 # Backward-compatible alias

--- a/tests/test_remaining_zero_review.py
+++ b/tests/test_remaining_zero_review.py
@@ -1,0 +1,203 @@
+"""Shipped-path tests for leftover master zero-review findings (post-#365)."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.auth import authorize_session_write, verify_token
+from app.models.db_model import User
+from app.services.session_data import MemorySessionStore
+
+
+def test_issue_token_pair_includes_org_id():
+    from app.api.routes.auth import _issue_token_pair
+
+    user = User(
+        id="u-org",
+        username="orguser",
+        email="org@example.com",
+        role="viewer",
+        org_id=7,
+        token_version=0,
+    )
+    pair = _issue_token_pair(user)
+    payload = verify_token(pair.access_token)
+    assert payload is not None
+    assert payload["org_id"] == 7
+    assert payload["sub"] == "u-org"
+
+
+def test_get_client_ip_prefers_x_real_ip_not_leftmost_xff():
+    from app.api.routes.auth import _get_client_ip
+
+    request = MagicMock()
+    request.headers.get.side_effect = lambda key, default=None: {
+        "x-real-ip": "10.0.0.9",
+        "x-forwarded-for": "1.1.1.1, 8.8.8.8, 10.0.0.9",
+    }.get(key, default)
+    request.client.host = "127.0.0.1"
+    assert _get_client_ip(request) == "10.0.0.9"
+
+
+def test_get_client_ip_uses_last_xff_hop_without_x_real_ip():
+    from app.api.routes.auth import _get_client_ip
+
+    request = MagicMock()
+    request.headers.get.side_effect = lambda key, default=None: {
+        "x-forwarded-for": "1.1.1.1, 8.8.8.8, 10.0.0.9",
+    }.get(key, default)
+    request.client.host = "127.0.0.1"
+    assert _get_client_ip(request) == "10.0.0.9"
+
+
+def test_pi_stream_capability_emits_token_only_on_create():
+    from app.api.routes.chat import _pi_stream_capability
+
+    created = SimpleNamespace(user_id=None, owner_token="new-secret")
+    assert _pi_stream_capability(created, True, None, None) == "new-secret"
+
+    existing = SimpleNamespace(user_id=None, owner_token="victim-secret")
+    with pytest.raises(HTTPException) as ei:
+        _pi_stream_capability(existing, False, None, None)
+    assert ei.value.status_code == 404
+
+    assert _pi_stream_capability(existing, False, None, "victim-secret") is None
+    assert authorize_session_write(existing, None, "victim-secret") is True
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_reports_created_flag(tmp_path):
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.models.db_model import Base
+    from app.services.history_service_async import AsyncHistoryService
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'created.db'}")
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        async with Session() as db:
+            svc = AsyncHistoryService(db)
+            first, created = await svc.get_or_create_conversation_with_created("sess-new")
+            assert created is True
+            assert first.owner_token
+            second, created_again = await svc.get_or_create_conversation_with_created("sess-new")
+            assert created_again is False
+            assert second.owner_token == first.owner_token
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_memory_cleanup_keeps_last_touched_session():
+    mgr = MemorySessionStore(capacity=20)
+    refs = {}
+    for i in range(15):
+        refs[f"s{i}"] = await mgr.store(f"s{i}", {"i": i})
+    assert await mgr.get("s0", refs["s0"]) == {"i": 0}
+    await mgr.cleanup_idle_sessions(max_sessions=12)
+    assert await mgr.get("s0", refs["s0"]) == {"i": 0}
+
+
+@pytest.mark.asyncio
+async def test_redis_set_map_state_refreshes_payload_ttl():
+    import fakeredis.aioredis
+
+    from app.services.session_data_redis import DATA_TTL, RedisSessionStore
+
+    raw = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    store = RedisSessionStore(redis_url="redis://unused", redis=raw, capacity=20)
+    ref = await store.store("sess-ttl", {"v": 1})
+    data_key = store._data_key("sess-ttl", ref)
+    await raw.expire(data_key, 10)
+    assert await raw.ttl(data_key) <= 10
+    await store.set_map_state("sess-ttl", "viewport", {"zoom": 8})
+    ttl = await raw.ttl(data_key)
+    assert ttl > 10
+    assert ttl >= DATA_TTL - 5
+
+
+@pytest.mark.asyncio
+async def test_redis_cleanup_keeps_viewport_touched_session():
+    import fakeredis.aioredis
+
+    from app.services.session_data_redis import RedisSessionStore
+
+    raw = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    store = RedisSessionStore(redis_url="redis://unused", redis=raw, capacity=20)
+    refs = {}
+    for i in range(15):
+        refs[f"s{i}"] = await store.store(f"s{i}", {"i": i})
+    await store.set_map_state("s0", "viewport", {"zoom": 3})
+    await store.cleanup_idle_sessions(max_sessions=12)
+    assert await store.get("s0", refs["s0"]) == {"i": 0}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_records_harness_evidence_once(monkeypatch):
+    import app.agent_pi_bridge as bridge
+    from app.lib.harness.pi_agent_harness import PiAgentHarness
+    from app.services.tool_dispatch_service import ToolDispatchResult
+
+    harness = PiAgentHarness(session_id="dup-sess")
+    monkeypatch.setattr(bridge, "_harness", harness)
+    monkeypatch.setattr(bridge, "_harnesses", {**getattr(bridge, "_harnesses", {}), "dup-sess": harness})
+
+    result = ToolDispatchResult(
+        status="ok",
+        llm_payload="ok",
+        slim_event={},
+        geojson_ref=None,
+        raw_result={
+            "success": True,
+            "is_compiled": True,
+            "mapspec_fingerprint": "fp-1",
+            "mutation_revision": 1,
+        },
+        error_msg=None,
+        map_actions=[{
+            "action_id": "ma-dup",
+            "command": "upsert_layer",
+            "requested": {},
+            "mapspec_fingerprint": "fp-1",
+        }],
+    )
+    fake_service = MagicMock()
+    fake_service.dispatch = AsyncMock(return_value=result)
+    monkeypatch.setattr(bridge, "ToolDispatchService", lambda **kw: fake_service)
+
+    fake_registry = MagicMock()
+    fake_registry.list_tools = MagicMock(return_value=["webgis_layer_upsert"])
+    fake_registry.metadata = MagicMock(return_value={"tier": 1})
+    monkeypatch.setattr(bridge, "_tool_registry", fake_registry)
+
+    evals = {"n": 0}
+
+    async def _fake_eval(session_id):
+        evals["n"] += 1
+        return None
+
+    async def _fake_persist(session_id, event, map_actions):
+        return True
+
+    monkeypatch.setattr(bridge, "evaluate_cartographic_session", _fake_eval)
+    monkeypatch.setattr(bridge, "_persist_cartographic_harness_context", _fake_persist)
+
+    request = bridge.PiToolRequest(
+        toolCallId="tc-dup",
+        name="webgis_layer_upsert",
+        arguments={},
+        sessionId="dup-sess",
+    )
+    try:
+        resp = await bridge.dispatch_tool(request)
+        assert not resp.isError
+        issued = [e for e in harness.map_actions_issued if e.get("action_id") == "ma-dup"]
+        assert len(issued) == 1, issued
+        tool_rows = [c for c in harness.tool_calls if c.get("tool_call_id") == "tc-dup"]
+        assert len(tool_rows) == 1, harness.tool_calls
+        assert evals["n"] == 1
+    finally:
+        bridge._session_executed_sets.pop("dup-sess", None)

--- a/tests/unit/test_templates_api.py
+++ b/tests/unit/test_templates_api.py
@@ -157,7 +157,8 @@ async def test_user_template_appears_in_list_templates(client):
     assert post_res.status_code == 201
 
     # Check GET endpoint —— 分页形状 {items, total, ...}
-    get_res = await client.get("/api/v1/templates?kind=basemap")
+    # List is scoped to the caller: unauthenticated gallery is builtins only.
+    get_res = await client.get("/api/v1/templates?kind=basemap", headers=user_headers)
     assert get_res.status_code == 200
     templates_list = get_res.json()["items"]
     assert any(t["name"] == "我的夜间大屏底图" for t in templates_list)
@@ -266,3 +267,43 @@ async def test_setup_purge_deletes_non_builtin_templates():
             )
         ).scalar_one_or_none()
         assert probe is None
+
+
+_LAYOUT_PAYLOAD = {
+    "paperSize": "A4",
+    "orientation": "landscape",
+    "showLegend": True,
+    "showNorthArrow": True,
+    "showScaleBar": True,
+    "showGrid": False,
+}
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_list_hides_user_templates(client):
+    """Anonymous gallery must not enumerate another tenant's saved templates."""
+    post_res = await client.post(
+        "/api/v1/templates",
+        json={"name": "他人模板", "kind": "layout", "payload": _LAYOUT_PAYLOAD},
+        headers=user_headers,
+    )
+    assert post_res.status_code == 201
+    tmpl_id = post_res.json()["id"]
+
+    anon = await client.get("/api/v1/templates?source=user&summary=false")
+    assert anon.status_code == 200
+    names = {t["name"] for t in anon.json()["items"]}
+    assert "他人模板" not in names
+
+    other = await client.get("/api/v1/templates?source=user&summary=false", headers=other_user_headers)
+    assert other.status_code == 200
+    assert "他人模板" not in {t["name"] for t in other.json()["items"]}
+
+    owner = await client.get("/api/v1/templates?source=user&summary=false", headers=user_headers)
+    assert any(t["name"] == "他人模板" for t in owner.json()["items"])
+
+    forbidden = await client.get(f"/api/v1/templates/{tmpl_id}", headers=other_user_headers)
+    assert forbidden.status_code == 404
+    allowed = await client.get(f"/api/v1/templates/{tmpl_id}", headers=user_headers)
+    assert allowed.status_code == 200
+    assert allowed.json()["name"] == "他人模板"


### PR DESCRIPTION
## Summary
Closes the six leftover whole-repo zero-review findings that did not land in #365.

- **Templates (P0):** list/detail are scoped to builtins + creator (and org when the JWT actually has `org_id`). Issued tokens now carry `org_id`. `org_id IS NULL` user rows are no longer treated as public.
- **Auth rate limit (P1):** `_get_client_ip` uses `X-Real-IP`, then the last `X-Forwarded-For` hop (nginx appends the real peer), not the spoofable leftmost hop.
- **Chat TOCTOU (P1):** `get_or_create` reports whether this request inserted the row. Existing conversations must pass `authorize_session_write`. SSE emits `owner_token` only on create.
- **Dispatch duplicate harness (P1):** drop the pre-persist record/evaluate; keep turn-evidence issued recording and the persist + single evaluate path.
- **Redis payload TTL (P1):** `DATA_TTL` matches `SESSION_TTL`; viewport/event/alias refreshes expire data + descriptor keys.
- **Idle cleanup (P1):** evict by last-touch (memory order + Redis `sessions:activity`), not first-insert / oldest leftover ref.

## Test plan
- [x] `pytest tests/test_remaining_zero_review.py tests/unit/test_templates_api.py tests/unit/test_conversation_toctou.py tests/test_session_store_evict_and_lru.py tests/unit/test_session_data.py tests/unit/test_harness_dispatch_hook.py tests/test_sec08_session_owner_token.py tests/test_zero_review_authz.py tests/test_auth_routes.py`
- [x] `ruff check` on touched files
- Do not wait on CI (repo convention).