### PR TITLE
fix(stream): harden SSE resume and event ordering under network churn

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -334,6 +334,20 @@ async def _recorded(stream, buffer: TurnEventBuffer):
         yield chunk
 
 
+def _synthesize_terminal_event(session_key: str, terminal_event: str) -> str:
+    """Synthesize truthful terminal event matching the original terminal type (INV-4)."""
+    term_type = sse_event_type(terminal_event)
+    if term_type == "task_cancelled":
+        return sse_event("task_cancelled", {"session_id": session_key, "resumed": True})
+    if term_type in ("task_error", "error", "step_error"):
+        return sse_event(term_type, {
+            "session_id": session_key,
+            "error": "本轮执行失败；请重试。",
+            "resumed": True,
+        })
+    return sse_event("done", {"session_id": session_key, "resumed": True})
+
+
 async def _resume_generator(
     session_key: str,
     last_event_id: int,
@@ -456,8 +470,8 @@ async def _resume_generator_impl(
         terminal_id = sse_event_id(buffered.terminal_event)
         if terminal_id is None or terminal_id <= last_event_id:
             # Client already consumed the terminal; reconnect for nothing but
-            # a clean close — synthesize one so the stream terminates.
-            yield sse_event("done", {"session_id": session_key, "resumed": True})
+            # a clean close — synthesize matching terminal type so the stream terminates truthfully.
+            yield _synthesize_terminal_event(session_key, buffered.terminal_event)
         # Otherwise the terminal was replayed above — nothing more to add.
     else:
         # Ended without a terminal: the turn was interrupted (client

--- a/frontend/lib/hooks/use-sse-adversarial.test.ts
+++ b/frontend/lib/hooks/use-sse-adversarial.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMapBridge } from './useMapBridge';
+import { useSSEStream } from './use-sse-stream';
+import { useHudStore } from '@/lib/store/useHudStore';
+import type { SSEEvent } from '@/lib/api/chat';
+
+vi.mock('@/lib/api/chat', () => ({
+  streamChat: vi.fn(),
+}));
+
+import { streamChat } from '@/lib/api/chat';
+const mockStreamChat = vi.mocked(streamChat);
+
+async function* makeAsyncGen(events: SSEEvent[], delayMs = 0): AsyncGenerator<SSEEvent> {
+  for (const ev of events) {
+    if (delayMs > 0) {
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+    yield ev;
+  }
+}
+
+describe('Frontend SSE Adversarial Stress Tests', () => {
+  const dispatchAction = vi.fn();
+  const onEvent = vi.fn();
+  const getMapSnapshot = vi.fn().mockReturnValue({});
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    useHudStore.getState().clearLayers();
+    useHudStore.getState().clearResults();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('Adversarial 1: Rapid session hopping (A -> B -> A) during active token stream with reconnect', async () => {
+    let streamCount = 0;
+    mockStreamChat.mockImplementation(async function* (
+      msg,
+      sid,
+      _snap,
+      signal,
+    ) {
+      const idx = ++streamCount;
+      yield { event: 'thinking', data: { session_id: sid } };
+      yield { event: 'token', data: { content: `s${idx}_t1 `, session_id: sid }, id: '1' };
+      if (signal?.aborted) return;
+      yield { event: 'token', data: { content: `s${idx}_t2 `, session_id: sid }, id: '2' };
+      yield { event: 'done', data: { session_id: sid }, id: '3' };
+    });
+
+    let currentSid = 'session-A';
+    const sidRef = { current: currentSid };
+    const setSid = vi.fn((s) => {
+      currentSid = s;
+      sidRef.current = s;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ sid }) =>
+        useSSEStream(
+          sid,
+          setSid,
+          sidRef,
+          dispatchAction,
+          getMapSnapshot,
+          null,
+          { current: null },
+        ),
+      { initialProps: { sid: 'session-A' } },
+    );
+
+    // 1. Start send on session A
+    let sendPromiseA: Promise<void> | undefined;
+    act(() => {
+      sendPromiseA = result.current.handleSend('hello session A');
+    });
+
+    // 2. Mid-flight hop to session B (aborts session A)
+    rerender({ sid: 'session-B' });
+    sidRef.current = 'session-B';
+
+    // 3. Start and await send on session B
+    await act(async () => {
+      await result.current.handleSend('hello session B');
+      vi.runAllTimers();
+    });
+
+    await act(async () => {
+      await sendPromiseA;
+    });
+
+    // 4. Mid-flight hop back to session A
+    rerender({ sid: 'session-A' });
+    sidRef.current = 'session-A';
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    // Verify: No infinite loops, no uncaught exceptions, active status is stable
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('Adversarial 2: Duplicate out-of-order burst delivery does not corrupt state or trigger duplicate actions', async () => {
+    mockStreamChat.mockReturnValue(
+      makeAsyncGen([
+        { event: 'thinking', data: { session_id: 's1' } },
+        { event: 'token', data: { content: 'chunk 1 ' }, id: '1' },
+        { event: 'token', data: { content: 'chunk 1 ' }, id: '1' }, // Network duplicate F9
+        { event: 'token', data: { content: 'chunk 2 ' }, id: '2' },
+        {
+          event: 'step_result',
+          data: {
+            session_id: 's1',
+            tool: 'custom_search',
+            result: { command: 'fly_to', bbox: [116, 39, 117, 40] },
+          },
+          id: '3',
+        },
+        {
+          event: 'step_result',
+          data: {
+            session_id: 's1',
+            tool: 'custom_search',
+            result: { command: 'fly_to', bbox: [116, 39, 117, 40] },
+          },
+          id: '3', // Duplicate step_result F9
+        },
+        { event: 'done', data: { session_id: 's1' }, id: '4' },
+        { event: 'acting', data: { session_id: 's1' } }, // Out of order running event F10
+      ]),
+    );
+
+    const { result } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent),
+    );
+
+    await act(async () => {
+      await result.current.send('test dup burst', {});
+    });
+
+    // fly_to action dispatched exactly once (deduped id: 3)
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'fly_to' }),
+    );
+    // Terminal status remains 'done' despite late 'acting' event
+    expect(result.current.aiStatus).toBe('done');
+  });
+
+  it('Adversarial 3: Unmount during exponential backoff timer cleans up timer and aborts immediately', async () => {
+    async function* failingStream(): AsyncGenerator<SSEEvent> {
+      throw new Error('dropped');
+    }
+    mockStreamChat.mockImplementation(() => failingStream());
+
+    const { result, unmount } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent, undefined, {
+        maxAttempts: 3,
+        baseDelayMs: 2000,
+      }),
+    );
+
+    act(() => {
+      void result.current.send('failing turn', {});
+    });
+    await act(async () => {}); // Attempt 1 fails, enters 2000ms sleep
+
+    // Unmount hook while sleeping
+    unmount();
+
+    // Advance time far into future
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    // Stream must NOT have retried further after unmount
+    expect(mockStreamChat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -456,4 +456,75 @@ describe('canonical MapSpec runtime patch', () => {
       type: 'FeatureCollection',
     }));
   });
