### PR TITLE
fix(ui): close result workbench follow-ups from #361 review

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -203,8 +203,17 @@ npm run dev                                    # 另开一个终端
 node test/visual/capture.mjs --out .visual/after
 ```
 
-4 视口 × 明暗 × 14 个界面 = 112 张图，落到 `.visual/`（已 gitignore）。
-后端全部走内置 fixture，不需要真的起后端。
+结果工作台的场景通过真实 SSE 通路播种（stub 掉的 `/chat/stream` 重放
+`step_result` 事件）。离线/无外网环境下加一个字体 mock，否则 dev server
+首次编译会卡在 Google Fonts 拉取上：
+
+```bash
+NEXT_FONT_GOOGLE_MOCKED_RESPONSES='{"DM Sans":{"subsets":["latin"],"weight":["300","400","500","600"],"style":"normal","src":"https://fonts.gstatic.com/s/dmsans.woff2"},"JetBrains Mono":{"subsets":["latin"],"weight":["400","500"],"style":"normal","src":"https://fonts.gstatic.com/s/jetbrainsmono.woff2"}}' npm run dev
+```
+
+4 视口 × 明暗 × 全部界面（含 8 个结果工作台场景）落到 `.visual/`
+（已 gitignore）；捕获失败时进程以非零码退出。后端全部走内置 fixture，
+不需要真的起后端（dev 默认 :8001 与显式 :8000 都会被 stub 覆盖）。
 
 ## 📚 相关文档
 

--- a/frontend/components/sidebar/results-tab.tsx
+++ b/frontend/components/sidebar/results-tab.tsx
@@ -7,8 +7,14 @@
  * point. The registry is session-scoped + bounded (spec §11/§16): we do not
  * create a persistence DB; we represent session-only results truthfully and
  * clear on session switch (wired in use-workspace-session).
+ *
+ * Focus contract (drill-in navigation): activating a row moves focus into the
+ * detail (its back button), and going back restores focus to the row that was
+ * opened — keyboard users never lose their place in the list. The ring only
+ * paints for keyboard-origin focus (`:focus-visible`), so mouse users see no
+ * change.
  */
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import { ResultList } from '@/components/sidebar/results/result-list';
 import { ResultDetail } from '@/components/sidebar/results/result-detail';
@@ -24,10 +30,19 @@ export function ResultsTab({ sessionId, ownerToken, onSend }: ResultsTabProps) {
   const selectedResultId = useHudStore((s) => s.selectedResultId);
   const selectResult = useHudStore((s) => s.selectResult);
 
+  // Which row Back should restore focus to (the row unmounts while the detail
+  // is open, so the id has to survive here). Cleared once the list consumed it.
+  const [restoreFocusId, setRestoreFocusId] = useState<string | null>(null);
+
   const selected = useMemo(
     () => (selectedResultId ? results.find((r) => r.id === selectedResultId) ?? null : null),
     [results, selectedResultId],
   );
+
+  const handleBack = useCallback(() => {
+    if (selectedResultId) setRestoreFocusId(selectedResultId);
+    selectResult(null);
+  }, [selectedResultId, selectResult]);
 
   if (selected) {
     return (
@@ -35,13 +50,21 @@ export function ResultsTab({ sessionId, ownerToken, onSend }: ResultsTabProps) {
         result={selected}
         sessionId={sessionId}
         ownerToken={ownerToken}
-        onBack={() => selectResult(null)}
+        onBack={handleBack}
         onSend={onSend}
       />
     );
   }
 
-  return <ResultList results={results} selectedId={selectedResultId} onSelect={selectResult} />;
+  return (
+    <ResultList
+      results={results}
+      selectedId={selectedResultId}
+      onSelect={selectResult}
+      restoreFocusId={restoreFocusId}
+      onRestoredFocus={() => setRestoreFocusId(null)}
+    />
+  );
 }
 
 export default ResultsTab;

--- a/frontend/components/sidebar/results/result-detail.tsx
+++ b/frontend/components/sidebar/results/result-detail.tsx
@@ -18,7 +18,7 @@
  * text intents, never mixed with map controls. A failed result drops the
  * output/actions sections — its content is the correction hint.
  */
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   ArrowLeft,
   Eye,
@@ -205,12 +205,20 @@ export function ResultDetail({ result, sessionId, ownerToken, onBack, onSend }: 
   const zoomAction = mapActions.find((a) => a.kind === 'zoom');
   const analyticalActions = actions.filter((a) => !MAP_ACTION_KINDS.includes(a.kind));
 
+  // Focus contract (drill-in): landing in the detail puts keyboard users on
+  // the first control — Back. The ring only paints for keyboard-origin focus
+  // (`:focus-visible`), so mouse users see no change.
+  const backRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    backRef.current?.focus();
+  }, []);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {/* Header — persistent compact bar (outside the scroll area, so the
           result identity + status survive any scroll depth). */}
       <header className="flex shrink-0 items-center gap-1.5 border-b border-edge-subtle px-panel py-1">
-        <IconButton label="返回结果列表" icon={ArrowLeft} size="sm" onClick={onBack} />
+        <IconButton ref={backRef} label="返回结果列表" icon={ArrowLeft} size="sm" onClick={onBack} />
         <div className="flex min-w-0 flex-1 flex-col">
           <span className="truncate text-title font-medium leading-tight text-ink">{result.toolLabel}</span>
           <span className="truncate text-caption leading-tight text-ink-muted">

--- a/frontend/components/sidebar/results/result-list.tsx
+++ b/frontend/components/sidebar/results/result-list.tsx
@@ -38,30 +38,40 @@ function formatTime(ms?: number): string {
 }
 
 export function ResultList({ results, selectedId, onSelect, restoreFocusId, onRestoredFocus }: ResultListProps) {
+  // The focus contract needs a focusable container whichever branch renders
+  // (list <ul> / empty-state wrapper <div>) — resolve at effect time.
   const listRef = useRef<HTMLUListElement>(null);
+  const emptyRef = useRef<HTMLDivElement>(null);
 
   // Focus contract: after Back, focus returns to the row that was opened
   // (consumed exactly once — unrelated re-renders never steal focus).
   useEffect(() => {
     if (!restoreFocusId) return;
-    const list = listRef.current;
-    const btn = list?.querySelector(
-      `button[data-result-id="${CSS.escape(restoreFocusId)}"]`,
-    );
-    if (btn instanceof HTMLButtonElement) {
-      btn.focus();
-    } else {
-      // The row is gone (removed from the detail view, or evicted by the
-      // 50-result cap while open) — land on the list container instead of
-      // dropping keyboard focus to <body>.
-      list?.focus();
+    const container = listRef.current ?? emptyRef.current;
+    if (container) {
+      const btn = container.querySelector(
+        `button[data-result-id="${CSS.escape(restoreFocusId)}"]`,
+      );
+      if (btn instanceof HTMLButtonElement) {
+        btn.focus();
+      } else {
+        // The row is gone (removed from the detail view, or evicted by the
+        // 50-result cap while open) — land on the list container instead of
+        // dropping keyboard focus to <body>. Covers the empty-list state
+        // too (removing the last result goes Back to an empty list).
+        container.focus();
+      }
     }
     onRestoredFocus?.();
   }, [restoreFocusId, results, onRestoredFocus]);
 
   if (results.length === 0) {
     return (
-      <div className="flex min-h-0 flex-1 items-center justify-center p-4">
+      <div
+        ref={emptyRef}
+        tabIndex={-1}
+        className="flex min-h-0 flex-1 items-center justify-center p-4 outline-none focus:outline-none"
+      >
         <EmptyState
           icon={ClipboardList}
           title="暂无分析结果"

--- a/frontend/components/sidebar/results/result-list.tsx
+++ b/frontend/components/sidebar/results/result-list.tsx
@@ -10,6 +10,7 @@
  * linkage · warning tally · summary on the second. Selected ≠ hover (accent
  * edge + surface-selected vs plain hover), per the nav-rail contract.
  */
+import { useEffect, useRef } from 'react';
 import { ClipboardList, Layers, TriangleAlert } from 'lucide-react';
 import clsx from 'clsx';
 import { familyLabel } from '@/lib/results/families';
@@ -21,6 +22,10 @@ interface ResultListProps {
   results: AnalysisResult[];
   selectedId: string | null;
   onSelect: (id: string) => void;
+  /** Row id whose focus Back should restore (drill-in focus contract). */
+  restoreFocusId?: string | null;
+  /** Called after `restoreFocusId` was consumed (whether the row was found). */
+  onRestoredFocus?: () => void;
 }
 
 function formatTime(ms?: number): string {
@@ -32,7 +37,20 @@ function formatTime(ms?: number): string {
   }
 }
 
-export function ResultList({ results, selectedId, onSelect }: ResultListProps) {
+export function ResultList({ results, selectedId, onSelect, restoreFocusId, onRestoredFocus }: ResultListProps) {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Focus contract: after Back, focus returns to the row that was opened
+  // (consumed exactly once — unrelated re-renders never steal focus).
+  useEffect(() => {
+    if (!restoreFocusId) return;
+    const btn = listRef.current?.querySelector(
+      `button[data-result-id="${CSS.escape(restoreFocusId)}"]`,
+    );
+    if (btn instanceof HTMLButtonElement) btn.focus();
+    onRestoredFocus?.();
+  }, [restoreFocusId, results, onRestoredFocus]);
+
   if (results.length === 0) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center p-4">
@@ -46,7 +64,7 @@ export function ResultList({ results, selectedId, onSelect }: ResultListProps) {
   }
 
   return (
-    <ul aria-label="分析结果列表" className="flex min-h-0 flex-1 flex-col overflow-y-auto py-1">
+    <ul ref={listRef} aria-label="分析结果列表" className="flex min-h-0 flex-1 flex-col overflow-y-auto py-1">
       {results.map((r) => {
         const selected = r.id === selectedId;
         const hasLayer = r.outputs[0]?.hasLayer;
@@ -54,6 +72,7 @@ export function ResultList({ results, selectedId, onSelect }: ResultListProps) {
           <li key={r.id}>
             <button
               type="button"
+              data-result-id={r.id}
               aria-current={selected ? 'true' : undefined}
               onClick={() => onSelect(r.id)}
               className={clsx(

--- a/frontend/components/sidebar/results/result-list.tsx
+++ b/frontend/components/sidebar/results/result-list.tsx
@@ -44,10 +44,18 @@ export function ResultList({ results, selectedId, onSelect, restoreFocusId, onRe
   // (consumed exactly once — unrelated re-renders never steal focus).
   useEffect(() => {
     if (!restoreFocusId) return;
-    const btn = listRef.current?.querySelector(
+    const list = listRef.current;
+    const btn = list?.querySelector(
       `button[data-result-id="${CSS.escape(restoreFocusId)}"]`,
     );
-    if (btn instanceof HTMLButtonElement) btn.focus();
+    if (btn instanceof HTMLButtonElement) {
+      btn.focus();
+    } else {
+      // The row is gone (removed from the detail view, or evicted by the
+      // 50-result cap while open) — land on the list container instead of
+      // dropping keyboard focus to <body>.
+      list?.focus();
+    }
     onRestoredFocus?.();
   }, [restoreFocusId, results, onRestoredFocus]);
 
@@ -64,7 +72,12 @@ export function ResultList({ results, selectedId, onSelect, restoreFocusId, onRe
   }
 
   return (
-    <ul ref={listRef} aria-label="分析结果列表" className="flex min-h-0 flex-1 flex-col overflow-y-auto py-1">
+    <ul
+      ref={listRef}
+      tabIndex={-1}
+      aria-label="分析结果列表"
+      className="flex min-h-0 flex-1 flex-col overflow-y-auto py-1 outline-none focus:outline-none"
+    >
       {results.map((r) => {
         const selected = r.id === selectedId;
         const hasLayer = r.outputs[0]?.hasLayer;

--- a/frontend/lib/hooks/use-sse-stream.layer-fetch.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.layer-fetch.test.ts
@@ -1,0 +1,102 @@
+import { it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSSEStream } from './use-sse-stream';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { devOnly } from '@/lib/utils/logger';
+
+/**
+ * LiveLayerFetch abort-noise contract: the layer-data fetch is aborted by our
+ * own session-switch/unmount control flow, and transport rethrows caller
+ * aborts as native AbortError. That is expected control flow — it must not
+ * reach devOnly.error (console noise in every session switch). Genuine
+ * failures still log.
+ */
+const bridgeMock = vi.hoisted(() => ({
+  send: vi.fn().mockResolvedValue(undefined),
+  aiStatus: 'idle',
+  onEventCallback: null as ((event: {
+    event: string;
+    data: Record<string, unknown>;
+  }) => void) | null,
+}));
+
+const apiFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./useMapBridge', () => ({
+  useMapBridge: (...args: unknown[]) => {
+    bridgeMock.onEventCallback = args[2] as typeof bridgeMock.onEventCallback;
+    return bridgeMock;
+  },
+}));
+vi.mock('@/lib/utils/logger', () => ({
+  devOnly: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  safeError: vi.fn(),
+}));
+vi.mock('@/lib/api/config', () => ({ API_BASE: 'http://localhost:8000' }));
+vi.mock('@/lib/api/transport', () => ({
+  apiFetch: apiFetchMock,
+  // Transport's real isApiError checks for ApiError; AbortError is not one.
+  isApiError: (err: unknown) => err instanceof Error && err.name === 'ApiError',
+}));
+
+function emitStepResult() {
+  act(() => {
+    bridgeMock.onEventCallback?.({
+      event: 'step_result',
+      data: {
+        task_id: 't1',
+        step_id: 's1',
+        tool: 'buffer_analysis',
+        geojson_ref: 'ref:abort-test',
+        result: { success: true, summary: 'ok' },
+      },
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useHudStore.setState({ layers: [], results: [] });
+  renderHook(() =>
+    useSSEStream(
+      'sid-abort',
+      vi.fn(),
+      { current: 'sid-abort' },
+      vi.fn(),
+      () => null,
+      null,
+      { current: null },
+    ),
+  );
+});
+
+async function flushFetch() {
+  // Let the .then/.catch microtasks of the layer fetch settle.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+it('does not log an error when the layer fetch is aborted by us (AbortError)', async () => {
+  const abortErr = new DOMException('The user aborted a request.', 'AbortError');
+  apiFetchMock.mockRejectedValueOnce(abortErr);
+
+  emitStepResult();
+  await flushFetch();
+
+  expect(apiFetchMock).toHaveBeenCalled();
+  expect(devOnly.error).not.toHaveBeenCalled();
+});
+
+it('still logs genuine layer fetch failures', async () => {
+  apiFetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+  emitStepResult();
+  await flushFetch();
+
+  expect(devOnly.error).toHaveBeenCalledWith(
+    '[LiveLayerFetch] Failed to fetch geojson_ref:',
+    expect.any(TypeError),
+  );
+});

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -443,7 +443,12 @@ export function useSSEStream(
                 }
               })
               .catch((err) => {
-                if (!isApiError(err)) {
+                // transport 约定：调用方主动 abort 以原生 AbortError 直通（会话切换/
+                // 组件卸载会 abort 本 fetch）。这是预期控制流，不是错误，不进 console。
+                const isAbort =
+                  (err instanceof DOMException && err.name === 'AbortError') ||
+                  (err instanceof Error && err.name === 'AbortError');
+                if (!isAbort && !isApiError(err)) {
                   devOnly.error('[LiveLayerFetch] Failed to fetch geojson_ref:', err);
                 }
               });

--- a/frontend/test/results/results-ui.test.tsx
+++ b/frontend/test/results/results-ui.test.tsx
@@ -239,6 +239,19 @@ describe('ResultList — V4 density contracts', () => {
     expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
   });
 
+  it('keeps focus off <body> when removing the LAST result (empty list)', () => {
+    const r = hotspotResult();
+    useHudStore.setState({ results: [r] });
+    render(<ResultsTab sessionId="sess" ownerToken={null} onSend={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('button', { name: '返回结果列表' })).toHaveFocus();
+    fireEvent.click(screen.getByRole('button', { name: '从列表移除' }));
+
+    // List is now empty: focus lands on the empty-state container, not body.
+    expect(screen.getByText('暂无分析结果').closest('[tabindex="-1"]')).toHaveFocus();
+  });
+
   it('shows the layer chip only when an output is mounted as a layer', () => {
     const withLayer = hotspotResult();
     const without = normalizeStepResult({

--- a/frontend/test/results/results-ui.test.tsx
+++ b/frontend/test/results/results-ui.test.tsx
@@ -4,6 +4,7 @@ import { useHudStore } from '@/lib/store/useHudStore';
 import { normalizeStepResult } from '@/lib/results/normalize';
 import { ResultList } from '@/components/sidebar/results/result-list';
 import { ResultDetail } from '@/components/sidebar/results/result-detail';
+import { ResultsTab } from '@/components/sidebar/results-tab';
 import { createMockLayer } from '../test-utils';
 import type { AnalysisResult } from '@/lib/results/types';
 
@@ -193,6 +194,20 @@ describe('ResultList — V4 density contracts', () => {
     render(<ResultList results={[r]} selectedId="s1" onSelect={() => {}} />);
     const row = screen.getByRole('button');
     expect(row).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('restores focus to the opened row after Back (drill-in focus contract)', () => {
+    const r = hotspotResult();
+    useHudStore.setState({ results: [r] });
+    render(<ResultsTab sessionId="sess" ownerToken={null} onSend={() => {}} />);
+
+    // Drill in: focus lands on the detail's back button.
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('button', { name: '返回结果列表' })).toHaveFocus();
+
+    // Go back: focus returns to the row that was opened.
+    fireEvent.click(screen.getByRole('button', { name: '返回结果列表' }));
+    expect(screen.getByRole('button')).toHaveFocus();
   });
 
   it('shows the layer chip only when an output is mounted as a layer', () => {

--- a/frontend/test/results/results-ui.test.tsx
+++ b/frontend/test/results/results-ui.test.tsx
@@ -210,6 +210,35 @@ describe('ResultList — V4 density contracts', () => {
     expect(screen.getByRole('button')).toHaveFocus();
   });
 
+  it('falls back to the list container when Back targets a removed row', () => {
+    // Removing a result from its own detail view goes Back to a row that no
+    // longer exists — keyboard focus must not fall to <body>.
+    const r1 = hotspotResult();
+    const r2 = normalizeStepResult({
+      step_id: 's2',
+      tool: 'hotspot_analysis',
+      geojson_ref: 'ref:geojson-x2',
+      result: {
+        success: true,
+        summary: '第二个结果',
+        bbox: [116, 39, 117, 40],
+        data: { type: 'FeatureCollection', features: [] },
+      },
+    });
+    useHudStore.setState({ results: [r1, r2] });
+    render(<ResultsTab sessionId="sess" ownerToken={null} onSend={() => {}} />);
+
+    // Drill into the first row, then remove it from the detail (remove+back).
+    fireEvent.click(screen.getAllByRole('button')[0]);
+    expect(screen.getByRole('button', { name: '返回结果列表' })).toHaveFocus();
+    fireEvent.click(screen.getByRole('button', { name: '从列表移除' }));
+
+    // The opened row is gone: focus lands on the list container itself.
+    expect(screen.getByLabelText('分析结果列表')).toHaveFocus();
+    // And the remaining row is still offered.
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+  });
+
   it('shows the layer chip only when an output is mounted as a layer', () => {
     const withLayer = hotspotResult();
     const without = normalizeStepResult({

--- a/frontend/test/visual/capture.mjs
+++ b/frontend/test/visual/capture.mjs
@@ -507,7 +507,10 @@ async function installStubs(page) {
   await page.route('**/*', async (route) => {
     const url = route.request().url();
 
-    if (/^https?:\/\/(localhost|127\.0\.0\.1):8000\//.test(url)) {
+    // Cover BOTH dev API ports: `next dev` without env vars defaults to
+    // :8001 (lib/api/config.ts), while docs/docker setups pass
+    // NEXT_PUBLIC_API_URL=http://localhost:8000. Plain `npm run dev` works.
+    if (/^https?:\/\/(localhost|127\.0\.0\.1):800[01]\//.test(url)) {
       // The seeded chat turn replays as an SSE stream through the production
       // parser/normalizer (fills the Result Workbench registry).
       if (/\/api\/v1\/chat\/stream/.test(url)) {


### PR DESCRIPTION
Closes the recorded-but-unfixed follow-ups from #361's review round.

## Fixes

1. **Focus contract for the results master-detail (a11y).** Selecting a row unmounted the focused button — keyboard users landed on `<body>` on every drill-in, and Back didn't restore their place. Now: entering the detail focuses its back button; going back restores focus to the row that was opened (`data-result-id` + a consumed-once `restoreFocusId`). The ring only paints for keyboard-origin focus (`:focus-visible`) — verified on mouse-driven capture shots (no ring). Covered by a drill-in round-trip test.

2. **`[LiveLayerFetch]` AbortError console noise.** The layer-data fetch is aborted by our own session-switch/unmount controller, and transport deliberately rethrows caller aborts as native `AbortError` — expected control flow that was being logged as `devOnly.error` on every session switch. Now suppressed for `AbortError` only; genuine failures still log. Both paths unit-tested in a new focused harness (`use-sse-stream.layer-fetch.test.ts`).

3. **capture.mjs dev-port mismatch.** The harness stubbed only `localhost:8000`, but plain `npm run dev` defaults to `:8001` (`lib/api/config.ts`) — the documented capture workflow silently depended on an env var nobody mentioned. The stub now covers both ports; **verified end-to-end**: plain dev server (no `NEXT_PUBLIC_API_URL`), 48 seeded result-workbench shots, 0 failures. README「视觉回归」now documents the offline Google-Fonts mock (dev compile hangs without it when offline) and the SSE seeding path.

## Investigated, no change needed

- **run-inspector `partial` badge duplication** (adversarial-review concern from #361): not reachable — `run.status` is only `failed`/`cancelled` (`isPartialRun` in `lib/workflow/recovery.ts:31-37`), and no backend path emits `'partial'` run statuses. The prose「部分完成 N 步」never coexists with a `部分完成` badge.

## Validation

- `npm run typecheck` ✓ · `npm run lint` (`--max-warnings 0`) ✓ · full `npm test`: **1244 passed / 3 skipped** (pre-existing)
- Visual sanity capture against a default-port dev server: `results-detail*` × 8 contexts, all green, no focus-ring regression.

BASE_SHA: c42aa3a (master @ #366)