### PR TITLE
fix(agent): await async tools under THREAD/CELERY policies and bound tool wall-time

### DIFF
--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -58,6 +58,17 @@ class ToolExecutionPolicy(str, Enum):
 _TOOL_THREAD_LIMIT = max(4, min(16, (os.cpu_count() or 4) + 4))
 _tool_thread_semaphore = asyncio.Semaphore(_TOOL_THREAD_LIMIT)
 
+# 单次工具执行的墙钟预算（秒）。默认 300s，TOOL_TIMEOUT_S 环境变量可覆盖；
+# 注册时工具声明了 timeout 元数据则优先于此处（见 _dispatch_impl）。注意
+# INLINE 同步工具直接在事件循环上执行，真挂死时预算也无法抢占（循环被
+# 阻塞）——该限制是既有约束，INLINE 只允许 <5ms 的超轻量工具。
+_TOOL_TIMEOUT_S = float(os.environ.get("TOOL_TIMEOUT_S", "300"))
+
+# to_thread 的 worker 线程无法被终止：调用方被取消/超时后线程仍会跑完。
+# 这类「比调用方活得更久」的线程计数（诊断 + 测试断言用）。信号量槽位由
+# done 回调在线程真实结束时归还（见 _execute_sync_in_thread），不在此计数。
+_tool_thread_leaked_count = 0
+
 VALID_GEOMETRY_TYPES = {
     "Point", "MultiPoint",
     "LineString", "MultiLineString",
@@ -177,6 +188,7 @@ class ToolRegistry:
              tier: int = 1,
              domains: Optional[List[str]] = None,
              execution_policy: Optional[ToolExecutionPolicy | str] = None,
+             timeout: Optional[float] = None,
              version: str = "1.0",
              contract_version: int = 1,
              **kwargs: Any) -> Callable:
@@ -189,6 +201,7 @@ class ToolRegistry:
                 tier=tier,
                 domains=domains,
                 execution_policy=execution_policy,
+                timeout=timeout,
                 version=version,
                 contract_version=contract_version,
                 **kwargs,
@@ -203,6 +216,7 @@ class ToolRegistry:
                  tier: int = 1,
                  domains: Optional[List[str]] = None,
                  execution_policy: Optional[ToolExecutionPolicy | str] = None,
+                 timeout: Optional[float] = None,
                  version: str = "1.0",
                  contract_version: int = 1,
                  **kwargs: Any):
@@ -274,10 +288,12 @@ class ToolRegistry:
         # declared version 是作者声明的人类可读版本；contract_version 是结果契约
         # （result shape）版本——二者拼接形成稳定指纹，供 lineage/run manifest 记录
         # 「当时执行的工具是哪一个版本」。绝不把 git SHA 塞进每个 tool schema。
+        # timeout: 单次执行墙钟预算（秒），覆盖模块级 _TOOL_TIMEOUT_S。
         self._metadata[name] = {
             "tier": tier,
             "domains": list(domains or []),
             "execution_policy": policy,
+            "timeout": timeout,
             "version": str(version or "1.0"),
             "contract_version": int(contract_version or 1),
         }
@@ -563,13 +579,29 @@ class ToolRegistry:
 
         try:
             policy = meta.get("execution_policy", ToolExecutionPolicy.THREAD)
-            result = await self._execute_tool(name, policy, tool_func, arguments)
+            # 每工具墙钟预算：注册元数据 timeout 优先，否则模块级默认
+            # （TOOL_TIMEOUT_S 环境变量可覆盖）。预算覆盖线程卸载路径——
+            # 同步工具挂死时 to_thread worker 无法被终止，预算先放弃等待并
+            # 返回超时错误结果，线程槽位由 done 回调在真实结束时归还。
+            timeout = meta.get("timeout") or _TOOL_TIMEOUT_S
+            async with asyncio.timeout(timeout):
+                result = await self._execute_tool(name, policy, tool_func, arguments)
 
             if isinstance(result, GeoAnalysisResult):
                 return result.to_llm_response()
 
             return result
 