+
+  it('INV-2: stale event from old session A does not flip active session B or mutate state', () => {
+    const setSid = vi.fn();
+    const sidRef = { current: 'session-B' };
+    renderHook(() =>
+      useSSEStream(
+        'session-B',
+        setSid,
+        sidRef,
+        dispatchAction,
+        getMapSnapshot,
+        null,
+        { current: null },
+      )
+    );
+
+    act(() => {
+      // Event arriving with session_id: 'session-A'
+      bridgeMock.onEventCallback?.({
+        event: 'step_result',
+        data: {
+          session_id: 'session-A',
+          tool: 'search_poi',
+          name: 'Stale POI',
+        },
+      });
+    });
+
+    // setSessionId must NOT have been called with 'session-A'!
+    expect(setSid).not.toHaveBeenCalledWith('session-A');
+    expect(sidRef.current).toBe('session-B');
+  });
+
+  it('INV-4: task_cancelled event marks thinking message as cancelled without fabricating fake completion', async () => {
+    const { result } = renderHook(() =>
+      useSSEStream(
+        'session-1',
+        vi.fn(),
+        { current: 'session-1' },
+        dispatchAction,
+        getMapSnapshot,
+        null,
+        { current: null },
+      )
+    );
+
+    let sendPromise: Promise<void> | undefined;
+    act(() => {
+      sendPromise = result.current.handleSend('cancel me');
+    });
+
+    // Simulate task_cancelled event from server
+    act(() => {
+      bridgeMock.onEventCallback?.({
+        event: 'task_cancelled',
+        data: { session_id: 'session-1', task_id: 't-cancel' },
+      });
+    });
+
+    await act(async () => {
+      await sendPromise;
+    });
+
+    const msgs = result.current.messages;
+    const lastMsg = msgs[msgs.length - 1];
+    expect(lastMsg.content).toContain('已取消');
+    expect(lastMsg.content).not.toBe('完成。');
+    expect(lastMsg.isThinking).toBe(false);
+  });
 });
+
+

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -152,6 +152,13 @@ export function buildSelectedFeatureSnapshot(
   };
 }
 
