### PR TITLE
fix: close second-pass whole-repo review findings

### DIFF
--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -1380,18 +1380,13 @@ class PiBridge:
             )
             return {}
         result = await self._rpc.request("abort")
-        # F24: ignite the active turn's cancellation token so checkpoint()-
-        # cooperative tool dispatches (HTTP callback path) stop promptly too,
-        # not just the Pi subprocess.
-        if _active_turn_token is not None:
-            _active_turn_token.cancel("abort requested")
-        # P1 (TOCTOU): the active sid above was read lock-free BEFORE the abort
-        # RPC was awaited. In that gap the matching turn can end and a
-        # DIFFERENT session's turn start — the global abort RPC then hits the
-        # wrong turn. The damage is done by the time we can observe it, but
-        # re-reading the sid and logging the flip explicitly documents the
-        # known limit (futures already failed by fail_all_pending cannot be
-        # un-failed) instead of silently killing the wrong turn.
+        # P1 (TOCTOU) / R2-5: the active sid above was read lock-free BEFORE
+        # the abort RPC was awaited. In that gap the matching turn can end and
+        # a DIFFERENT session's turn start (notably when a shielded
+        # abort-on-disconnect outlives its turn's finally). In that case the
+        # abort RPC itself has already flown — nothing can un-send it — but we
+        # must NOT also ignite the NEW turn's token or fail its pending
+        # futures, so skip both global effects and log the flip.
         active_after = self._active_turn_sid
         if (
             session_id is not None
@@ -1400,11 +1395,16 @@ class PiBridge:
         ):
             logger.warning(
                 "[PiBridge] abort(session_id=%s) TOCTOU: the active turn "
-                "flipped %s -> %s while the abort RPC was in flight; the "
-                "global abort may have hit session %s's turn (known limit — "
-                "cannot un-fail futures)",
-                session_id, active, active_after, active_after,
+                "flipped %s -> %s while the abort RPC was in flight; skipping "
+                "token-cancel/fail_all_pending so the new turn is not killed",
+                session_id, active, active_after,
             )
+            return result or {}
+        # F24: ignite the active turn's cancellation token so checkpoint()-
+        # cooperative tool dispatches (HTTP callback path) stop promptly too,
+        # not just the Pi subprocess.
+        if _active_turn_token is not None:
+            _active_turn_token.cancel("abort requested")
         # Cancel any pending request future the client hasn't resolved yet.
         # Without this, an in-flight `prompt` would keep waiting for its
         # response up to the stream timeout (30s) and then emit a generic
@@ -1470,7 +1470,11 @@ class PiBridge:
         must never raise into the generator-cleanup path.
         """
         try:
-            await self.abort()
+            # Scope the abort to THIS turn's session: the F5 guard inside
+            # abort() then skips the global RPC/fail_all_pending when another
+            # session's turn is already active (the shielded caller may resume
+            # long after this turn ended and the lock was released).
+            await self.abort(session_id=turn_sid)
             logger.info("[PiBridge] abort sent on client disconnect (turn=%s)", turn_sid)
         except Exception as e:  # noqa: BLE001 — abort failure must not break cleanup
             logger.warning("[PiBridge] abort-on-disconnect failed (turn=%s): %s", turn_sid, e)

--- a/app/agent_pi_bridge.py
+++ b/app/agent_pi_bridge.py
@@ -1729,9 +1729,14 @@ class PiBridge:
                                     tool_call_id, _sid
                                 ),
                             )
-                            if _harness is not None:
-                                # V3: 给原始 SSE 事件记录补 turn/run correlation（显式透传）。
-                                _harness.record_sse_event({
+                            # V3: 给原始 SSE 事件记录补 turn/run correlation（显式透传）。
+                            # B-8: record against THIS turn's session harness, not the
+                            # module-global "most recently created" harness — otherwise
+                            # two interleaved sessions misattribute one session's events
+                            # to the other (record_sse_event stamps self.session_id).
+                            turn_harness = _get_session_harness(turn_sid)
+                            if turn_harness is not None:
+                                turn_harness.record_sse_event({
                                     **event, "run_id": run_id, "turn_id": turn_id,
                                 })
                             if sse:
@@ -1803,12 +1808,16 @@ class PiBridge:
                     )
                     if _active_turn_token is not None:
                         _active_turn_token.cancel("pi process exited unexpectedly")
-                elif cancelled or timed_out:
+                elif cancelled or timed_out or send_failed:
                     # Tell Pi to stop generating tokens / executing tools. F10:
                     # this now covers the stall-timeout path too — previously a
                     # stalled turn yielded error+done and returned WITHOUT the
                     # abort RPC, so Pi kept executing tools (up to the 300s RPC
                     # timeout) and a user retry duplicated side effects.
+                    # B-6: ``send_failed`` (the prompt RPC raised) must also
+                    # abort — Pi may already have started executing the prompt
+                    # and its tools, so without the abort a retry duplicates the
+                    # side effects (same class of bug F10 fixed for the stall).
                     try:
                         await asyncio.wait_for(
                             asyncio.shield(self._abort_on_disconnect(turn_sid)),

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import (
     authorize_session_write,
+    get_current_user,
     get_current_user_optional,
     get_owner_token,
     require_admin,
@@ -1159,7 +1160,7 @@ async def push_map_action_acks(
 
 
 @router.get("/skills")
-async def list_skills_api(_user: dict = Depends(get_current_user_optional)):
+async def list_skills_api(_user: dict = Depends(get_current_user)):
     """列出可用的 .md 技能 — 需要认证（技能列表属于内部元数据）。"""
     from app.tools.skills import list_md_skills
     return {"skills": list_md_skills()}
@@ -1236,7 +1237,7 @@ async def clear_session(
 
 
 @router.get("/tools")
-async def list_tools(_user: dict = Depends(get_current_user_optional)):
+async def list_tools(_user: dict = Depends(get_current_user)):
     """列出可用工具 — 需要认证（工具 schema 含 tier-3 危险工具）。"""
     return {"tools": get_registry().get_schemas()}
 

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -1160,8 +1160,15 @@ async def push_map_action_acks(
 
 
 @router.get("/skills")
-async def list_skills_api(_user: dict = Depends(get_current_user)):
-    """列出可用的 .md 技能 — 需要认证（技能列表属于内部元数据）。"""
+async def list_skills_api(_user: dict = Depends(get_current_user_optional)):
+    """列出可用的 .md 技能。
+
+    Metadata only ({name, description}); skill bodies stay server-side. The
+    shipped UI (SkillsHub) is anonymous-first with no Bearer capability, and
+    the anonymous chat agent surfaces these same skills in conversation —
+    so the catalog read stays optionally-authenticated. /tools below DOES
+    require auth: it returns full schemas including tier-3 parameters.
+    """
     from app.tools.skills import list_md_skills
     return {"skills": list_md_skills()}
 

--- a/app/api/routes/data_fabric.py
+++ b/app/api/routes/data_fabric.py
@@ -468,9 +468,13 @@ async def preview_catalog_item(
     item_id: str,
     limit: int = Query(10, ge=1, le=100),
     db: Session = Depends(get_db),
-    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
+    user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """获取 Spatial Catalog 项的有界样例数据预览"""
+    """获取 Spatial Catalog 项的有界样例数据预览
+
+    Requires authentication: preview triggers a server-side remote fetch against
+    the source endpoint, so anonymous callers must not be able to initiate it.
+    """
     try:
         _authorize_catalog_item(db, item_id, user)
         q_spec = QuerySpec(limit=limit)
@@ -494,9 +498,13 @@ async def query_catalog_item(
     item_id: str,
     query_spec: QuerySpec,
     db: Session = Depends(get_db),
-    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
+    user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """执行下推（Pushdown）选择性查询"""
+    """执行下推（Pushdown）选择性查询
+
+    Requires authentication: query runs a remote fetch against the source
+    endpoint, so anonymous callers must not be able to initiate it.
+    """
     try:
         _authorize_catalog_item(db, item_id, user)
         q_res = data_fabric_manager.query_catalog_item(db, item_id, query_spec)
@@ -513,9 +521,13 @@ async def materialize_catalog_item(
     req: MaterializeRequest,
     owner_token: Optional[str] = Header(None, alias="X-Session-Token"),
     db: Session = Depends(get_db),
-    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
+    user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """按需实例化（Materialize）数据至会话 SessionStore 并产生 ref_id 游标"""
+    """按需实例化（Materialize）数据至会话 SessionStore 并产生 ref_id 游标
+
+    Requires authentication: materialize runs a remote fetch and writes session
+    store refs, so anonymous callers must not be able to initiate it.
+    """
     try:
         _authorize_catalog_item(db, req.catalog_item_id, user)
         _require_existing_session_owner(db, req.session_id, user, owner_token)

--- a/app/api/routes/data_fabric.py
+++ b/app/api/routes/data_fabric.py
@@ -10,7 +10,7 @@ from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
-from app.core.auth import get_current_user_optional
+from app.core.auth import get_current_user, get_current_user_optional
 from app.models.data_fabric import DataSourceModel, CatalogItemModel
 from app.schemas.data_fabric_schema import (
     ConnectionProfile,
@@ -162,9 +162,15 @@ class MaterializeRequest(BaseModel):
 async def create_data_source(
     req: CreateDataSourceRequest,
     db: Session = Depends(get_db),
-    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
+    user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """注册新的地理空间数据源连接配置"""
+    """注册新的地理空间数据源连接配置
+
+    Requires authentication: an anonymous caller previously created a tenant-
+    GLOBAL source (org_id NULL, owner_id NULL) that then appeared in every
+    anonymous user's list and was probe/sync-able by anyone. State-changing +
+    outbound-request-triggering endpoints must not be unauthenticated.
+    """
     try:
         # SSRF is always enforced at registration (ADR-0050 §5 P0). A previous
         # `allow_private` request field let any caller disable all private/loopback/
@@ -276,9 +282,14 @@ async def delete_data_source(
 async def probe_data_source(
     source_id: str,
     db: Session = Depends(get_db),
-    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
+    user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """探查数据源健康状况与连通性"""
+    """探查数据源健康状况与连通性
+
+    Requires authentication: probe triggers a server-side outbound HTTP request
+    to the source endpoint — anonymous callers must not be able to initiate
+    arbitrary outbound requests.
+    """
     s = db.query(DataSourceModel).filter(DataSourceModel.id == source_id).first()
     _require_tenant_owned(s, user)
 
@@ -302,9 +313,13 @@ async def probe_data_source(
 async def sync_data_source_catalog(
     source_id: str,
     db: Session = Depends(get_db),
-    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
+    user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """主动刷新/同步数据源图层元数据至 Spatial Catalog"""
+    """主动刷新/同步数据源图层元数据至 Spatial Catalog
+
+    Requires authentication: sync triggers outbound requests against the source
+    endpoint; anonymous callers must not initiate them.
+    """
     s = db.query(DataSourceModel).filter(DataSourceModel.id == source_id).first()
     _require_tenant_owned(s, user)
     try:

--- a/app/api/routes/data_fabric.py
+++ b/app/api/routes/data_fabric.py
@@ -267,9 +267,15 @@ async def get_data_source(
 async def delete_data_source(
     source_id: str,
     db: Session = Depends(get_db),
-    user: Optional[Dict[str, Any]] = Depends(get_current_user_optional),
+    user: Dict[str, Any] = Depends(get_current_user),
 ):
-    """删除指定数据源及其关联目录项"""
+    """删除指定数据源及其关联目录项
+
+    Requires authentication: DELETE is destructive and cascade-removes catalog
+    items. The anonymous branch of _require_tenant_owned still matched legacy
+    GLOBAL sources (org_id/owner_id both NULL), making them deletable by any
+    unauthenticated caller.
+    """
     s = db.query(DataSourceModel).filter(DataSourceModel.id == source_id).first()
     _require_tenant_owned(s, user)
 

--- a/app/lib/geo_analysis/network.py
+++ b/app/lib/geo_analysis/network.py
@@ -58,17 +58,16 @@ def calculate_isochrones(network_geojson: dict | str, facility_points: dict | st
                 coords = list(geom.coords)
                 start_node = coords[0]
                 end_node = coords[-1]
-                
-                # Weight by length (meters in UTM)
-                if "length" in row and row["length"] is not None:
-                    weight = float(row["length"])
-                else:
-                    weight = geom.length
-                    logger.warning(
-                        "Edge at index %d has no 'length' property; using geometry.length (%fm). "
-                        "Accuracy depends on input CRS being projected (meters).",
-                        idx, weight,
-                    )
+
+                # Weight by edge length in METERS. The GeoDataFrame has already
+                # been reprojected to a metric UTM CRS (to_utm_gdf above), so
+                # ``geom.length`` is always in meters. The previous code trusted
+                # a source ``length`` attribute verbatim — but the attribute is
+                # NOT reprojected, so a geographic (EPSG:4326) source carried
+                # degree-valued lengths (~0.01). With max_dist in meters that
+                # made every connected edge "reachable" and the isochrone
+                # swallowed the whole network. Derive from geometry instead.
+                weight = float(geom.length) if geom.length else 0.0
                 G.add_edge(start_node, end_node, weight=weight, geometry=geom)
         
         isochrone_features = []

--- a/app/services/data_parser.py
+++ b/app/services/data_parser.py
@@ -203,8 +203,12 @@ def _parse_csv(
         crs="EPSG:4326",
     )
 
-    # 去掉无效几何 (NaN/Inf coordinates included)
-    finite = np.isfinite(lng.to_numpy()) & np.isfinite(lat.to_numpy())
+    # 去掉无效几何 (NaN/Inf coordinates included). Build the mask as a Series
+    # aligned to df's index so it stays correct even if read_csv gains an
+    # index_col or the frame is reindexed before masking.
+    finite = pd.Series(
+        np.isfinite(lng.to_numpy()) & np.isfinite(lat.to_numpy()), index=df.index
+    )
     gdf = gdf[finite & ~gdf.geometry.is_empty & gdf.geometry.notna()]
     if gdf.empty:
         raise ParseError("CSV 中没有有效的坐标数据")

--- a/app/services/data_parser.py
+++ b/app/services/data_parser.py
@@ -176,6 +176,7 @@ def _parse_csv(
     upload_id: str,
 ) -> Dict[str, Any]:
     """解析 CSV 文件，自动检测经纬度列"""
+    import numpy as np
     import pandas as pd
 
     df = pd.read_csv(file_path)
@@ -190,15 +191,21 @@ def _parse_csv(
             f"支持的列名: 经度({', '.join(LNG_COLUMNS)}), 纬度({', '.join(LAT_COLUMNS)})"
         )
 
-    # 转为 GeoDataFrame
+    # 转为 GeoDataFrame. Coerce non-numeric / blank cells to NaN (instead of a
+    # raw ValueError -> HTTP 500), then drop every row whose coordinates are not
+    # finite. A ``POINT (nan nan)`` is neither empty nor NA, so the old filter
+    # kept it and downstream consumers (mvt/utm/stats) silently propagated NaN.
+    lng = pd.to_numeric(df[lng_col], errors="coerce")
+    lat = pd.to_numeric(df[lat_col], errors="coerce")
     gdf = gpd.GeoDataFrame(
         df,
-        geometry=gpd.points_from_xy(df[lng_col].astype(float), df[lat_col].astype(float)),
+        geometry=gpd.points_from_xy(lng, lat),
         crs="EPSG:4326",
     )
 
-    # 去掉无效几何
-    gdf = gdf[~gdf.geometry.is_empty & gdf.geometry.notna()]
+    # 去掉无效几何 (NaN/Inf coordinates included)
+    finite = np.isfinite(lng.to_numpy()) & np.isfinite(lat.to_numpy())
+    gdf = gdf[finite & ~gdf.geometry.is_empty & gdf.geometry.notna()]
     if gdf.empty:
         raise ParseError("CSV 中没有有效的坐标数据")
 

--- a/app/services/mapspec/pipeline.py
+++ b/app/services/mapspec/pipeline.py
@@ -119,7 +119,12 @@ def process_layer_ingestion(
     if is_raster_entry(source_entry) or is_data_fabric_entry(source_entry):
         data_to_profile = source_entry.get("inlineData")
     else:
-        data_to_profile = processed_source_data or profile_data(source_entry)
+        # Profile only what the ENTRY actually carries (inline/url/path —
+        # store_data already normalized the carrier). Never re-profile the
+        # raw source_data dict: for ref-carried sources it is a metadata
+        # carrier (no features), and profiling it overwrote the
+        # descriptor-derived profile with an empty one.
+        data_to_profile = profile_data(source_entry)
 
     if data_to_profile and isinstance(data_to_profile, dict) and (
         processed_source_data is not None or "profile" not in source_entry

--- a/app/services/mapspec_source.py
+++ b/app/services/mapspec_source.py
@@ -31,6 +31,15 @@ def store_data(entry: Dict[str, Any], data: Any) -> None:
                 entry[_BOUNDS] = data[_BOUNDS]
             if _IMAGE_SIZE in data:
                 entry[_IMAGE_SIZE] = data[_IMAGE_SIZE]
+        elif "catalog_item_id" in data or data.get("type") in DATAFABRIC_SOURCE_TYPES:
+            # DataFabric protocol source (ADR-0050). MUST be checked before
+            # the plain-ref branch: a lazy/materialized fabric payload can
+            # carry BOTH catalog_item_id and a ref:df-* ref_id, and the old
+            # ordering demoted it to a geojson ref source, silently dropping
+            # the lazy fabric semantics.
+            entry["type"] = data.get("type", "data_fabric")
+            for k, v in data.items():
+                entry[k] = v
         elif isinstance(data.get("ref_id"), str) and data["ref_id"].startswith("ref:"):
             # Session-owned metadata carrier. It deliberately contains no
             # feature body: cartographic review can use the descriptor-derived
@@ -45,10 +54,6 @@ def store_data(entry: Dict[str, Any], data: Any) -> None:
                 entry["profile_fingerprint"] = data["profile_fingerprint"]
             if isinstance(data.get("data_fingerprint"), str):
                 entry["data_fingerprint"] = data["data_fingerprint"]
-        elif "catalog_item_id" in data or data.get("type") in DATAFABRIC_SOURCE_TYPES:
-            entry["type"] = data.get("type", "data_fabric")
-            for k, v in data.items():
-                entry[k] = v
         else:
             # An ordinary object is a GeoJSON/inline carrier. Explicit source
             # replacement must not retain a prior raster/vector discriminator.
@@ -87,11 +92,18 @@ def is_raster_entry(entry: Dict[str, Any]) -> bool:
 
 
 def is_data_fabric_entry(entry: Dict[str, Any]) -> bool:
-    """True if the entry is a DataFabric lazy or materialized protocol source entry (ADR-0050)."""
+    """True if the entry is a DataFabric lazy or materialized protocol source entry (ADR-0050).
+
+    Deliberately does NOT treat a bare ``ref_id`` as a fabric marker: the
+    geojson ref branch of :func:`store_data` also writes ``ref_id``, so that
+    heuristic misclassified every session geojson-ref source as fabric (and
+    pipeline.py's profiler then skipped them). Fabric entries carry an
+    explicit ``type``, a ``catalog_item_id``, the ``lazy`` flag, or a fabric
+    ``ref:`` URL."""
     st = entry.get("type")
     if st in DATAFABRIC_SOURCE_TYPES:
         return True
-    if "catalog_item_id" in entry or "ref_id" in entry or entry.get("lazy") is True:
+    if "catalog_item_id" in entry or entry.get("lazy") is True:
         return True
     url_val = entry.get(_URL)
     if isinstance(url_val, str) and url_val.startswith("ref:"):

--- a/app/services/mapspec_store.py
+++ b/app/services/mapspec_store.py
@@ -29,6 +29,7 @@ from app.services.mapspec.store import (
     view_has_center,
 )
 from app.services.session_data import session_data_manager
+from app.services.session_data_protocol import is_unavailable_ref
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +147,16 @@ class MapSpecStore:
                 if isinstance(geojson_data, dict)
                 else None
             )
+            # R3-3 (sibling path): a Redis outage makes store() return the
+            # unavailable-ref sentinel. UpsertSourceIntent would persist a
+            # source pointing at a ref with no payload anywhere — and unlike
+            # the tool path there is no result_ref for the dispatch-level
+            # check to catch. Refuse before the MapSpec write.
+            if is_unavailable_ref(ref_id):
+                raise RuntimeError(
+                    "session store unavailable: refusing to persist source "
+                    "with an unreadable ref; retry shortly"
+                )
 
         profile_payload = json.dumps(
             profile, ensure_ascii=False, sort_keys=True, separators=(",", ":"),

--- a/app/services/mvt.py
+++ b/app/services/mvt.py
@@ -988,8 +988,11 @@ def _pure_bounds(gtype: str, coords) -> Optional[Tuple[float, float, float, floa
     count = 0
     for _kind, _role, part in parts:
         for lon, lat in part:
-            if lon is None or lat is None:
-                return None
+            # R2F-1: skip non-finite vertices (same guard as the pure encoder)
+            # — a NaN y silently "passes" the clamp comparisons, and its finite
+            # x would still enter the bbox, producing an oversized envelope.
+            if not _finite_pair(lon, lat):
+                continue
             px, py = _project(lon, lat, 0)
             if px < minx:
                 minx = px

--- a/app/services/mvt.py
+++ b/app/services/mvt.py
@@ -82,7 +82,8 @@ def _finite_pair(lon, lat) -> bool:
     """True iff both coordinates are present and finite (drops NaN/Inf inputs)."""
     try:
         return math.isfinite(float(lon)) and math.isfinite(float(lat))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: float(huge_int) overflows (e.g. a pathological coord).
         return False
 
 _SUPPORTED_TYPES = frozenset(

--- a/app/services/mvt.py
+++ b/app/services/mvt.py
@@ -70,6 +70,21 @@ _BUFFER_PX = _BUFFER_UNITS / (_EXTENT / 256.0)
 # minimum ring area (extent units^2) after quantization; smaller is invisible
 _AREA_EPS = 1.0
 
+# Web-Mercator is only defined for |lat| <= ~85.051129°. A vertex at the poles
+# (lat = ±90) makes tan(±π/2)/1/cos(±π/2) blow up: the pure path raises
+# ValueError (math domain), the shapely path emits +inf/NaN. Clamp latitude
+# before projecting so pole-spanning geometries (e.g. Antarctica) render at the
+# world edge instead of crashing or distorting.
+_MAX_WEBMERCATOR_LAT = 85.05112878
+
+
+def _finite_pair(lon, lat) -> bool:
+    """True iff both coordinates are present and finite (drops NaN/Inf inputs)."""
+    try:
+        return math.isfinite(float(lon)) and math.isfinite(float(lat))
+    except (TypeError, ValueError):
+        return False
+
 _SUPPORTED_TYPES = frozenset(
     {"Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon"}
 )
@@ -128,8 +143,15 @@ def _project(lon: float, lat: float, z: int) -> Tuple[float, float]:
     Projection is homogeneous in z: _project(lon, lat, z) ==
     _project(lon, lat, 0) * 2^z, so geometries indexed in z0 world pixels
     (world = 256) can be re-used at any zoom by a simple scale.
+
+    Latitude is clamped to the Web-Mercator valid range (|lat| <= 85.0511°);
+    without this, a pole vertex (lat = ±90) makes the projection diverge.
     """
     world = 256.0 * (1 << z)
+    if lat > _MAX_WEBMERCATOR_LAT:
+        lat = _MAX_WEBMERCATOR_LAT
+    elif lat < -_MAX_WEBMERCATOR_LAT:
+        lat = -_MAX_WEBMERCATOR_LAT
     x = (lon + 180.0) / 360.0 * world
     lat_rad = math.radians(lat)
     y = (1.0 - math.log(math.tan(lat_rad) + 1.0 / math.cos(lat_rad)) / math.pi) / 2.0 * world
@@ -137,9 +159,13 @@ def _project(lon: float, lat: float, z: int) -> Tuple[float, float]:
 
 
 def _transform_z0(coords):
-    """Vectorized _project(..., z=0) for shapely.transform (y-down world px)."""
+    """Vectorized _project(..., z=0) for shapely.transform (y-down world px).
+
+    Latitude is clamped to the Web-Mercator valid range (see ``_project``); a
+    pole vertex otherwise produces inf/NaN and corrupts the indexed geometry.
+    """
     x = coords[:, 0]
-    y = coords[:, 1]
+    y = np.clip(coords[:, 1], -_MAX_WEBMERCATOR_LAT, _MAX_WEBMERCATOR_LAT)
     xs = (x + 180.0) / 360.0 * 256.0
     lat_rad = np.radians(y)
     ys = (1.0 - np.log(np.tan(lat_rad) + 1.0 / np.cos(lat_rad)) / np.pi) / 2.0 * 256.0
@@ -640,7 +666,7 @@ def _encode_line_polygon_pure(gtype: str, coords, z: int, x: int, y: int) -> Opt
         if kind == "ring":
             if not is_poly:
                 continue
-            projected = [_project(lon, lat, 0) for lon, lat in part]
+            projected = [_project(lon, lat, 0) for lon, lat in part if _finite_pair(lon, lat)]
             clipped = _clip_polygon_rect(projected, *rect)
             ring = _normalize_ring(clipped)
             if ring is None:
@@ -654,7 +680,7 @@ def _encode_line_polygon_pure(gtype: str, coords, z: int, x: int, y: int) -> Opt
         elif kind == "line":
             if is_poly:
                 continue
-            projected = [_project(lon, lat, 0) for lon, lat in part]
+            projected = [_project(lon, lat, 0) for lon, lat in part if _finite_pair(lon, lat)]
             for run in _clip_polyline_lb(projected, *rect):
                 q = _quantize_line(run, factor, x, y)
                 if len(q) < 2:

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -32,14 +32,22 @@ from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-# Terminal statuses for the first-terminal-wins guard. Only completed/cancelled
-# are truly immutable: ``partially_completed`` is a resumable intermediate, and
-# ``failed`` is resumable too (a transient failure is meant to be retried — the
-# livelock guard separately blocks re-running DETERMINISTIC failures). Treating
-# either as terminal silently dropped the resume convergence write, so a
-# resumed-and-finished plan kept its old status in storage forever while the
-# caller received the new terminal.
+# First-terminal-wins status transition rules.
+#   * ``completed`` / ``cancelled`` are immutable (except a ``superseded``
+#     annotation, which merges into a fresh payload read).
+#   * ``failed`` is RESUMABLE but not freely overwritable: the executor may
+#     legitimately converge it (failed -> running -> completed/partial), yet a
+#     concurrent ``cancelled`` write must NOT flip it (chaos P2) — a cancel
+#     that races the failure write loses, same as before.
+#   * ``partially_completed`` / running / pending have no restriction.
+# Previously ``partially_completed`` and ``failed`` were both fully terminal,
+# which silently dropped the resume convergence write: a resumed-and-finished
+# plan kept its old status in storage forever while the caller received the
+# new terminal.
 _TERMINAL_STATUSES = frozenset({"completed", "cancelled"})
+_FAILED_RESUME_TARGETS = frozenset(
+    {"failed", "running", "completed", "partially_completed", "superseded"}
+)
 
 
 async def _cancel_wave_tasks(wave_tasks: set[asyncio.Task]) -> None:
@@ -346,19 +354,17 @@ async def update_plan_status(session_id: str, plan_id: str, **updates: Any) -> N
         return
     current_status = plan_data.get("__status__")
     new_status = updates.get("__status__")
-    # First-terminal-wins: a true terminal (completed/cancelled) must not
-    # be revived to running. One legitimate override is exempt:
-    #   * ``superseded`` — an external lifecycle signal that a newer plan
-    #     won. It merges into a FRESH payload read (update_plan_status
-    #     reloads before writing), so it cannot clobber __step_results__;
-    #     it only records the supersede on an already-finished plan.
-    #   * (``partially_completed`` and ``failed`` are no longer terminal, so
-    #     they converge freely.)
+    # First-terminal-wins / resume convergence (see _TERMINAL_STATUSES above):
+    # completed/cancelled are immutable (a ``superseded`` annotation is the one
+    # exemption — it merges into a fresh payload read, so it cannot clobber
+    # __step_results__); ``failed`` only accepts executor-resume targets.
     if (
         new_status is not None
-        and current_status in _TERMINAL_STATUSES
         and new_status != current_status
-        and new_status != "superseded"
+        and (
+            (current_status in _TERMINAL_STATUSES and new_status != "superseded")
+            or (current_status == "failed" and new_status not in _FAILED_RESUME_TARGETS)
+        )
     ):
         logger.warning(
             f"update_plan_status: plan {plan_id} 已处于终态 {current_status}，"

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -32,7 +32,12 @@ from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "partially_completed"})
+# Terminal statuses for the first-terminal-wins guard. ``partially_completed``
+# is intentionally NOT terminal: it is a resumable intermediate (the resume
+# path re-executes and must converge to completed/failed/cancelled). Treating
+# it as terminal silently dropped the partial->completed transition, so a
+# resumed-and-finished plan stayed partially_completed in storage forever.
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
 
 
 async def _cancel_wave_tasks(wave_tasks: set[asyncio.Task]) -> None:
@@ -339,10 +344,16 @@ async def update_plan_status(session_id: str, plan_id: str, **updates: Any) -> N
         return
     current_status = plan_data.get("__status__")
     new_status = updates.get("__status__")
+    # First-terminal-wins: a true terminal (completed/failed/cancelled) must not
+    # be revived to running. Two legitimate overrides are exempt:
+    #   * ``superseded`` — an external lifecycle signal that a newer plan won;
+    #     it must be recordable on a finished plan so later reads see it.
+    #   * (``partially_completed`` is no longer terminal, so it converges freely.)
     if (
         new_status is not None
         and current_status in _TERMINAL_STATUSES
         and new_status != current_status
+        and new_status != "superseded"
     ):
         logger.warning(
             f"update_plan_status: plan {plan_id} 已处于终态 {current_status}，"

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -32,12 +32,14 @@ from app.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-# Terminal statuses for the first-terminal-wins guard. ``partially_completed``
-# is intentionally NOT terminal: it is a resumable intermediate (the resume
-# path re-executes and must converge to completed/failed/cancelled). Treating
-# it as terminal silently dropped the partial->completed transition, so a
-# resumed-and-finished plan stayed partially_completed in storage forever.
-_TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+# Terminal statuses for the first-terminal-wins guard. Only completed/cancelled
+# are truly immutable: ``partially_completed`` is a resumable intermediate, and
+# ``failed`` is resumable too (a transient failure is meant to be retried — the
+# livelock guard separately blocks re-running DETERMINISTIC failures). Treating
+# either as terminal silently dropped the resume convergence write, so a
+# resumed-and-finished plan kept its old status in storage forever while the
+# caller received the new terminal.
+_TERMINAL_STATUSES = frozenset({"completed", "cancelled"})
 
 
 async def _cancel_wave_tasks(wave_tasks: set[asyncio.Task]) -> None:

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -346,11 +346,14 @@ async def update_plan_status(session_id: str, plan_id: str, **updates: Any) -> N
         return
     current_status = plan_data.get("__status__")
     new_status = updates.get("__status__")
-    # First-terminal-wins: a true terminal (completed/failed/cancelled) must not
-    # be revived to running. Two legitimate overrides are exempt:
-    #   * ``superseded`` — an external lifecycle signal that a newer plan won;
-    #     it must be recordable on a finished plan so later reads see it.
-    #   * (``partially_completed`` is no longer terminal, so it converges freely.)
+    # First-terminal-wins: a true terminal (completed/cancelled) must not
+    # be revived to running. One legitimate override is exempt:
+    #   * ``superseded`` — an external lifecycle signal that a newer plan
+    #     won. It merges into a FRESH payload read (update_plan_status
+    #     reloads before writing), so it cannot clobber __step_results__;
+    #     it only records the supersede on an already-finished plan.
+    #   * (``partially_completed`` and ``failed`` are no longer terminal, so
+    #     they converge freely.)
     if (
         new_status is not None
         and current_status in _TERMINAL_STATUSES
@@ -899,6 +902,15 @@ async def _execute_plan_locked(
             await _write_terminal(
                 __status__=_failure_status(),
                 __error__=f"执行异常: {e}",
+                # R2-4: record the failure class + failed step so the resume
+                # livelock guard can engage — without these, every resume of an
+                # internally-failed plan re-executed its tools from scratch
+                # (guard needs both fields and a non-transient class).
+                __failure_class__="internal",
+                __failed_step__=next(
+                    (s["id"] for s in plan.get("steps", []) if s["id"] not in step_results),
+                    None,
+                ),
                 __step_results__=await _persist_step_results(session_id, plan_id, step_results),
             )
         except Exception as e2:  # noqa: BLE001 —— 收敛写失败不能替换原始异常

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -819,14 +819,20 @@ async def _execute_plan_locked(
                     except Exception as e:
                         logger.exception(f"[PlanMode] step {sid} raised")
                         fc, ra = _classify_failure(exception=e)
-                        failure = (sid, str(e), None, fc, ra)
-                        break
+                        if failure is None:
+                            failure = (sid, str(e), None, fc, ra)
+                        # R3-5: keep scanning the SAME wait batch — breaking
+                        # here dropped already-done siblings' successes from
+                        # step_results whenever the failing task iterated
+                        # first (non-deterministic set order).
+                        continue
                     # 工具返回 success=False（V3.x Exception As Thought 包装）也视为失败
                     if isinstance(result, dict) and result.get("success") is False:
                         err = result.get("message") or result.get("error", "tool failed")
                         fc, ra = _classify_failure(result=result)
-                        failure = (sid, err, result, fc, ra)
-                        break
+                        if failure is None:
+                            failure = (sid, err, result, fc, ra)
+                        continue
                     wave_successes[sid] = result
                 if failure is not None:
                     break

--- a/app/services/plan_mode.py
+++ b/app/services/plan_mode.py
@@ -905,6 +905,15 @@ async def _execute_plan_locked(
         await _cancel_wave_tasks(wave_tasks)
         logger.exception(f"[PlanMode] execute_plan_async aborted: {e}")
         try:
+            # R2-4: classify the exception instead of hard-coding "internal" —
+            # transient infra errors (e.g. a redis blip raising through the
+            # executor) must stay transient_network or the livelock guard will
+            # permanently refuse resume for a recoverable plan.
+            fc_int, _ra_int = _classify_failure(exception=e)
+            first_unfinished = next(
+                (s.id for s in plan.steps if s.id not in step_results),
+                None,
+            )
             await _write_terminal(
                 __status__=_failure_status(),
                 __error__=f"执行异常: {e}",
@@ -912,11 +921,11 @@ async def _execute_plan_locked(
                 # livelock guard can engage — without these, every resume of an
                 # internally-failed plan re-executed its tools from scratch
                 # (guard needs both fields and a non-transient class).
-                __failure_class__="internal",
-                __failed_step__=next(
-                    (s["id"] for s in plan.get("steps", []) if s["id"] not in step_results),
-                    None,
-                ),
+                # NOTE: plan is a PlanProposal model — attribute access only
+                # (dict access here raised AttributeError that the inner
+                # except swallowed, silently skipping the terminal write).
+                __failure_class__=fc_int or "internal",
+                __failed_step__=first_unfinished,
                 __step_results__=await _persist_step_results(session_id, plan_id, step_results),
             )
         except Exception as e2:  # noqa: BLE001 —— 收敛写失败不能替换原始异常

--- a/app/services/project_service.py
+++ b/app/services/project_service.py
@@ -23,24 +23,42 @@ logger = logging.getLogger(__name__)
 def _caller_may_access_project(project: Project, user_id: Optional[str], org_id: Optional[int]) -> bool:
     """Tenant / owner gate shared by lookup, fingerprint, and context summary.
 
-    Missing user_id AND org_id used to mean "no restriction" — but JWT helpers
-    never populate ``id`` / ``org_id``, so every HTTP caller hit that branch.
-    Anonymous callers may only see unowned (legacy/public) rows. Authenticated
-    callers are limited to their org or their own owner_id.
+    Mirrors ``list_projects`` scoping:
+      * an OWNED project is visible only to its owner or members of the
+        project's org — never to another user and never to anonymous callers;
+      * an OWNERLESS row (public, or org-owned with no personal owner) follows
+        the list query's ``owner_id IS NULL`` branches: visible to callers with
+        no org claim (incl. anonymous) and to same-org callers; a different-org
+        caller is denied.
+
+    The previous guard ``owner_id != user_id and not org_id`` skipped the owner
+    check whenever the caller carried *any* org_id — so a different user in an
+    org could read/mutate a NULL-org private project (org_id IS NULL) owned by
+    someone else. The list query hides those rows; detail/update did not.
     """
-    if org_id and project.org_id and project.org_id != org_id:
+    same_org = (
+        project.org_id is not None
+        and org_id is not None
+        and project.org_id == org_id
+    )
+    if project.owner_id:
+        # Owned row: owner or same-org member only.
+        if user_id is not None and str(project.owner_id) == str(user_id):
+            return True
+        if same_org:
+            return True
         logger.warning(
-            "IDOR attempt: user %s (org %s) tried accessing project %s (org %s)",
+            "IDOR attempt: user %s (org %s) tried accessing project %s (owner %s, org %s)",
+            user_id, org_id, project.id, project.owner_id, project.org_id,
+        )
+        return False
+    # Ownerless row (public or org-owned): a different-org caller is denied;
+    # no-org-claim callers (incl. anonymous) may see it, matching the list.
+    if project.org_id is not None and org_id is not None and project.org_id != org_id:
+        logger.warning(
+            "IDOR attempt: user %s (org %s) tried accessing org project %s (org %s)",
             user_id, org_id, project.id, project.org_id,
         )
-        return False
-    if user_id and project.owner_id and project.owner_id != user_id and not org_id:
-        logger.warning(
-            "IDOR attempt: user %s tried accessing private project %s (owner %s)",
-            user_id, project.id, project.owner_id,
-        )
-        return False
-    if not user_id and not org_id and project.owner_id:
         return False
     return True
 

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -131,11 +131,17 @@ async def delete_document(
 
     try:
         async with async_db_session() as db:
+            # Delete is creator-only (docstring: "仅删除属于自己的文档"). The
+            # previous org-scoped check let any member of an org delete another
+            # member's document — inconsistent with templates/projects, which
+            # are creator-or-admin. org_id stays on the TenantContext below for
+            # the vector-store cleanup, but it must NOT broaden the SQL guard.
             owner_check = select(Document).where(Document.id == document_id)
-            if org_id is not None:
-                owner_check = owner_check.where(Document.org_id == org_id)
-            elif user_id is not None:
+            if user_id is not None:
                 owner_check = owner_check.where(Document.creator_id == user_id)
+            else:
+                # No authenticated creator identity -> cannot authorize delete.
+                return False
             existing = (await db.execute(owner_check)).scalar_one_or_none()
             if existing is None:
                 logger.warning(

--- a/app/services/raster_tile_service.py
+++ b/app/services/raster_tile_service.py
@@ -95,7 +95,22 @@ def render_raster_tile(
 
     try:
         with rasterio.open(raster_path) as src:
-            src_crs = src.crs or "EPSG:4326"
+            # A GeoTIFF does NOT guarantee a CRS (unlike GeoJSON RFC 7946).
+            # Previously a missing CRS was silently treated as EPSG:4326, which
+            # produced wildly wrong tile windows for projected (UTM/3857)
+            # rasters. Treat a CRS-less raster as already in the rendering CRS
+            # (EPSG:3857 -> identity transform) and warn loudly so it is not
+            # silently misprojected.
+            if src.crs is None:
+                logger.warning(
+                    "raster_tile_service: %s has no CRS tag; assuming source "
+                    "is already in EPSG:3857 (no reprojection). Assign a CRS "
+                    "for correct tiling.",
+                    raster_path,
+                )
+                src_crs = "EPSG:3857"
+            else:
+                src_crs = src.crs
             src_bounds = transform_bounds("EPSG:3857", src_crs, *bounds_3857)
 
             # Read windowed slice from source

--- a/app/services/raster_tile_service.py
+++ b/app/services/raster_tile_service.py
@@ -40,6 +40,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Paths warned about lacking a CRS (bounded by the distinct-file working set;
+# not a leak — rasters are a small, short-lived set per process).
+_CRS_LESS_WARNED: set[str] = set()
+
 
 def _normalize_channel(arr: np.ndarray, valid_mask: np.ndarray) -> np.ndarray:
     """Normalize numeric array to 0-255 uint8 channel."""
@@ -102,12 +106,16 @@ def render_raster_tile(
             # (EPSG:3857 -> identity transform) and warn loudly so it is not
             # silently misprojected.
             if src.crs is None:
-                logger.warning(
-                    "raster_tile_service: %s has no CRS tag; assuming source "
-                    "is already in EPSG:3857 (no reprojection). Assign a CRS "
-                    "for correct tiling.",
-                    raster_path,
-                )
+                # Warn at most once per file: a pan/zoom touches many tiles and
+                # would otherwise emit thousands of identical warnings.
+                if raster_path not in _CRS_LESS_WARNED:
+                    _CRS_LESS_WARNED.add(raster_path)
+                    logger.warning(
+                        "raster_tile_service: %s has no CRS tag; assuming source "
+                        "is already in EPSG:3857 (no reprojection). Assign a CRS "
+                        "for correct tiling.",
+                        raster_path,
+                    )
                 src_crs = "EPSG:3857"
             else:
                 src_crs = src.crs

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -606,9 +606,11 @@ class RedisSessionStore(BaseSessionStore):
                     pipe.expire(state_key, STATE_TTL)
                     pipe.sadd(self._active_key(), session_id)
                     # D-2: a layer edit is session activity — refresh the whole
-                    # key family + bump the activity zset so a long editing
-                    # session does not lose its ref registry/payloads at the 4h
-                    # mark, and is not evicted as idle.
+                    # session KEY FAMILY (aliases/refs/refs_order/index/state/
+                    # events/ACKs) and bump the activity zset so a long editing
+                    # session is not evicted as idle and keeps its metadata.
+                    # (Per-ref payloads are TTL-refreshed on get()/ref_exists()
+                    # reads; this call refreshes the shared family keys.)
                     self._refresh_session_ttl(pipe, session_id)
                     await pipe.execute()
                     self._l1_invalidate_session(session_id)
@@ -775,9 +777,9 @@ class RedisSessionStore(BaseSessionStore):
                     pipe.expire(actions_key, STATE_TTL)
                     pipe.expire(order_key, STATE_TTL)
                     pipe.sadd(self._active_key(), session_id)
-                    # D-2: an ACK is session activity — refresh the whole key
-                    # family + bump activity so a long ACK-only session keeps its
-                    # payloads/registry and is not evicted as idle.
+                    # D-2: an ACK is session activity — refresh the session key
+                    # family + bump the activity zset so a long ACK-only session
+                    # keeps its metadata and is not evicted as idle.
                     self._refresh_session_ttl(pipe, session_id)
                     await pipe.execute()
                 return True

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -307,6 +307,11 @@ class RedisSessionStore(BaseSessionStore):
         try:
             async with self._r.pipeline() as pipe:
                 pipe.set(data_key, json.dumps(data, ensure_ascii=False), ex=DATA_TTL)
+                # D-4: the payload changed, so the cached descriptor (bbox /
+                # feature_count / geometry_types from the OLD payload) is stale.
+                # Drop it so the next get_ref_descriptor recomputes from the new
+                # payload instead of returning store-time metadata forever.
+                pipe.delete(self._descriptor_key(session_id, ref_id))
                 pipe.zadd(self._refs_order_key(session_id), {ref_id: time.time()})
                 self._refresh_session_ttl(pipe, session_id)
                 await pipe.execute()
@@ -400,12 +405,23 @@ class RedisSessionStore(BaseSessionStore):
             if raw is None:
                 return None
 
-            async with self._r.pipeline() as pipe:
-                pipe.expire(data_key, DATA_TTL)
-                pipe.expire(self._descriptor_key(session_id, ref_id), DATA_TTL)
-                pipe.zadd(self._refs_order_key(session_id), {ref_id: time.time()})
-                self._refresh_session_ttl(pipe, session_id)
-                await pipe.execute()
+            # Best-effort TTL/recency refresh: a transient Redis error on the
+            # expire/zadd pipeline must NOT turn a successful read into a
+            # cache-miss (the previous code shared one try/except with the read
+            # and returned None on a refresh hiccup — live data looked deleted
+            # during Redis jitter).
+            try:
+                async with self._r.pipeline() as pipe:
+                    pipe.expire(data_key, DATA_TTL)
+                    pipe.expire(self._descriptor_key(session_id, ref_id), DATA_TTL)
+                    pipe.zadd(self._refs_order_key(session_id), {ref_id: time.time()})
+                    self._refresh_session_ttl(pipe, session_id)
+                    await pipe.execute()
+            except aioredis.RedisError as e:
+                logger.warning(
+                    "Redis TTL refresh failed for session %s ref %s: %s — returning cached data",
+                    session_id, ref_id_or_alias, e,
+                )
 
             raw_str = raw.decode() if isinstance(raw, bytes) else raw
             try:
@@ -589,6 +605,11 @@ class RedisSessionStore(BaseSessionStore):
                     pipe.hset(state_key, "layers", json.dumps(layers, ensure_ascii=False))
                     pipe.expire(state_key, STATE_TTL)
                     pipe.sadd(self._active_key(), session_id)
+                    # D-2: a layer edit is session activity — refresh the whole
+                    # key family + bump the activity zset so a long editing
+                    # session does not lose its ref registry/payloads at the 4h
+                    # mark, and is not evicted as idle.
+                    self._refresh_session_ttl(pipe, session_id)
                     await pipe.execute()
                     self._l1_invalidate_session(session_id)
                     return True
@@ -634,6 +655,8 @@ class RedisSessionStore(BaseSessionStore):
                     pipe.hset(state_key, "layers", json.dumps(new_layers, ensure_ascii=False))
                     pipe.expire(state_key, STATE_TTL)
                     pipe.sadd(self._active_key(), session_id)
+                    # D-2: same rationale as update_layer_in_state.
+                    self._refresh_session_ttl(pipe, session_id)
                     await pipe.execute()
                     self._l1_invalidate_session(session_id)
                     return True
@@ -752,6 +775,10 @@ class RedisSessionStore(BaseSessionStore):
                     pipe.expire(actions_key, STATE_TTL)
                     pipe.expire(order_key, STATE_TTL)
                     pipe.sadd(self._active_key(), session_id)
+                    # D-2: an ACK is session activity — refresh the whole key
+                    # family + bump activity so a long ACK-only session keeps its
+                    # payloads/registry and is not evicted as idle.
+                    self._refresh_session_ttl(pipe, session_id)
                     await pipe.execute()
                 return True
             except aioredis.WatchError:
@@ -988,11 +1015,21 @@ class RedisSessionStore(BaseSessionStore):
             pipe.expire(self._descriptor_key(session_id, ref_id), DATA_TTL)
 
     def _refresh_session_ttl(self, pipe, session_id: str, ref_ids=None) -> None:
+        # Refresh the WHOLE per-session key family, not just the ref registry.
+        # Session activity (a read, a layer edit, an ACK) must keep every live
+        # key alive for as long as the session is active; otherwise the
+        # state/events/ACK keys expired at the 4h mark after their last WRITE
+        # while payloads (refreshed by get()) stayed alive — an active session
+        # silently lost its viewport, event log and ACK history.
         for key in [
             self._aliases_key(session_id),
             self._refs_key(session_id),
             self._refs_order_key(session_id),
             self._index_key(session_id),
+            self._state_key(session_id),
+            self._events_key(session_id),
+            self._map_actions_key(session_id),
+            self._map_actions_order_key(session_id),
         ]:
             pipe.expire(key, SESSION_TTL)
         pipe.zadd(self._activity_key(), {session_id: time.time()})

--- a/app/services/tool_dispatch_service.py
+++ b/app/services/tool_dispatch_service.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Literal, Optional
 
 from app.services.session_data import session_data_manager
+from app.services.session_data_protocol import is_unavailable_ref
 from app.tools.registry import ToolRegistry
 from app.utils.security import sanitize_error_msg
 from app.utils.geojson import geojson_bbox
@@ -313,6 +314,7 @@ class ToolDispatchService:
 
         # 4. 正常路径：大型 GeoJSON 存为 ref；热力图等元数据落地
         geojson_ref: Optional[str] = None
+        heatmap_ref: Optional[str] = None
         ref_descriptor: Optional[dict] = None
         target_data = None
         if isinstance(result, dict):
@@ -328,6 +330,28 @@ class ToolDispatchService:
                 )
                 result = dict(result)
                 result.setdefault("result_ref", heatmap_ref)
+            # H-1: a Redis outage makes store() return the unavailable-ref
+            # sentinel (``ref:redis-unavailable-…``) per the session-data
+            # protocol. Treating that sentinel as a real ref authored a MapSpec
+            # layer pointing at a ref with NO payload, marked the call
+            # completed, and made the failure unrecoverable by the LLM. Detect
+            # it and fail the dispatch truthfully instead.
+            if is_unavailable_ref(geojson_ref) or is_unavailable_ref(heatmap_ref):
+                self._release_key(executed_tools, tool_key)
+                return ToolDispatchResult(
+                    status="error",
+                    llm_payload=(
+                        "会话存储暂时不可用，无法保存分析结果；请稍后重试，无需改变参数。"
+                    ),
+                    slim_event={
+                        "type": "tool_error",
+                        "name": tool_name,
+                        "error": "session store unavailable",
+                    },
+                    geojson_ref=None,
+                    raw_result=result,
+                    error_msg="session store unavailable",
+                )
             # Canonical MapSpec layer authoring points at an existing
             # session-owned analysis ref instead of returning the dataset
             # again.  Preserve that stable identity through the existing SSE

--- a/app/services/tool_dispatch_service.py
+++ b/app/services/tool_dispatch_service.py
@@ -364,6 +364,29 @@ class ToolDispatchService:
                     and result_ref.startswith("ref:raster/")
                 )
             )
+            # H-1 (R2-2): tools that store data themselves (e.g.
+            # webgis_layer_upsert's inline branch) can hand back the
+            # unavailable-ref sentinel as ``result_ref`` — the dispatch-level
+            # store() check above cannot see it. Fail truthfully before the
+            # sentinel is promoted to geojson_ref and a MapSpec layer /
+            # event-log entry / dedup-completed marking latch onto a phantom
+            # ref with no payload anywhere.
+            if is_unavailable_ref(result_ref):
+                self._release_key(executed_tools, tool_key)
+                return ToolDispatchResult(
+                    status="error",
+                    llm_payload=(
+                        "会话存储暂时不可用，无法保存分析结果；请稍后重试，无需改变参数。"
+                    ),
+                    slim_event={
+                        "type": "tool_error",
+                        "name": tool_name,
+                        "error": "session store unavailable",
+                    },
+                    geojson_ref=None,
+                    raw_result=result,
+                    error_msg="session store unavailable",
+                )
             if (
                 isinstance(result_ref, str)
                 and result_ref.startswith("ref:")

--- a/app/tools/cartography_tools.py
+++ b/app/tools/cartography_tools.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from app.tools.registry import ToolRegistry, tool
 from app.services.mapspec_store import mapspec_store
 from app.services.session_data import session_data_manager
+from app.services.session_data_protocol import is_unavailable_ref
 
 logger = logging.getLogger(__name__)
 
@@ -350,14 +351,25 @@ def register_mapspec_cartography_tools(registry: ToolRegistry) -> None:
         provenance["result_ref"] = source_ref
         layer["provenance"] = provenance
     elif (
-      isinstance(source_data, dict)
-      and source_data.get("type") in ("Feature", "FeatureCollection")
+        isinstance(source_data, dict)
+        and source_data.get("type") in ("Feature", "FeatureCollection")
     ):
       # Inline inputs are already in memory; persist them once and let MapSpec
       # retain only the resulting opaque identity plus its derived profile.
       source_ref = await session_data_manager.store(
           session_id, source_data, prefix="geojson"
       )
+      # R2-2 (tool-level): a Redis outage makes store() return the
+      # unavailable-ref sentinel. Bailing out HERE keeps the phantom ref out
+      # of MapSpec desired state — the dispatch-level check fires after
+      # layer_upsert has already persisted a layer pointing at a ref with no
+      # payload anywhere.
+      if is_unavailable_ref(source_ref):
+        return {
+            "success": False,
+            "code": "SESSION_STORE_UNAVAILABLE",
+            "message": "会话存储暂时不可用，无法保存图层数据；请稍后重试，无需改变参数。",
+        }
       provenance = (
           dict(layer.get("provenance"))
           if isinstance(layer.get("provenance"), dict) else {}

--- a/app/tools/upload_tools.py
+++ b/app/tools/upload_tools.py
@@ -9,8 +9,30 @@ from app.core.config import settings
 from app.tools._utils import db_session
 from app.models.upload import UploadRecord
 from app.utils.path import validate_data_path
+from app.lib.runtime.context import current_runtime_context
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_session_id(provided: Optional[str]) -> Optional[str]:
+    """Return the session id the caller is actually authorized for.
+
+    The ``session_id`` argument an LLM passes to a tool is untrusted — a
+    prompt-injection payload (e.g. inside an uploaded file the agent reads) can
+    coax the model into naming another user's session id, and these tools used
+    to query ``UploadRecord`` by that id with no ownership proof (the HTTP
+    upload routes do verify ownership). The runtime context carries the
+    verified session id this turn is bound to (propagated through
+    ``asyncio.to_thread`` into sync tools). If a verified id exists and the
+    LLM-supplied id disagrees, deny (return None -> empty / NOT_FOUND) rather
+    than exfiltrate another session's uploads.
+    """
+    ctx = current_runtime_context()
+    verified = getattr(ctx, "session_id", None)
+    if verified:
+        return verified if provided in (None, verified) else None
+    # No runtime context (direct execution / tests): trust the provided id.
+    return provided
 
 
 def register_upload_tools(registry: ToolRegistry):
@@ -21,6 +43,7 @@ def register_upload_tools(registry: ToolRegistry):
           description="列出当前会话中用户上传的 GIS 数据文件列表。返回文件名、类型、格式、要素数量等摘要信息。")
     def list_uploaded_data(session_id: Optional[str] = None) -> dict:
         """列出上传数据"""
+        session_id = _resolve_session_id(session_id)
         if not session_id:
             return {
                 "success": True,
@@ -70,6 +93,7 @@ def register_upload_tools(registry: ToolRegistry):
           })
     def get_upload_info(upload_id: int, session_id: Optional[str] = None) -> dict:
         """获取上传数据详情"""
+        session_id = _resolve_session_id(session_id)
         with db_session() as db:
             record = db.query(UploadRecord).filter(UploadRecord.id == upload_id).first()
 

--- a/frontend/components/settings/account-section.test.tsx
+++ b/frontend/components/settings/account-section.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { installInMemoryLocalStorage } from '../../test/in-memory-local-storage';
+
+/**
+ * Round-2 auth wiring: data-fabric write endpoints require Bearer auth, so
+ * the settings panel gains an account section for login/logout. These tests
+ * pin the UI contract: sign-in persists tokens, failures surface the backend
+ * detail, sign-out clears state even when the server call fails.
+ */
+
+vi.mock('@/lib/api/auth', () => ({
+  login: vi.fn(),
+  logout: vi.fn(),
+}));
+
+import { AccountSection } from './account-section';
+import { login, logout } from '@/lib/api/auth';
+import { getAccessToken, getAuthUser, setAuth, clearAuth } from '@/lib/auth/tokenStore';
+
+const mockLogin = vi.mocked(login);
+const mockLogout = vi.mocked(logout);
+
+beforeAll(() => {
+  installInMemoryLocalStorage();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  clearAuth();
+});
+
+describe('AccountSection', () => {
+  it('shows the login form when signed out', () => {
+    render(<AccountSection />);
+    expect(screen.getByLabelText('用户名 / 邮箱')).toBeTruthy();
+    expect(screen.getByLabelText('密码')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '登录' })).toBeTruthy();
+  });
+
+  it('signs in: persists tokens and switches to the signed-in view', async () => {
+    mockLogin.mockResolvedValue({
+      access_token: 'acc-1',
+      refresh_token: 'ref-1',
+      token_type: 'bearer',
+      expires_in: 1800,
+      user: { id: 'u1', username: 'ops', role: 'admin' },
+    });
+    render(<AccountSection />);
+
+    fireEvent.change(screen.getByLabelText('用户名 / 邮箱'), {
+      target: { value: 'ops' },
+    });
+    fireEvent.change(screen.getByLabelText('密码'), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '登录' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('ops')).toBeTruthy();
+    });
+    expect(mockLogin).toHaveBeenCalledWith('ops', 'secret123');
+    expect(getAccessToken()).toBe('acc-1');
+    expect(getAuthUser()?.username).toBe('ops');
+    expect(screen.getByRole('button', { name: '退出登录' })).toBeTruthy();
+  });
+
+  it('surfaces the backend error detail on failed login', async () => {
+    mockLogin.mockRejectedValue(
+      Object.assign(new Error('login failed'), {
+        body: { detail: '用户名或密码错误' },
+      }),
+    );
+    render(<AccountSection />);
+
+    fireEvent.change(screen.getByLabelText('用户名 / 邮箱'), {
+      target: { value: 'ops' },
+    });
+    fireEvent.change(screen.getByLabelText('密码'), {
+      target: { value: 'wrong' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '登录' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('用户名或密码错误');
+    });
+    expect(getAccessToken()).toBeNull();
+    // Still on the login form.
+    expect(screen.getByLabelText('用户名 / 邮箱')).toBeTruthy();
+  });
+
+  it('requires both fields before calling the API', async () => {
+    render(<AccountSection />);
+    fireEvent.click(screen.getByRole('button', { name: '登录' }));
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('请输入');
+    });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it('signs out: clears local state even when the server logout fails', async () => {
+    setAuth({ accessToken: 'acc-1', refreshToken: 'ref-1' }, { id: 'u1', username: 'ops' });
+    // Server logout fails AND the local clear (owned by the real logout)
+    // still runs — replicate the real contract on the mock.
+    mockLogout.mockImplementation(async () => {
+      clearAuth();
+      throw new TypeError('offline');
+    });
+
+    render(<AccountSection />);
+    fireEvent.click(screen.getByRole('button', { name: '退出登录' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('用户名 / 邮箱')).toBeTruthy();
+    });
+    expect(getAccessToken()).toBeNull();
+  });
+});

--- a/frontend/components/settings/account-section.tsx
+++ b/frontend/components/settings/account-section.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React, { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import { STitle } from '@/components/shared/section-title';
+import { login, logout } from '@/lib/api/auth';
+import {
+  getAuthUser,
+  setAuth,
+  subscribeAuth,
+  type AuthUser,
+} from '@/lib/auth/tokenStore';
+
+/**
+ * 账户设置：登录 / 登出（JWT）。
+ *
+ * Round-2 审计把 data-fabric 写路径（创建/删除/探查/同步/预览/查询/物化）
+ * 与 /chat/tools 收紧为需要认证 —— 但已发布前端此前完全没有持有或发送
+ * Bearer token 的能力，这些端点（及其驱动的"数据源"页签）对所有真实用户
+ * 都会 401。此面板补上客户端认证：
+ * - 登录后将 access/refresh token 存入 tokenStore，transport 自动附带
+ *   Authorization 头（401 时单次 refresh 重试）。
+ * - 账号由运维通过 `manage.py create_admin` 创建（公开注册默认关闭）。
+ * - 匿名用户不受影响：所有原有匿名功能照旧，只是数据源管理等写操作
+ *   需要登录。
+ */
+
+function useAuthUser(): AuthUser | null {
+  return useSyncExternalStore(
+    subscribeAuth,
+    getAuthUser,
+    () => null,
+  );
+}
+
+export function AccountSection() {
+  const user = useAuthUser();
+  const [identifier, setIdentifier] = useState('');
+  const [password, setPassword] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Sign-in state changes clear stale form errors.
+    setError(null);
+  }, [user]);
+
+  const handleLogin = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (busy) return;
+      const trimmed = identifier.trim();
+      if (!trimmed || !password) {
+        setError('请输入用户名/邮箱和密码');
+        return;
+      }
+      setBusy(true);
+      setError(null);
+      try {
+        const res = await login(trimmed, password);
+        setAuth(
+          { accessToken: res.access_token, refreshToken: res.refresh_token ?? null },
+          res.user,
+        );
+        setPassword('');
+        setIdentifier('');
+      } catch (err) {
+        const detail =
+          (err as { body?: { detail?: string } })?.body?.detail ??
+          (err instanceof Error ? err.message : '登录失败');
+        setError(String(detail));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, identifier, password],
+  );
+
+  const handleLogout = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await logout();
+    } catch {
+      // logout() already cleared local credentials in its finally block —
+      // a failed server call (offline / already-revoked token) must not keep
+      // the user signed in locally.
+    } finally {
+      setBusy(false);
+    }
+  }, [busy]);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <STitle title="账户" sub="Account" />
+
+      {user ? (
+        <div className="rounded-md border border-edge-subtle bg-surface-raised px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-title font-semibold text-ink">{user.username}</div>
+              <div className="text-body text-ink-muted">
+                {user.email ?? ''}
+                {user.role ? ` · ${user.role}` : ''}
+              </div>
+            </div>
+            <button
+              onClick={handleLogout}
+              disabled={busy}
+              className="rounded-md border border-edge-subtle bg-surface-raised px-3 py-1.5 text-body font-medium text-ink-secondary transition-colors hover:bg-surface-hover disabled:opacity-50"
+            >
+              退出登录
+            </button>
+          </div>
+          <div className="mt-2 text-body text-ink-muted">
+            已登录：数据源管理等需要认证的操作现在可用。
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={handleLogin} className="flex flex-col gap-3" aria-label="登录">
+          <div>
+            <label
+              htmlFor="auth-identifier"
+              className="mb-1 block text-body font-medium text-ink-secondary"
+            >
+              用户名 / 邮箱
+            </label>
+            <input
+              id="auth-identifier"
+              autoComplete="username"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+              className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-3 py-2 text-body text-ink outline-none focus:border-[var(--agent-accent)]"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="auth-password"
+              className="mb-1 block text-body font-medium text-ink-secondary"
+            >
+              密码
+            </label>
+            <input
+              id="auth-password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full rounded-md border border-edge-subtle bg-surface-sunken px-3 py-2 text-body text-ink outline-none focus:border-[var(--agent-accent)]"
+            />
+          </div>
+          {error && (
+            <div role="alert" className="text-body text-red-500">
+              {error}
+            </div>
+          )}
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-md px-3 py-2 text-body font-semibold text-ink-on-accent disabled:opacity-50"
+            style={{ backgroundColor: 'var(--agent-accent, #16a34a)' }}
+          >
+            {busy ? '登录中…' : '登录'}
+          </button>
+          <div className="text-body text-ink-muted">
+            账号由运维通过 <code>manage.py create_admin</code> 创建（公开注册默认关闭）。
+            匿名使用不受影响；数据源管理等写操作需要登录。
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/settings/settings-panel.tsx
+++ b/frontend/components/settings/settings-panel.tsx
@@ -7,6 +7,7 @@ import {
   Brain,
   Crosshair,
   Settings,
+  UserRound,
   X,
   ShieldCheck,
 } from 'lucide-react';
@@ -17,13 +18,14 @@ import { SkillsHub } from './skills-hub';
 import { RagConfig } from './rag-config';
 import { MapConfig } from './map-config';
 import { SystemSettings } from './system-settings';
+import { AccountSection } from './account-section';
 
 /* ------------------------------------------------------------------ */
 /*  Nav item definition                                                */
 /* ------------------------------------------------------------------ */
 
 interface NavItem {
-  key: 'llm' | 'skills' | 'rag' | 'map' | 'system';
+  key: 'llm' | 'skills' | 'rag' | 'map' | 'system' | 'account';
   label: string;
   icon: React.ElementType;
   count?: number;
@@ -35,6 +37,7 @@ const NAV_ITEMS: NavItem[] = [
   { key: 'rag', label: '知识库', icon: Brain },
   { key: 'map', label: '地图配置', icon: Crosshair },
   { key: 'system', label: '系统', icon: Settings },
+  { key: 'account', label: '账户', icon: UserRound },
 ];
 
 /* ------------------------------------------------------------------ */
@@ -53,6 +56,8 @@ function TabContent({ tab }: { tab: string }) {
       return <MapConfig />;
     case 'system':
       return <SystemSettings />;
+    case 'account':
+      return <AccountSection />;
     default:
       return null;
   }

--- a/frontend/lib/api/auth.ts
+++ b/frontend/lib/api/auth.ts
@@ -1,0 +1,58 @@
+/**
+ * Auth API client: /auth/login and /auth/logout.
+ *
+ * Registration is intentionally absent — the backend disables public
+ * registration by default (ALLOW_PUBLIC_REGISTER); accounts are provisioned
+ * by operators via `manage.py create_admin`. Refresh runs inside the token
+ * store (plain fetch) so the transport can use it on 401 without a cycle.
+ */
+
+import { apiFetch } from './transport';
+import {
+  clearAuth,
+  getAccessToken,
+  type AuthUser,
+} from '../auth/tokenStore';
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string | null;
+  token_type: string;
+  expires_in: number;
+  user: AuthUser;
+}
+
+/**
+ * Sign in and persist the token pair. Importers must call setAuth — this
+ * returns the raw response so callers decide persistence (kept side-effect
+ * free for tests).
+ */
+export async function login(
+  identifier: string,
+  password: string,
+): Promise<TokenResponse> {
+  return apiFetch<TokenResponse>('/auth/login', {
+    method: 'POST',
+    body: { identifier, password },
+    label: '登录失败',
+    skipAuth: true,
+  });
+}
+
+/** Sign out: bump the server-side token version, then drop local state. */
+export async function logout(): Promise<void> {
+  try {
+    if (getAccessToken()) {
+      await apiFetch('/auth/logout', {
+        method: 'POST',
+        parseJson: false,
+        label: '登出失败',
+      });
+    }
+  } finally {
+    // Local sign-out must succeed even when the server call fails (offline,
+    // 401 from an already-revoked token): never keep credentials around on a
+    // user-initiated logout.
+    clearAuth();
+  }
+}

--- a/frontend/lib/api/transport.auth.test.ts
+++ b/frontend/lib/api/transport.auth.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { apiFetch, ApiError } from './transport';
+import { setAuth, clearAuth, getAccessToken } from '../auth/tokenStore';
+import { installInMemoryLocalStorage } from '../../test/in-memory-local-storage';
+
+/**
+ * Bearer wiring for the round-2 auth hardening: data-fabric writes and
+ * /chat/tools now require authentication, so the transport must
+ *   - attach Authorization when signed in,
+ *   - recover ONCE from a 401 via the refresh token,
+ *   - skip auth recovery on auth endpoints themselves (skipAuth).
+ */
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const jsonOk = (body: unknown, status = 200) => ({
+  ok: true,
+  status,
+  statusText: 'OK',
+  headers: { get: () => null },
+  text: () => Promise.resolve(JSON.stringify(body)),
+  json: () => Promise.resolve(body),
+});
+
+const errResponse = (status: number, body?: unknown) => ({
+  ok: false,
+  status,
+  statusText: '',
+  headers: { get: () => null },
+  text: () =>
+    Promise.resolve(body === undefined ? '' : JSON.stringify(body)),
+  json: () => Promise.resolve(body),
+});
+
+beforeAll(() => {
+  installInMemoryLocalStorage();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  clearAuth();
+});
+
+afterEach(() => {
+  clearAuth();
+});
+
+describe('transport auth (Bearer attach + 401 recovery)', () => {
+  it('attaches Authorization when signed in', async () => {
+    setAuth({ accessToken: 'acc-1', refreshToken: null }, null);
+    mockFetch.mockResolvedValueOnce(jsonOk({ ok: true }));
+
+    await apiFetch('/data-fabric/sources', {
+      method: 'POST',
+      body: { name: 'x' },
+    });
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers['Authorization']).toBe('Bearer acc-1');
+  });
+
+  it('attaches no Authorization header when signed out', async () => {
+    mockFetch.mockResolvedValueOnce(jsonOk({ sources: [] }));
+    await apiFetch('/data-fabric/sources');
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers['Authorization']).toBeUndefined();
+  });
+
+  it('honors skipAuth (no header even when signed in)', async () => {
+    setAuth({ accessToken: 'acc-1', refreshToken: null }, null);
+    mockFetch.mockResolvedValueOnce(jsonOk({ access_token: 'new' }));
+
+    await apiFetch('/auth/login', { method: 'POST', skipAuth: true });
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers['Authorization']).toBeUndefined();
+  });
+
+  it('refreshes once after a 401 and retries the original request', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, { id: 'u1', username: 'ops' });
+    // Original attempt → 401; refresh → new pair; retry with fresh token → ok.
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401, { detail: 'Not authenticated' }))
+      .mockResolvedValueOnce(
+        jsonOk({ access_token: 'fresh', refresh_token: 'ref-2', user: { id: 'u1', username: 'ops' } })
+      )
+      .mockResolvedValueOnce(jsonOk({ success: true }));
+
+    const out = await apiFetch('/data-fabric/sources/e2e/probe', { method: 'POST' });
+
+    expect(out).toEqual({ success: true });
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    const [retryUrl, retryInit] = mockFetch.mock.calls[2];
+    expect(String(retryUrl)).toContain('/probe');
+    expect(retryInit.headers['Authorization']).toBe('Bearer fresh');
+    expect(getAccessToken()).toBe('fresh');
+  });
+
+  it('retries a POST after refresh (a 401 was never processed server-side)', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(jsonOk({ access_token: 'fresh' }))
+      .mockResolvedValueOnce(jsonOk({ created: true }));
+
+    await apiFetch('/data-fabric/sources', {
+      method: 'POST',
+      body: { name: 'src' },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not refresh when the request already used the fresh token (single retry)', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(jsonOk({ access_token: 'fresh' }))
+      .mockResolvedValueOnce(errResponse(401)); // still rejected
+
+    const err = (await apiFetch('/x').catch((e: unknown) => e)) as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+    expect(mockFetch).toHaveBeenCalledTimes(3); // attempt + refresh + one retry
+  });
+
+  it('does not attempt refresh with no refresh token', async () => {
+    setAuth({ accessToken: 'acc-only', refreshToken: null }, null);
+    mockFetch.mockResolvedValueOnce(errResponse(401));
+
+    const err = (await apiFetch('/x').catch((e: unknown) => e)) as ApiError;
+    expect(err.status).toBe(401);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the 401 (no loop) when the refresh itself is rejected', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'revoked' }, null);
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(errResponse(401, { detail: 'Token revoked' }));
+
+    const err = (await apiFetch('/x').catch((e: unknown) => e)) as ApiError;
+    expect(err.status).toBe(401);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // Definitive rejection drops local credentials.
+    expect(getAccessToken()).toBeNull();
+  });
+
+  it('does not run auth recovery on a non-401 error', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
+    mockFetch.mockResolvedValueOnce(errResponse(500));
+
+    const err = (await apiFetch('/x').catch((e: unknown) => e)) as ApiError;
+    expect(err.status).toBe(500);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/lib/api/transport.ts
+++ b/frontend/lib/api/transport.ts
@@ -23,6 +23,7 @@
  */
 
 import { API_BASE } from './config';
+import { getAccessToken, getRefreshToken, refreshAuthToken } from '../auth/tokenStore';
 
 export const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -63,6 +64,11 @@ export interface ApiFetchOptions {
   label?: string;
   /** False → do not read the response body (204 deletes); resolves undefined. */
   parseJson?: boolean;
+  /**
+   * Skip Bearer attachment AND the 401 refresh-retry (auth endpoints
+   * themselves). Defaults to false.
+   */
+  skipAuth?: boolean;
   /**
    * Request credentials mode. Defaults to "same-origin" (browser default);
    * cross-origin cookie-bearing endpoints (data-fabric, layer types) pass
@@ -152,6 +158,10 @@ function buildRequest(
     'X-Request-ID': requestId,
   };
   if (options.ownerToken) headers['X-Session-Token'] = options.ownerToken;
+  // Bearer auth when the user is signed in (data-fabric writes, /chat/tools,
+  // admin surfaces). Rebuilt per attempt so a refreshed token is picked up.
+  const accessToken = options.skipAuth ? null : getAccessToken();
+  if (accessToken) headers['Authorization'] = `Bearer ${accessToken}`;
   const init: RequestInit = { method, headers };
   if (options.signal) init.signal = options.signal;
   if (options.credentials) init.credentials = options.credentials;
@@ -263,8 +273,32 @@ function isRetryable(err: unknown, method: string): boolean {
  *
  * The retry loop is the ONLY place requests are re-sent, and it is closed to
  * non-idempotent methods by construction — see isRetryable.
+ *
+ * Auth recovery wraps the loop: ONE refresh-and-retry after a 401 when a
+ * refresh token is held. Safe even for POST because a 401 response means the
+ * server rejected the request without processing it.
  */
 export async function apiFetch<T = unknown>(
+  path: string,
+  options: ApiFetchOptions = {},
+): Promise<T> {
+  try {
+    return await apiFetchAttempt<T>(path, options);
+  } catch (err) {
+    if (
+      !options.skipAuth &&
+      err instanceof ApiError &&
+      err.status === 401 &&
+      getRefreshToken() !== null
+    ) {
+      const refreshed = await refreshAuthToken();
+      if (refreshed) return apiFetchAttempt<T>(path, options);
+    }
+    throw err;
+  }
+}
+
+async function apiFetchAttempt<T = unknown>(
   path: string,
   options: ApiFetchOptions = {},
 ): Promise<T> {

--- a/frontend/lib/auth/tokenStore.test.ts
+++ b/frontend/lib/auth/tokenStore.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { installInMemoryLocalStorage } from '../../test/in-memory-local-storage';
+import {
+  getAccessToken,
+  getRefreshToken,
+  getAuthUser,
+  setAuth,
+  clearAuth,
+  subscribeAuth,
+  refreshAuthToken,
+} from './tokenStore';
+
+/**
+ * Round-2 audit auth wiring: data-fabric write endpoints now require Bearer
+ * auth, and the client needs a token store the transport can read. These
+ * tests pin the store contract: persistence, notification, and the
+ * single-flight refresh used by the transport's 401 recovery.
+ */
+
+const KEY = 'webgis_auth';
+
+beforeAll(() => {
+  installInMemoryLocalStorage();
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  clearAuth();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('tokenStore', () => {
+  it('starts signed out (no token, no user)', () => {
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+    expect(getAuthUser()).toBeNull();
+  });
+
+  it('setAuth persists tokens + user and round-trips through localStorage', () => {
+    setAuth(
+      { accessToken: 'acc-1', refreshToken: 'ref-1' },
+      { id: 'u1', username: 'ops', role: 'admin' },
+    );
+    expect(getAccessToken()).toBe('acc-1');
+    expect(getRefreshToken()).toBe('ref-1');
+    expect(getAuthUser()).toEqual({ id: 'u1', username: 'ops', role: 'admin' });
+    expect(JSON.parse(window.localStorage.getItem(KEY) ?? '{}')).toMatchObject({
+      accessToken: 'acc-1',
+      refreshToken: 'ref-1',
+    });
+  });
+
+  it('clearAuth drops everything, including the persisted entry', () => {
+    setAuth({ accessToken: 'acc-1', refreshToken: 'ref-1' }, null);
+    clearAuth();
+    expect(getAccessToken()).toBeNull();
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('notifies subscribers on set and clear, and unsubscribes correctly', () => {
+    const fn = vi.fn();
+    const unsubscribe = subscribeAuth(fn);
+    setAuth({ accessToken: 'a', refreshToken: null }, null);
+    expect(fn).toHaveBeenCalledTimes(1);
+    clearAuth();
+    expect(fn).toHaveBeenCalledTimes(2);
+    unsubscribe();
+    setAuth({ accessToken: 'b', refreshToken: null }, null);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats corrupt localStorage content as signed out', () => {
+    window.localStorage.setItem(KEY, '{not json');
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+});
+
+describe('refreshAuthToken', () => {
+  const refreshOk = (access: string, refresh = 'ref-2') =>
+    new Response(JSON.stringify({ access_token: access, refresh_token: refresh }), {
+      status: 200,
+    });
+
+  it('resolves false with no refresh token and never fetches', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(refreshAuthToken()).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('exchanges the refresh token for a new pair and persists it', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, { id: 'u1', username: 'ops' });
+    const fetchMock = vi.fn().mockResolvedValue(refreshOk('fresh'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(refreshAuthToken()).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/auth/refresh');
+    expect(JSON.parse(String(init.body))).toEqual({ refresh_token: 'ref-1' });
+    expect(getAccessToken()).toBe('fresh');
+    expect(getRefreshToken()).toBe('ref-2');
+    // User profile survives a refresh that does not echo one.
+    expect(getAuthUser()).toEqual({ id: 'u1', username: 'ops' });
+  });
+
+  it('drops local auth when the refresh token is definitively rejected', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{"detail":"revoked"}', { status: 401 })),
+    );
+    await expect(refreshAuthToken()).resolves.toBe(false);
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+  });
+
+  it('keeps tokens on a network failure (transient) and resolves false', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('offline')));
+    await expect(refreshAuthToken()).resolves.toBe(false);
+    expect(getAccessToken()).toBe('stale');
+    expect(getRefreshToken()).toBe('ref-1');
+  });
+
+  it('shares one in-flight refresh across concurrent callers', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
+    let resolveFetch!: (r: Response) => void;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() => new Promise<Response>((res) => (resolveFetch = res)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const p1 = refreshAuthToken();
+    const p2 = refreshAuthToken();
+    // The refresh body awaits a dynamic import before fetch — let it start.
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    resolveFetch(refreshOk('fresh'));
+    await expect(p1).resolves.toBe(true);
+    await expect(p2).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/lib/auth/tokenStore.test.ts
+++ b/frontend/lib/auth/tokenStore.test.ts
@@ -108,7 +108,7 @@ describe('refreshAuthToken', () => {
     expect(getAuthUser()).toEqual({ id: 'u1', username: 'ops' });
   });
 
-  it('drops local auth when the refresh token is definitively rejected', async () => {
+  it('drops local auth when the refresh token is definitively rejected (401)', async () => {
     setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
     vi.stubGlobal(
       'fetch',
@@ -117,6 +117,42 @@ describe('refreshAuthToken', () => {
     await expect(refreshAuthToken()).resolves.toBe(false);
     expect(getAccessToken()).toBeNull();
     expect(getRefreshToken()).toBeNull();
+  });
+
+  it('keeps tokens on transient refresh failures (429 / 5xx)', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
+    for (const status of [429, 500, 503]) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(new Response('{"detail":"slow down"}', { status })),
+      );
+      await expect(refreshAuthToken()).resolves.toBe(false);
+      expect(getAccessToken()).toBe('stale');
+      expect(getRefreshToken()).toBe('ref-1');
+    }
+  });
+
+  it('does not clobber credentials changed while a refresh was in flight', async () => {
+    setAuth({ accessToken: 'stale', refreshToken: 'ref-1' }, null);
+    let resolveFetch!: (r: Response) => void;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() => new Promise<Response>((res) => (resolveFetch = res)));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const p = refreshAuthToken();
+    // User switches account mid-flight (login as someone else).
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    setAuth({ accessToken: 'account-b', refreshToken: 'ref-b' }, { id: 'b', username: 'b' });
+    resolveFetch(
+      new Response(JSON.stringify({ access_token: 'account-a-fresh', refresh_token: 'ref-a-2' }), {
+        status: 200,
+      }),
+    );
+    await expect(p).resolves.toBe(false);
+    // Account B's state survives; A's refreshed pair was discarded.
+    expect(getAccessToken()).toBe('account-b');
+    expect(getRefreshToken()).toBe('ref-b');
   });
 
   it('keeps tokens on a network failure (transient) and resolves false', async () => {

--- a/frontend/lib/auth/tokenStore.ts
+++ b/frontend/lib/auth/tokenStore.ts
@@ -1,0 +1,178 @@
+/**
+ * Client-side auth token store (JWT access + refresh pair).
+ *
+ * The backend has had Bearer-auth endpoints since S41 (/auth/login,
+ * /auth/refresh, /auth/logout), and round-2 audit hardening made the
+ * data-fabric write paths (create/delete/probe/sync/preview/query/
+ * materialize) require authentication. Until now the shipped UI had NO
+ * ability to hold or send a Bearer token, which made those endpoints — and
+ * the Data Sources tab that drives them — unusable for every real user.
+ * This store plus the transport wiring below closes that gap.
+ *
+ * Storage: localStorage under one JSON key. The access token is short-lived
+ * (30 min) and the refresh token is rotated on every refresh; neither is a
+ * long-lived password. localStorage (not a cookie) keeps the token out of
+ * every cross-site request automatically — the transport attaches it
+ * explicitly per request.
+ */
+
+const STORAGE_KEY = 'webgis_auth';
+
+export interface AuthUser {
+  id: string;
+  username: string;
+  email?: string | null;
+  full_name?: string | null;
+  role?: string;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string | null;
+}
+
+interface StoredAuth extends AuthTokens {
+  user: AuthUser | null;
+}
+
+let cached: StoredAuth | null = null;
+let loaded = false;
+
+const listeners = new Set<() => void>();
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function load(): StoredAuth | null {
+  if (!isBrowser()) return null;
+  if (loaded) return cached;
+  loaded = true;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredAuth;
+    if (typeof parsed?.accessToken === 'string' && parsed.accessToken) {
+      cached = {
+        accessToken: parsed.accessToken,
+        refreshToken: typeof parsed.refreshToken === 'string' ? parsed.refreshToken : null,
+        user: parsed.user ?? null,
+      };
+    }
+  } catch {
+    // Corrupt entry — treat as signed out.
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* storage unavailable (private mode quota) — ignore */
+    }
+  }
+  return cached;
+}
+
+function persist(next: StoredAuth | null): void {
+  cached = next;
+  loaded = true;
+  if (isBrowser()) {
+    try {
+      if (next) window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      else window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      /* storage write failed — in-memory state still updated */
+    }
+  }
+  listeners.forEach((fn) => {
+    try {
+      fn();
+    } catch {
+      /* a broken listener must not break auth state changes */
+    }
+  });
+}
+
+/** Current access token, or null when signed out. */
+export function getAccessToken(): string | null {
+  return load()?.accessToken ?? null;
+}
+
+/** Current refresh token (null for anonymous sessions). */
+export function getRefreshToken(): string | null {
+  return load()?.refreshToken ?? null;
+}
+
+/** The signed-in user profile from the last login/refresh, if any. */
+export function getAuthUser(): AuthUser | null {
+  return load()?.user ?? null;
+}
+
+/** Persist a login/refresh result and notify listeners. */
+export function setAuth(tokens: AuthTokens, user: AuthUser | null): void {
+  persist({
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    user,
+  });
+}
+
+/** Drop all credentials (logout, or refresh definitively rejected). */
+export function clearAuth(): void {
+  persist(null);
+}
+
+/** Minimal reactivity for UI: callback fires on every auth state change. */
+export function subscribeAuth(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+/**
+ * Single-flight token refresh shared by every concurrent 401.
+ *
+ * Uses plain fetch (NOT apiFetch): the transport itself calls this while
+ * handling a 401, so routing through the transport would recurse.
+ */
+let refreshInFlight: Promise<boolean> | null = null;
+
+export function refreshAuthToken(): Promise<boolean> {
+  if (refreshInFlight) return refreshInFlight;
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return Promise.resolve(false);
+  refreshInFlight = (async () => {
+    try {
+      // Late import to avoid a config/init cycle at module load.
+      const { API_BASE } = await import('../api/config');
+      const res = await fetch(`${API_BASE}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      });
+      if (!res.ok) {
+        // Revoked/expired refresh token — drop the session so the UI falls
+        // back to anonymous instead of retrying a dead credential forever.
+        clearAuth();
+        return false;
+      }
+      const body = (await res.json()) as {
+        access_token: string;
+        refresh_token?: string | null;
+        user?: AuthUser;
+      };
+      const existingUser = getAuthUser();
+      setAuth(
+        {
+          accessToken: body.access_token,
+          refreshToken: body.refresh_token ?? refreshToken,
+        },
+        body.user ?? existingUser,
+      );
+      return true;
+    } catch {
+      // Network error during refresh: keep the (possibly still valid) tokens
+      // and report failure — the caller surfaces the original 401.
+      return false;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+}

--- a/frontend/lib/auth/tokenStore.ts
+++ b/frontend/lib/auth/tokenStore.ts
@@ -135,8 +135,8 @@ let refreshInFlight: Promise<boolean> | null = null;
 
 export function refreshAuthToken(): Promise<boolean> {
   if (refreshInFlight) return refreshInFlight;
-  const refreshToken = getRefreshToken();
-  if (!refreshToken) return Promise.resolve(false);
+  const startedWith = getRefreshToken();
+  if (!startedWith) return Promise.resolve(false);
   refreshInFlight = (async () => {
     try {
       // Late import to avoid a config/init cycle at module load.
@@ -144,12 +144,14 @@ export function refreshAuthToken(): Promise<boolean> {
       const res = await fetch(`${API_BASE}/auth/refresh`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refresh_token: refreshToken }),
+        body: JSON.stringify({ refresh_token: startedWith }),
       });
       if (!res.ok) {
-        // Revoked/expired refresh token — drop the session so the UI falls
-        // back to anonymous instead of retrying a dead credential forever.
-        clearAuth();
+        // 401/403 = the token is definitively revoked/expired — drop the
+        // session so the UI falls back to anonymous instead of retrying a
+        // dead credential forever. 429 (rate limit) and 5xx are transient:
+        // keep the tokens and surface the original 401 to the caller.
+        if (res.status === 401 || res.status === 403) clearAuth();
         return false;
       }
       const body = (await res.json()) as {
@@ -157,11 +159,14 @@ export function refreshAuthToken(): Promise<boolean> {
         refresh_token?: string | null;
         user?: AuthUser;
       };
+      // Epoch guard: if the user signed in/out (or into another account)
+      // while this refresh was in flight, do not clobber the newer state.
+      if (getRefreshToken() !== startedWith) return false;
       const existingUser = getAuthUser();
       setAuth(
         {
           accessToken: body.access_token,
-          refreshToken: body.refresh_token ?? refreshToken,
+          refreshToken: body.refresh_token ?? startedWith,
         },
         body.user ?? existingUser,
       );

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -653,7 +653,6 @@ export function useSSEStream(
   const handleSend = useCallback(
     async (userMsg: string) => {
       if (!userMsg || isLoadingRef.current || sendingRef.current) return;
-      sendingRef.current = true;
 
       const { viewport, baseLayer, is3D, layers: hudLayers, selectedFeature, focusLayerId } = useHudStore.getState();
       const liveSnapshot = getMapSnapshot();
@@ -721,6 +720,11 @@ export function useSSEStream(
       ]);
 
       try {
+        // F-5: set inside the try so a synchronous throw in the setup above
+        // (which runs before this point, no awaits) cannot leave the guard
+        // stuck. It is still set before the first await, so a same-tick second
+        // send (which can only run once we yield at bridge.send) sees it.
+        sendingRef.current = true;
         await bridge.send(userMsg, mapState);
 
         // Flush any tokens still pending in the current frame so the final

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -538,6 +538,11 @@ export function useSSEStream(
         // 保持 message 对象身份不变。
         const stepId = data.step_id;
         const tool = data.tool;
+        // R2F-2: the cancelled call will never emit its step_result — drop its
+        // queued args so the retry's step_result pairs with the retry's args.
+        if (typeof tool === 'string' && tool) {
+          useHudStore.getState().discardPendingToolArgs(tool);
+        }
         if (typeof stepId === 'string' && stepId) {
           setMessages((prev) => {
             const msgIdx = prev.findIndex(
@@ -571,6 +576,11 @@ export function useSSEStream(
         // ENTIRE message with a generic string, discarding whatever had
         // already streamed and the server's real error detail. Preserve the
         // partial answer and append the actual error (or a fallback note).
+        // R2F-2: a failed call never emits its step_result — drop its queued
+        // args so the retry's step_result pairs with the retry's args.
+        if (event.event === 'step_error' && typeof data?.tool === 'string' && data.tool) {
+          useHudStore.getState().discardPendingToolArgs(data.tool);
+        }
         const raw = data?.error;
         const detail =
           typeof raw === "string" && raw.trim()

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -644,10 +644,16 @@ export function useSSEStream(
   const handleSendRef = useRef<((text: string) => void) | null>(null);
   const isLoadingRef = useRef(isLoading);
   isLoadingRef.current = isLoading;
+  // F-5: synchronous in-flight guard. ``isLoadingRef`` is only refreshed during
+  // render, so two sends in the same tick (before re-render) both passed the
+  // guard and produced duplicate user/thinking messages plus a phantom "完成。"
+  // bubble. This ref is set synchronously at entry and cleared in finally.
+  const sendingRef = useRef(false);
 
   const handleSend = useCallback(
     async (userMsg: string) => {
-      if (!userMsg || isLoadingRef.current) return;
+      if (!userMsg || isLoadingRef.current || sendingRef.current) return;
+      sendingRef.current = true;
 
       const { viewport, baseLayer, is3D, layers: hudLayers, selectedFeature, focusLayerId } = useHudStore.getState();
       const liveSnapshot = getMapSnapshot();
@@ -714,19 +720,25 @@ export function useSSEStream(
         },
       ]);
 
-      await bridge.send(userMsg, mapState);
+      try {
+        await bridge.send(userMsg, mapState);
 
-      // Flush any tokens still pending in the current frame so the final
-      // streamed text is applied before the thinking→done transition.
-      tokenBatcherRef.current?.flush();
+        // Flush any tokens still pending in the current frame so the final
+        // streamed text is applied before the thinking→done transition.
+        tokenBatcherRef.current?.flush();
 
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === thinkingMsgId && (m as any).isThinking
-            ? { ...m, isThinking: false, content: (m as any).content || '完成。' }
-            : m
-        )
-      );
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === thinkingMsgId && (m as any).isThinking
+              ? { ...m, isThinking: false, content: (m as any).content || '完成。' }
+              : m
+          )
+        );
+      } finally {
+        // F-5: release the synchronous in-flight guard only after the send has
+        // committed (success or error); by then isLoading governs re-entry.
+        sendingRef.current = false;
+      }
     },
     [bridge, getMapSnapshot, userLocation]
   );

--- a/frontend/lib/hooks/use-workspace-session.test.ts
+++ b/frontend/lib/hooks/use-workspace-session.test.ts
@@ -292,4 +292,33 @@ describe('useWorkspaceSession selectSession (F-09)', () => {
     expect(result.current.getSessionTokenFor('session-1')).toBe('token-1');
     expect(result.current.getSessionTokenFor('session-128')).toBe('token-128');
   });
+
+  it('F-1: startNewSession aborts an in-flight selectSession restore', async () => {
+    // A slow restore for session A resolving AFTER the user started a new
+    // session must not mutate the fresh session (no onRestoreMessages).
+    let resolveRestore: (v: unknown) => void = () => {};
+    fetchMock.mockImplementation(() => new Promise((r) => { resolveRestore = r; }));
+    const onRestore = vi.fn();
+    const { result } = renderHook(() => useWorkspaceSession(vi.fn()));
+
+    let restorePromise!: Promise<unknown>;
+    act(() => {
+      restorePromise = result.current.selectSession('session-a', onRestore);
+    });
+    // New session while the restore fetch is still pending -> aborts it.
+    act(() => {
+      result.current.startNewSession(vi.fn());
+    });
+    await act(async () => {
+      resolveRestore(jsonOk({
+        messages: [{ id: 'm1', role: 'assistant', content: 'A', timestamp: '2026-01-01T00:00:00Z' }],
+        map_state: null,
+      }));
+      await restorePromise.catch(() => undefined);
+    });
+
+    expect(onRestore).not.toHaveBeenCalled();
+    // F-4: the result registry must also be cleared for the fresh session.
+    expect(vi.mocked(hudState.clearResults)).toHaveBeenCalled();
+  });
 });

--- a/frontend/lib/hooks/use-workspace-session.ts
+++ b/frontend/lib/hooks/use-workspace-session.ts
@@ -283,6 +283,12 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
 
   const startNewSession = useCallback(
     (onClearMessages: () => void) => {
+      // F-1: abort any in-flight session restore. selectSession aborts its own
+      // controller on re-entry, but startNewSession did not — so a slow restore
+      // for session A could resolve AFTER the user started a new session and
+      // mutate the fresh session (onRestoreMessages / addLayer / fetchAnalysisAssets).
+      sessionLoadAbortRef.current?.abort();
+      sessionLoadAbortRef.current = null;
       setSessionId(undefined);
       // SEC-08：新会话清掉旧 token；新匿名会话创建后由 SSE 响应重新填充。
       sessionTokenRef.current = null;
@@ -294,13 +300,18 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
       setSelectedFeature(null);
       setAiStatus('idle');
       clearTask();
+      // F-4: the result registry references session-scoped ``ref:`` cursors that
+      // are dead in the new session — clear it (selectSession does; this path
+      // did not), so a stale Result Workbench does not persist into the new
+      // session. Also resets pendingArgs (F-3 leak surface).
+      clearResults();
       // F4: per-session viewport seq tracker — fresh session, fresh counter.
       resetViewportSeq();
       // FE-15：移除死代码 localStorage.removeItem('webgis_session_id')
       // (session ID 从未写入 localStorage，此 removeItem 是 no-op)
       onClearMessages();
     },
-    [clearLayers, clearAnnotations, clearOpsLog, clearCausalChain, setSelectedFeature, setAiStatus, clearTask]
+    [clearLayers, clearAnnotations, clearOpsLog, clearCausalChain, setSelectedFeature, setAiStatus, clearTask, clearResults]
   );
 
   const rememberSessionToken = useCallback((sid: string, token: string) => {

--- a/frontend/lib/store/hud-types.ts
+++ b/frontend/lib/store/hud-types.ts
@@ -72,7 +72,7 @@ export interface CausalEntry {
 }
 
 export type LeftTab = 'chat' | 'project' | 'layers' | 'analysis' | 'exports' | 'export_layout' | 'data_sources' | 'tasks' | 'results';
-export type SettingsTab = 'llm' | 'skills' | 'rag' | 'layers' | 'map' | 'system';
+export type SettingsTab = 'llm' | 'skills' | 'rag' | 'layers' | 'map' | 'system' | 'account';
 
 export interface SkillEntry {
   id: string;

--- a/frontend/lib/store/hud-types.ts
+++ b/frontend/lib/store/hud-types.ts
@@ -316,6 +316,8 @@ export interface HudState {
   selectedResultId: string | null;
   /** Stash preceding tool_call args (best-effort input evidence). */
   captureToolCallArgs: (tool: string, argsStr: string) => void;
+  /** Discard the oldest queued args for a tool (its call failed or was cancelled). */
+  discardPendingToolArgs: (tool: string) => void;
   /** Normalize + record a step_result event; returns the result id (or undefined if ignored). */
   captureStepResult: (step: StepResultEvent) => string | undefined;
   /** Merge lazy /layers/descriptor metadata into a result's output (no CRS fabrication). */

--- a/frontend/lib/store/slices/layersSlice.ts
+++ b/frontend/lib/store/slices/layersSlice.ts
@@ -149,6 +149,9 @@ export const createLayersSlice: StateCreator<HudState, [], [], Partial<HudState>
       );
       set({ analysisAssets: assets });
     } catch (e) {
+      // F-2: if the NEWEST fetch fails, clear the stale assets rather than
+      // leave the previous session's list visible on the fresh session.
+      if (seq === _analysisAssetsSeq) set({ analysisAssets: [] });
       if (!isApiError(e)) devOnly.error('Failed to fetch assets:', e);
     }
     void get;

--- a/frontend/lib/store/slices/layersSlice.ts
+++ b/frontend/lib/store/slices/layersSlice.ts
@@ -11,6 +11,12 @@ import type { HudState } from '../hud-types';
 
 import { devOnly } from "@/lib/utils/logger";
 
+// F-2: last-writer-wins guard for fetchAnalysisAssets. A slow response for a
+// previous session must not overwrite the current session's asset list after a
+// session switch (the action takes no AbortSignal, so this is the correctness
+// guard). Only the most recent call's resolved value is applied.
+let _analysisAssetsSeq = 0;
+
 /**
  * FE-3: 注释（annotation）队列上限。AI 长会话中反复标注会无限增长
  * （findings E4 无界数组），超限丢弃最旧条目。
@@ -129,11 +135,15 @@ export const createLayersSlice: StateCreator<HudState, [], [], Partial<HudState>
   /* ─── Analysis Assets (后端遥感产物) ─── */
   analysisAssets: [],
   fetchAnalysisAssets: async (sessionId: string | undefined) => {
+    // F-2: capture a per-call sequence so a stale response (e.g. for a previous
+    // session after a switch) cannot overwrite the current session's assets.
+    const seq = ++_analysisAssetsSeq;
     try {
       // listUploads goes through the Fast Path — parallel mount callers and
       // session-switch follow-up fetch share one roundtrip. errors flow as
       // typed ApiError so we can distinguish abort/timeout/HTTP.
       const data = await listUploads(sessionId);
+      if (seq !== _analysisAssetsSeq) return; // superseded by a newer fetch
       const assets = (data.uploads || []).filter(
         (u) => u.geometry_type === 'raster_analysis'
       );

--- a/frontend/lib/store/slices/resultsSlice.ts
+++ b/frontend/lib/store/slices/resultsSlice.ts
@@ -81,6 +81,20 @@ export const createResultsSlice: StateCreator<HudState, [], [], Partial<HudState
       pendingArgs = { ...pendingArgs, [tool]: queue };
     },
 
+    discardPendingToolArgs: (tool) => {
+      // R2F-2: a failed/cancelled call never emits its step_result, so its
+      // queued args would otherwise be FIFO-consumed by the RETRY's
+      // step_result (mispairing the workbench input evidence with the wrong
+      // attempt). Drop the oldest queued entry for this tool.
+      const queue = pendingArgs[tool];
+      if (!queue || !queue.length) return;
+      const nextQueue = queue.slice(1);
+      const rest = { ...pendingArgs };
+      if (nextQueue.length) rest[tool] = nextQueue;
+      else delete rest[tool];
+      pendingArgs = rest;
+    },
+
     captureStepResult: (stepInput: StepResultEvent) => {
       // Ignore pure orchestration/map-action events that carry no inspectable result.
       const step = stepInput as StepResultEvent;

--- a/frontend/lib/store/slices/resultsSlice.ts
+++ b/frontend/lib/store/slices/resultsSlice.ts
@@ -62,8 +62,12 @@ function sanitizeRaw(raw: unknown): unknown {
 }
 
 export const createResultsSlice: StateCreator<HudState, [], [], Partial<HudState>> = (set) => {
-  /** Pending tool_call args, keyed by tool name (best-effort, last-writer per turn). */
-  let pendingArgs: Record<string, Record<string, any>> = {};
+  // F-3: pending tool_call args, keyed by tool name as a FIFO queue. The
+  // previous last-writer-per-tool slot meant two same-tool calls in one turn
+  // collided: the first step_result was attached the SECOND call's args, and
+  // the second got none. A queue pairs each step_result with its own preceding
+  // tool_call args in order.
+  let pendingArgs: Record<string, Record<string, any>[]> = {};
 
   return {
     /* ─── Analysis Results Workbench ─── */
@@ -72,7 +76,9 @@ export const createResultsSlice: StateCreator<HudState, [], [], Partial<HudState
 
     captureToolCallArgs: (tool, argsStr) => {
       const parsed = parseArgs(argsStr);
-      if (parsed) pendingArgs = { ...pendingArgs, [tool]: parsed };
+      if (!parsed) return;
+      const queue = pendingArgs[tool] ? [...pendingArgs[tool], parsed] : [parsed];
+      pendingArgs = { ...pendingArgs, [tool]: queue };
     },
 
     captureStepResult: (stepInput: StepResultEvent) => {
@@ -80,16 +86,24 @@ export const createResultsSlice: StateCreator<HudState, [], [], Partial<HudState
       const step = stepInput as StepResultEvent;
       if (!step || !step.tool || IGNORED_TOOLS.has(step.tool)) return undefined;
 
-      const args = pendingArgs[step.tool];
+      // FIFO-consume the oldest captured args for this tool.
+      const queue = pendingArgs[step.tool];
+      const args = queue && queue.length ? queue[0] : undefined;
       const base = normalizeStepResult(step, { captured: !!args, args });
       const normalized: AnalysisResult = {
         ...base,
         capturedAt: Date.now(),
         raw: sanitizeRaw(base.raw),
       };
-      // Drop stale args for this tool so a later same-name call doesn't reuse them.
-      const { [step.tool]: _used, ...rest } = pendingArgs;
-      pendingArgs = rest;
+      // Shift the consumed entry; drop the tool key once its queue is empty so a
+      // later same-name call does not reuse stale args.
+      if (queue && queue.length) {
+        const nextQueue = queue.slice(1);
+        const rest = { ...pendingArgs };
+        if (nextQueue.length) rest[step.tool] = nextQueue;
+        else delete rest[step.tool];
+        pendingArgs = rest;
+      }
 
       set((s) => {
         // Dedup by id (re-emitted step_result for the same step updates in place).

--- a/frontend/test/in-memory-local-storage.ts
+++ b/frontend/test/in-memory-local-storage.ts
@@ -1,0 +1,25 @@
+/**
+ * Install a real (in-memory) localStorage on window for tests that assert
+ * persistence semantics. The global test setup replaces window.localStorage
+ * with no-op vi.fn()s, which silently discard every write.
+ */
+export function installInMemoryLocalStorage(): void {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => {
+        store.set(k, String(v));
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+}

--- a/tests/integration/test_skill_api.py
+++ b/tests/integration/test_skill_api.py
@@ -25,17 +25,32 @@ def client():
 
 @pytest.fixture
 def auth_headers():
-    """The skill list is internal metadata and requires authentication."""
+    """Authenticated callers use the same metadata endpoint."""
     from app.core.auth import create_access_token
     token = create_access_token({"sub": "skill-user", "username": "s", "role": "viewer"})
     return {"Authorization": f"Bearer {token}"}
 
 
 class TestSkillListAPI:
-    def test_list_skills_requires_authentication(self, client):
-        """A-7 regression: anonymous callers must get 401, not the skill list."""
+    def test_list_skills_anonymous_gets_metadata_only(self, client):
+        """The catalog read is anonymous-accessible (the shipped SkillsHub UI is
+        anonymous-first with no Bearer capability), but MUST expose metadata
+        only — never skill bodies or filenames."""
+        _md_skills["urban_planning_x"] = {
+            "description": "城市规划设计",
+            "body": "SECRET BODY 分析城市布局...",
+            "filename": "urban_planning.md",
+        }
         resp = client.get("/api/v1/chat/skills")
-        assert resp.status_code == 401
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["skills"] == [
+            {"name": "urban_planning_x", "description": "城市规划设计"}
+        ]
+        raw = resp.text
+        assert "SECRET BODY" not in raw
+        assert "urban_planning.md" not in raw
+        _md_skills.pop("urban_planning_x", None)
 
     def test_list_skills_empty(self, client, auth_headers):
         resp = client.get("/api/v1/chat/skills", headers=auth_headers)

--- a/tests/integration/test_skill_api.py
+++ b/tests/integration/test_skill_api.py
@@ -41,16 +41,18 @@ class TestSkillListAPI:
             "body": "SECRET BODY 分析城市布局...",
             "filename": "urban_planning.md",
         }
-        resp = client.get("/api/v1/chat/skills")
-        assert resp.status_code == 200
-        payload = resp.json()
-        assert payload["skills"] == [
-            {"name": "urban_planning_x", "description": "城市规划设计"}
-        ]
-        raw = resp.text
-        assert "SECRET BODY" not in raw
-        assert "urban_planning.md" not in raw
-        _md_skills.pop("urban_planning_x", None)
+        try:
+            resp = client.get("/api/v1/chat/skills")
+            assert resp.status_code == 200
+            payload = resp.json()
+            assert payload["skills"] == [
+                {"name": "urban_planning_x", "description": "城市规划设计"}
+            ]
+            raw = resp.text
+            assert "SECRET BODY" not in raw
+            assert "urban_planning.md" not in raw
+        finally:
+            _md_skills.pop("urban_planning_x", None)
 
     def test_list_skills_empty(self, client, auth_headers):
         resp = client.get("/api/v1/chat/skills", headers=auth_headers)

--- a/tests/integration/test_skill_api.py
+++ b/tests/integration/test_skill_api.py
@@ -23,19 +23,32 @@ def client():
     return TestClient(app)
 
 
+@pytest.fixture
+def auth_headers():
+    """The skill list is internal metadata and requires authentication."""
+    from app.core.auth import create_access_token
+    token = create_access_token({"sub": "skill-user", "username": "s", "role": "viewer"})
+    return {"Authorization": f"Bearer {token}"}
+
+
 class TestSkillListAPI:
-    def test_list_skills_empty(self, client):
+    def test_list_skills_requires_authentication(self, client):
+        """A-7 regression: anonymous callers must get 401, not the skill list."""
         resp = client.get("/api/v1/chat/skills")
+        assert resp.status_code == 401
+
+    def test_list_skills_empty(self, client, auth_headers):
+        resp = client.get("/api/v1/chat/skills", headers=auth_headers)
         assert resp.status_code == 200
         assert resp.json() == {"skills": []}
 
-    def test_list_skills_returns_loaded_skills(self, client):
+    def test_list_skills_returns_loaded_skills(self, client, auth_headers):
         _md_skills["urban_planning"] = {
             "description": "城市规划设计",
             "body": "分析城市布局...",
             "filename": "urban_planning.md",
         }
-        resp = client.get("/api/v1/chat/skills")
+        resp = client.get("/api/v1/chat/skills", headers=auth_headers)
         assert resp.status_code == 200
         data = resp.json()
         assert len(data["skills"]) == 1

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -29,7 +29,14 @@ async def client(app):
 @pytest.mark.asyncio
 async def test_list_tools(client):
     with patch.object(_chat_mod, "registry", MagicMock(get_schemas=lambda: [])):
+        # A-7: the tool catalog (incl. tier-3 schemas) requires authentication.
         resp = await client.get("/api/chat/tools")
+        assert resp.status_code == 401
+        from app.core.auth import create_access_token
+        token = create_access_token({"sub": "tools-user", "username": "t", "role": "viewer"})
+        resp = await client.get(
+            "/api/chat/tools", headers={"Authorization": f"Bearer {token}"}
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert "tools" in data

--- a/tests/test_critical_backend_correctness.py
+++ b/tests/test_critical_backend_correctness.py
@@ -359,6 +359,14 @@ def _make_manager_with_failing_redis(monkeypatch, fail_method: str):
                 raise aioredis.RedisError("get timeout")
             return None
 
+        async def smembers(self, *a, **kw):
+            # append_event refreshes the session key family via the ref
+            # index before writing; missing here it crashed the fake (the
+            # real client always has it).
+            if fail_method == "smembers":
+                raise aioredis.RedisError("smembers timeout")
+            return set()
+
     manager._r = _FakeRedis()
     return manager
 

--- a/tests/test_pi_integration.py
+++ b/tests/test_pi_integration.py
@@ -433,7 +433,7 @@ class TestPiToolsEndpoint:
         )
         set_tool_registry(registry)
 
-        req = PiToolRequest(toolCallId="tc-1", name="pi_test_echo", arguments={"msg": "hello"})
+        req = PiToolRequest(toolCallId="tc-1", name="pi_test_echo", arguments={"msg": "hello"}, sessionId="sess-pi-tools")
         resp = await dispatch_tool(req)
         assert resp.toolCallId == "tc-1"
         assert not resp.isError
@@ -445,7 +445,7 @@ class TestPiToolsEndpoint:
         registry = ToolRegistry()
         set_tool_registry(registry)
 
-        req = PiToolRequest(toolCallId="tc-2", name="does_not_exist", arguments={})
+        req = PiToolRequest(toolCallId="tc-2", name="does_not_exist", arguments={}, sessionId="sess-pi-tools")
         resp = await dispatch_tool(req)
         assert resp.isError
         assert "not found" in resp.content[0]["text"].lower()
@@ -462,7 +462,7 @@ class TestPiToolsEndpoint:
         )
         set_tool_registry(registry)
 
-        req = PiToolRequest(toolCallId="tc-3", name="pi_test_fail", arguments={})
+        req = PiToolRequest(toolCallId="tc-3", name="pi_test_fail", arguments={}, sessionId="sess-pi-tools")
         resp = await dispatch_tool(req)
         # The registry catches exceptions and returns a structured error dict.
         # pi_tools wraps it as content with isError=False so the LLM can read
@@ -490,7 +490,7 @@ class TestPiToolsEndpoint:
         )
         set_tool_registry(registry)
 
-        req = PiToolRequest(toolCallId="tc-4", name="pi_test_async", arguments={"x": "42"})
+        req = PiToolRequest(toolCallId="tc-4", name="pi_test_async", arguments={"x": "42"}, sessionId="sess-pi-tools")
         resp = await dispatch_tool(req)
         assert not resp.isError
         assert "async:42" in resp.content[0]["text"]

--- a/tests/test_round2_review_findings.py
+++ b/tests/test_round2_review_findings.py
@@ -372,3 +372,171 @@ async def test_R2_2_dispatch_detects_tool_supplied_result_ref_sentinel(monkeypat
     result = await svc.dispatch(tc, session_id="s-r22", executed_tools=set())
     assert result.status == "error"
     assert result.geojson_ref is None
+
+
+# ── R3-1: unexpected executor exceptions must converge the plan AND record
+# the livelock-guard fields (pre-fix: dict access on the PlanProposal model
+# raised AttributeError that the inner except swallowed → _write_terminal
+# never ran → plan stuck `running` until the 300s stale rescue).
+
+@pytest.mark.asyncio
+async def test_R3_1_crash_convergence_records_guard_fields(monkeypatch):
+    from app.services import plan_mode as svc
+    from app.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+
+    @reg.tool(name="fake_get_bbox", description="x")
+    def fake_get_bbox(area: str) -> dict:  # noqa: ARG001
+        return {"success": True, "bbox": [0, 0, 1, 1]}
+
+    @reg.tool(name="fake_always_fails", description="x")
+    def fake_always_fails(area: str) -> dict:  # noqa: ARG001
+        return {"success": False, "message": "tool failed"}
+
+    sid = "test-r3-crash-converge"
+    plan = svc.PlanProposal(
+        title="g",
+        steps=[
+            svc.PlanStep(id="s1", tool="fake_get_bbox", args={"area": "x"}),
+            svc.PlanStep(id="s2", tool="fake_always_fails", args={"area": "x"}),
+        ],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    # Fail the FIRST _persist_step_results call — with s2 failing, that call
+    # happens in the failure-terminal write, i.e. the executor machinery
+    # itself blows up mid-run with s2 still unfinished. The crash handler
+    # must converge the plan (real persist works on its second call).
+    real_persist = svc._persist_step_results
+    calls = {"n": 0}
+
+    async def _flaky_persist(session_id, plan_id_, step_results):
+        if calls["n"] == 0:
+            calls["n"] += 1
+            raise RuntimeError("machinery blew up")
+        return await real_persist(session_id, plan_id_, step_results)
+
+    monkeypatch.setattr(svc, "_persist_step_results", _flaky_persist)
+
+    with pytest.raises(RuntimeError, match="machinery blew up"):
+        await svc.execute_plan_async(sid, plan_id, reg)
+
+    data = await svc.load_plan(sid, plan_id)
+    assert data is not None
+    # Pre-fix: stayed "running" (terminal write skipped by the swallowed
+    # AttributeError from plan.get on the PlanProposal model).
+    assert data["__status__"] in ("failed", "partially_completed")
+    assert data["__failed_step__"] == "s2"
+    # RuntimeError classifies as internal — livelock guard can engage.
+    assert data["__failure_class__"] == "internal"
+
+
+# ── R3-2: a transient infra exception (ConnectionError) in the machinery must
+# stay transient_network — the crash handler used to hard-code "internal",
+# which made the livelock guard permanently refuse resume after a redis blip.
+
+@pytest.mark.asyncio
+async def test_R3_2_transient_crash_stays_resumable(monkeypatch):
+    from app.services import plan_mode as svc
+    from app.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+
+    @reg.tool(name="fake_get_bbox", description="x")
+    def fake_get_bbox(area: str) -> dict:  # noqa: ARG001
+        return {"success": True, "bbox": [0, 0, 1, 1]}
+
+    # Fails on the first execution, succeeds on resume — lets the test assert
+    # both the transient classification AND actual resume convergence.
+    flaky = {"failed_once": False}
+
+    @reg.tool(name="fake_flaky_step", description="x")
+    def fake_flaky_step(area: str) -> dict:  # noqa: ARG001
+        if not flaky["failed_once"]:
+            flaky["failed_once"] = True
+            return {"success": False, "message": "transient step failure"}
+        return {"success": True, "bbox": [2, 2, 3, 3]}
+
+    sid = "test-r3-transient"
+    plan = svc.PlanProposal(
+        title="g",
+        steps=[
+            svc.PlanStep(id="s1", tool="fake_get_bbox", args={"area": "x"}),
+            svc.PlanStep(
+                id="s2", tool="fake_flaky_step", args={"area": "x"}, depends_on=["s1"]
+            ),
+        ],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    real_persist = svc._persist_step_results
+    calls = {"n": 0}
+
+    async def _flaky_persist(session_id, plan_id_, step_results):
+        if calls["n"] == 0:
+            calls["n"] += 1
+            raise ConnectionError("redis blip")
+        return await real_persist(session_id, plan_id_, step_results)
+
+    monkeypatch.setattr(svc, "_persist_step_results", _flaky_persist)
+
+    with pytest.raises(ConnectionError, match="redis blip"):
+        await svc.execute_plan_async(sid, plan_id, reg)
+
+    data = await svc.load_plan(sid, plan_id)
+    assert data is not None
+    assert data["__status__"] in ("failed", "partially_completed")
+    assert data["__failed_step__"] == "s2"
+    # Pre-fix this was hard-coded "internal"; transient stays resumable.
+    assert data["__failure_class__"] == "transient_network"
+
+    # And the resume actually re-executes (livelock guard must NOT engage for
+    # a transient class).
+    ret = await svc.execute_plan_async(sid, plan_id, reg)
+    assert ret["success"] is True
+    assert ret["status"] == "completed"
+    data2 = await svc.load_plan(sid, plan_id)
+    assert data2["__status__"] == "completed"
+
+
+# ── R3-3: webgis_layer_upsert's inline branch must not persist a MapSpec
+# layer pointing at the unavailable-ref sentinel (dispatch-level R2-2 fires
+# only AFTER layer_upsert has already latched the phantom layer).
+
+@pytest.mark.asyncio
+async def test_R3_3_layer_upsert_inline_refuses_store_sentinel(monkeypatch):
+    from app.services.session_data_protocol import UNAVAILABLE_REF_PREFIX
+    from app.tools.registry import ToolRegistry
+    from app.tools.cartography_tools import register_mapspec_cartography_tools
+
+    sentinel = f"{UNAVAILABLE_REF_PREFIX}deadbeef"
+
+    async def _unavailable_store(session_id, data, prefix="geojson"):
+        return sentinel
+
+    upserted = {"calls": 0}
+
+    class _FakeMapspecStore:
+        async def layer_upsert(self, *a, **k):
+            upserted["calls"] += 1
+            return {"success": True, "mapspec": {}}
+
+    monkeypatch.setattr(
+        "app.tools.cartography_tools.session_data_manager.store", _unavailable_store
+    )
+    monkeypatch.setattr(
+        "app.tools.cartography_tools.mapspec_store", _FakeMapspecStore()
+    )
+
+    reg = ToolRegistry()
+    register_mapspec_cartography_tools(reg)
+    fn = reg._tools["webgis_layer_upsert"]
+
+    result = await fn(
+        layer={"id": "l1", "type": "fill"},
+        source_data={"type": "FeatureCollection", "features": []},
+        session_id="s-r3-inline",
+    )
+    assert result["success"] is False
+    assert upserted["calls"] == 0, "layer_upsert must not run on a phantom ref"

--- a/tests/test_round2_review_findings.py
+++ b/tests/test_round2_review_findings.py
@@ -540,3 +540,109 @@ async def test_R3_3_layer_upsert_inline_refuses_store_sentinel(monkeypatch):
     )
     assert result["success"] is False
     assert upserted["calls"] == 0, "layer_upsert must not run on a phantom ref"
+
+
+# ── R3-4: mapspec_store.source_profile must refuse the unavailable-ref sentinel
+# before UpsertSourceIntent (sibling of R3-3; no result_ref for dispatch to see).
+
+@pytest.mark.asyncio
+async def test_R3_4_source_profile_refuses_store_sentinel(monkeypatch):
+    from app.services.session_data_protocol import UNAVAILABLE_REF_PREFIX
+
+    sentinel = f"{UNAVAILABLE_REF_PREFIX}deadbeef"
+
+    async def _unavailable_store(session_id, data, prefix="geojson"):
+        return sentinel
+
+    applied = {"calls": 0}
+
+    class _FakeEngine:
+        async def apply_mutation(self, session_id, intent):
+            applied["calls"] += 1
+            class _Res:
+                is_error = False
+                error_msg = ""
+                mapspec = {}
+            return _Res()
+
+    monkeypatch.setattr(
+        "app.services.mapspec_store.session_data_manager.store", _unavailable_store
+    )
+    from app.services import mapspec_store as ms
+
+    fake_store = ms.MapSpecStore.__new__(ms.MapSpecStore)
+    fake_store.engine = _FakeEngine()
+
+    with pytest.raises(RuntimeError, match="session store unavailable"):
+        await fake_store.source_profile(
+            "s-r34", "src_1", {"type": "FeatureCollection", "features": []}
+        )
+    assert applied["calls"] == 0, "UpsertSourceIntent must not run on a phantom ref"
+
+
+# ── R3-5: same-wait-batch siblings must not lose their successes when another
+# step in the batch fails (non-deterministic `for t in done` set-iteration
+# order used to drop them via `break`).
+
+@pytest.mark.asyncio
+async def test_R3_5_same_batch_sibling_success_counted_on_failure():
+    from app.services import plan_mode as svc
+    from app.tools.registry import ToolRegistry
+
+    reg = ToolRegistry()
+
+    @reg.tool(name="fake_sync_ok", description="x")
+    def fake_sync_ok(area: str) -> dict:  # noqa: ARG001
+        return {"success": True, "bbox": [0, 0, 1, 1]}
+
+    @reg.tool(name="fake_sync_fail", description="x")
+    def fake_sync_fail(area: str) -> dict:  # noqa: ARG001
+        return {"success": False, "message": "nope"}
+
+    sid = "test-r3-same-batch"
+    # Both steps are instant sync tools: they complete in the SAME
+    # asyncio.wait batch, so the batch-scan order decides whether the
+    # sibling's success is collected when the failure is seen first.
+    plan = svc.PlanProposal(
+        title="g",
+        steps=[
+            svc.PlanStep(id="ok_a", tool="fake_sync_ok", args={"area": "x"}),
+            svc.PlanStep(id="ok_b", tool="fake_sync_ok", args={"area": "x"}),
+            svc.PlanStep(id="bad", tool="fake_sync_fail", args={"area": "x"}),
+        ],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    # Force the failing task to iterate FIRST in the done batch (native set
+    # order is hash-dependent; this makes the dropped-sibling path
+    # deterministic).
+    import asyncio as _aio
+
+    real_wait = _aio.wait
+
+    async def _ordered_wait(fs, **kw):
+        done, pending = await real_wait(fs, **kw)
+
+        def _rank(t):
+            try:
+                r = t.result()
+            except Exception:
+                return 0
+            return 1 if (isinstance(r, dict) and r.get("success") is False) else 2
+
+        return (sorted(done, key=_rank), pending)
+
+    monkeypatch_fixture = pytest.MonkeyPatch()
+    monkeypatch_fixture.setattr(_aio, "wait", _ordered_wait)
+    try:
+        ret = await svc.execute_plan_async(sid, plan_id, reg)
+    finally:
+        monkeypatch_fixture.undo()
+
+    assert ret["success"] is False
+    assert ret["failed_step"] == "bad"
+    # Both successful siblings must count regardless of batch iteration order.
+    assert set(ret["executed"]) == {"ok_a", "ok_b"}
+    data = await svc.load_plan(sid, plan_id)
+    assert data["__status__"] == "partially_completed"
+    assert data["__failed_step__"] == "bad"

--- a/tests/test_round2_review_findings.py
+++ b/tests/test_round2_review_findings.py
@@ -1,0 +1,286 @@
+"""Round-2 second-pass review regression tests.
+
+Each test is keyed to a finding ID (A-/B-/C-/D-/E-/F-/H-) and was written to
+FAIL on the BASE_SHA before the corresponding fix (RED -> GREEN).
+"""
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.database import Base
+from app.models.db_model import Organization, User
+from app.services.project_service import ProjectService, _caller_may_access_project
+
+
+# ── Shared fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    session.add(Organization(id=1, name="org1", slug="org1"))
+    session.add(Organization(id=2, name="org2", slug="org2"))
+    session.add(User(id="alice", org_id=1, username="alice", email="a@x", role="editor"))
+    session.add(User(id="bob", org_id=1, username="bob", email="b@x", role="editor"))
+    session.add(User(id="carol", org_id=2, username="carol", email="c@x", role="editor"))
+    session.commit()
+    yield session
+    session.close()
+
+
+# ── A-1: project IDOR — NULL-org private project readable by any org caller ──
+
+def test_A1_null_org_private_project_blocked_for_org_caller(db):
+    """A project with org_id=NULL owned by alice must NOT be readable by bob
+    (a different user) just because bob carries an org_id. The pre-fix guard
+    `and not org_id` skipped the owner check whenever the caller had an org."""
+    alice_proj = ProjectService.create_project(db, name="Alice private", owner_id="alice")
+    assert alice_proj.org_id is None
+
+    # alice herself can still access her own private project (she has org 1)
+    assert ProjectService.get_project_with_auth(
+        db, alice_proj.id, user_id="alice", org_id=1
+    ) is not None
+
+    # bob (same org 1) must NOT access alice's NULL-org private project
+    assert ProjectService.get_project_with_auth(
+        db, alice_proj.id, user_id="bob", org_id=1
+    ) is None
+
+    # carol (different org 2) must NOT access it either
+    assert ProjectService.get_project_with_auth(
+        db, alice_proj.id, user_id="carol", org_id=2
+    ) is None
+
+
+def test_A1_org_project_visible_to_same_org_member(db):
+    """An org-scoped project is visible to other members of the same org."""
+    proj = ProjectService.create_project(
+        db, name="Org shared", owner_id="alice", org_id=1
+    )
+    # bob is in org 1 -> may access even though owner is alice
+    assert ProjectService.get_project_with_auth(
+        db, proj.id, user_id="bob", org_id=1
+    ) is not None
+    # carol is in org 2 -> blocked
+    assert ProjectService.get_project_with_auth(
+        db, proj.id, user_id="carol", org_id=2
+    ) is None
+
+
+def test_A1_public_project_visible_to_everyone(db):
+    """A truly public project (no owner, no org) is visible to all callers."""
+    proj = ProjectService.create_project(db, name="public", owner_id=None)
+    assert _caller_may_access_project(proj, None, None) is True
+    assert _caller_may_access_project(proj, "bob", 1) is True
+
+
+# ── A-4: data-fabric create/probe/sync must require authentication ───────────
+
+def test_A4_data_fabric_mutations_require_auth():
+    """Anonymous callers must not create data sources or trigger probe/sync
+    (which initiate server-side outbound requests)."""
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    client = TestClient(app)
+    payload = {
+        "name": "evil",
+        "source_type": "ogc_api",
+        "endpoint_url": "https://example.com/data",
+        "options": {},
+    }
+    # create without token -> 401
+    res = client.post("/api/v1/data-fabric/sources", json=payload)
+    assert res.status_code == 401, res.text
+    # probe / sync on any id without token -> 401 (auth runs before lookup)
+    assert client.post("/api/v1/data-fabric/sources/ds_x/probe").status_code == 401
+    assert client.post("/api/v1/data-fabric/sources/ds_x/sync").status_code == 401
+
+
+# ── A-2: upload tools must not read another session's uploads ────────────────
+
+def test_A2_upload_tools_deny_foreign_session_via_runtime_context():
+    """The LLM-supplied session_id is untrusted. When the turn is bound to a
+    verified session (RuntimeContext), a mismatched id must be refused rather
+    than used to query another session's UploadRecord rows."""
+    from app.tools.upload_tools import register_upload_tools, _resolve_session_id
+    from app.tools.registry import ToolRegistry
+    from app.lib.runtime.context import bind_runtime_context
+
+    reg = ToolRegistry()
+    register_upload_tools(reg)
+    list_uploaded_data = reg._tools["list_uploaded_data"]
+
+    # Turn is bound to "own-session"; the (injected) arg names a victim session.
+    with bind_runtime_context(session_id="own-session"):
+        assert _resolve_session_id("victim-session") is None  # denied
+        assert _resolve_session_id("own-session") == "own-session"
+        result = list_uploaded_data(session_id="victim-session")
+    assert result["count"] == 0  # did not attempt to read victim uploads
+
+    # Without a runtime context, the provided id passes through (back-compat).
+    assert _resolve_session_id("any") == "any"
+
+
+# ── E-2/E-5: MVT projection poles + NaN/Inf vertex robustness ─────────────────
+
+def test_E2_mvt_pole_vertex_does_not_crash():
+    """A polygon spanning the pole (lat=-90) must encode without raising
+    (previously: math domain error in the pure path; inf in the shapely path)."""
+    from app.services.mvt import encode_tile
+
+    fc = {"type": "FeatureCollection", "features": [
+        {"type": "Feature", "properties": {"id": 1},
+         "geometry": {"type": "Polygon", "coordinates": [[
+             [-180.0, -90.0], [180.0, -90.0], [180.0, -80.0], [-180.0, -80.0], [-180.0, -90.0],
+         ]]}}
+    ]}
+    # z0 whole-world tile — must not raise and must produce non-empty bytes.
+    blob = encode_tile(fc, 0, 0, 0)
+    assert isinstance(blob, (bytes, bytearray))
+    assert len(blob) > 0
+
+
+def test_E5_mvt_linestring_nan_vertex_does_not_crash():
+    """A LineString containing a NaN/Inf vertex must skip it, not raise
+    ValueError in the pure path (the points path already guarded this)."""
+    from app.services.mvt import encode_tile
+
+    fc = {"type": "FeatureCollection", "features": [
+        {"type": "Feature", "properties": {"id": 1},
+         "geometry": {"type": "LineString", "coordinates": [
+             [0.0, float("nan")], [10.0, float("inf")], [20.0, 30.0],
+         ]}}
+    ]}
+    blob = encode_tile(fc, 0, 0, 0)  # must not raise
+    assert isinstance(blob, (bytes, bytearray))
+
+
+# ── E-4: isochrone weight must be meters, not a degree-valued attribute ───────
+
+def test_E4_isochrone_weight_is_metric_not_degree_attribute():
+    """A geographic (EPSG:4326) network whose features carry a ``length``
+    attribute in DEGREES must not have its edge weight taken from that
+    attribute — otherwise the meter cutoff reaches the whole network."""
+    from app.lib.geo_analysis.network import calculate_isochrones
+
+    # Two short road edges near the equator, each ~0.01 deg (~1.1 km).
+    def _line(fid, x1, y1, x2, y2):
+        return {"type": "Feature", "properties": {"id": fid, "length": 0.001},
+                "geometry": {"type": "LineString", "coordinates": [[x1, y1], [x2, y2]]}}
+    net = {"type": "FeatureCollection", "features": [_line("e1", 0, 0, 0.01, 0)]}
+    fac = {"type": "FeatureCollection", "features": [
+        {"type": "Feature", "properties": {"id": "f1"},
+         "geometry": {"type": "Point", "coordinates": [0.0, 0.0]}}]}
+    res = calculate_isochrones(net, fac, travel_time_min=1, mode="walking")
+    # 1 min walking ~ 80 m; the ~1.1 km edge is NOT fully reachable. With the
+    # old degree-weight bug (0.001 "m"), the whole edge (and any connected
+    # network) was reachable. Assert we got a result, not a network-swallowing
+    # polygon; the key correctness check is that no exception + bounded result.
+    assert res.success in (True, False)
+
+
+# ── D-1: session activity must refresh state/events/ACK key TTLs ─────────────
+
+@pytest.mark.asyncio
+async def test_D1_refresh_session_ttl_covers_state_events_and_acks():
+    """A read (get) must refresh the state/events/map_actions key TTLs, not
+    only the ref registry. Pre-fix an active session lost its viewport/event
+    log/ACK history at 4h while payloads stayed alive."""
+    import fakeredis.aioredis
+    from app.services.session_data_redis import RedisSessionStore, SESSION_TTL
+
+    raw = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    store = RedisSessionStore(redis_url="redis://unused", redis=raw, capacity=8)
+    sid = "s1"
+    ref = await store.store(sid, {"type": "FeatureCollection", "features": []}, prefix="geojson")
+
+    # Seed the sibling state/events/ACK keys with a SHORT ttl (simulate a key
+    # that is about to expire after its last write).
+    state_key = RedisSessionStore._state_key(sid)
+    events_key = RedisSessionStore._events_key(sid)
+    actions_key = RedisSessionStore._map_actions_key(sid)
+    await raw.hset(state_key, "viewport", b"{}")
+    await raw.rpush(events_key, b"{}")
+    await raw.hset(actions_key, "act1", b"{}")
+    for k in (state_key, events_key, actions_key):
+        await raw.expire(k, 5)  # near expiry
+
+    # A read triggers _refresh_session_ttl.
+    await store.get(sid, ref)
+
+    # All three sibling keys must now be refreshed to ~SESSION_TTL, not 5s.
+    assert await raw.ttl(state_key) > SESSION_TTL - 120
+    assert await raw.ttl(events_key) > SESSION_TTL - 120
+    assert await raw.ttl(actions_key) > SESSION_TTL - 120
+
+
+# ── B-1: partially_completed is resumable, not terminal ──────────────────────
+
+@pytest.mark.asyncio
+async def test_B1_partially_completed_can_converge_to_completed():
+    """A plan that paused at partially_completed must be able to advance to
+    completed on resume. Pre-fix partially_completed was in _TERMINAL_STATUSES,
+    so the first-terminal-wins guard dropped the partial->completed write and
+    the stored status stayed partially_completed forever."""
+    from app.services import plan_mode as svc
+
+    sid = "test-b1-converge"
+    plan = svc.PlanProposal(
+        title="g",
+        steps=[svc.PlanStep(id="s1", tool="fake_get_bbox", args={"area": "x"})],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+
+    # Simulate a mid-way pause then a successful resume.
+    await svc.update_plan_status(sid, plan_id, __status__="partially_completed")
+    await svc.update_plan_status(sid, plan_id, __status__="completed")
+
+    data = await svc.load_plan(sid, plan_id)
+    assert data is not None
+    assert data["__status__"] == "completed"
+
+    # And a true terminal still refuses to be revived (first-terminal-wins).
+    await svc.update_plan_status(sid, plan_id, __status__="running")
+    data2 = await svc.load_plan(sid, plan_id)
+    assert data2["__status__"] == "completed"
+
+
+# ── H-1: dispatch must detect the unavailable-ref store sentinel ──────────────
+
+@pytest.mark.asyncio
+async def test_H1_dispatch_detects_unavailable_ref_sentinel(monkeypatch):
+    """When Redis is down, store() returns the ``ref:redis-unavailable-`` sentinel.
+    dispatch must not author a MapSpec layer at that phantom ref and mark the
+    call completed; it must return status=error so the LLM can retry."""
+    from app.tools.registry import ToolRegistry
+    from app.services.tool_dispatch_service import ToolDispatchService
+    from app.services.session_data_protocol import UNAVAILABLE_REF_PREFIX
+
+    reg = ToolRegistry()
+
+    @reg.tool(name="make_features", description="returns a feature collection")
+    def make_features() -> dict:
+        return {"type": "FeatureCollection", "features": [
+            {"type": "Feature", "properties": {},
+             "geometry": {"type": "Point", "coordinates": [0.0, 0.0]}},
+        ]}
+
+    svc = ToolDispatchService(registry=reg)
+
+    async def _unavailable_store(session_id, data, prefix="geojson"):
+        return f"{UNAVAILABLE_REF_PREFIX}deadbeef"
+
+    monkeypatch.setattr(
+        "app.services.tool_dispatch_service.session_data_manager.store",
+        _unavailable_store,
+    )
+
+    tc = {"id": "call_1", "function": {"name": "make_features", "arguments": "{}"}}
+    result = await svc.dispatch(tc, session_id="s-h1", executed_tools=set())
+    assert result.status == "error"
+    assert result.geojson_ref is None
+    assert "unavailable" in (result.error_msg or "")

--- a/tests/test_round2_review_findings.py
+++ b/tests/test_round2_review_findings.py
@@ -332,3 +332,43 @@ async def test_B1_failed_plan_can_converge_on_resume():
     data = await svc.load_plan(sid, plan_id)
     assert data is not None
     assert data["__status__"] == "completed"
+
+
+# ── R2-1: data-fabric DELETE must require authentication ─────────────────────
+
+def test_R2_1_data_fabric_delete_requires_auth():
+    """The destructive DELETE route must not accept anonymous callers (the
+    anonymous branch of _require_tenant_owned matched legacy GLOBAL sources)."""
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    client = TestClient(app)
+    assert client.delete("/api/v1/data-fabric/sources/ds_x").status_code == 401
+
+
+# ── R2-2: tool-supplied result_ref sentinel must fail dispatch ───────────────
+
+@pytest.mark.asyncio
+async def test_R2_2_dispatch_detects_tool_supplied_result_ref_sentinel(monkeypatch):
+    """A tool that stores data itself can hand back the unavailable-ref sentinel
+    as result_ref (e.g. webgis_layer_upsert's inline branch). The sentinel must
+    not be promoted to geojson_ref with status=ok."""
+    from app.tools.registry import ToolRegistry
+    from app.services.tool_dispatch_service import ToolDispatchService
+    from app.services.session_data_protocol import UNAVAILABLE_REF_PREFIX
+
+    reg = ToolRegistry()
+
+    @reg.tool(name="self_storing_tool", description="returns its own result_ref")
+    def self_storing_tool() -> dict:
+        return {
+            "success": True,
+            "result_ref": f"{UNAVAILABLE_REF_PREFIX}cafebabe",
+            "bbox": [0, 0, 1, 1],
+        }
+
+    svc = ToolDispatchService(registry=reg)
+    tc = {"id": "call_r22", "function": {"name": "self_storing_tool", "arguments": "{}"}}
+    result = await svc.dispatch(tc, session_id="s-r22", executed_tools=set())
+    assert result.status == "error"
+    assert result.geojson_ref is None

--- a/tests/test_round2_review_findings.py
+++ b/tests/test_round2_review_findings.py
@@ -98,6 +98,14 @@ def test_A4_data_fabric_mutations_require_auth():
     # probe / sync on any id without token -> 401 (auth runs before lookup)
     assert client.post("/api/v1/data-fabric/sources/ds_x/probe").status_code == 401
     assert client.post("/api/v1/data-fabric/sources/ds_x/sync").status_code == 401
+    # preview / query / materialize also trigger outbound remote fetches on
+    # global sources — anonymous callers must not initiate them (R1S-A4).
+    assert client.get("/api/v1/data-fabric/catalog/cat_x/preview").status_code == 401
+    assert client.post("/api/v1/data-fabric/catalog/cat_x/query", json={"limit": 1}).status_code == 401
+    assert client.post(
+        "/api/v1/data-fabric/materialize",
+        json={"session_id": "s", "catalog_item_id": "cat_x"},
+    ).status_code == 401
 
 
 # ── A-2: upload tools must not read another session's uploads ────────────────
@@ -167,7 +175,7 @@ def test_E4_isochrone_weight_is_metric_not_degree_attribute():
     attribute — otherwise the meter cutoff reaches the whole network."""
     from app.lib.geo_analysis.network import calculate_isochrones
 
-    # Two short road edges near the equator, each ~0.01 deg (~1.1 km).
+    # One short road edge near the equator: 0.01 deg lon ≈ 1.11 km.
     def _line(fid, x1, y1, x2, y2):
         return {"type": "Feature", "properties": {"id": fid, "length": 0.001},
                 "geometry": {"type": "LineString", "coordinates": [[x1, y1], [x2, y2]]}}
@@ -176,11 +184,27 @@ def test_E4_isochrone_weight_is_metric_not_degree_attribute():
         {"type": "Feature", "properties": {"id": "f1"},
          "geometry": {"type": "Point", "coordinates": [0.0, 0.0]}}]}
     res = calculate_isochrones(net, fac, travel_time_min=1, mode="walking")
-    # 1 min walking ~ 80 m; the ~1.1 km edge is NOT fully reachable. With the
-    # old degree-weight bug (0.001 "m"), the whole edge (and any connected
-    # network) was reachable. Assert we got a result, not a network-swallowing
-    # polygon; the key correctness check is that no exception + bounded result.
-    assert res.success in (True, False)
+    assert res.success is True, getattr(res, "error", None)
+    # 1 min walking ≈ 80 m, so only ~80 m of the ~1.11 km edge is reachable.
+    # Extract the isochrone polygon's longitude extent.
+    feats = res.data["features"] if isinstance(res.data, dict) else res.data
+    assert feats, "expected an isochrone polygon feature"
+    lons: list[float] = []
+
+    def _collect(node):
+        if isinstance(node, (list, tuple)) and node and isinstance(node[0], (int, float)):
+            lons.append(float(node[0]))
+        elif isinstance(node, (list, tuple)):
+            for child in node:
+                _collect(child)
+
+    _collect(feats[0]["geometry"]["coordinates"])
+    span = max(lons) - min(lons)
+    # Post-fix (metric weight): polygon spans ~0.001-0.002 deg (reachable
+    # ~80 m + ~30 m road buffer). Pre-fix (degree-valued attribute used as
+    # meters): the 0.001 "m" weight makes the WHOLE 1.11 km edge reachable,
+    # so the polygon spans ≈ 0.01 deg. 0.005 deg cleanly separates the two.
+    assert span < 0.005, f"isochrone swallowed the network: lon span {span:.5f} deg"
 
 
 # ── D-1: session activity must refresh state/events/ACK key TTLs ─────────────
@@ -284,3 +308,27 @@ async def test_H1_dispatch_detects_unavailable_ref_sentinel(monkeypatch):
     assert result.status == "error"
     assert result.geojson_ref is None
     assert "unavailable" in (result.error_msg or "")
+
+
+# ── B-1 (R1C-3): a transient 'failed' plan must be resumable and converge ────
+
+@pytest.mark.asyncio
+async def test_B1_failed_plan_can_converge_on_resume():
+    """A plan that failed (no stored step results) and is legitimately resumed
+    must be able to advance to completed. ``failed`` is resumable (transient
+    failures are retried); only completed/cancelled are truly terminal."""
+    from app.services import plan_mode as svc
+
+    sid = "test-b1-failed-resume"
+    plan = svc.PlanProposal(
+        title="g",
+        steps=[svc.PlanStep(id="s1", tool="fake_get_bbox", args={"area": "x"})],
+    )
+    plan_id = await svc.store_plan(sid, plan)
+    await svc.update_plan_status(sid, plan_id, __status__="failed")
+    # Resume: failed -> running -> completed must all be writable.
+    await svc.update_plan_status(sid, plan_id, __status__="running")
+    await svc.update_plan_status(sid, plan_id, __status__="completed")
+    data = await svc.load_plan(sid, plan_id)
+    assert data is not None
+    assert data["__status__"] == "completed"

--- a/tests/test_runtime_chaos_pi.py
+++ b/tests/test_runtime_chaos_pi.py
@@ -607,7 +607,7 @@ async def test_process_death_mid_stream_fast_fails_turn(monkeypatch):
     # token (F24); it captures the token object for the cancellation assert.
     dispatch = asyncio.create_task(dispatch_tool(PiToolRequest(
         name="query_map_features", toolCallId="tc-death", arguments={},
-        sessionId=None,
+        sessionId="sess-death",  # required by the hardened callback contract
     )))
     await dispatch
 

--- a/tests/test_runtime_chaos_store.py
+++ b/tests/test_runtime_chaos_store.py
@@ -105,6 +105,9 @@ class _FaultyRedis:
     async def lrange(self, *a, **kw):
         raise aioredis.RedisError("lrange timed out")
 
+    async def smembers(self, *a, **kw):
+        raise aioredis.RedisError("smembers timed out")
+
 
 def _faulty_store():
     return RedisSessionStore(redis_url="redis://unused", redis=_FaultyRedis())

--- a/tests/unit/test_data_fabric_routes.py
+++ b/tests/unit/test_data_fabric_routes.py
@@ -21,7 +21,13 @@ def setup_db():
 def test_data_fabric_rest_routes():
     client = TestClient(app)
 
-    # 1. List sources
+    # create/probe/sync now require authentication (anonymous callers used to
+    # create GLOBAL sources and trigger outbound probe/sync requests).
+    from app.core.auth import create_access_token
+    auth_token = create_access_token({"sub": "df-user", "username": "df", "role": "editor"})
+    auth_headers = {"Authorization": f"Bearer {auth_token}"}
+
+    # 1. List sources (read path stays anonymous-optional)
     res = client.get("/api/v1/data-fabric/sources")
     assert res.status_code == 200
     data = res.json()
@@ -40,29 +46,29 @@ def test_data_fabric_rest_routes():
         mock_probe.return_value = DataFabricHealth(status="healthy", message="OK", latency_ms=12.5)
         mock_sync.return_value = []
 
-        create_res = client.post("/api/v1/data-fabric/sources", json=create_payload)
+        create_res = client.post("/api/v1/data-fabric/sources", json=create_payload, headers=auth_headers)
         assert create_res.status_code == 200
         create_data = create_res.json()
         assert create_data["success"] is True
         source_id = create_data["data_source"]["id"]
         assert source_id.startswith("ds_")
 
-    # 3. Get single data source
-    get_res = client.get(f"/api/v1/data-fabric/sources/{source_id}")
+    # 3. Get single data source (owned by df-user -> authenticate)
+    get_res = client.get(f"/api/v1/data-fabric/sources/{source_id}", headers=auth_headers)
     assert get_res.status_code == 200
     assert get_res.json()["name"] == "Test OGC API Source"
 
     # 4. Probe data source health
     with patch("app.services.data_fabric.manager.DataFabricManager.probe_profile") as mock_probe:
         mock_probe.return_value = DataFabricHealth(status="healthy", message="OK", latency_ms=10.0)
-        probe_res = client.post(f"/api/v1/data-fabric/sources/{source_id}/probe")
+        probe_res = client.post(f"/api/v1/data-fabric/sources/{source_id}/probe", headers=auth_headers)
         assert probe_res.status_code == 200
         assert probe_res.json()["status"] == "healthy"
 
     # 5. Sync catalog
     with patch("app.services.data_fabric.manager.DataFabricManager.sync_catalog") as mock_sync:
         mock_sync.return_value = []
-        sync_res = client.post(f"/api/v1/data-fabric/sources/{source_id}/sync")
+        sync_res = client.post(f"/api/v1/data-fabric/sources/{source_id}/sync", headers=auth_headers)
         assert sync_res.status_code == 200
         assert "synced_count" in sync_res.json()
 
@@ -107,7 +113,7 @@ def test_data_fabric_rest_routes():
             "catalog_item_id": f"cat_{source_id}_default",
             "query_spec": {"limit": 5},
         }
-        mat_res = client.post("/api/v1/data-fabric/materialize", json=mat_payload)
+        mat_res = client.post("/api/v1/data-fabric/materialize", json=mat_payload, headers=auth_headers)
         assert mat_res.status_code == 200
         mat_data = mat_res.json()
         assert mat_data["success"] is True
@@ -115,7 +121,7 @@ def test_data_fabric_rest_routes():
         assert mat_data["feature_count"] == 1
 
     # 8. Delete source
-    del_res = client.delete(f"/api/v1/data-fabric/sources/{source_id}")
+    del_res = client.delete(f"/api/v1/data-fabric/sources/{source_id}", headers=auth_headers)
     assert del_res.status_code == 200
     assert del_res.json()["success"] is True
 

--- a/tests/unit/test_pi_bridge_leak.py
+++ b/tests/unit/test_pi_bridge_leak.py
@@ -1,8 +1,9 @@
 """Regression: Pi-bridge per-turn state must not leak across long-lived sessions.
 
-Simulates 50 long chat sessions, each with tool dispatches (the Pi extension
-posts sessionId=None, so every dispatch lands in the "" bucket of
-_session_executed_sets) and a client that disconnects mid-stream. Asserts the
+Simulates 50 long chat sessions, each with tool dispatches (the hardened
+callback contract requires the verified turn sessionId — SEC fix — so every
+dispatch lands in that session's bucket of _session_executed_sets) and a
+client that disconnects mid-stream. Asserts the
 module-level dedup sets and dispatch-result cache return to baseline after
 every turn, and that gc/tracemalloc don't accumulate retained tool results.
 
@@ -75,7 +76,10 @@ async def _run_one_session(i, monkeypatch):
             name="query_map_features",
             toolCallId=f"tc-{i}-{j}",
             arguments={"bbox": [116.0, 39.0, 116.1, 39.1]},
-            sessionId=None,  # Pi extension posts no sessionId
+            # The signed-token HTTP route always stamps the verified turn
+            # session; the bridge rejects sessionId-less callbacks since the
+            # cross-session mutation fix.
+            sessionId=f"session-{i}",
         ))
     rpc = _make_event_rpc([make_token_event("hello")])
     bridge = PiBridge(rpc=rpc)


### PR DESCRIPTION
## Second-Pass (Round-2) Whole-Repository Review

```
BASE_SHA: c42aa3af27cf7eb9854d1a46c99acf5210c94a90
FINAL_SHA: 8fea92d
Branch: audit/master-round2-zero-review-zcode (isolated worktree)
```

## Methodology

- Multi-agent review across 7 axes (security/authz, agent-runtime/Pi/SSE,
  identity/correlation, storage/Redis/lifecycle, GIS correctness, frontend
  async state, error-handling/failure semantics), each with adversarial
  mandates targeting first-pass negative space.
- Every finding verified against actual code before fixing; every real bug
  fixed RED → GREEN (regression tests fail on BASE).
- Two rounds of independent re-review of the full diff (5 reviewers total);
  Round-2 adversarial reviewers assumed Round 1 was wrong.

## Coverage

backend (app/api, core, services, tools, lib) · agent runtime (Pi bridge,
SSE, cancellation) · auth/security · GIS (MVT, network, parser, raster) ·
persistence/cache (session_data_redis) · frontend (hooks, store, results) ·
tests/config.

## Findings & fixes

**P1 (5):**
- Project IDOR: `_caller_may_access_project` skipped the owner check whenever
  the caller carried any org_id → any org user could read/mutate another
  user's NULL-org private project.
- Upload tools (agent path) queried UploadRecord by an LLM-supplied
  session_id with no ownership proof (sibling of the S42 HTTP fix).
- data-fabric create/probe/sync/DELETE/preview/query/materialize: anonymous
  callers could create tenant-global sources, delete legacy global sources,
  and trigger outbound requests.
- Tool-supplied `result_ref` sentinel bypass: Redis-outage sentinel promoted
  to geojson_ref with status=ok + dedup-completed marking (unrecoverable).
- Vacuous regression test (E-4) tightened — now genuinely discriminates
  degree-vs-meter isochrone weights.

**P2 (12):** partially_completed/failed plan-terminal over-reach (resume
convergence dropped, now reconciled with chaos-P2 via explicit transition
rules); plan livelock guard blind on internal failures; session TTL family
(state/events/ACKs) not refreshed on activity/mutations; read-path refresh
failures converting successful reads to misses; stale descriptor after
overwrite; late abort killing the next turn's futures; cross-session harness
evidence misattribution; send_failed without abort (duplicate side effects);
Web-Mercator pole vertices (crash/drop/distortion); NaN line/polygon MVT
vertices (500); degree-valued network `length` attribute (isochrone swallows
network); anonymous /chat/tools + /chat/skills catalog disclosure; RAG doc
delete org-scoped; frontend: startNewSession not aborting in-flight restore /
not clearing results; stale fetchAnalysisAssets overwrite; same-tick
double-send; FIFO args mispairing on retry.

**P3:** documented in commits (rate-limit keying inconsistency, raster
warn-once, CSV index alignment, etc. — fixed where low-risk, recorded
otherwise).

**Counts:** P0: 0 · P1: 5 · P2: 12 · P3: ~15 (fixed or documented).

## Regression tests

`tests/test_round2_review_findings.py` — each test verified to FAIL on
BASE_SHA (A-1/A-2/A-4/B-1/D-1/E-2/E-4/E-5/H-1/R2-1/R2-2 + plan transitions).
Frontend: F-1 abort/clear regression in `use-workspace-session.test.ts`.
Also fixed 4 plan-mode tests that were failing on BASE (resume/supersede
convergence class).

## Local test evidence

- Backend: `pytest` 3318 passed / 22 failed — **all 22 pre-existing on BASE**
  (verified by running the identical suite on BASE and diffing failure sets;
  the deltas are wall-clock perf flakes under load + a known test-order
  pollution that passes in isolation on both BASE and this branch). Two
  files excluded from full-suite runs hang identically on BASE
  (env-specific teardown stall), pass in isolation. `ruff check app tests`
  clean.
- Frontend: `tsc` (app + test) clean · `eslint --max-warnings 0` clean ·
  vitest 1242 passed / 3 skipped · `next build` succeeds.
- `git diff --check` clean.

## Relationship with concurrent PRs

PR #367 (result workbench follow-ups) is still open and NOT merged; this
branch is based purely on master (c42aa3a). Both touch
`frontend/lib/store/slices/resultsSlice.ts` (F-3 pendingArgs FIFO here);
merge-order conflicts will need trivial resolution.

## Validation statement

GitHub Actions / CI/CD was not used as completion evidence. All validation
was performed locally.