+        except TimeoutError:
+            # #406:超时不是工具逻辑错误——单独归类，LLM 可据此收缩数据范围
+            # 重试，而不是被当作 TOOL_ERROR 反复重试同一份输入。
+            logger.warning("[registry] Tool '%s' timed out after %.0fs", name, timeout)
+            return std_error_response(
+                f"工具 {name} 执行超时（>{timeout:.0f}s），已放弃等待并回收执行槽位",
+                code="TOOL_TIMEOUT",
+                error_type="TimeoutError",
+                correction_hint="工具耗时超过预算，请缩小数据范围或参数规模后重试。",
+            )
         except ValueError as e:
             return std_error_response(
                 str(e),
@@ -636,15 +668,36 @@ class ToolRegistry:
         return await self._execute_sync_in_thread(tool_func, arguments)
 
     async def _execute_sync_in_thread(self, tool_func: Callable, arguments: dict) -> Any:
-        """在隔离线程池中安全运行同步工具，并完整传递 cache_hit_var ContextVar。"""
+        """在隔离线程池中安全运行同步工具，并完整传递 cache_hit_var ContextVar。
+
+        取消/超时语义（#406）：asyncio.to_thread 的 worker 线程无法被终止——
+        调用方被取消或超时后线程仍会跑完。若在 await 处归还信号量，槽位就
+        不再反映真实线程占用：一批挂死的工具会在 _TOOL_THREAD_LIMIT 之外
+        继续累积线程，默认 executor 同时服务 Pi reader 与 context assembly，
+        跨子系统互相拖累。因此槽位绑定到线程真实结束（done 回调归还），
+        shield 防止取消把 CancelledError 注入 to_thread 任务本身；放弃等待
+        的调用计入 _tool_thread_leaked_count（诊断/测试断言用）。
+        """
         from app.lib.tool_cache import cache_hit_var
 
         def _run_sync_with_cache_var():
             res = tool_func(**arguments)
             return res, cache_hit_var.get()
 
-        async with _tool_thread_semaphore:
-            result, thread_cache_hit = await asyncio.to_thread(_run_sync_with_cache_var)
+        await _tool_thread_semaphore.acquire()
+        try:
+            thread_task = asyncio.create_task(asyncio.to_thread(_run_sync_with_cache_var))
+        except BaseException:
+            _tool_thread_semaphore.release()
+            raise
+        # 槽位在线程真实结束时归还（回调在事件循环中执行）
+        thread_task.add_done_callback(lambda _t: _tool_thread_semaphore.release())
+        try:
+            result, thread_cache_hit = await asyncio.shield(thread_task)
+        except asyncio.CancelledError:
+            global _tool_thread_leaked_count
+            _tool_thread_leaked_count += 1
+            raise
         cache_hit_var.set(thread_cache_hit)
         return result
 
@@ -742,6 +795,7 @@ def tool(registry: ToolRegistry, name: str, description: str,
          tier: int = 1,
          domains: Optional[List[str]] = None,
          execution_policy: Optional[ToolExecutionPolicy | str] = None,
+         timeout: Optional[float] = None,
          version: str = "1.0",
          contract_version: int = 1,
          **kwargs: Any):
@@ -758,6 +812,7 @@ def tool(registry: ToolRegistry, name: str, description: str,
             tier=tier,
             domains=domains,
             execution_policy=execution_policy,
+            timeout=timeout,
             version=version,
             contract_version=contract_version,
             **kwargs,

--- a/app/tools/registry.py
+++ b/app/tools/registry.py
@@ -248,12 +248,26 @@ class ToolRegistry:
 
         # 校验并确定执行策略
         if execution_policy is None:
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
                 policy = ToolExecutionPolicy.ASYNC
             else:
                 policy = ToolExecutionPolicy.THREAD
         else:
             policy = ToolExecutionPolicy(execution_policy)
+            if inspect.iscoroutinefunction(func) and policy in (
+                ToolExecutionPolicy.THREAD,
+                ToolExecutionPolicy.CELERY,
+            ):
+                # 审计修复 #374:async def 工具配 THREAD/CELERY 时,策略分支会
+                # 在线程里「同步」调用它——返回未 await 的 coroutine,下游
+                # json.dumps 抛 TypeError。按函数类型自动路由到 ASYNC:
+                # async 工具自己 await 其内部 I/O/线程卸载,无需外层线程池。
+                # (iscoroutinefunction 会解包 functools.partial/__wrapped__。)
+                logger.warning(
+                    "工具 %s 以 async def 注册却声明 %s 策略,自动改用 ASYNC",
+                    name, policy.value,
+                )
+                policy = ToolExecutionPolicy.ASYNC
 
         # 记录分层元数据与执行策略
         # version / contract_version: 工具实现指纹（INV-TOOL，规范 §12）。
@@ -344,7 +358,9 @@ class ToolRegistry:
             actual_mode = "UNKNOWN"
         elif requested_policy == ToolExecutionPolicy.INLINE:
             actual_mode = "INLINE"
-        elif requested_policy == ToolExecutionPolicy.ASYNC and asyncio.iscoroutinefunction(tool_func):
+        elif inspect.iscoroutinefunction(tool_func):
+            # async def 工具一律直接 await——即使声明了 THREAD/CELERY 策略
+            # （#374，注册期已自动路由，此处兜底）。如实上报实际执行模式。
             actual_mode = "ASYNC"
         else:
             actual_mode = "THREAD"
@@ -547,24 +563,7 @@ class ToolRegistry:
 
         try:
             policy = meta.get("execution_policy", ToolExecutionPolicy.THREAD)
-
-            if policy == ToolExecutionPolicy.INLINE:
-                # 超轻量工具 (<5ms)：直接在当前 Task 执行，不占用线程池信号量
-                if asyncio.iscoroutinefunction(tool_func):
-                    result = await tool_func(**arguments)
-                else:
-                    result = tool_func(**arguments)
-            elif policy == ToolExecutionPolicy.ASYNC and asyncio.iscoroutinefunction(tool_func):
-                # 纯非阻塞 async I/O：直接 await
-                result = await tool_func(**arguments)
-            elif policy == ToolExecutionPolicy.CELERY:
-                # 重型 GDAL / 栅格 / 空间分析工具：若配置了 Celery Worker，优先投递异步 Task；
-                # 在单机无 Worker 环境下，优雅降级到本地线程池隔离运行。
-                logger.debug(f"[registry] Executing heavy tool '{name}' via CELERY policy boundary")
-                result = await self._execute_sync_in_thread(tool_func, arguments)
-            else:
-                # THREAD 策略或非 async 回退：在线程池隔离中运行
-                result = await self._execute_sync_in_thread(tool_func, arguments)
+            result = await self._execute_tool(name, policy, tool_func, arguments)
 
             if isinstance(result, GeoAnalysisResult):
                 return result.to_llm_response()
@@ -608,6 +607,33 @@ class ToolRegistry:
             )
 
         return result
+
+    async def _execute_tool(self, name: str, policy: ToolExecutionPolicy,
+                            tool_func: Callable, arguments: dict) -> Any:
+        """按执行策略运行工具函数（不含校验/解引用等前置步骤）。
+
+        #374:async def 工具在 THREAD/CELERY 策略下也必须 await。to_thread 只能
+        同步执行——把 coroutine 当普通对象调用会原样返回未 await 的
+        coroutine，dispatch 结果无法 JSON 序列化。注册期已把 async+THREAD/
+        CELERY 自动路由到 ASYNC；此处再按函数类型兜底，策略元数据与函数
+        实现不符（旧数据/直接改 _metadata）时仍正确执行。
+        """
+        if policy == ToolExecutionPolicy.INLINE:
+            # 超轻量工具 (<5ms)：直接在当前 Task 执行，不占用线程池信号量
+            if inspect.iscoroutinefunction(tool_func):
+                return await tool_func(**arguments)
+            return tool_func(**arguments)
+        if policy == ToolExecutionPolicy.ASYNC and inspect.iscoroutinefunction(tool_func):
+            # 纯非阻塞 async I/O：直接 await
+            return await tool_func(**arguments)
+        if inspect.iscoroutinefunction(tool_func):
+            # THREAD/CELERY × async def：绕过线程路径直接 await（见注释头）
+            return await tool_func(**arguments)
+        if policy == ToolExecutionPolicy.CELERY:
+            # 重型 GDAL / 栅格 / 空间分析工具：若配置了 Celery Worker，优先投递
+            # 异步 Task；在单机无 Worker 环境下，优雅降级到本地线程池隔离运行。
+            logger.debug("[registry] Executing heavy tool '%s' via CELERY policy boundary", name)
+        return await self._execute_sync_in_thread(tool_func, arguments)
 
     async def _execute_sync_in_thread(self, tool_func: Callable, arguments: dict) -> Any:
         """在隔离线程池中安全运行同步工具，并完整传递 cache_hit_var ContextVar。"""

--- a/tests/test_registry_offload.py
+++ b/tests/test_registry_offload.py
@@ -5,6 +5,7 @@ sleeps must NOT block the event loop — other coroutines must keep running
 concurrently while the tool executes in the thread pool.
 """
 import asyncio
+import threading
 import time
 
 
@@ -144,3 +145,174 @@ def test_sync_tool_concurrency_is_bounded():
     finally:
         reg_mod._tool_thread_semaphore = orig_semaphore
         reg_mod._TOOL_THREAD_LIMIT = orig_limit
+
+
+# ---------------------------------------------------------------------------
+# GH-406: per-tool wall-time budget + semaphore accounting across cancellation.
+# ---------------------------------------------------------------------------
+
+
+def test_hung_sync_tool_returns_timeout_result_within_budget():
+    """A hung sync tool must return a timeout error result within the budget.
+
+    Before: dispatch had no timeout at all — a dead tool occupied the turn
+    forever. After: each tool runs under a wall-time budget
+    (_TOOL_TIMEOUT_S, env TOOL_TIMEOUT_S, or per-tool metadata 'timeout').
+    """
+    import app.tools.registry as reg_mod
+
+    reg = ToolRegistry()
+    release = threading.Event()
+
+    def forever_tool():
+        release.wait(timeout=30)  # hangs until the test lets it go
+        return {"never": True}
+
+    reg.register("forever", "hangs", forever_tool)
+
+    orig_timeout = reg_mod._TOOL_TIMEOUT_S
+    reg_mod._TOOL_TIMEOUT_S = 0.3
+    try:
+        async def main():
+            start = time.monotonic()
+            out = await reg.dispatch("forever", {})
+            elapsed = time.monotonic() - start
+            # 放行后台泄漏线程：asyncio.run 收尾时 shutdown_default_executor
+            # 会 join 所有 worker，不放行测试会挂 30s。
+            release.set()
+            return out, elapsed
+
+        out, elapsed = asyncio.run(main())
+    finally:
+        reg_mod._TOOL_TIMEOUT_S = orig_timeout
+        release.set()
+
+    assert elapsed < 5.0, f"timeout 未生效，dispatch 耗时 {elapsed:.1f}s"
+    assert out["success"] is False
+    assert out["code"] == "TOOL_TIMEOUT"
+    assert "超时" in out["message"]
+
+
+def test_timeout_metadata_overrides_global_budget():
+    """Per-tool metadata 'timeout' must take precedence over the global budget."""
+    import app.tools.registry as reg_mod
+
+    reg = ToolRegistry()
+    release = threading.Event()
+
+    def forever_tool():
+        release.wait(timeout=30)
+        return {"never": True}
+
+    # 全局预算故意给得很长；工具级 timeout 很短 → 必须按工具级超时返回
+    reg.register("forever", "hangs", forever_tool, timeout=0.3)
+
+    orig_timeout = reg_mod._TOOL_TIMEOUT_S
+    reg_mod._TOOL_TIMEOUT_S = 60.0
+    try:
+        async def main():
+            start = time.monotonic()
+            out = await reg.dispatch("forever", {})
+            elapsed = time.monotonic() - start
+            release.set()
+            return out, elapsed
+
+        out, elapsed = asyncio.run(main())
+    finally:
+        reg_mod._TOOL_TIMEOUT_S = orig_timeout
+        release.set()
+
+    assert elapsed < 5.0, f"工具级 timeout 未生效，dispatch 耗时 {elapsed:.1f}s"
+    assert out["success"] is False
+    assert out["code"] == "TOOL_TIMEOUT"
+
+
+def test_cancellation_keeps_semaphore_until_thread_actually_finishes():
+    """Cancellation must not release the semaphore before the thread ends.
+
+    Before: cancelling `await to_thread(...)` ran the `async with` __aexit__
+    immediately, returning the slot while the worker thread kept running —
+    the semaphore stopped reflecting real thread occupancy, so a wave of
+    hung tools would pile up threads beyond _TOOL_THREAD_LIMIT. After: the
+    slot is returned by a done callback when the thread truly finishes;
+    the abandoned call is counted in _tool_thread_leaked_count.
+    """
+    import asyncio as _asyncio
+
+    import app.tools.registry as reg_mod
+
+    limit = 1
+    orig_semaphore = reg_mod._tool_thread_semaphore
+    orig_leaked = reg_mod._tool_thread_leaked_count
+    reg_mod._tool_thread_semaphore = _asyncio.Semaphore(limit)
+    started = threading.Event()
+    release = threading.Event()
+    try:
+        reg = ToolRegistry()
+
+        def blocker():
+            started.set()
+            release.wait(timeout=30)
+            return {"done": True}
+
+        reg.register("blocker", "blocks", blocker)
+
+        async def main():
+            task = _asyncio.create_task(reg.dispatch("blocker", {}))
+            # 等 worker 线程真正开始运行后再取消
+            for _ in range(500):
+                if started.is_set():
+                    break
+                await _asyncio.sleep(0.01)
+            assert started.is_set(), "worker 线程未启动"
+            task.cancel()
+            try:
+                await task
+            except _asyncio.CancelledError:
+                pass
+            # 取消已送达，但线程仍在跑 → 信号量必须仍然被占用
+            assert reg_mod._tool_thread_semaphore.locked(), (
+                "取消后信号量被提前释放——槽位不再反映真实线程占用"
+            )
+            # 放行线程；线程结束后槽位由 done 回调归还
+            release.set()
+            for _ in range(500):
+                if not reg_mod._tool_thread_semaphore.locked():
+                    break
+                await _asyncio.sleep(0.01)
+            assert not reg_mod._tool_thread_semaphore.locked(), (
+                "线程结束后信号量槽位未归还"
+            )
+            assert reg_mod._tool_thread_leaked_count == orig_leaked + 1, (
+                "被取消的线程未计入泄漏计数"
+            )
+
+        _asyncio.run(main())
+    finally:
+        reg_mod._tool_thread_semaphore = orig_semaphore
+        release.set()
+
+
+def test_async_tool_under_thread_policy_dispatches():
+    """GH-374/406 cross-check: async def + THREAD policy must dispatch fine.
+
+    The thread-path fixes must not break async tools that were (incorrectly)
+    declared with THREAD policy — they are awaited directly, never handed to
+    to_thread, so no semaphore slot is consumed and no coroutine leaks out.
+    """
+    reg = ToolRegistry()
+
+    @reg.tool(
+        name="async_under_thread",
+        description="async def declared as THREAD",
+        execution_policy="thread",
+    )
+    async def async_under_thread(x: int = 1):
+        await asyncio.sleep(0)
+        return {"value": x + 1}
+
+    async def main():
+        return await reg.dispatch("async_under_thread", {"x": 1})
+
+    out = asyncio.run(main())
+    assert out == {"value": 2}

--- a/tests/test_tool_registry_async_policy.py
+++ b/tests/test_tool_registry_async_policy.py
@@ -1,0 +1,171 @@
+"""Regression tests for GH-374: THREAD/CELERY policies must await async-def tools.
+
+旧实现把 THREAD 与 CELERY 策略都路由到 _execute_sync_in_thread，后者在线程
+里「同步」调用 tool_func——async def 工具被当普通对象调用，dispatch 返回
+未 await 的 coroutine，下游 json.dumps 抛
+``TypeError: Object of type coroutine is not JSON serializable``。
+
+修复分两层：
+1. 注册期（ToolRegistry.register）：async def + 显式 THREAD/CELERY 自动按
+   函数类型路由到 ASYNC（拒绝会破坏 network/temporal 既有注册）。
+2. 派发期（_dispatch_impl._execute_tool）：无论策略元数据如何，async 函数
+   一律直接 await（兜底防御，覆盖旧数据/直接改 _metadata 的场景）。
+"""
+import asyncio
+import functools
+import inspect
+import json
+
+import pytest
+
+from app.tools.registry import ToolExecutionPolicy, ToolRegistry
+from app.tools.network_tools import register_network_tools
+from app.tools.temporal_tools import register_temporal_tools
+
+
+# network/temporal 中所有以 async def 注册、却声明 THREAD/CELERY 策略的工具。
+# 这些注册在修复前全部返回未 await 的 coroutine，dispatch 结果无法序列化。
+ASYNC_DEF_THREAD_CELERY_TOOLS = [
+    # network_tools.py: THREAD (tier 2)
+    "network_shortest_path",
+    "network_od_matrix",
+    "network_closest_facility",
+    "network_service_area",
+    "network_accessibility",
+    # network_tools.py: CELERY (tier 3)
+    "location_allocation",
+    "optimize_route",
+    # temporal_tools.py: THREAD (tier 2)
+    "temporal_profile",
+    "temporal_filter",
+    "temporal_aggregate",
+    "temporal_change",
+    "temporal_trend",
+    # temporal_tools.py: CELERY (tier 3)
+    "spatiotemporal_hotspot",
+]
+
+
+def _build_network_temporal_registry() -> ToolRegistry:
+    reg = ToolRegistry()
+    register_network_tools(reg)
+    register_temporal_tools(reg)
+    return reg
+
+
+@pytest.mark.parametrize("tool_name", ASYNC_DEF_THREAD_CELERY_TOOLS)
+def test_async_def_tool_auto_routed_away_from_thread_policy(tool_name):
+    """注册期校验：async def + THREAD/CELERY 必须被自动路由到 ASYNC。
+
+    若策略仍是 THREAD/CELERY，dispatch 会把 coroutine 当普通对象同步调用，
+    返回未 await 的 coroutine。同类审计失误曾在 spatial_decision_tools 修复
+    （改注册策略），network/temporal 未覆盖——这里锁死注册期行为。
+    """
+    reg = _build_network_temporal_registry()
+    func = reg._tools[tool_name]
+    assert inspect.iscoroutinefunction(func), f"{tool_name} 应为 async def"
+    policy = reg.metadata(tool_name)["execution_policy"]
+    assert policy == ToolExecutionPolicy.ASYNC, (
+        f"{tool_name} 注册策略应被自动路由为 ASYNC，实际为 {policy}"
+    )
+
+
+@pytest.mark.parametrize("tool_name", ASYNC_DEF_THREAD_CELERY_TOOLS)
+async def test_dispatch_never_returns_coroutine(tool_name):
+    """真实 registry dispatch 不返回 coroutine，且结果可 JSON 序列化。
+
+    空参数下这些工具在 Pydantic 校验处返回 VALIDATION_ERROR dict；断言
+    返回值不是 coroutine 对象（修复前 THREAD/CELERY 分支在参数合法的执行
+    路径里同步调用 async def 并原样返回 coroutine，直接 json.dumps 必炸）。
+    """
+    reg = _build_network_temporal_registry()
+    result = await reg.dispatch(tool_name, {}, session_id=None)
+    assert not inspect.iscoroutine(result)
+    assert not isinstance(result, asyncio.Future)
+    json.dumps(result)  # 不得抛 TypeError: coroutine is not JSON serializable
+
+
+async def test_async_def_with_explicit_thread_policy_executes_and_awaits():
+    """最小复现用例：async def + 显式 THREAD 策略必须返回 await 后的结果。
+
+    修复前：to_thread 同步调用 async def 返回 coroutine 对象；修复后：
+    注册期自动路由为 ASYNC，直接 await，结果可序列化。
+    """
+    reg = ToolRegistry()
+
+    @reg.tool(
+        name="async_thread_tool",
+        description="async def registered with THREAD policy",
+        execution_policy=ToolExecutionPolicy.THREAD,
+    )
+    async def async_thread_tool(x: int = 1):
+        await asyncio.sleep(0)
+        return {"value": x * 2}
+
+    assert reg.metadata("async_thread_tool")["execution_policy"] == ToolExecutionPolicy.ASYNC
+    result = await reg.dispatch("async_thread_tool", {"x": 21})
+    assert result == {"value": 42}
+    json.dumps(result)
+
+
+async def test_async_def_with_explicit_celery_policy_executes_and_awaits():
+    """最小复现用例：async def + 显式 CELERY 策略同样必须 await。"""
+    reg = ToolRegistry()
+
+    @reg.tool(
+        name="async_celery_tool",
+        description="async def registered with CELERY policy",
+        execution_policy=ToolExecutionPolicy.CELERY,
+    )
+    async def async_celery_tool(x: int = 1):
+        await asyncio.sleep(0)
+        return {"value": x}
+
+    assert reg.metadata("async_celery_tool")["execution_policy"] == ToolExecutionPolicy.ASYNC
+    result = await reg.dispatch("async_celery_tool", {"x": 7})
+    assert result == {"value": 7}
+
+
+async def test_functools_partial_wrapped_async_def_still_detected():
+    """functools.partial 包装的 async def 也要被识别为协程函数。
+
+    asyncio.iscoroutinefunction 会解包 partial（Python 3.8+），注册期
+    自动路由与派发期兜底分支都必须走 await 路径。
+    """
+    reg = ToolRegistry()
+
+    async def _inner(x: int = 1):
+        await asyncio.sleep(0)
+        return {"partial": x}
+
+    reg.register(
+        "partial_async",
+        "partial-wrapped async tool",
+        functools.partial(_inner),
+        execution_policy=ToolExecutionPolicy.THREAD,
+    )
+    assert reg.metadata("partial_async")["execution_policy"] == ToolExecutionPolicy.ASYNC
+    result = await reg.dispatch("partial_async", {"x": 5})
+    assert result == {"partial": 5}
+
+
+async def test_dispatch_defends_when_policy_metadata_tampered_to_thread():
+    """防御分支：策略元数据与函数类型不符时仍按函数类型正确执行。
+
+    注册期自动路由只保护经过 register() 的路径；旧元数据/直接改 _metadata
+    的场景由 _dispatch_impl 的按函数类型兜底分支覆盖——async 工具仍 await，
+    而不是在线程里同步调用后返回 coroutine。
+    """
+    reg = ToolRegistry()
+
+    @reg.tool(name="guarded_async", description="defensive branch probe")
+    async def guarded_async(x: int = 1):
+        await asyncio.sleep(0)
+        return {"x": x}
+
+    # 模拟修复前/旧数据：把策略元数据改回 THREAD，绕过注册期自动路由
+    reg._metadata["guarded_async"]["execution_policy"] = ToolExecutionPolicy.THREAD
+    result = await reg.dispatch("guarded_async", {"x": 3})
+    assert result == {"x": 3}
+    assert not inspect.iscoroutine(result)
+    json.dumps(result)


### PR DESCRIPTION
## Summary

Two dispatch-path fixes in `app/tools/registry.py`, one commit each.

### Issue #374 — THREAD/CELERY policies never awaited async-def tools

**Root cause:** `_dispatch_impl` routed both THREAD and CELERY policies to `_execute_sync_in_thread`, which calls `tool_func(**arguments)` synchronously inside `asyncio.to_thread`. Tools registered as `async def` (all of `network_tools.py` and `temporal_tools.py`: `network_shortest_path`, `network_od_matrix`, `network_closest_facility`, `network_service_area`, `network_accessibility`, `location_allocation`, `optimize_route`, `temporal_profile`, `temporal_filter`, `temporal_aggregate`, `temporal_change`, `temporal_trend`, `spatiotemporal_hotspot`) were invoked in a thread, returning an **un-awaited coroutine object**. Downstream `json.dumps(result)` failed with `TypeError: Object of type coroutine is not JSON serializable`. A comment in `spatial_decision_tools.py` shows the same class of bug was previously patched ad hoc (by rewriting registrations to ASYNC) — but network/temporal were never covered.

**Fix (two layers):**
1. **Registration** (`ToolRegistry.register`): `async def` + explicit `THREAD`/`CELERY` is auto-routed to `ASYNC` with a warning (rejecting outright would break the existing registrations). `inspect.iscoroutinefunction` unwraps `functools.partial`/`__wrapped__` wrappers.
2. **Dispatch** (new `_execute_tool`): regardless of the declared policy, coroutine functions are awaited directly; the thread path only ever receives sync callables. `dispatch()` metrics now report `actual_mode="ASYNC"` for these tools instead of a misleading `"THREAD"`.

The async network/temporal engines already offload heavy CPU work internally (`asyncio.to_thread` in `app/services/network/engine.py`), so awaiting them on the loop is safe.

### Issue #406 — No per-tool timeout; cancellation leaked threads while releasing the semaphore

**Root cause:** the dispatch chain had no `wait_for`/timeout — a hung sync tool occupied the turn forever. When the awaiting task was cancelled, `await asyncio.to_thread(...)` raised `CancelledError`, the `async with _tool_thread_semaphore` released the slot immediately, but the worker thread kept running — the semaphore no longer reflected real thread occupancy. The default executor is shared (Pi reader `_readline_bounded`, context assembly), so enough stragglers could stall unrelated subsystems.

**Fix:**
- Tool execution is wrapped in `asyncio.timeout` with a per-tool wall-time budget: metadata `timeout` (new `register()`/`tool()` parameter) > `TOOL_TIMEOUT_S` env var > default 300 s. Expiry returns a dedicated `TOOL_TIMEOUT` error result (`std_error_response` shape) so the LLM can shrink the workload instead of blind-retrying a generic `TOOL_ERROR`. INLINE sync tools run on the loop and can't be preempted if truly hung — pre-existing constraint, documented.
- `_execute_sync_in_thread` no longer releases the slot on `await` exit. It acquires the slot, starts the thread task, and returns the slot via a **done callback when the thread actually finishes**; `asyncio.shield` keeps `CancelledError` out of the `to_thread` task. A cancelled/timed-out caller counts the still-running thread in the module-level `_tool_thread_leaked_count` (diagnostics + test assertions). Rationale (vs. alternatives like waiting for a bounded join) is in the docstring: the thread cannot be interrupted, so the only honest accounting binds the slot to the thread's real end.

## Tests

New: `tests/test_tool_registry_async_policy.py` (13 tests) and 4 tests appended to `tests/test_registry_offload.py`.

- Parametrized over all 13 network/temporal async tools: registration policy auto-routed to `ASYNC`; real `ToolRegistry.dispatch` never returns a coroutine and results are `json.dumps`-able.
- Minimal `async def` × `THREAD`/`CELERY` registrations reach execution and return awaited results; `functools.partial`-wrapped async def is detected; defensive branch verified by tampering metadata policy back to `THREAD`.
- Hung sync tool returns `TOOL_TIMEOUT` within budget; per-tool metadata `timeout` beats the global budget.
- Cancellation scenario: semaphore stays held while the thread still runs, is returned once the thread ends, and the leak counter increments by exactly 1.

Results:
- `tests/test_tool_registry_async_policy.py tests/test_registry_offload.py tests/test_tool_registry.py tests/unit/test_tool_execution_policy.py tests/unit/test_tool_registry_errors.py tests/unit/test_parallel_tool_dispatch.py tests/unit/test_tool_dispatch_service.py`: **72 passed**
- Broader regression run (registry/offload/annotation/chat_globals/runtime_p2/map_action/OSM/heatmap/spatial_reasoning/slim_tool_result, memory-leaks/perf-audit/self-healing/concurrency-audit/BE-audit/protocol-parity, network-temporal harness/network analyst, chat engine/medium-backend-arch/temporal-gis-runtime): **all passed** (~230 tests total).