+function extractEventSessionId(data: unknown): string | undefined {
+  if (typeof data === 'object' && data !== null && typeof (data as Record<string, unknown>).session_id === 'string') {
+    return (data as Record<string, unknown>).session_id as string;
+  }
+  return undefined;
+}
+
 export function useSSEStream(
   sessionId: string | undefined,
   setSessionId: (sid: string) => void,
@@ -256,10 +263,17 @@ export function useSSEStream(
     (event: SSEEvent) => {
       const data = event.data as any;
 
-      // Session ID assignment (first response carries the server-assigned session)
-      if (data?.session_id && data.session_id !== sessionIdRef.current) {
-        setSessionId(data.session_id);
-        sessionIdRef.current = data.session_id;
+      // INV-2: An event from another session must never mutate the active session or flip session state.
+      const eventSid = extractEventSessionId(data);
+      if (eventSid && sessionIdRef.current && eventSid !== sessionIdRef.current) {
+        devOnly.warn('[useSSEStream] ignored cross-session SSE event:', eventSid);
+        return;
+      }
+
+      // Session ID assignment (first response binds the initially undefined session)
+      if (eventSid && !sessionIdRef.current) {
+        setSessionId(eventSid);
+        sessionIdRef.current = eventSid;
       }
 
       // SEC-08：服务端在新建匿名会话时签发 owner_token（随 task_start / session 事件下发）。
@@ -562,6 +576,18 @@ export function useSSEStream(
             return next;
           });
         }
+      } else if (event.event === 'task_cancelled') {
+        setMessages((prev) =>
+          prev.map((m) => {
+            if (m.id !== thinkingId) return m;
+            const existing = m.content && !m.isThinking ? m.content : "";
+            return {
+              ...m,
+              content: existing ? `${existing}\n\n⏹️ [已取消]` : "⏹️ [已取消]",
+              isThinking: false,
+            };
+          }),
+        );
       } else if (
         event.event === 'error' ||
         event.event === 'step_error' ||

--- a/frontend/lib/hooks/useMapBridge.test.ts
+++ b/frontend/lib/hooks/useMapBridge.test.ts
@@ -1172,4 +1172,92 @@ describe('useMapBridge', () => {
       status: 'succeeded',
     }));
   });
+
+  // ─── Invariants Hardening Tests (INV-1, INV-3, INV-9, INV-10) ────────────
+
+  it('INV-3: terminal state cannot be rolled back by subsequent out-of-order running events', async () => {
+    // Stream delivers a terminal done, followed by an out-of-order acting event
+    mockStreamChat.mockReturnValue(makeAsyncGen([
+      { event: 'thinking', data: {} },
+      { event: 'done', data: {} },
+      { event: 'acting', data: {} }, // out-of-order late event
+    ]));
+    const { result } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent)
+    );
+    await act(async () => { await result.current.send('q', {}); });
+
+    expect(result.current.aiStatus).toBe('done'); // Must NOT roll back to 'acting'
+  });
+
+  it('INV-3: error terminal cannot be rolled back by subsequent out-of-order step_start', async () => {
+    mockStreamChat.mockReturnValue(makeAsyncGen([
+      { event: 'thinking', data: {} },
+      { event: 'error', data: { error: 'something broke' } },
+      { event: 'step_start', data: {} }, // out-of-order late event
+    ]));
+    const { result } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent)
+    );
+    await act(async () => { await result.current.send('q', {}); });
+
+    expect(result.current.aiStatus).toBe('error'); // Must NOT roll back to 'acting'
+  });
+
+  it('INV-10: non-retryable 4xx HTTP errors (e.g. 400/401/403/404) stop reconnect immediately', async () => {
+    const apiError = new Error('Not found');
+    (apiError as any).status = 404;
+    mockStreamChat.mockImplementation(() => {
+      throw apiError;
+    });
+
+    const { result } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent, undefined, { maxAttempts: 3, baseDelayMs: 500 })
+    );
+
+    await act(async () => {
+      await result.current.send('q', {});
+    });
+
+    // Must NOT retry 3 times when error is a 404 client error!
+    expect(mockStreamChat).toHaveBeenCalledTimes(1);
+    expect(result.current.aiStatus).toBe('error');
+  });
+
+  it('INV-9: aborting stream during reconnect backoff sleep stops immediately without sending next request', async () => {
+    async function* failingTurn(): AsyncGenerator<SSEEvent> {
+      throw new TypeError('network dropped');
+    }
+    async function* resumedTurn(): AsyncGenerator<SSEEvent> {
+      yield { event: 'done', data: {} };
+    }
+    mockStreamChat
+      .mockImplementationOnce(() => failingTurn())
+      .mockImplementationOnce(() => resumedTurn());
+
+    const { result } = renderHook(() =>
+      useMapBridge('s1', dispatchAction, onEvent, undefined, { maxAttempts: 2, baseDelayMs: 1000 })
+    );
+
+    act(() => {
+      void result.current.send('first', {});
+    });
+    await act(async () => {}); // Attempt 1 fails, enters 1000ms backoff sleep
+
+    // New send() is initiated while attempt 1 is sleeping
+    act(() => {
+      void result.current.send('second', {});
+    });
+
+    // Advance timers past the first backoff
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // The sleeping first stream must have been aborted and never made its 2nd attempt
+    // Total mockStreamChat calls should be: 1 (first attempt 1) + 1 (second stream attempt 1) = 2
+    expect(mockStreamChat).toHaveBeenCalledTimes(2);
+    expect(mockStreamChat.mock.calls[1][0]).toBe('second');
+  });
 });
+

