### PR TITLE
perf(ui): optimize ContextPanel resize and responsive shell

### DIFF
--- a/frontend/components/layout/context-panel.test.tsx
+++ b/frontend/components/layout/context-panel.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 
 /**
  * ContextPanel (UI V3) — 统一上下文面板。
@@ -8,8 +8,34 @@ import { render, screen, fireEvent } from '@testing-library/react';
  *   - role=tabpanel + PanelHeader（title/description/badge/close）；
  *   - tab 切换即卸载（只渲染 active tab 的内容）；
  *   - 折叠时 aria-hidden + visibility 隐藏；
- *   - 右缘 separator 键盘调宽（280–420 clamp）。
+ *   - 右缘 separator 键盘调宽（280–420 clamp）+ 双击复位；
+ *   - 拖拽调宽：pointermove 只走命令式草稿（CSS 变量 + aria），全程零
+ *     全局 store 写；终止（up/cancel/lostcapture/blur/折叠）恰好提交一次。
  */
+
+const counters = vi.hoisted(() => ({ chatRenders: 0 }));
+
+/**
+ * jsdom 没有 PointerEvent 构造器，fireEvent.pointer* 会退化成裸 Event ——
+ * pointerId/clientX/button 等 init 属性全部丢失（探测验证：handler 触发但
+ * 属性全 undefined）。补一个基于 MouseEvent 的最小 polyfill，让拖拽契约
+ * 可以在 jsdom 里确定性验证。
+ */
+if (typeof window.PointerEvent !== 'function') {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    isPrimary: boolean;
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+      this.pointerType = init.pointerType ?? '';
+      this.isPrimary = init.isPrimary ?? false;
+    }
+  }
+  // @ts-expect-error -- 补齐 jsdom 缺失的 DOM API 形状
+  window.PointerEvent = PointerEventPolyfill;
+}
 
 const toggleLeftPanel = vi.fn();
 const setSidebarWidth = vi.fn();
@@ -30,7 +56,13 @@ vi.mock('@/lib/store/useHudStore', () => ({
 }));
 
 // 重依赖 tab 全部打桩，只验证 ContextPanel 自身的编排逻辑。
-vi.mock('@/components/sidebar/chat-tab', () => ({ ChatTab: () => <div data-testid="tab-chat" /> }));
+// ChatTab 带渲染计数 —— 拖拽性能断言用（活动 tab 不得逐 pointermove 重渲染）。
+vi.mock('@/components/sidebar/chat-tab', () => ({
+  ChatTab: () => {
+    counters.chatRenders += 1;
+    return <div data-testid="tab-chat" />;
+  },
+}));
 vi.mock('@/components/sidebar/project-tab', () => ({ ProjectTab: () => <div data-testid="tab-project" /> }));
 vi.mock('@/components/sidebar/layers-tab', () => ({ LayersTab: () => <div data-testid="tab-layers" /> }));
 vi.mock('@/components/sidebar/analysis-tab', () => ({ AnalysisTab: () => <div data-testid="tab-analysis" /> }));
@@ -48,14 +80,36 @@ const baseProps = {
   onSend: vi.fn(),
 };
 
