### PR TITLE
fix(map): restore z-order sync on reorder, re-raise annotation stack, re-mount selection highlight after basemap switch

### DIFF
--- a/frontend/components/map/map-panel.test.tsx
+++ b/frontend/components/map/map-panel.test.tsx
@@ -550,6 +550,49 @@ describe('MapPanel — FE-3 interaction UX', () => {
     expect(annotationMoves[annotationMoves.length - 1].beforeId).toBeNull();
   });
 
+  // FIX-3-9 (#402): a basemap switch (setStyle diff) wipes the imperative
+  // highlight layers while the selection effect (deps [selectedFeature,
+  // mapReady]) never re-runs. The post-reconcile raise must RE-MOUNT the
+  // highlight instead of early-returning when its layers are missing.
+  it('re-mounts the selection highlight after a basemap-style wipe', async () => {
+    const view = await renderPanel([pointLayer('poi', 'POI')]);
+    await settleInteractive(['poi__point']);
+
+    const geometry = { type: 'Point', coordinates: [116.4, 39.9] };
+    rmg.queryResults = [featureOn('poi__point', { name: 'X' }, geometry)];
+    act(() => rmg.lastOnClick?.(clickPoint));
+    await waitFor(() => expect(hud.state.selectedFeature).toBeTruthy());
+    await waitFor(() =>
+      expect(rmg.map.getLayer('claude-selection-highlight-fill')).toBeTruthy(),
+    );
+
+    // Simulate the setStyle diff of a basemap switch: MapLibre drops every
+    // source + layer (spec and imperative alike).
+    for (const l of [...rmg.map._layers]) rmg.map.removeLayer(l.id);
+    for (const id of Object.keys(rmg.map._sources)) rmg.map.removeSource(id);
+    expect(rmg.map.getLayer('claude-selection-highlight-fill')).toBeNull();
+
+    // A reconcile settles after the style swap (same layer list, new object):
+    // the highlight must come back with the pending geometry.
+    rerenderPanel(view, [pointLayer('poi', 'POI')]);
+    await drainRuntime();
+
+    await waitFor(() => {
+      expect(rmg.map.getLayer('claude-selection-highlight-fill')).toBeTruthy();
+      expect(rmg.map.getLayer('claude-selection-highlight-circle')).toBeTruthy();
+    });
+    const hlDataCalls = rmg.map._calls.setData.filter(
+      (c: { id: string }) => c.id === 'claude-selection-highlight',
+    );
+    const last = hlDataCalls[hlDataCalls.length - 1];
+    expect(last.data.features[0].geometry).toEqual(geometry);
+    // And it is re-raised above the freshly re-applied spec layers.
+    const hlMoves = rmg.map._calls.moveLayer.filter((c: { id: string }) =>
+      c.id.startsWith('claude-selection-highlight-'),
+    );
+    expect(hlMoves.length).toBeGreaterThan(0);
+  });
+
   it('clears selection + highlight when the selected layer is removed', async () => {
     const view = await renderPanel([pointLayer('poi', 'POI')]);
     await settleInteractive(['poi__point']);

--- a/frontend/components/map/map-panel.test.tsx
+++ b/frontend/components/map/map-panel.test.tsx
@@ -505,6 +505,51 @@ describe('MapPanel — FE-3 interaction UX', () => {
     expect(hlMoves[hlMoves.length - 1].beforeId).toBeNull();
   });
 
+  // FIX-3-9 (#401): the imperative annotation stack (markers/measurements/
+  // labels) is mounted once outside MapSpecRuntime. Any layer-changing
+  // reconcile buries it under the spec sublayers via syncLayerZOrder; the panel
+  // must re-raise it alongside the selection highlight.
+  it('re-raises the annotation stack above spec layers after a reconcile', async () => {
+    // Pre-mount the annotation stack the way MapActionHandler does.
+    rmg.map.addSource('claude-annotations', {
+      type: 'geojson',
+      data: { type: 'FeatureCollection', features: [] },
+    });
+    for (const [suffix, type] of [
+      ['fill', 'fill'],
+      ['line', 'line'],
+      ['circle', 'circle'],
+      ['label', 'symbol'],
+    ] as const) {
+      rmg.map.addLayer({
+        id: `claude-annotations-${suffix}`,
+        source: 'claude-annotations',
+        type,
+      });
+    }
+
+    const view = await renderPanel([pointLayer('poi', 'POI')]);
+    await settleInteractive(['poi__point']);
+    rmg.map._calls.moveLayer.length = 0;
+
+    // Visibility-toggle reconcile (layout.visibility → recompile → z-order
+    // sync): the annotation stack must be moved back to the top afterwards.
+    rerenderPanel(view, [{ ...pointLayer('poi', 'POI'), visible: false }]);
+    await drainRuntime();
+
+    const annotationMoves = rmg.map._calls.moveLayer.filter((c: { id: string }) =>
+      c.id.startsWith('claude-annotations-'),
+    );
+    expect(annotationMoves.length).toBeGreaterThan(0);
+    // Every stack member re-raised; the last move (label) is at the very top.
+    for (const suffix of ['fill', 'line', 'circle', 'label']) {
+      expect(
+        annotationMoves.some((c: { id: string }) => c.id === `claude-annotations-${suffix}`),
+      ).toBe(true);
+    }
+    expect(annotationMoves[annotationMoves.length - 1].beforeId).toBeNull();
+  });
+
   it('clears selection + highlight when the selected layer is removed', async () => {
     const view = await renderPanel([pointLayer('poi', 'POI')]);
     await settleInteractive(['poi__point']);

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -22,6 +22,7 @@ import {
   clearSelectionHighlight,
   SELECTION_HIGHLIGHT_SOURCE_ID,
 } from "@/lib/map-kit/selection-highlight"
+import { raiseAnnotationLayers } from "@/lib/map-commands/annotationHelpers"
 import { notifyUserGestureStart, notifyUserGestureEnd } from "@/lib/map-commands/camera-arbitration"
 import { devOnly } from "@/lib/utils/logger"
 
@@ -316,6 +317,12 @@ export function MapPanel({
         // spec sublayers — put it back on top now that the reconcile settled.
         raiseSelectionHighlight()
         const map = mapRef.current?.getMap()
+        // FIX-3-9 (#401): the imperative annotation stack (markers /
+        // measurements / labels) suffers the same burying — syncLayerZOrder
+        // stacks every spec sublayer above it on any layer-changing patch.
+        // Re-raise it alongside the selection highlight (no-op when the
+        // stack isn't mounted, so reconcile-only patches stay cheap).
+        if (map) raiseAnnotationLayers(map)
         const generation = layers.reduce<Layer | null>((latest, layer) => {
           if (!layer._mapspecFingerprint) return latest
           if (!latest) return layer

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -279,8 +279,16 @@ export function MapPanel({
   // highlight above the top spec layer whenever a reconcile completes. Guarded:
   // no-op when the highlight isn't mounted, and moveLayer is wrapped so a layer
   // that vanished mid-reconcile is skipped silently.
+  //
+  // FIX-3-9 (#402): a basemap switch (setStyle diff) wipes every imperative
+  // layer — including the highlight — while the selection effect (deps
+  // [selectedFeature, mapReady]) never re-runs. When the highlight layers are
+  // gone but a selection is live, RE-MOUNT them (source + layers + data) via
+  // setSelectionHighlight instead of early-returning, so the yellow overlay
+  // comes back once the new style has settled; then re-raise as usual.
   const raiseSelectionHighlight = useCallback(() => {
-    if (!useHudStore.getState().selectedFeature || !pendingSelectionGeometryRef.current) return
+    const selectedFeature = useHudStore.getState().selectedFeature
+    if (!selectedFeature || !pendingSelectionGeometryRef.current) return
     const map = mapRef.current?.getMap()
     if (!map || !mapReady) return
     const highlightIds = [
@@ -288,7 +296,12 @@ export function MapPanel({
       `${SELECTION_HIGHLIGHT_SOURCE_ID}-line`,
       `${SELECTION_HIGHLIGHT_SOURCE_ID}-circle`,
     ]
-    if (!highlightIds.some((id) => map.getLayer(id))) return
+    if (!highlightIds.some((id) => map.getLayer(id))) {
+      setSelectionHighlight(map, {
+        geometry: pendingSelectionGeometryRef.current,
+        properties: selectedFeature.properties,
+      })
+    }
     for (const id of highlightIds) {
       if (!map.getLayer(id)) continue
       try {

--- a/frontend/lib/map-commands/annotationHelpers.ts
+++ b/frontend/lib/map-commands/annotationHelpers.ts
@@ -98,3 +98,44 @@ export function refreshAnnotations(map: Map): boolean {
   }
   return false;
 }
+
+/**
+ * Annotation stack layer ids, bottom-to-top (matches ensureAnnotationLayers
+ * mount order: fill → line → circle → label). Moving each to the top in this
+ * order ends with label on top.
+ */
+const ANNOTATION_LAYER_IDS = [
+  `${ANNOTATION_SOURCE_ID}-fill`,
+  `${ANNOTATION_SOURCE_ID}-line`,
+  `${ANNOTATION_SOURCE_ID}-circle`,
+  `${ANNOTATION_SOURCE_ID}-label`,
+];
+
+/**
+ * FIX-3-9 (#401): re-raise the imperative annotation stack above the spec
+ * layers after a reconcile.
+ *
+ * MapSpecRuntime.syncLayerZOrder moves every spec sublayer to the TOP of the
+ * style after any patch with layer changes (visibility toggles, opacity edits,
+ * layer adds, 3D switches), burying the annotations — they are added once
+ * imperatively and nothing else ever lifts them. Markers/measurements end up
+ * under 0.3-opacity data fills; labels become fully invisible.
+ *
+ * Guarded the same way as raiseSelectionHighlight (map-panel.tsx FIX-3-2):
+ * no-op when the stack isn't mounted, and moveLayer is wrapped so a layer
+ * that vanished mid-reconcile is skipped silently. Callers run it after a
+ * reconcile settles, alongside the selection-highlight re-raise.
+ */
+export function raiseAnnotationLayers(map: Map): void {
+  if (!ANNOTATION_LAYER_IDS.some((id) => map.getLayer(id))) return;
+  for (const id of ANNOTATION_LAYER_IDS) {
+    if (!map.getLayer(id)) continue;
+    try {
+      // moveLayer without beforeId → end of the layer order (top), i.e.
+      // directly above every spec layer syncLayerZOrder just stacked.
+      map.moveLayer(id);
+    } catch {
+      // Layer vanished mid-reconcile — nothing to re-raise.
+    }
+  }
+}

--- a/frontend/lib/mapspec-compiler/reconciler.test.ts
+++ b/frontend/lib/mapspec-compiler/reconciler.test.ts
@@ -176,10 +176,11 @@ describe("MapSpec Reconciler (ADR-0036)", () => {
         ],
       });
       // Layers are structurally equal but reordered. Signature compares the
-      // layer object itself (unchanged), so neither is recompiled — but the
-      // caller is expected to re-sync z-order from next.layers order on every
-      // reconcile. The runtime always calls syncLayerZOrder unconditionally,
-      // so reordering is handled there, not via recompile noise.
+      // layer object itself (unchanged), so neither is recompiled — the diff
+      // deliberately stays silent about positions (FIX-3-9/#375). The runtime
+      // detects the order change with its own cheap order-key tracker and
+      // re-syncs z-order, so reordering is handled there, not via recompile
+      // noise.
       const patch = diffSpecs(a, b);
       expect(patch.layers).toEqual([]);
     });

--- a/frontend/lib/mapspec-runtime/runtime.test.ts
+++ b/frontend/lib/mapspec-runtime/runtime.test.ts
@@ -255,6 +255,80 @@ describe("MapSpecRuntime (ADR-0036)", () => {
       // (Exact count depends on helper internals; we assert it was called.)
       expect(map._calls.moveLayer.length).toBeGreaterThan(0);
     });
+
+    // ── FIX-3-9 (#375): pure reorder produces an EMPTY layer patch ──────────
+    // diffSpecs compares layers by id and never notices a position change, so
+    // the old `patch.layers.length > 0` gate skipped the z-order sync and the
+    // Layers-tab drag-reorder was a visual no-op. The runtime's order-key
+    // tracker must still call syncLayerZOrder (observable as moveLayer calls).
+
+    function twoLayerSpec(): MapSpec {
+      return {
+        version: "1.0",
+        sources: {
+          A: { type: "geojson", inlineData: { type: "FeatureCollection", features: [] } },
+          B: { type: "geojson", inlineData: { type: "FeatureCollection", features: [] } },
+        },
+        layers: [
+          { id: "A__point", source: "A", type: "circle", paint: { "circle-radius": 6 } },
+          { id: "B__point", source: "B", type: "circle", paint: { "circle-radius": 6 } },
+        ],
+      };
+    }
+
+    it("re-syncs z-order on a pure reorder (empty layer patch, direct path)", () => {
+      const rt = new MapSpecRuntime(map);
+      rt.reconcile(twoLayerSpec());
+      map._calls.addLayer.length = 0;
+      map._calls.removeLayer.length = 0;
+      map._calls.moveLayer.length = 0;
+
+      // Same layers, swapped positions — the HUD drag-reorder shape.
+      const reordered = twoLayerSpec();
+      reordered.layers = [reordered.layers[1], reordered.layers[0]];
+      rt.reconcile(reordered);
+
+      // The diff is silent about the reorder: no layer add/remove...
+      expect(map._calls.addLayer).toEqual([]);
+      expect(map._calls.removeLayer).toEqual([]);
+      // ...but the z-order sync must still run so the map stacks follow the
+      // store (moveLayer is invoked by syncLayerZOrder).
+      expect(map._calls.moveLayer.length).toBeGreaterThan(0);
+    });
+
+    it("re-syncs z-order on a pure reorder through the debounced path", async () => {
+      const rt = new MapSpecRuntime(map);
+      const p1 = rt.reconcileAsync(twoLayerSpec());
+      rt.flush();
+      await p1;
+      map._calls.addLayer.length = 0;
+      map._calls.removeLayer.length = 0;
+      map._calls.moveLayer.length = 0;
+
+      const reordered = twoLayerSpec();
+      reordered.layers = [reordered.layers[1], reordered.layers[0]];
+      const p2 = rt.reconcileAsync(reordered);
+      rt.flush();
+      await p2;
+
+      expect(map._calls.addLayer).toEqual([]);
+      expect(map._calls.removeLayer).toEqual([]);
+      expect(map._calls.moveLayer.length).toBeGreaterThan(0);
+      expect(rt.getAppliedSpec()).toEqual(reordered);
+    });
+
+    it("does not re-sync z-order when the order is unchanged (no-op perf contract)", () => {
+      const rt = new MapSpecRuntime(map);
+      rt.reconcile(twoLayerSpec());
+      map._calls.moveLayer.length = 0;
+
+      // Structurally-equal-but-distinct spec with the SAME order: no layer
+      // changes and no order change → syncLayerZOrder must stay silent
+      // (fa108d3 work-count contract: no extra MapLibre work on no-ops).
+      rt.reconcile(twoLayerSpec());
+
+      expect(map._calls.moveLayer).toEqual([]);
+    });
   });
 
   describe("dispose", () => {

--- a/frontend/lib/mapspec-runtime/runtime.ts
+++ b/frontend/lib/mapspec-runtime/runtime.ts
@@ -47,6 +47,16 @@ export class MapSpecRuntime {
   private applySeq = 0;
   private currentApplyResolve: (() => void) | null = null;
   private lastError: string | null = null;
+  /**
+   * FIX-3-9 (#375): the last layer ORDER (ids joined) that syncLayerZOrder was
+   * invoked for. diffSpecs compares layers by id and never notices a pure
+   * reordering (empty layer patch), so `patch.layers.length > 0` alone cannot
+   * gate the z-order re-sync — a reorder must too. Comparing this cheap joined
+   * key against the next spec's order costs one string build per apply and
+   * stays silent for the common no-op/unchanged-order reconciles (fa108d3's
+   * work-count contract: no extra MapLibre work when nothing reordered).
+   */
+  private lastLayerOrderKey: string | null = null;
   private styleRecoveryHandler: (() => void) | null = null;
   private pendingRecoverySpec: MapSpec | null = null;
   private readonly onStyleRecovery?: () => void;
@@ -200,10 +210,16 @@ export class MapSpecRuntime {
       }
     }
 
-    // --- z-order: re-sync only when layers were modified ---
-    if (patch.layers.length > 0) {
-      const orderedIds = nextSpec.layers.map((l) => l.id);
+    // --- z-order: re-sync when layers were modified OR the order changed ---
+    // The order half is #375: diffSpecs never reports a pure reordering (empty
+    // layer patch), so without this gate the drag-reorder in the Layers tab was
+    // a silent visual no-op. The joined-key comparison is cheap and skips
+    // unchanged orders, preserving fa108d3's no-op work-count contract.
+    const orderedIds = nextSpec.layers.map((l) => l.id);
+    const orderKey = orderedIds.join("\u0000");
+    if (patch.layers.length > 0 || orderKey !== this.lastLayerOrderKey) {
       renderer.syncLayerZOrder(this.map, "", orderedIds);
+      this.lastLayerOrderKey = orderKey;
     }
 
     if (!this.lastError) this.appliedSpec = nextSpec;
@@ -287,14 +303,19 @@ export class MapSpecRuntime {
     }
 
     const orderedIds = nextSpec.layers.map((l) => l.id);
+    // #375: same order-key gate as applyPatchDirect — computed at enqueue time,
+    // compared against the last EXECUTED order at op-run time (queued patches
+    // run sequentially, so each comparison sees the previous patch's outcome).
+    const orderKey = orderedIds.join("\u0000");
     const zorderId = `zorder:sync:${++this.applySeq}`; // unique per patch — never coalesced
     ops.push({
       id: zorderId,
       type: "SET_STYLE",
       priority: "high",
       execute: () => {
-        if (patch.layers.length > 0) {
+        if (patch.layers.length > 0 || orderKey !== this.lastLayerOrderKey) {
           renderer.syncLayerZOrder(this.map, "", orderedIds);
+          this.lastLayerOrderKey = orderKey;
         }
         // All ops of this patch have now run (z-order is enqueued last in the
         // high-priority FIFO). appliedSpec may now legitimately equal the map.


### PR DESCRIPTION
Three map-rendering z-order/overlay regressions in the frontend, one commit each.

## #375 (P1) — Layer drag-reorder was a silent visual no-op
`diffSpecs` compares layers by id and never reports a position change, so a pure reorder produced an **empty layer patch** and the `patch.layers.length > 0` gate (added in fa108d3) skipped `syncLayerZOrder` — the map stacking never followed the store's layer order.

**Fix (lowest-risk option b):** keep the pure reconciler untouched; track a cheap order key (joined layer ids) in `MapSpecRuntime` and re-sync z-order when the next spec's layer **order** differs from the last synced one, in addition to the existing layers-changed gate. Both the direct and debounced apply paths use the same gate. Unchanged orders still skip the sync, preserving fa108d3's no-op work-count contract (exactly one completion-marker op per no-op reconcile — verified by the FIX-3-7 perf test).

## #401 (P3) — Imperative annotation layers buried under data fills
`syncLayerZOrder` moves every spec sublayer to the top after any layer-changing reconcile (visibility toggle, opacity, add layer, 3D switch), burying the imperatively-mounted `claude-annotations-*` stack — markers/measurements under 0.3-opacity fills, labels invisible. The selection highlight got a re-raise (FIX-3-2); annotations were missed.

**Fix:** new `raiseAnnotationLayers(map)` helper in `annotationHelpers.ts` (guarded — no-op when the stack isn't mounted) called at the same reconcile seam in `map-panel.tsx` as `raiseSelectionHighlight`.

## #402 (P3) — Selection highlight lost after basemap switch
A basemap `setStyle` diff wipes the imperative `claude-selection-highlight-*` layers, but `raiseSelectionHighlight` early-returned when they were missing and the selection effect (deps `[selectedFeature, mapReady]`) never re-runs — the popup stayed, the yellow highlight didn't come back until re-click.

**Fix:** when a live selection has no highlight layers, re-run `setSelectionHighlight` (idempotent ensure + `setData` with the pending geometry) instead of early-returning, then re-raise as usual. The reconcile seam already re-fires after a style swap (`currentMapStyle` is in the reconcile effect deps).

## Tests
- `runtime.test.ts`: reorder re-sync on the direct **and** debounced paths (moveLayer observed, zero add/remove), plus unchanged-order no-op stays silent.
- `map-panel.test.tsx`: annotation stack re-raised after a visibility-toggle reconcile; highlight re-mounted (layers + geometry data) after a full source/layer wipe.
- `reconciler.test.ts`: comment updated to the new runtime order-tracking contract (assertion unchanged).

**Verification:** `npm run typecheck` clean; full `npx vitest run` — 121 files / 1319 tests passed, 3 skipped, 0 failures.