--- a/frontend/lib/hooks/useMapBridge.ts
+++ b/frontend/lib/hooks/useMapBridge.ts
@@ -22,8 +22,32 @@ import {
   viewportSeqTracker,
 } from "@/lib/utils/viewport-seq";
 const MAP_STATE_THROTTLE_MS = 2000;
+const MAX_SEEN_EVENT_IDS = 512;
 
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+function cancellableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+function isNonRetryableError(err: unknown): boolean {
+  if (!err) return false;
+  const status = (err as any).status;
+  // 4xx client errors (400, 401, 403, 404, 422) except 429 (rate-limit backoff is allowed)
+  if (typeof status === 'number' && status >= 400 && status < 500 && status !== 429) {
+    return true;
+  }
+  return false;
+}
 
 // V3 (design §6): client-minted fallback action ids. Locally synthesized
 // actions (bbox-fallback fly_to) have no backend `ma-…` id, so mint a
@@ -205,13 +229,14 @@ export function useMapBridge(
         // that transition is the server assigning the currently live stream.
         abortControllerRef.current?.abort();
         streamEpochRef.current += 1;
+        setAiStatus('idle');
       }
       resetViewportSeq();
       mapActionCtx?.clearActions?.();
       ackSender.flush();
     }
     prevSessionIdRef.current = sessionId;