+/** 同步执行的 rAF 桩 —— 草稿宽度断言不依赖真实帧时序。 */
+function stubRafSync() {
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0);
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+}
+
+/** 在 separator 上执行一次完整拖拽的 pointer 序列（不释放）。 */
+function dragTo(clientX: number, { pointerId = 1, startX = 100 } = {}) {
+  const separator = screen.getByRole('separator', { name: '调整面板宽度' });
+  fireEvent.pointerDown(separator, { pointerId, button: 0, clientX: startX, clientY: 50 });
+  fireEvent.pointerMove(separator, { pointerId, clientX, clientY: 50 });
+  return separator;
+}
+
 describe('ContextPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    counters.chatRenders = 0;
     store.activeLeftTab = 'chat';
     store.leftPanelOpen = true;
     store.sidebarWidth = 320;
     store.layers = [];
     store.exports = [];
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('renders tabpanel with PanelHeader meta for the active tab', () => {
@@ -131,5 +185,215 @@ describe('ContextPanel', () => {
     render(<ContextPanel {...baseProps} />);
     fireEvent.doubleClick(screen.getByRole('separator', { name: '调整面板宽度' }));
     expect(setSidebarWidth).toHaveBeenCalledWith(320);
+  });
+});
+
+describe('ContextPanel resize drag (perf + lifecycle contract)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    counters.chatRenders = 0;
+    store.activeLeftTab = 'chat';
+    store.leftPanelOpen = true;
+    store.sidebarWidth = 320;
+    store.layers = [];
+    store.exports = [];
+    stubRafSync();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('PERF: 100 pointer moves → 0 store writes while dragging, exactly 1 commit on release', () => {
+    render(<ContextPanel {...baseProps} />);
+    const separator = screen.getByRole('separator', { name: '调整面板宽度' });
+
+    fireEvent.pointerDown(separator, { pointerId: 1, button: 0, clientX: 100, clientY: 50 });
+    const rendersAtDragStart = counters.chatRenders; // 含 dragging=true 的一次重渲染
+    for (let i = 1; i <= 100; i += 1) {
+      fireEvent.pointerMove(separator, { pointerId: 1, clientX: 100 + i * 2, clientY: 50 });
+    }
+
+    // 拖拽全程：零全局宽度提交，活动 tab 零额外渲染
+    expect(setSidebarWidth).not.toHaveBeenCalled();
+    expect(counters.chatRenders).toBe(rendersAtDragStart);
+
+    fireEvent.pointerUp(separator, { pointerId: 1, clientX: 300, clientY: 50 });
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+    // 320 + 200 → clamp 到 420
+    expect(setSidebarWidth).toHaveBeenCalledWith(420);
+  });
+
+  it('PERF: draft width is applied imperatively and clamped to the min bound', () => {
+    render(<ContextPanel {...baseProps} />);
+    const panel = screen.getByRole('tabpanel');
+    const separator = dragTo(100 - 90); // 320 - 90 → clamp 280
+
+    expect(panel.style.getPropertyValue('--panel-draft-w')).toBe('280px');
+    expect(separator).toHaveAttribute('aria-valuenow', '280');
+    expect(counters.chatRenders).toBe(2); // 初次渲染 + dragStart，无逐 move 渲染
+
+    fireEvent.pointerUp(separator, { pointerId: 1, clientX: 10, clientY: 50 });
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+    expect(setSidebarWidth).toHaveBeenCalledWith(280);
+  });
+
+  it('a plain click on the handle (no movement) commits nothing', () => {
+    render(<ContextPanel {...baseProps} />);
+    const separator = screen.getByRole('separator', { name: '调整面板宽度' });
+    fireEvent.pointerDown(separator, { pointerId: 1, button: 0, clientX: 100, clientY: 50 });
+    fireEvent.pointerUp(separator, { pointerId: 1, clientX: 100, clientY: 50 });
+    expect(setSidebarWidth).not.toHaveBeenCalled();
+  });
+
+  it('non-primary buttons never start a drag', () => {
+    render(<ContextPanel {...baseProps} />);
+    const separator = screen.getByRole('separator', { name: '调整面板宽度' });
+    fireEvent.pointerDown(separator, { pointerId: 1, button: 2, clientX: 100, clientY: 50 });
+    fireEvent.pointerMove(separator, { pointerId: 1, clientX: 260, clientY: 50 });
+    fireEvent.pointerUp(separator, { pointerId: 1, clientX: 260, clientY: 50 });
+    expect(setSidebarWidth).not.toHaveBeenCalled();
+  });
+
+  it('STAB: pointercancel ends the drag and commits the visible draft once', () => {
+    render(<ContextPanel {...baseProps} />);
+    const separator = dragTo(140); // 360
+    fireEvent.pointerCancel(separator, { pointerId: 1 });
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+    expect(setSidebarWidth).toHaveBeenCalledWith(360);
+
+    // 终止后残余事件不再有任何写入
+    fireEvent.pointerMove(separator, { pointerId: 1, clientX: 600, clientY: 50 });
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+  });
+
+  it('STAB: lostpointercapture ends the drag and commits once', () => {
+    render(<ContextPanel {...baseProps} />);
+    const separator = dragTo(120); // 340
+    // jsdom 无 PointerEvent 构造器 —— 裸 Event 上补 pointerId
+    // （真实浏览器里 lostpointercapture 天然携带）
+    const ev = new Event('lostpointercapture', { bubbles: true });
+    Object.defineProperty(ev, 'pointerId', { value: 1 });
+    fireEvent(separator, ev);
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+    expect(setSidebarWidth).toHaveBeenCalledWith(340);
+  });
+
+  it('STAB: window blur ends the drag (capture 语义不可靠) and commits once', () => {
+    render(<ContextPanel {...baseProps} />);
+    dragTo(160); // 380
+    act(() => {
+      fireEvent(window, new Event('blur'));
+    });
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+    expect(setSidebarWidth).toHaveBeenCalledWith(380);
+  });
+
+  it('STAB: collapsing the panel mid-drag terminates and commits the draft', () => {
+    const { rerender } = render(<ContextPanel {...baseProps} />);
+    dragTo(150); // 370
+
+    store.leftPanelOpen = false;
+    rerender(<ContextPanel {...baseProps} />);
+
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+    expect(setSidebarWidth).toHaveBeenCalledWith(370);
+  });
+
+  it('STAB: unmounting mid-drag leaves no listener and commits nothing', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = render(<ContextPanel {...baseProps} />);
+    dragTo(130); // 350
+
+    unmount();
+
+    expect(setSidebarWidth).not.toHaveBeenCalled(); // 卸载后不写 store
+    // jsdom 无 pointer capture → 兜底 window 监听也必须被摘除
+    expect(removeSpy).toHaveBeenCalledWith('blur', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('pointermove', expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith('pointerup', expect.any(Function));
+    removeSpy.mockRestore();
+
+    // 卸载后派发的事件不再触发任何提交
+    act(() => {
+      fireEvent(window, new Event('blur'));
+      fireEvent(window, new Event('pointermove'));
+    });
+    expect(setSidebarWidth).not.toHaveBeenCalled();
+  });
+
+  it('STAB: rapid drag start/stop cycles stay idempotent', () => {
+    render(<ContextPanel {...baseProps} />);
+    // 每轮都从 320 起（mock store 不回写）：330 / 350 提交，第三轮回到 320
+    // —— 与起点相同 ⇒ 不提交，验证“变化才提交”语义
+    const targets = [110, 130, 100];
+    targets.forEach((clientX, i) => {
+      const separator = dragTo(clientX, { pointerId: i + 1 });
+      fireEvent.pointerUp(separator, { pointerId: i + 1 });
+    });
+    expect(setSidebarWidth).toHaveBeenCalledTimes(2);
+    expect(setSidebarWidth).toHaveBeenNthCalledWith(1, 330);
+    expect(setSidebarWidth).toHaveBeenNthCalledWith(2, 350);
+  });
+
+  it('STAB: a second pointerdown during an active drag is ignored (no draft hijack)', () => {
+    render(<ContextPanel {...baseProps} />);
+    const separator = dragTo(120, { pointerId: 1 }); // 340
+    // 第二根手指落在手柄上：不得覆盖在途拖拽
+    fireEvent.pointerDown(separator, { pointerId: 2, button: 0, clientX: 500, clientY: 50 });
+    fireEvent.pointerMove(separator, { pointerId: 2, clientX: 560, clientY: 50 });
+    // 原指针释放：按第一指针的草稿恰好提交一次
+    fireEvent.pointerUp(separator, { pointerId: 1, clientX: 120, clientY: 50 });
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+    expect(setSidebarWidth).toHaveBeenCalledWith(340);
+  });
+
+  it('STAB: keyboard arrows during an active drag fold into the draft (single commit)', () => {
+    render(<ContextPanel {...baseProps} />);
+    const separator = dragTo(120, { pointerId: 1 }); // 340
+    fireEvent.keyDown(separator, { key: 'ArrowRight' }); // 356
+    fireEvent.keyDown(separator, { key: 'ArrowRight' }); // 372
+    expect(setSidebarWidth).not.toHaveBeenCalled(); // 拖拽中零直写
+    fireEvent.pointerUp(separator, { pointerId: 1, clientX: 120, clientY: 50 });
+    expect(setSidebarWidth).toHaveBeenCalledTimes(1);
+    expect(setSidebarWidth).toHaveBeenCalledWith(372);
+  });
+
+  it('A11Y: closing the panel returns focus to the corresponding rail tab', () => {
+    const railTab = document.createElement('button');
+    railTab.id = 'rail-tab-chat';
+    document.body.appendChild(railTab);
+
+    const { rerender } = render(<ContextPanel {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: '收起面板' }));
+    expect(toggleLeftPanel).toHaveBeenCalledTimes(1);
+
+    // store mock 不会翻转 leftPanelOpen —— 手动模拟 store 提交后的重渲染；
+    // effect 在面板隐藏落地后归还焦点（无 setTimeout 竞态）
+    store.leftPanelOpen = false;
+    rerender(<ContextPanel {...baseProps} />);
+    expect(railTab).toHaveFocus();
+
+    document.body.removeChild(railTab);
+  });
+
+  it('A11Y: focus restore does not steal focus the user already moved elsewhere', () => {
+    const railTab = document.createElement('button');
+    railTab.id = 'rail-tab-chat';
+    const elsewhere = document.createElement('button');
+    elsewhere.id = 'somewhere-else';
+    document.body.append(railTab, elsewhere);
+    elsewhere.focus();
+
+    const { rerender } = render(<ContextPanel {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: '收起面板' }));
+    store.leftPanelOpen = false;
+    rerender(<ContextPanel {...baseProps} />);
+
+    expect(elsewhere).toHaveFocus();
+    expect(railTab).not.toHaveFocus();
+
+    document.body.removeChild(railTab);
+    document.body.removeChild(elsewhere);
   });
 });

--- a/frontend/components/layout/context-panel.tsx
+++ b/frontend/components/layout/context-panel.tsx
@@ -8,8 +8,16 @@
  * - 右缘拖拽调整宽度（280–420px，键盘 ArrowLeft/Right ±16，双击复位 320）；
  * - 折叠时整体 translateX 隐藏且不可聚焦（地图优先）；
  * - tab 内容保持切换即卸载（保留 map-studio isExportMode 与 tasks 轮询语义）。
+ *
+ * 拖拽调宽的数据通路（perf 收敛）：
+ *   pointerdown → 记录起点 + 命令式 CSS 变量 --panel-draft-w（不进 React 状态）
+ *   pointermove → 只更新 ref 里的草稿宽度，RAF 逐帧写到 <aside>（无全局 store 写）
+ *   终止（pointerup/cancel/lostpointercapture/blur/折叠/卸载）
+ *            → 取消 RAF + 摘除监听 + 恰好一次 setSidebarWidth 提交
+ * 旧实现在每个原始 pointermove 上写全局 store，导致本面板（含重型活动 tab）
+ * 与订阅 sidebarWidth 的 page.tsx 全部逐事件重渲染。
  */
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   MessageCircle,
   Folder,
@@ -53,8 +61,23 @@ export interface ContextPanelProps {
 const PANEL_MIN = 280;
 const PANEL_MAX = 420;
 const PANEL_DEFAULT = 320;
+const PANEL_STEP = 16;
 
 const clampWidth = (w: number) => Math.min(PANEL_MAX, Math.max(PANEL_MIN, Math.round(w)));
+
+/** 一次拖拽的全部可变状态：只在 ref 里演进，pointermove 不触碰 React/store。 */
+interface DragState {
+  pointerId: number;
+  startX: number;
+  startWidth: number;
+  /** 最新（尚未必已 paints）的钳制草稿宽度。 */
+  width: number;
+  rafId: number | null;
+  /** 一帧内已排队未画（含 rAF 被同步执行的测试桩的场景）。 */
+  rafPending: boolean;
+  /** 拖拽期间挂上的 window 监听（blur + capture 兜底）的摘除函数。 */
+  detachListeners: Array<() => void>;
+}
 
 interface PanelMeta {
   icon: LucideIcon;
@@ -101,65 +124,197 @@ export function ContextPanel({
     : metaKey === 'results' ? resultCount
     : undefined;
 
-  /* ─── 右缘拖拽调宽 ─── */
+  /* ─── 右缘拖拽调宽：草稿走命令式 CSS 变量，终止时一次性提交 store ─── */
   const [dragging, setDragging] = useState(false);
-  const dragStart = useRef<{ x: number; width: number } | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const panelRef = useRef<HTMLElement | null>(null);
+  const separatorRef = useRef<HTMLDivElement | null>(null);
+  // 关闭面板后待归还焦点的 rail tab（见 handleClose / leftPanelOpen effect）。
+  const pendingFocusTab = useRef<string | null>(null);
 
-  // Review P1 修复：pointer capture + cancel/blur 兜底。
-  // 之前用 window pointermove/up 监听，指针在窗口外释放（或 pointercancel）
-  // 时 onUp 不触发，会留下永久 dragging 状态 + 泄漏的监听器。
-  const endDrag = useCallback(() => {
-    dragStart.current = null;
-    setDragging(false);
+  // 把草稿宽度写到 <aside> 的 CSS 变量与 separator 的 aria-valuenow。
+  // 拖拽期间 render 用 width: var(--panel-draft-w)，因此这些命令式写入
+  // 不会被无关重渲染覆盖，也不需要触发任何重渲染。
+  const applyDraft = useCallback((w: number) => {
+    panelRef.current?.style.setProperty('--panel-draft-w', `${w}px`);
+    separatorRef.current?.setAttribute('aria-valuenow', String(w));
   }, []);
+
+  // RAF 合帧：pointermove 事件频率可能高于刷新率，同一帧内多次 style 写入
+  // 只保留最后一次；rafPending 与 dragRef 判同保证过期帧回调（终止后、或
+  // rAF 被同步执行的测试桩）不会把旧宽度落到 DOM 或卡住后续帧。
+  const scheduleApply = useCallback(() => {
+    const d = dragRef.current;
+    if (!d || d.rafPending) return;
+    d.rafPending = true;
+    const id = requestAnimationFrame(() => {
+      d.rafPending = false;
+      if (dragRef.current !== d) return; // 过期帧：拖拽已终止
+      applyDraft(d.width);
+    });
+    d.rafId = id;
+  }, [applyDraft]);
+
+  // 唯一的终止函数，所有路径幂等（dragRef 判空即返回）：
+  // 取消 RAF → 摘除 window 监听 → 若宽度实际变化恰好提交一次 →
+  // dragging=false 让 render 切回 store 宽度。
+  const terminateDrag = useCallback(() => {
+    const d = dragRef.current;
+    if (!d) return;
+    dragRef.current = null;
+    if (d.rafId !== null) cancelAnimationFrame(d.rafId);
+    d.detachListeners.forEach((detach) => detach());
+    applyDraft(d.width); // 先让可见宽度 == 即将提交的宽度
+    if (d.width !== d.startWidth) setSidebarWidth(d.width);
+    setDragging(false);
+  }, [applyDraft, setSidebarWidth]);
+
+  // window blur（Alt-Tab / 系统打断）时捕获语义不再可靠 —— 按当前草稿收尾。
+  const handleWindowBlur = useCallback(() => terminateDrag(), [terminateDrag]);
+
+  // pointer capture 不可用（老浏览器/jsdom）时的有界兜底：window 级
+  // pointermove/up/cancel，保证指针离开 8px 手柄后拖拽仍可终止。
+  const onFallbackMove = useCallback(
+    (e: PointerEvent) => {
+      const d = dragRef.current;
+      if (!d || e.pointerId !== d.pointerId) return;
+      d.width = clampWidth(d.startWidth + (e.clientX - d.startX));
+      scheduleApply();
+    },
+    [scheduleApply]
+  );
+  const onFallbackEnd = useCallback(
+    (e: PointerEvent) => {
+      if (dragRef.current?.pointerId === e.pointerId) terminateDrag();
+    },
+    [terminateDrag]
+  );
 
   const onHandlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return; // 仅主键/触摸
+      // 拖拽已在进行（第二根手指/画笔落在手柄上）：忽略新指针，而不是
+      // 覆盖在途 DragState —— 否则前一个指针的草稿被无声丢弃（视觉回跳）。
+      if (dragRef.current) return;
       e.preventDefault();
-      dragStart.current = { x: e.clientX, width: sidebarWidth };
+      const d: DragState = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startWidth: sidebarWidth,
+        width: sidebarWidth,
+        rafId: null,
+        rafPending: false,
+        detachListeners: [],
+      };
+      dragRef.current = d;
+      applyDraft(d.width); // 先初始化变量，render 切到 var() 时无回跳
       setDragging(true);
-      // 指针捕获后 move/up/cancel 全部重定向到本元素，无需 window 监听。
+      window.addEventListener('blur', handleWindowBlur);
+      d.detachListeners.push(() => window.removeEventListener('blur', handleWindowBlur));
+      let captured = false;
       try {
         e.currentTarget.setPointerCapture(e.pointerId);
+        captured = e.currentTarget.hasPointerCapture(e.pointerId);
       } catch {
-        /* jsdom / 老浏览器无 pointer capture，退化为仅键盘调宽可用 */
+        captured = false;
+      }
+      if (!captured) {
+        window.addEventListener('pointermove', onFallbackMove);
+        window.addEventListener('pointerup', onFallbackEnd);
+        window.addEventListener('pointercancel', onFallbackEnd);
+        d.detachListeners.push(() => {
+          window.removeEventListener('pointermove', onFallbackMove);
+          window.removeEventListener('pointerup', onFallbackEnd);
+          window.removeEventListener('pointercancel', onFallbackEnd);
+        });
       }
     },
-    [sidebarWidth]
+    [sidebarWidth, applyDraft, handleWindowBlur, onFallbackMove, onFallbackEnd]
   );
 
+  // 捕获路径：capture 把 move/up/cancel 全部重定向到本元素。
   const onHandlePointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      if (!dragStart.current) return;
-      setSidebarWidth(clampWidth(dragStart.current.width + (e.clientX - dragStart.current.x)));
+      const d = dragRef.current;
+      if (!d || e.pointerId !== d.pointerId) return;
+      d.width = clampWidth(d.startWidth + (e.clientX - d.startX));
+      scheduleApply();
     },
-    [setSidebarWidth]
+    [scheduleApply]
+  );
+
+  const endIfPointer = useCallback(
+    (pointerId: number) => {
+      if (dragRef.current?.pointerId === pointerId) terminateDrag();
+    },
+    [terminateDrag]
   );
 
   const onHandleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
         e.preventDefault();
-        setSidebarWidth(clampWidth(sidebarWidth + (e.key === 'ArrowRight' ? 16 : -16)));
+        const delta = e.key === 'ArrowRight' ? PANEL_STEP : -PANEL_STEP;
+        const d = dragRef.current;
+        if (d) {
+          // 拖拽进行中按方向键（双手操作）：增量并入草稿而不是直写 store，
+          // 否则 store 与可见宽度中途分叉、且释放时的提交会覆盖键盘值。
+          d.width = clampWidth(d.width + delta);
+          scheduleApply();
+        } else {
+          setSidebarWidth(clampWidth(sidebarWidth + delta));
+        }
       }
     },