-  }, [sessionId, mapActionCtx, ackSender]);
+  }, [sessionId, mapActionCtx, ackSender, setAiStatus]);
 
   useEffect(() => {
     return () => {
@@ -233,6 +258,22 @@ export function useMapBridge(
     // eslint-disable-next-line react-hooks/exhaustive-deps -- ackSender is stable; mapActionCtx is intentionally omitted (register is idempotent and re-running on provider-value churn would flush mid-session)
   }, [ackSender]);
 
+  const emitSyntheticError = useCallback(
+    (err: unknown) => {
+      const errorMsg =
+        typeof err === 'string'
+          ? err
+          : err instanceof Error
+            ? err.message
+            : String(err ?? 'Unknown error');
+      onEvent({
+        event: 'error',
+        data: { error: errorMsg } as unknown as Record<string, unknown>,
+      });
+    },
+    [onEvent],
+  );
+
   const send = useCallback(
     async (content: string, mapSnapshot: Record<string, unknown>): Promise<void> => {
       // [ENG-P4] abort any in-flight stream before starting a new one
@@ -253,6 +294,8 @@ export function useMapBridge(
       // back as `Last-Event-ID` so the backend replays only the missed events
       // (resume is a read — it never re-executes the turn).
       let lastEventId: string | undefined;
+      // Bounded intra-turn event dedup set (INV-1 / INV-7)
+      const seenEventIds = new Set<string>();
       // A stream may begin without a session id, then bind exactly once to the
       // server-minted session. Events from any other session are stale/mixed
       // and must never switch workspace state or mount their result.
@@ -262,6 +305,7 @@ export function useMapBridge(
 
       try {
         for (let attempt = 0; ; attempt++) {
+          if (controller.signal.aborted || streamEpoch !== streamEpochRef.current) break;
           const isLastAttempt = attempt >= maxAttempts;
           let attemptError: unknown = null;
 
@@ -317,17 +361,24 @@ export function useMapBridge(
               // should never overlap what the client already processed — but if
               // the server replays an id we have seen (stale Last-Event-ID, ring
               // eviction, races), skip it so token appends / layer adds / map
-              // commands are NOT applied twice.
+              // commands are NOT applied twice (INV-1 / INV-7).
               if (event.id) {
+                const idStr = String(event.id);
                 const idNum = Number(event.id);
                 if (
-                  lastEventId !== undefined &&
-                  !Number.isNaN(idNum) &&
-                  idNum <= Number(lastEventId)
+                  seenEventIds.has(idStr) ||
+                  (lastEventId !== undefined &&
+                    !Number.isNaN(idNum) &&
+                    idNum <= Number(lastEventId))
                 ) {
                   continue;
                 }
-                lastEventId = event.id;
+                seenEventIds.add(idStr);
+                if (seenEventIds.size > MAX_SEEN_EVENT_IDS) {
+                  const firstKey = seenEventIds.keys().next().value;
+                  if (firstKey !== undefined) seenEventIds.delete(firstKey);
+                }
+                lastEventId = idStr;
               }
 
               // Skip unparseable data — streamChat yields raw string on JSON.parse failure
@@ -339,10 +390,8 @@ export function useMapBridge(
 
               const data = event.data as Record<string, unknown>;
 
-              // aiStatus transitions
-              if (event.event === 'thinking') setAiStatus('thinking');
-              else if (event.event === 'acting' || event.event === 'step_start') setAiStatus('acting');
-              else if (event.event === 'done' || event.event === 'task_complete') {
+              // aiStatus transitions — monotonic: terminal state cannot be rolled back by running events (INV-3)
+              if (event.event === 'done' || event.event === 'task_complete') {
                 gotTerminal = true;
                 setAiStatus('done');
               } else if (event.event === 'error' || event.event === 'step_error' || event.event === 'task_error') {
@@ -355,6 +404,9 @@ export function useMapBridge(
               else if (event.event === 'task_cancelled') {
                 gotTerminal = true;
                 setAiStatus('idle');
+              } else if (!gotTerminal) {
+                if (event.event === 'thinking') setAiStatus('thinking');
+                else if (event.event === 'acting' || event.event === 'step_start') setAiStatus('acting');
               }
 
               // ROUND-2: store-mounted commands are executed by use-sse-stream's
@@ -495,6 +547,14 @@ export function useMapBridge(
 
           if (gotTerminal || controller.signal.aborted) break;
 
+          // INV-10: Non-retryable 4xx client errors (400, 401, 403, 404, 422) must fail immediately without reconnect storm
+          if (attemptError && isNonRetryableError(attemptError)) {
+            setAiStatus('error');
+            devOnly.error('[useMapBridge] SSE stream non-retryable error:', attemptError);
+            emitSyntheticError(attemptError);
+            break;
+          }
+
           // DUP-1 reconnect decision. Two reasons to retry, both meaning "the
           // stream was cut before a terminal event":
           //   1. the read threw a network-level error (TypeError / ApiError), or
@@ -513,17 +573,15 @@ export function useMapBridge(
             if (attemptError) {
               setAiStatus('error');
               devOnly.error('[useMapBridge] SSE stream error:', attemptError);
-              onEvent({
-                event: 'error',
-                data: { error: attemptError instanceof Error ? attemptError.message : String(attemptError) } as unknown as Record<string, unknown>,
-              });
+              emitSyntheticError(attemptError);
             }
             break;
           }
 
           if (!attemptError && !abruptClose) break; // clean end, nothing to resume
 
-          await sleep(baseDelayMs * 2 ** attempt); // backoff before the next attempt
+          await cancellableSleep(baseDelayMs * 2 ** attempt, controller.signal); // backoff before the next attempt (cancellable, INV-9)
+          if (controller.signal.aborted || streamEpoch !== streamEpochRef.current) break;
         }
       } finally {
         if (
@@ -544,10 +602,7 @@ export function useMapBridge(
               setAiStatus('done');
             } else {
               setAiStatus('error');
-              onEvent({
-                event: 'error',
-                data: { error: '连接已断开（未收到完成信号）。' } as unknown as Record<string, unknown>,
-              });
+              emitSyntheticError('连接已断开（未收到完成信号）。');
             }
           }
           abortControllerRef.current = null;
@@ -555,7 +610,7 @@ export function useMapBridge(
         // If not the active controller, a new send() has taken over — leave aiStatus alone
       }
     },
-    [dispatchAction, onEvent, setAiStatus, sessionTokenRef, reconnect]
+    [dispatchAction, onEvent, setAiStatus, sessionTokenRef, reconnect, emitSyntheticError]
   );
 
   // [ENG-D3] useCallback([sessionId]) — stable ref so MapPanel's handleMove deps don't churn

--- a/tests/test_adversarial_sse_chaos.py
+++ b/tests/test_adversarial_sse_chaos.py
@@ -1,0 +1,246 @@
+"""Adversarial stress testing for SSE transport, resume, and stream invariants.
+
+Combines random/rapid sequences of:
+  - disconnect + cancel + reconnect + session switch
+  - multi-client concurrent resume
+  - rapid double send & late event races
+  - buffer eviction boundaries & ring capacity
+  - terminal immutability under out-of-order arrival
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.api.routes import chat as chat_route
+from app.services.chat.event_resume import RESUME_MAX_EVENTS, TurnEventBuffer, TurnResumeRegistry
+from app.utils.sse import sse_event, sse_event_id, sse_event_type
+
+
+class _AdversarialBridge:
+    def __init__(self, turns: int = 1) -> None:
+        self.prompt_calls = 0
+        self.current_turn = 0
+        self.parked = [asyncio.Event() for _ in range(turns)]
+        self.gates = [asyncio.Event() for _ in range(turns)]
+
+    async def stream_prompt(
+        self, message: str, session_id: Optional[str] = None
+    ) -> AsyncIterator[str]:
+        idx = self.prompt_calls
+        self.prompt_calls += 1
+        sid = session_id or "s"
+        yield sse_event("task_start", {"task_id": f"t{idx}", "session_id": sid})
+        for i in range(5):
+            yield sse_event("token", {"content": f"tok_{idx}_{i} ", "session_id": sid})
+        yield sse_event("step_start", {"tool": "search_poi", "session_id": sid})
+        yield sse_event(
+            "step_result",
+            {"tool": "search_poi", "result": {"ok": True}, "session_id": sid},
+        )
+        if idx < len(self.parked):
+            self.parked[idx].set()
+            await self.gates[idx].wait()
+        yield sse_event("token", {"content": f"final_{idx} ", "session_id": sid})
+        yield sse_event("done", {"session_id": sid})
+
+
+def _block_events(chunk: str) -> list[str]:
+    return [p for p in chunk.split("\n\n") if p]
+
+
+def _event_id(block: str) -> Optional[int]:
+    return sse_event_id(block)
+
+
+def _event_type(block: str) -> str:
+    return sse_event_type(block)
+
+
+async def _drain_into(resp, out: list[str]) -> None:
+    async for chunk in resp.body_iterator:
+        out.extend(_block_events(chunk))
+
+
+async def _start_stream(message: str, session_id: Optional[str] = None):
+    resp = await chat_route.chat_stream(
+        chat_route.ChatRequest(message=message, session_id=session_id, map_state=None),
+        _user={},
+        owner_token=None,
+        db=None,
+    )
+    out: list[str] = []
+    return out, asyncio.create_task(_drain_into(resp, out))
+
+
+async def _open_resume(message: str, last_event_id: int, session_id: Optional[str] = None):
+    resp = await chat_route.chat_stream(
+        chat_route.ChatRequest(message=message, session_id=session_id, map_state=None),
+        _user={},
+        owner_token=None,
+        db=None,
+        last_event_id_header=last_event_id,
+    )
+    out: list[str] = []
+    return out, asyncio.create_task(_drain_into(resp, out))
+
+
+@pytest.fixture(autouse=True)
+def _fresh_resume_registry(monkeypatch):
+    monkeypatch.setattr(chat_route, "_turn_resume_registry", TurnResumeRegistry())
+    monkeypatch.setattr(chat_route, "_RESUME_LIVE_HOLD_S", 0.05)
+    monkeypatch.setattr(
+        chat_route.AsyncHistoryService,
+        "get_session",
+        AsyncMock(return_value=MagicMock()),
+    )
+    yield
+
+
+@pytest.fixture
+def _pi_path(monkeypatch):
+    def _install(bridge) -> None:
+        monkeypatch.setattr(chat_route, "USE_NEW_AGENT", True)
+        monkeypatch.setattr(chat_route, "pi_bridge", bridge)
+
+    return _install
+
+
+# ─── Chaos 1: Rapid Disconnect-Resume-Cancel Race ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chaos_disconnect_resume_cancel_race(_pi_path):
+    """Adversary: client connects, disconnects mid-turn, resumes, and then
+    the resume client disconnects while the turn is still parked live.
+    Verifies no task leaks, buffer state remains consistent, and subsequent
+    resume gets truthful state."""
+    bridge = _AdversarialBridge(turns=1)
+    _pi_path(bridge)
+
+    # 1. Start stream 1 in background drain
+    out1, t1 = await _start_stream("chaos msg", session_id="sid-chaos-1")
+    await bridge.parked[0].wait()
+    assert len(out1) > 0
+
+    # 2. Client 1 abruptly cancels / disconnects
+    t1.cancel()
+    try:
+        await t1
+    except asyncio.CancelledError:
+        pass
+    await asyncio.sleep(0.01)
+
+    # 3. Resume 1 connects with last_event_id=1
+    resumed1, rtask1 = await _open_resume("chaos msg", last_event_id=1, session_id="sid-chaos-1")
+    await asyncio.sleep(0.01)
+
+    # 4. Resume 1 also cancels / disconnects before gate is opened
+    rtask1.cancel()
+    try:
+        await rtask1
+    except asyncio.CancelledError:
+        pass
+
+    # 5. Resume 2 connects with last_event_id=1
+    resumed2, rtask2 = await _open_resume("chaos msg", last_event_id=1, session_id="sid-chaos-1")
+    await asyncio.sleep(0.01)
+
+    # 6. Unpark bridge turn
+    bridge.gates[0].set()
+    await rtask2
+
+    # Verification: Prompt was only called once, resume 2 completed cleanly with all tokens in order
+    assert bridge.prompt_calls == 1
+    ids2 = [_event_id(b) for b in resumed2 if _event_id(b) is not None]
+    assert ids2 == sorted(ids2), f"IDs must be strictly monotonic: {ids2}"
+    # Because client 1 disconnected and aborted the prompt mid-stream,
+    # the resume correctly reports that the turn was interrupted (truthful error terminal, not fake done)
+    assert _event_type(resumed2[-1]) == "error"
+
+
+# ─── Chaos 2: Session Switch + Simultaneous Multi-Session Resumes ───────────
+
+
+@pytest.mark.asyncio
+async def test_chaos_multi_session_interleaved_resumes(_pi_path):
+    """Adversary: 3 independent sessions run turns, get interrupted, and resume
+    simultaneously across interleaved event loops.
+    Verifies INV-2 (no cross-session bleeding) and INV-5 (no duplicate tool runs)."""
+    bridge = _AdversarialBridge(turns=3)
+    _pi_path(bridge)
+
+    # Start 3 sessions
+    out1, t1 = await _start_stream("msg1", session_id="sess-1")
+    out2, t2 = await _start_stream("msg2", session_id="sess-2")
+    out3, t3 = await _start_stream("msg3", session_id="sess-3")
+
+    await asyncio.gather(bridge.parked[0].wait(), bridge.parked[1].wait(), bridge.parked[2].wait())
+    assert bridge.prompt_calls == 3
+
+    # Release all 3
+    bridge.gates[0].set()
+    bridge.gates[1].set()
+    bridge.gates[2].set()
+    await asyncio.gather(t1, t2, t3)
+
+    # Resume all 3 simultaneously from id=2
+    r1, rt1 = await _open_resume("msg1", last_event_id=2, session_id="sess-1")
+    r2, rt2 = await _open_resume("msg2", last_event_id=2, session_id="sess-2")
+    r3, rt3 = await _open_resume("msg3", last_event_id=2, session_id="sess-3")
+
+    await asyncio.gather(rt1, rt2, rt3)
+
+    # No duplicate prompt executions
+    assert bridge.prompt_calls == 3
+
+    # Verify each session received only its own tokens
+    assert all("tok_0" in b or _event_type(b) in ("step_start", "step_result", "done") for b in r1 if "tok_" in b)
+    assert all("tok_1" in b or _event_type(b) in ("step_start", "step_result", "done") for b in r2 if "tok_" in b)
+    assert all("tok_2" in b or _event_type(b) in ("step_start", "step_result", "done") for b in r3 if "tok_" in b)
+
+
+# ─── Chaos 3: Ring Buffer Overflow with Interleaved Resumes ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_chaos_ring_buffer_overflow_with_interleaved_resumes(_pi_path):
+    """Adversary: Turn generates 300 events (> RESUME_MAX_EVENTS=256).
+    Multiple clients resume at different offsets (recent vs evicted).
+    Verifies ring buffer truncation is clean, monotonic, and bounded."""
+
+    class _MassiveBridge:
+        def __init__(self) -> None:
+            self.prompt_calls = 0
+
+        async def stream_prompt(self, message: str, session_id: Optional[str] = None):
+            self.prompt_calls += 1
+            sid = session_id or "s"
+            yield sse_event("task_start", {"task_id": "t", "session_id": sid})
+            for i in range(300):
+                yield sse_event("token", {"content": f"t{i} ", "session_id": sid})
+            yield sse_event("done", {"session_id": sid})
+
+    bridge = _MassiveBridge()
+    _pi_path(bridge)
+
+    out, t = await _start_stream("massive", session_id="sess-massive")
+    await t
+    assert bridge.prompt_calls == 1
+
+    # Client A resumes with very old ID (e.g. 5) -> gets ring tail
+    rA, rtA = await _open_resume("massive", last_event_id=5, session_id="sess-massive")
+    await rtA
+    assert len(rA) == RESUME_MAX_EVENTS
+    idsA = [_event_id(b) for b in rA]
+    assert idsA == list(range(302 - RESUME_MAX_EVENTS + 1, 303))
+
+    # Client B resumes with recent ID (e.g. 290) -> gets events 291..302
+    rB, rtB = await _open_resume("massive", last_event_id=290, session_id="sess-massive")
+    await rtB
+    idsB = [_event_id(b) for b in rB]
+    assert idsB == list(range(291, 303))
+    assert _event_type(rB[-1]) == "done"

--- a/tests/test_runtime_chaos_resume.py
+++ b/tests/test_runtime_chaos_resume.py
@@ -914,3 +914,124 @@ async def test_ack_persist_redis_tombstone_is_410(monkeypatch):
             chat_route.MapActionAckRequest(acks=[_ack_payload("ma-late")]),
         )
     assert ei.value.status_code == 410
+
+
+# ─── F18: terminal type preservation (cancelled != failed != succeeded) ────
+
+
+@pytest.mark.asyncio
+async def test_resume_after_cancelled_turn_replays_cancelled_terminal(_pi_path, _pass_ownership):
+    """INV-4 / F18: a turn that ended in `task_cancelled` must NOT produce a
+    synthesized `done` on reconnect — reconnecting for a clean close when the
+    client already saw the terminal must synthesize `task_cancelled`, preserving
+    cancellation status (cancelled != succeeded)."""
+
+    class _CancelledBridge:
+        def __init__(self) -> None:
+            self.prompt_calls = 0
+
+        async def stream_prompt(self, message: str, session_id: Optional[str] = None):
+            self.prompt_calls += 1
+            sid = session_id or "s"
+            yield sse_event("task_start", {"task_id": "t", "session_id": sid})
+            yield sse_event("token", {"content": "partial ", "session_id": sid})
+            yield sse_event("task_cancelled", {"task_id": "t", "session_id": sid})
+
+    bridge = _CancelledBridge()
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("cancel me", session_id="s-cancel")
+    await task_a
+    ids = [_event_id(b) for b in out_a]
+    assert _event_type(out_a[-1]) == "task_cancelled"
+    terminal_id = ids[-1]
+    assert terminal_id is not None
+
+    # Reconnect after consuming the terminal event (last_event_id == terminal_id)
+    resumed, rtask = await _open_resume(
+        "cancel me", last_event_id=terminal_id, session_id="s-cancel"
+    )
+    await rtask
+    assert bridge.prompt_calls == 1
+    assert len(resumed) == 1
+    # MUST NOT be synthesized "done" — must preserve cancellation!
+    assert _event_type(resumed[0]) == "task_cancelled", (
+        f"reconnecting after task_cancelled must synthesize task_cancelled, got {_event_type(resumed[0])}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_after_task_error_replays_error_terminal_not_done(_pi_path, _pass_ownership):
+    """INV-4 / F18: a turn that ended in `task_error` must NOT produce a
+    synthesized `done` on reconnect (failed != succeeded)."""
+
+    class _TaskErrorBridge:
+        def __init__(self) -> None:
+            self.prompt_calls = 0
+
+        async def stream_prompt(self, message: str, session_id: Optional[str] = None):
+            self.prompt_calls += 1
+            sid = session_id or "s"
+            yield sse_event("task_start", {"task_id": "t", "session_id": sid})
+            yield sse_event("task_error", {"task_id": "t", "error": "failed", "session_id": sid})
+
+    bridge = _TaskErrorBridge()
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("err turn", session_id="s-err")
+    await task_a
+    ids = [_event_id(b) for b in out_a]
+    assert _event_type(out_a[-1]) == "task_error"
+    terminal_id = ids[-1]
+    assert terminal_id is not None
+
+    resumed, rtask = await _open_resume(
+        "err turn", last_event_id=terminal_id, session_id="s-err"
+    )
+    await rtask
+    assert bridge.prompt_calls == 1
+    assert len(resumed) == 1
+    assert _event_type(resumed[0]) == "task_error", (
+        f"reconnecting after task_error must synthesize task_error, got {_event_type(resumed[0])}"
+    )
+
+
+# ─── F8: two browser tabs resume same session concurrently ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_two_tabs_concurrent_resume_same_session(_pi_path, _pass_ownership):
+    """F8: two tabs reconnecting for the same completed turn with Last-Event-ID
+    both receive the exact same replay without corrupting the buffer or
+    triggering duplicate prompt dispatches."""
+
+    class _MultiTokenBridge:
+        def __init__(self) -> None:
+            self.prompt_calls = 0
+
+        async def stream_prompt(self, message: str, session_id: Optional[str] = None):
+            self.prompt_calls += 1
+            sid = session_id or "s"
+            yield sse_event("task_start", {"task_id": "t", "session_id": sid})
+            yield sse_event("token", {"content": "1 ", "session_id": sid})
+            yield sse_event("token", {"content": "2 ", "session_id": sid})
+            yield sse_event("done", {"session_id": sid})
+
+    bridge = _MultiTokenBridge()
+    _pi_path(bridge)
+
+    out_a, task_a = await _start_stream("two tabs", session_id="s-tabs")
+    await task_a
+    assert bridge.prompt_calls == 1
+
+    # Tab 1 resumes after id 1; Tab 2 resumes after id 2 concurrently
+    resumed1, rtask1 = await _open_resume("two tabs", last_event_id=1, session_id="s-tabs")
+    resumed2, rtask2 = await _open_resume("two tabs", last_event_id=2, session_id="s-tabs")
+    await asyncio.gather(rtask1, rtask2)
+
+    assert bridge.prompt_calls == 1, "concurrent resumes must never dispatch new turns"
+    assert [_event_id(b) for b in resumed1] == [2, 3, 4]
+    assert [_event_id(b) for b in resumed2] == [3, 4]
+    assert _event_type(resumed1[-1]) == "done"
+    assert _event_type(resumed2[-1]) == "done"
+


### PR DESCRIPTION
## Summary
Hardens Agent SSE transport, resume replay, and event ordering reliability under network churn:
- **Terminal Preservation**: Resume replay truthfully synthesizes the matching terminal event (`task_cancelled`, `task_error`, `done`) when reconnecting for a clean close.
- **Session Isolation**: Guards `use-sse-stream` against cross-session event leakage and unintended session switching.
- **Monotonic Terminal Transitions**: Prevents out-of-order `thinking`/`acting` events from rolling back terminal `done`/`error` status.
- **Cancellable Sleep & Bounded Retry**: Implements `cancellableSleep` for immediate abort during backoff and fast-fails non-retryable 4xx client errors.
- **Bounded Event Dedup**: Implements bounded intra-stream event deduplication.
- **Clean Code Smells**: Refactored synthetic error emissions, typed session extractors, and cancellation handlers.

## Invariants Enforced
- **INV-1 to INV-10** strictly verified with automated chaos and adversarial tests.

## Test Results
- Backend: 47/47 passed (`test_sse_resume.py`, `test_runtime_chaos_resume.py`, `test_adversarial_sse_chaos.py`, `test_streaming_lifecycle.py`)
- Frontend: 106/106 passed (`useMapBridge.test.ts`, `use-sse-stream.test.ts`, `use-sse-adversarial.test.ts`, `sse-stream-parser.test.ts`, `chat.test.ts`)