-    [sidebarWidth, setSidebarWidth]
+    [sidebarWidth, setSidebarWidth, scheduleApply]
   );
 
-  // Review P2 修复：PanelHeader close 收起面板后，焦点从不可见按钮归还到
-  // rail 对应 tab。
+  // 卸载兜底：取消在途 RAF / 摘监听。不做 store 提交、不 setState
+  // （组件已卸载；store 里保留拖拽前宽度即可）。
+  useEffect(
+    () => () => {
+      const d = dragRef.current;
+      if (!d) return;
+      dragRef.current = null;
+      if (d.rafId !== null) cancelAnimationFrame(d.rafId);
+      d.detachListeners.forEach((detach) => detach());
+    },
+    []
+  );
+
+  // 拖拽中面板被折叠（rail 再次点击 active tab / close 按钮）：立即收尾，
+  // 否则面板已 visibility:hidden 而捕获仍在把事件重定向给手柄。
+  useEffect(() => {
+    if (!leftPanelOpen) terminateDrag();
+  }, [leftPanelOpen, terminateDrag]);
+
+  // Review P2 修复（V2）：close 收起面板后，焦点从不可见的 close 按钮归还到
+  // rail 对应 tab。用 leftPanelOpen 提交后的 effect 替代旧 setTimeout(0) 竞态：
+  // effect 在面板隐藏落地后运行，focus 不会被浏览器随后踢回 body；
+  // 若用户此刻已把焦点移到别处（快速切换 tab），则不打扰。
   const handleClose = useCallback(() => {
+    terminateDrag(); // 拖拽中点 close 的防御路径
+    pendingFocusTab.current = metaKey;
     toggleLeftPanel();
-    setTimeout(() => {
-      document.getElementById(`rail-tab-${metaKey}`)?.focus();
-    }, 0);
-  }, [toggleLeftPanel, metaKey]);
+  }, [terminateDrag, toggleLeftPanel, metaKey]);
+
+  useEffect(() => {
+    if (leftPanelOpen || pendingFocusTab.current === null) return;
+    const key = pendingFocusTab.current;
+    pendingFocusTab.current = null;
+    const target = document.getElementById(`rail-tab-${key}`);
+    const active = document.activeElement;
+    const focusNeedsRestore =
+      !active || active === document.body || panelRef.current?.contains(active);
+    if (target && focusNeedsRestore) target.focus();
+  }, [leftPanelOpen]);
 
   return (
     // V4：壳层度量改用 token（left-rail / top-topbar），背景改为不透明
     // surface-panel 并移除 backdrop-blur —— 面板压在持续重绘的地图画布上，
     // blur 是最贵的那一类滤镜，且半透明会让地图细节透进密集文本。
     <aside
+      ref={panelRef}
       role="tabpanel"
       id="workspace-panel"
       aria-labelledby={`rail-tab-${metaKey}`}
@@ -167,7 +322,8 @@ export function ContextPanel({
       className="fixed left-rail top-topbar z-40 flex flex-col border-r border-edge-subtle bg-surface-panel shadow-overlay"
       style={{
         bottom: hudOpen ? 234 : 24,
-        width: sidebarWidth,
+        // 拖拽中读命令式草稿变量（pointermove 不产生重渲染）；平时读 store。
+        width: dragging ? 'var(--panel-draft-w)' : sidebarWidth,
         maxWidth: 'calc(100vw - var(--railW))',
         transform: leftPanelOpen ? 'translateX(0)' : 'translateX(-110%)',
         visibility: leftPanelOpen ? 'visible' : 'hidden',
@@ -207,8 +363,13 @@ export function ContextPanel({
         )}
       </div>
 
-      {/* 右缘调宽手柄 */}
+      {/* 右缘调宽手柄：8px 命中区跨在面板边框上（-right-1 + w-2），
+          可见部分只是 hover/focus/drag 时的 accent 着色，无布局位移。
+          注意 hover/focus 着色必须用可编译的 token 类：Tailwind 3 对
+          var() 颜色加 /NN 透明度修饰符会静默丢弃整个规则（旧实现的
+          hover:bg-[var(--agent-accent,#16a34a)]/30 从未生效过）。 */}
       <div
+        ref={separatorRef}
         role="separator"
         aria-orientation="vertical"
         aria-label="调整面板宽度"
@@ -219,13 +380,13 @@ export function ContextPanel({
         tabIndex={0}
         onPointerDown={onHandlePointerDown}
         onPointerMove={onHandlePointerMove}
-        onPointerUp={endDrag}
-        onPointerCancel={endDrag}
-        onLostPointerCapture={endDrag}
+        onPointerUp={(e) => endIfPointer(e.pointerId)}
+        onPointerCancel={(e) => endIfPointer(e.pointerId)}
+        onLostPointerCapture={(e) => endIfPointer(e.pointerId)}
         onKeyDown={onHandleKeyDown}
         onDoubleClick={() => setSidebarWidth(PANEL_DEFAULT)}
-        className="absolute -right-[3px] bottom-0 top-0 w-1.5 cursor-col-resize hover:bg-[var(--agent-accent,#16a34a)]/30"
-        style={dragging ? { background: 'var(--agent-accent, #16a34a)', opacity: 0.4 } : undefined}
+        className="absolute -right-1 bottom-0 top-0 w-2 cursor-col-resize touch-none hover:bg-status-accent-soft focus-visible:bg-status-accent-soft"
+        style={dragging ? { background: 'var(--agent-accent)', opacity: 0.4 } : undefined}
       />
     </aside>
   );

--- a/frontend/components/shared/panel-header.tsx
+++ b/frontend/components/shared/panel-header.tsx
@@ -9,6 +9,11 @@
  * UI V4：全部改用语义 token（text-title / text-meta / surface-*），并与
  * EmptyState 共用同一个 accent icon tile 配方 —— 审计发现两处 tile 的 accent
  * 透明度分别是 12% 与 10%，肉眼可辨的不一致。
+ *
+ * 窄宽（280px 下限）降级约定：标题行 min-w-0 + truncate 先于徽标收缩
+ * （badge shrink-0），description 允许换到第二行（line-clamp-2）而不是被
+ * 单行 truncate 硬切 —— ContextPanel 的元数据（如“结果工作台 · 输入 ·
+ * 指标 · 输出”）在 280px 下放不进一行。
  */
 import type { ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
@@ -42,17 +47,17 @@ export function PanelHeader({ icon: Icon, title, description, badge, actions, on
         </span>
       )}
       <div className="min-w-0 flex-1 leading-tight">
-        <div className="flex items-center gap-1.5">
-          <h2 id={id} className="truncate text-title font-semibold text-ink">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <h2 id={id} className="min-w-0 truncate text-title font-semibold text-ink">
             {title}
           </h2>
           {showBadge && (
-            <span className="inline-flex h-4 min-w-[16px] items-center justify-center rounded-pill bg-surface-sunken px-1 text-micro font-semibold tabular-nums text-ink-secondary">
+            <span className="inline-flex h-4 min-w-[16px] shrink-0 items-center justify-center rounded-pill bg-surface-sunken px-1 text-micro font-semibold tabular-nums text-ink-secondary">
               {badge}
             </span>
           )}
         </div>
-        {description && <p className="mt-0.5 truncate text-meta text-ink-muted">{description}</p>}
+        {description && <p className="mt-0.5 line-clamp-2 text-meta text-ink-muted">{description}</p>}
       </div>
       {actions && <div className="flex shrink-0 items-center gap-0.5">{actions}</div>}
       {onClose && <IconButton label="收起面板" icon={X} onClick={onClose} />}

--- a/frontend/components/shared/shared-primitives.test.tsx
+++ b/frontend/components/shared/shared-primitives.test.tsx
@@ -145,6 +145,25 @@ describe('PanelHeader', () => {
     const { container } = render(<PanelHeader title="图层" badge={0} />);
     expect(container.textContent).not.toContain('0');
   });
+
+  it('keeps a stable id on the h2 title for aria wiring', () => {
+    render(<PanelHeader title="图层" id="workspace-panel-title" />);
+    const heading = screen.getByRole('heading', { level: 2, name: '图层' });
+    expect(heading).toHaveAttribute('id', 'workspace-panel-title');
+  });
+
+  it('renders contextual actions before the close control in reading order', () => {
+    render(
+      <PanelHeader
+        title="图层"
+        actions={<button type="button">图例设置</button>}
+        onClose={() => {}}
+      />
+    );
+    const [actionBtn, closeBtn] = screen.getAllByRole('button');
+    expect(actionBtn).toHaveTextContent('图例设置');
+    expect(closeBtn).toHaveAccessibleName('收起面板');
+  });
 });
 
 describe('EmptyState', () => {

--- a/frontend/test/visual/capture.mjs
+++ b/frontend/test/visual/capture.mjs
@@ -47,6 +47,13 @@ const THEMES = ['light', 'dark'];
  */
 const SURFACES = [
   { name: 'chat', tab: '对话' },
+  /*
+    ContextPanel shell at the 280px resize floor on the most common tab
+    (short description + composer) — companion to results-detail-narrow,
+    which covers the longest header description + badge. Same real keyboard
+    resize path on the drag separator.
+  */
+  { name: 'chat-narrow', tab: '对话', panelArrows: -6 },
   { name: 'project', tab: '项目' },
   { name: 'data', tab: '数据' },
   { name: 'layers', tab: '图层' },


### PR DESCRIPTION
## Summary

One tightly scoped pass over the ContextPanel shell: resize-path performance, resize lifecycle stability, narrow-width header/handle quality, and focus-return robustness. Production footprint is concentrated in `context-panel.tsx` + `panel-header.tsx`; no store changes were needed.

## BASE_SHA

`6892f036f18a5ec8a782a687ddb8977a2e80afe7` (origin/master at branch start)

## Scope

- `frontend/components/layout/context-panel.tsx` — drag state machine rewrite, focus return, resize handle
- `frontend/components/shared/panel-header.tsx` — narrow-width degradation (min-w-0 chain, badge shrink-0, description line-clamp-2)
- `frontend/components/layout/context-panel.test.tsx` — 12 new deterministic contract tests (+ PointerEvent polyfill)
- `frontend/components/shared/shared-primitives.test.tsx` — 2 header structure tests
- `frontend/test/visual/capture.mjs` — one new `chat-narrow` surface (280px floor on the default tab)

## Root causes

1. **Per-move global writes**: `onHandlePointerMove` called `setSidebarWidth` on every raw pointermove → zustand write per event → `ContextPanel` (including the unmemoized active tab subtree) and `app/page.tsx` (`--workspace-offset`) rerendered per event.
2. **Lifecycle gaps**: window blur unhandled; `setPointerCapture` failure had an empty fallback (stuck `dragging=true` when released outside the 8px handle); panel collapse mid-drag kept the drag alive invisibly; focus return used a `setTimeout(0)` race.
3. **Dead CSS**: `hover:bg-[var(--agent-accent,#16a34a)]/30` never compiled — Tailwind 3 silently drops `/NN` alpha modifiers on `var()` colors (verified with a compile probe against this repo's config; pre-existing on master too).
4. **Header truncation**: title row lacked a complete `min-w-0` chain (long titles would overflow instead of ellipsing); description was hard-cut by single-line `truncate`; badge could be crushed instead of the title truncating first.

## Performance before / after

Deterministic work-count test (`100 pointer moves during one drag`):

| metric | before | after |
|---|---|---|
| `setSidebarWidth` calls during 100 raw pointermoves | ~100 (one per event) | **0** |
| `setSidebarWidth` calls on final release | 1 (of ~101 total) | **exactly 1** |
| active-tab renders during the 100 moves | 1 per move (unbounded) | **0** (render count frozen at drag start; asserted) |
| ContextPanel/page.tsx rerenders per move | yes | no (draft applied imperatively via `--panel-draft-w` CSS var, RAF-bounded) |

Keyboard ±16 and double-click reset remain discrete store writes (unchanged semantics). A pure click on the handle (no movement) now commits **0** times instead of writing the unchanged value.

## Resize lifecycle invariants

Single idempotent terminator (`terminateDrag`) covering pointerup / pointercancel / lostpointercapture (pointerId-guarded), window blur, panel collapse mid-drag (`leftPanelOpen` effect), close-during-drag, and unmount (partial teardown, no store write / setState after unmount). RAF is cancelled on every termination path and unmount; a stale-frame identity check (`dragRef.current !== d`) makes already-queued frames inert even if cancel fails. `rafPending` bounds scheduling to one frame regardless of event rate. Pointer-capture failure falls back to window-level pointermove/up/cancel listeners (bounded, detached on termination). All paths commit the visible draft exactly once and only when the width changed, so stored width == final visible width, clamped 280–420 by the store setter. Additional hardening from adversarial review: a second pointerdown during an active drag is ignored (no draft hijack), and keyboard arrows during a drag fold into the draft (no store/visual divergence).

## Visual changes

- **PanelHeader**: title truncates correctly (complete `min-w-0` chain); badge `shrink-0`; description degrades to a compact 2-line clamp (`line-clamp-2`) instead of a hard cut. Current meta strings still fit on one line at 280px (longest ≈180px in ≈192px), so default appearance is unchanged; the clamp is graceful-degradation insurance. Tokens only; light/dark parity preserved.
- **Resize handle**: 8px hit area straddling the border (`-right-1 w-2`, was 6px), `touch-action: none`, hover/focus tints now actually render (`hover:bg-status-accent-soft focus-visible:bg-status-accent-soft`), drag state unchanged (inline accent, no transition). No layout shift on hover/focus/drag.

## Accessibility

- `role="separator"`, `aria-orientation`, `aria-valuemin/max/now`, keyboard ArrowLeft/Right (±16), double-click reset (320) all retained; `aria-valuenow` tracks the draft imperatively during drag and reconverges with the store on commit.
- Focus return on close: `setTimeout(0)` race replaced by a post-commit effect with a focus-lost guard — focuses `rail-tab-{key}` only when focus actually needs restoring (rapid tab switch is not hijacked); robust against close-during-drag and missing targets.
- Collapsed panel descendants remain keyboard-unreachable (`visibility: hidden`).

## Local tests

- `npm run typecheck` — PASS
- `npm run lint` — PASS (0 warnings)
- focused: `npx vitest run components/layout/context-panel.test.tsx components/shared/shared-primitives.test.tsx` — **37/37 PASS**
- full: `npm test` — **120 files / 1308 tests PASS** (3 skipped, pre-existing)
- `npm run build` — PASS
- `git diff --check` — CLEAN

Pre-existing/environmental note: `components/sidebar/chat-tab.render-scope.test.tsx` ("streaming N token batches…") intermittently fails under full-suite load. Classified as pre-existing/environmental: reproduced on BASE code (changes stashed) in the same worktree; zero import relationship with the changed files; passes 3/3 in isolation on both branch and BASE. This branch introduces no new failure.

## Visual verification

Repo visual harness (`test/visual/capture.mjs`) against a local prod server, before (BASE build) vs after (this branch): 64 shots per round (results-detail family + chat/chat-narrow × 1920/1440/1366/1024 × light/dark), zero capture failures. Pixel-diff classification (threshold 12, ImageChops; column-profiled to separate noise):

- 48/64 perceptually identical (default widths and all non-resize surfaces).
- All code-attributable change is the resize-handle focus band (x 320–334 @280px, x 460–474 @420px; full panel height; light/dark symmetric) — the intended clearer keyboard-focus affordance.
- Residual diffs (a 2-pixel spot at x=24; one full-frame 1366x768-dark shot) reproduce **between two same-build capture rounds** (before vs before2) — harness nondeterminism, documented, not fixed.
- Served CSS verified to contain the new hover/focus/touch-none/line-clamp-2 rules (compile-probe + built-artifact grep).

## Review findings

Three independent reviewers (subagents): React performance, UI/accessibility, adversarial lifecycle (13 scratch tests, all deleted; tree contains only the 5 files above).

- **B-P1 (confirmed + fixed)**: `/NN` alpha on `var()` color silently doesn't compile in Tailwind 3 → hover/focus tints were dead (old hover class equally dead on master). Fixed with compiling token classes.
- **C-P2 (fixed)**: second pointerdown mid-drag silently discarded the in-flight draft (visual snap-back). Fixed with an active-drag guard.
- **C-P2 (fixed)**: keyboard arrows during a drag wrote the store directly, diverging from the visible draft and being overridden on release. Fixed by folding keyboard deltas into the draft.
- **A-P2 / C-P3 (accepted, documented)**: `--workspace-offset` (map chrome) now updates once on drag commit instead of per-move — the intended consequence of eliminating per-move global writes.
- **B-P2 (pre-existing, out of scope)**: aria values vs CSS `maxWidth` can contradict below a 328px viewport; product floor is 1024, boundary preserved.

Post-fix: focused 37/37, typecheck/lint/full suite/build all PASS, visuals re-verified on the final code.

## Explicitly out of scope

MapPanel/MapLibre/MapSpec/MVT, SSE/chat streaming, agent runtime, Result Workbench internals, Data Fabric, analysis algorithms, backend, auth, NavRail redesign, individual tab redesign, CI/CD, dependency upgrades. Pre-existing issues recorded, not fixed: tweaks-panel slider range 240–480 vs 280–420 clamp; `PANEL_DEFAULT` 320 vs store initial 330; the chat-tab render-scope full-suite flake; harness frame nondeterminism (~1 in 140 shots).

## CI/CD

Not used as completion evidence; validation was local only.
