### PR TITLE
fix(gis): compass aspect/hillshade conventions and STAC windowed reads bounded to the AOI

### DIFF
--- a/app/services/rs/band_math.py
+++ b/app/services/rs/band_math.py
@@ -100,12 +100,20 @@ def compute_index_array(index_type: str, **bands: np.ndarray) -> np.ndarray:
     return formula(*args)
 
 
-def compute_slope(dem: np.ndarray, cell_size: float) -> np.ndarray:
-    """使用 Horn 方法 (3x3 窗口) 计算坡度 (单位: 度)"""
+def compute_slope(dem: np.ndarray, cell_size: float,
+                  cell_size_x: Optional[float] = None) -> np.ndarray:
+    """使用 Horn 方法 (3x3 窗口) 计算坡度 (单位: 度)
+
+    cell_size_x: 可选 —— 东西 (x) 方向的像元地面尺寸 (米)。地理坐标
+    DEM (如 Copernicus GLO-30, EPSG:4326) 的经度向地面距离随纬度收缩
+    ~cos(lat)，若 x/y 用同一赤道比例会低估东西向坡度；由调用方 (stac_client)
+    传入经纬度向校正后的值，默认 None 时回退 cell_size (行为不变)。
+    """
     pad = np.pad(dem, 1, mode="edge")
-    dzdx = ((pad[1:-1, 2:] - pad[1:-1, :-2]) / (2 * cell_size) +
-             (pad[:-2, 2:] - pad[:-2, :-2]) / (4 * cell_size) +
-             (pad[2:, 2:] - pad[2:, :-2]) / (4 * cell_size)) / 2
+    dx = cell_size_x if cell_size_x is not None else cell_size
+    dzdx = ((pad[1:-1, 2:] - pad[1:-1, :-2]) / (2 * dx) +
+             (pad[:-2, 2:] - pad[:-2, :-2]) / (4 * dx) +
+             (pad[2:, 2:] - pad[2:, :-2]) / (4 * dx)) / 2
     dzdy = ((pad[2:, 1:-1] - pad[:-2, 1:-1]) / (2 * cell_size) +
              (pad[2:, :-2] - pad[:-2, :-2]) / (4 * cell_size) +
              (pad[2:, 2:] - pad[:-2, 2:]) / (4 * cell_size)) / 2
@@ -113,27 +121,46 @@ def compute_slope(dem: np.ndarray, cell_size: float) -> np.ndarray:
     return np.degrees(slope_rad)
 
 
-def compute_aspect(dem: np.ndarray, cell_size: float) -> np.ndarray:
-    """计算坡向 (0-360 度，顺时针自正北)"""
+def compute_aspect(dem: np.ndarray, cell_size: float,
+                   cell_size_x: Optional[float] = None) -> np.ndarray:
+    """计算坡向 (0-360 度，顺时针自正北) —— 下坡方位 (aspect = 水流方向)。
+
+    #379: 旧实现 arctan2(-dzdy, dzdx) 返回的是数学角 (自东逆时针)，
+    与文档承诺的罗盘角 (顺时针自正北) 相反：东抬升得 0° (真 270°)、
+    北抬升得 90° (真 180°)。ESRI 等价式 aspect = degrees(atan2(-dzdx, dzdy))
+    % 360：东抬升 -> 270° (下坡西)，北抬升 -> 180° (下坡南)，南抬升 -> 0°，
+    西抬升 -> 90°。cell_size_x 语义同 compute_slope。
+    """
     pad = np.pad(dem, 1, mode="edge")
-    dzdx = (pad[1:-1, 2:] - pad[1:-1, :-2]) / (2 * cell_size)
+    dx = cell_size_x if cell_size_x is not None else cell_size
+    dzdx = (pad[1:-1, 2:] - pad[1:-1, :-2]) / (2 * dx)
     dzdy = (pad[2:, 1:-1] - pad[:-2, 1:-1]) / (2 * cell_size)
-    aspect = np.degrees(np.arctan2(-dzdy, dzdx))
-    aspect = np.where(aspect < 0, aspect + 360, aspect)
+    aspect = np.mod(np.degrees(np.arctan2(-dzdx, dzdy)), 360.0)
     flat = (dzdx == 0) & (dzdy == 0)
     aspect[flat] = np.nan
     return aspect
 
 
 def compute_hillshade(dem: np.ndarray, cell_size: float,
-                      azimuth: float = 315, altitude: float = 45) -> np.ndarray:
-    """计算山体阴影照度 (0-255)"""
+                      azimuth: float = 315, altitude: float = 45,
+                      cell_size_x: Optional[float] = None) -> np.ndarray:
+    """计算山体阴影照度 (0-255)
+
+    #379: 旧实现把数学角 aspect 喂给 cos(az_rad - aspect_rad) 并镜像
+    radians(360 - azimuth)，导致光照相对配置的太阳方位旋转 ~90°
+    (如太阳 315° 时北向坡被算成暗面)。修正后 aspect 为罗盘角，
+    太阳方位直接使用罗盘 azimuth、不再镜像：两角同为顺时针自正北，
+    同坐标系相减。推导 (南北半球一致，仅依赖局部梯度符号)：
+    照度 = sin(alt)·cos(θ) + cos(alt)·sin(θ)·cos(az - aspect)。
+    cell_size_x 语义同 compute_slope。
+    """
     pad = np.pad(dem, 1, mode="edge")
-    dzdx = (pad[1:-1, 2:] - pad[1:-1, :-2]) / (2 * cell_size)
+    dx = cell_size_x if cell_size_x is not None else cell_size
+    dzdx = (pad[1:-1, 2:] - pad[1:-1, :-2]) / (2 * dx)
     dzdy = (pad[2:, 1:-1] - pad[:-2, 1:-1]) / (2 * cell_size)
     slope_rad = np.arctan(np.sqrt(dzdx ** 2 + dzdy ** 2))
-    aspect_rad = np.arctan2(-dzdy, dzdx)
-    az_rad = np.radians(360 - azimuth)
+    aspect_rad = np.arctan2(-dzdx, dzdy)  # 罗盘坡向 (顺时针自正北) 弧度
+    az_rad = np.radians(azimuth)          # 罗盘太阳方位，与 aspect 同基准，不镜像
     alt_rad = np.radians(altitude)
     hs = (np.sin(alt_rad) * np.cos(slope_rad) +
           np.cos(alt_rad) * np.sin(slope_rad) * np.cos(az_rad - aspect_rad))

--- a/app/services/rs/spectral_engine.py
+++ b/app/services/rs/spectral_engine.py
@@ -145,6 +145,7 @@ class SpectralRasterEngine:
                 nodata = dem <= -9999
                 dem[nodata] = np.nan
                 cell_size = fetch_res.get("cell_size_m", 30.0)
+                cell_size_x = fetch_res.get("cell_size_x_m")
 
                 # GIS-06: the default products = ["slope", "aspect", "hillshade"]
                 # but the previous if/elif chain (in a fixed branch order) only
@@ -153,9 +154,9 @@ class SpectralRasterEngine:
                 # Derivatives map to a single label deterministically: iterate
                 # the requested products in order and pick the first supported.
                 derivators = {
-                    "slope": lambda d: compute_slope(d, cell_size),
-                    "aspect": lambda d: compute_aspect(d, cell_size),
-                    "hillshade": lambda d: compute_hillshade(d, cell_size),
+                    "slope": lambda d: compute_slope(d, cell_size, cell_size_x=cell_size_x),
+                    "aspect": lambda d: compute_aspect(d, cell_size, cell_size_x=cell_size_x),
+                    "hillshade": lambda d: compute_hillshade(d, cell_size, cell_size_x=cell_size_x),
                 }
                 chosen = next((p for p in products if p in derivators), None)
                 if chosen is None:

--- a/app/services/rs/spectral_engine.py
+++ b/app/services/rs/spectral_engine.py
@@ -98,7 +98,10 @@ class SpectralRasterEngine:
             return RasterAnalysisResult(
                 index_type=idx,
                 array=arr,
-                bounds=list(bbox),
+                # #381: stac_client 返回实际读取窗口的 WGS84 范围 (bbox ∩
+                # 影像足迹)，而不是用户请求的整个 bbox —— 统计与栅格叠加
+                # 必须配准到真实数据 footprint。
+                bounds=fetch_res.get("bounds") or list(bbox),
                 stats=stats,
                 is_error=False,
             )
@@ -176,7 +179,9 @@ class SpectralRasterEngine:
             return RasterAnalysisResult(
                 index_type=label,
                 array=target_arr,
-                bounds=list(bbox),
+                # #381: 实际读取窗口 (bbox ∩ DEM 足迹) 的 WGS84 范围，
+                # 而非整个请求 bbox。
+                bounds=fetch_res.get("bounds") or list(bbox),
                 stats=stats,
                 is_error=False,
             )

--- a/app/services/rs/stac_client.py
+++ b/app/services/rs/stac_client.py
@@ -76,6 +76,7 @@ class StacClientPrimitive:
 
                     bands_dict: Dict[str, np.ndarray] = {}
                     cell_size_m = None
+                    cell_size_x_m = None
                     with rasterio_env():
                         for name, asset_key in band_mapping.items():
                             if asset_key not in item.assets:
@@ -104,14 +105,26 @@ class StacClientPrimitive:
                                 if cell_size_m is None and ds.transform.a:
                                     px = abs(ds.transform.a) * ds_factor
                                     if ds.crs is not None and ds.crs.is_geographic:
+                                        # #379: 地理 CRS 下经度向的地面尺寸随
+                                        # cos(lat) 收缩 —— 赤道比例 (~111320
+                                        # m/deg) 会把东西向坡度低估 ~cos(lat)。
+                                        # 用 AOI 中心纬度校正 x 方向；y (经线)
+                                        # 方向不受影响。投影 CRS 两方向同为米，
+                                        # 不设置 cell_size_x_m (派生函数回退
+                                        # cell_size，行为不变)。
+                                        lat = (bbox[1] + bbox[3]) / 2.0
                                         px *= 111320.0
+                                        cell_size_x_m = float(
+                                            px * abs(np.cos(np.radians(lat))))
                                     cell_size_m = float(px)
-                    return bands_dict, cell_size_m
+                    return bands_dict, cell_size_m, cell_size_x_m
 
-            bands_dict, cell_size_m = await asyncio.to_thread(_read_bands)
+            bands_dict, cell_size_m, cell_size_x_m = await asyncio.to_thread(_read_bands)
             result["bands"] = bands_dict
             if cell_size_m is not None:
                 result["cell_size_m"] = cell_size_m
+            if cell_size_x_m is not None:
+                result["cell_size_x_m"] = cell_size_x_m
 
             return result
         except Exception as e:

--- a/app/services/rs/stac_client.py
+++ b/app/services/rs/stac_client.py
@@ -37,7 +37,11 @@ class StacClientPrimitive:
         ds_factor: int = 4,
         empty_error_msg: str = "No data found",
     ) -> Dict[str, Any]:
-        """从 STAC Catalog 检索 item 并按需要读取波段 NumPy 数组"""
+        """从 STAC Catalog 检索 item 并按需要读取波段 NumPy 数组
+
+        读取波段时按 bbox ∩ 影像足迹做窗口化读取 (crop)，返回结果附带
+        "bounds": 实际读取窗口的 WGS84 范围 [w, s, e, n] (非请求 bbox，
+        统计与栅格叠加配准到真实数据 footprint)。"""
         try:
             catalog = await self.open_catalog()
             datetime_param = f"{date_from}/{date_to}" if date_from and date_to else None
@@ -70,13 +74,62 @@ class StacClientPrimitive:
                     band_mapping = bands_needed
 
                 def _read_bands():
+                    import math
                     import rasterio
+                    from rasterio.crs import CRS
                     from rasterio.enums import Resampling
+                    from rasterio.warp import transform_bounds
+                    from rasterio.windows import Window, from_bounds
                     from app.lib.geo_analysis.raster_math import rasterio_env
 
                     bands_dict: Dict[str, np.ndarray] = {}
                     cell_size_m = None
                     cell_size_x_m = None
+                    data_bounds = None  # 实际读取窗口的地理范围 [w,s,e,n] (WGS84)
+                    first_crs = None
+
+                    def _crop_window(ds):
+                        """请求 bbox ∩ 影像足迹 -> 像素窗口 (在影像 CRS 中)。
+
+                        #381: 旧实现整景读取 (仅 out_shape 抽稀)，却把请求 AOI
+                        的 bbox 贴到整 tile 数组上 —— 统计描述整个景幅、渲染的
+                        栅格叠加被挤压/位移到错误 footprint。bbox 是 WGS84，
+                        影像可能是投影 CRS (Sentinel-2 L2A 为 UTM)，先把 bbox
+                        变换到影像 CRS 求交，再 snap 到像素网格并裁剪到景幅。
+                        """
+                        xmin, ymin, xmax, ymax = bbox
+                        if ds.crs is not None:
+                            try:
+                                xmin, ymin, xmax, ymax = transform_bounds(
+                                    CRS.from_epsg(4326), ds.crs,
+                                    bbox[0], bbox[1], bbox[2], bbox[3],
+                                    densify_pts=21,
+                                )
+                            except Exception:
+                                logger.warning(
+                                    f"无法将 bbox 变换到影像 CRS {ds.crs}，按同 CRS 处理")
+                        left = max(xmin, ds.bounds.left)
+                        bottom = max(ymin, ds.bounds.bottom)
+                        right = min(xmax, ds.bounds.right)
+                        top = min(ymax, ds.bounds.top)
+                        if left >= right or bottom >= top:
+                            raise ValueError(
+                                f"bbox {bbox} 与影像 {item.id} 足迹无重叠，无法裁剪")
+                        win = from_bounds(left, bottom, right, top, ds.transform)
+                        # offsets 向下取整、长度向上取整：保证窗口覆盖 bbox。
+                        # 加浮点容差 (亚像元) 避免 (x - origin)/px 的二进制舍入
+                        # 噪声把恰好落在像素边界的 bbox 扩出 1 像素。
+                        snap_eps = 1e-9
+                        win = Window(math.floor(win.col_off + snap_eps),
+                                     math.floor(win.row_off + snap_eps),
+                                     math.ceil(win.width - snap_eps),
+                                     math.ceil(win.height - snap_eps))
+                        win = win.intersection(Window(0, 0, ds.width, ds.height))
+                        if win.width <= 0 or win.height <= 0:
+                            raise ValueError(
+                                f"bbox {bbox} 与影像 {item.id} 无重叠像素，无法裁剪")
+                        return win
+
                     with rasterio_env():
                         for name, asset_key in band_mapping.items():
                             if asset_key not in item.assets:
@@ -84,47 +137,73 @@ class StacClientPrimitive:
                                 continue
                             href = item.assets[asset_key].href
                             with rasterio.open(href) as ds:
-                                out_h = max(1, ds.height // ds_factor)
-                                out_w = max(1, ds.width // ds_factor)
+                                if ds.crs is not None:
+                                    crs_s = ds.crs.to_string()
+                                    if first_crs is None:
+                                        first_crs = crs_s
+                                    elif crs_s != first_crs:
+                                        # 同景各波段应同 CRS；不同时按各自窗口读取
+                                        logger.warning(
+                                            f"Band '{name}' CRS {crs_s} 与首波段 "
+                                            f"{first_crs} 不同，按各自窗口读取")
+                                win = _crop_window(ds)
+                                out_h = max(1, int(win.height) // ds_factor)
+                                out_w = max(1, int(win.width) // ds_factor)
                                 data = ds.read(
                                     1,
+                                    window=win,
                                     out_shape=(out_h, out_w),
                                     resampling=Resampling.bilinear,
                                 ).astype(float)
                                 bands_dict[name] = data
-                                # Effective pixel size after downsampling, in
-                                # metres (R-F02): terrain derivatives
-                                # (compute_slope/hillshade) need the *actual*
-                                # pixel size of the array they receive. The
-                                # previous code always passed 30 m even though
-                                # the DEM is read at ds_factor=2 (~60 m),
-                                # overstating slopes ~2x. Geographic DEMs report
-                                # pixel size in degrees -> convert at the
-                                # equator rate (~111320 m/deg, matching the
-                                # Copernicus GLO-30 "30 m" label convention).
+                                if data_bounds is None:
+                                    # 输出网格足迹 = 窗口 transform 按
+                                    # out_shape 比例缩放后的外边界 (非请求 bbox)。
+                                    wt = ds.window_transform(win)
+                                    raw_bounds = [
+                                        wt.c, wt.f + wt.e * win.height,
+                                        wt.c + wt.a * win.width, wt.f,
+                                    ]
+                                    if ds.crs is not None and not ds.crs.is_geographic:
+                                        raw_bounds = transform_bounds(
+                                            ds.crs, CRS.from_epsg(4326),
+                                            *raw_bounds, densify_pts=21)
+                                    data_bounds = [float(v) for v in raw_bounds]
+                                # Effective pixel size after windowed
+                                # downsampling, in metres (R-F02): terrain
+                                # derivatives (compute_slope/hillshade) need
+                                # the *actual* pixel size of the array they
+                                # receive (window width / out_w, not ds_factor
+                                # outright, so flooring of out_shape stays
+                                # exact). Geographic DEMs report pixel size in
+                                # degrees -> convert at the equator rate
+                                # (~111320 m/deg, matching the Copernicus
+                                # GLO-30 "30 m" label convention).
                                 if cell_size_m is None and ds.transform.a:
-                                    px = abs(ds.transform.a) * ds_factor
+                                    px_y = abs(ds.transform.e) * (win.height / out_h)
+                                    px_x = abs(ds.transform.a) * (win.width / out_w)
                                     if ds.crs is not None and ds.crs.is_geographic:
-                                        # #379: 地理 CRS 下经度向的地面尺寸随
-                                        # cos(lat) 收缩 —— 赤道比例 (~111320
-                                        # m/deg) 会把东西向坡度低估 ~cos(lat)。
-                                        # 用 AOI 中心纬度校正 x 方向；y (经线)
-                                        # 方向不受影响。投影 CRS 两方向同为米，
-                                        # 不设置 cell_size_x_m (派生函数回退
-                                        # cell_size，行为不变)。
-                                        lat = (bbox[1] + bbox[3]) / 2.0
-                                        px *= 111320.0
-                                        cell_size_x_m = float(
-                                            px * abs(np.cos(np.radians(lat))))
-                                    cell_size_m = float(px)
-                    return bands_dict, cell_size_m, cell_size_x_m
+                                        # #379: 地理 CRS 下经度向地面尺寸随
+                                        # cos(lat) 收缩 —— 赤道比例会把东西向
+                                        # 坡度低估 ~cos(lat)；用读取窗口中心
+                                        # 纬度校正 x 方向，y (经线) 不受影响。
+                                        # 投影 CRS 两方向同为米，不设置
+                                        # cell_size_x_m (派生函数回退 cell_size)。
+                                        lat = (data_bounds[1] + data_bounds[3]) / 2.0
+                                        px_y *= 111320.0
+                                        px_x *= 111320.0 * abs(np.cos(np.radians(lat)))
+                                        cell_size_x_m = float(px_x)
+                                    cell_size_m = float(px_y)
+                    return bands_dict, cell_size_m, cell_size_x_m, data_bounds
 
-            bands_dict, cell_size_m, cell_size_x_m = await asyncio.to_thread(_read_bands)
+            bands_dict, cell_size_m, cell_size_x_m, data_bounds = await asyncio.to_thread(_read_bands)
             result["bands"] = bands_dict
             if cell_size_m is not None:
                 result["cell_size_m"] = cell_size_m
             if cell_size_x_m is not None:
                 result["cell_size_x_m"] = cell_size_x_m
+            if data_bounds is not None:
+                result["bounds"] = data_bounds
 
             return result
         except Exception as e:

--- a/tests/unit/test_stac_windowed_read.py
+++ b/tests/unit/test_stac_windowed_read.py
@@ -1,0 +1,266 @@
+"""Issue #381 regression tests: STAC band reads must be cropped to the
+request AOI (bbox ∩ item footprint) instead of reading the whole scene tile
+and slapping the request bbox onto the full array.
+
+Verified: the returned bands cover only the AOI window, the reported bounds
+describe the actual data extent (not the request bbox), NDVI computed from
+the windowed bands matches a manual window read, and results flow the real
+footprint through SpectralRasterEngine.
+"""
+import numpy as np
+import pytest
+
+from app.services.rs.band_math import compute_index_array
+
+# Synthetic scene: 100 x 80 cells, 0.001 deg pixels, EPSG:4326.
+_WEST, _NORTH, _PX = 10.0, 60.0, 0.001
+_SCENE_WIDTH, _SCENE_HEIGHT = 100, 80
+_SCENE_BOUNDS = [_WEST, _NORTH - _PX * _SCENE_HEIGHT,
+                 _WEST + _PX * _SCENE_WIDTH, _NORTH]
+
+
+def _write_scene(path, values):
+    import rasterio
+    from rasterio.transform import from_origin
+    transform = from_origin(_WEST, _NORTH, _PX, _PX)
+    with rasterio.open(
+        str(path), "w", driver="GTiff", height=_SCENE_HEIGHT, width=_SCENE_WIDTH,
+        count=1, dtype="float64", crs="EPSG:4326", transform=transform,
+    ) as dst:
+        dst.write(values, 1)
+
+
+class _FakeAsset:
+    def __init__(self, href: str):
+        self.href = href
+
+
+class _FakeItem:
+    def __init__(self, item_id: str, bbox, hrefs):
+        self.id = item_id
+        self.bbox = list(bbox)
+        self.assets = {key: _FakeAsset(href) for key, href in hrefs.items()}
+
+
+class _FakeSearch:
+    def __init__(self, items):
+        self._items = items
+
+    def items(self):
+        return self._items
+
+
+class _FakeCatalog:
+    def __init__(self, items):
+        self._items = items
+
+    def search(self, **kwargs):
+        return _FakeSearch(self._items)
+
+
+def _fake_band_values(seed: int) -> np.ndarray:
+    """Spatially varying band so a windowed mean is a discriminating check."""
+    rng = np.random.default_rng(seed)
+    return 100.0 + rng.random((_SCENE_HEIGHT, _SCENE_WIDTH)) * 2000.0
+
+
+@pytest.fixture
+def scene(tmp_path):
+    red_path = tmp_path / "red.tif"
+    nir_path = tmp_path / "nir.tif"
+    red = _fake_band_values(7)
+    nir = _fake_band_values(11)
+    _write_scene(red_path, red)
+    _write_scene(nir_path, nir)
+    return red, nir, red_path, nir_path
+
+
+def _fetch(monkeypatch, item, bbox, bands_needed, ds_factor=1):
+    from app.services.rs.stac_client import StacClientPrimitive, stac_primitive
+    monkeypatch.setattr(StacClientPrimitive, "_get_catalog",
+                        lambda self: _FakeCatalog([item]))
+    import asyncio
+    return asyncio.run(stac_primitive.fetch_stac_items_and_bands(
+        collection="sentinel-2-l2a", bbox=bbox,
+        bands_needed=bands_needed, ds_factor=ds_factor,
+    ))
+
+
+def test_windowed_read_crops_to_aoi_and_reports_data_bounds(monkeypatch, scene, tmp_path):
+    """#381 acceptance: a small AOI must yield the AOI-sized window (not the
+    full scene tile), and result bounds must be the actual data extent —
+    here the bbox pokes outside the scene, so bounds == bbox ∩ scene."""
+    red, nir, red_path, nir_path = scene
+    item = _FakeItem("s2-item", _SCENE_BOUNDS, {"red": str(red_path), "nir": str(nir_path)})
+
+    # AOI extends beyond the scene on the east and south edges.
+    bbox = [10.08, 59.90, 10.15, 60.005]
+    res = _fetch(monkeypatch, item, bbox, {"red": "red", "nir": "nir"}, ds_factor=1)
+    assert "error" not in res, res.get("error")
+
+    # Window expected by hand: col 80..100, row 0..80 of the 100x80 scene.
+    assert res["bands"]["red"].shape == (_SCENE_HEIGHT, 20)
+    assert res["bands"]["nir"].shape == (_SCENE_HEIGHT, 20)
+    # Bounds describe the cropped data footprint, not the request bbox.
+    assert res["bounds"] == pytest.approx([10.08, 59.92, 10.1, 60.0], abs=1e-9)
+
+
+def test_windowed_ndvi_matches_manual_window_read(monkeypatch, scene, tmp_path):
+    """#381 acceptance: NDVI over the small AOI equals the NDVI computed from
+    a manual windowed read of the same window (ds_factor=1 -> exact)."""
+    import rasterio
+    from rasterio.windows import Window
+    red, nir, red_path, nir_path = scene
+    item = _FakeItem("s2-item", _SCENE_BOUNDS, {"red": str(red_path), "nir": str(nir_path)})
+
+    bbox = [10.03, 59.96, 10.07, 59.99]  # pixel-aligned window col 30..70, row 10..40
+    res = _fetch(monkeypatch, item, bbox, {"red": "red", "nir": "nir"}, ds_factor=1)
+    assert "error" not in res, res.get("error")
+
+    with rasterio.open(str(red_path)) as ds:
+        r_win = ds.read(1, window=Window(30, 10, 40, 30))
+    with rasterio.open(str(nir_path)) as ds:
+        n_win = ds.read(1, window=Window(30, 10, 40, 30))
+
+    assert res["bands"]["red"].shape == (30, 40)
+    np.testing.assert_array_equal(res["bands"]["red"], r_win)
+    np.testing.assert_array_equal(res["bands"]["nir"], n_win)
+
+    ndvi_stac = compute_index_array("ndvi", red=res["bands"]["red"], nir=res["bands"]["nir"])
+    ndvi_manual = compute_index_array("ndvi", red=r_win, nir=n_win)
+    np.testing.assert_array_equal(ndvi_stac, ndvi_manual)
+    assert float(np.nanmean(ndvi_stac)) == pytest.approx(float(np.nanmean(ndvi_manual)))
+
+
+def test_windowed_read_downsampled_shape_and_bounds(monkeypatch, scene, tmp_path):
+    """out_shape thinning must apply within the window; bounds stay the
+    window's outer footprint."""
+    import rasterio
+    from rasterio.windows import Window
+    red, nir, red_path, nir_path = scene
+    item = _FakeItem("s2-item", _SCENE_BOUNDS, {"red": str(red_path), "nir": str(nir_path)})
+
+    bbox = [10.03, 59.96, 10.07, 59.99]
+    res = _fetch(monkeypatch, item, bbox, {"red": "red", "nir": "nir"}, ds_factor=2)
+    assert "error" not in res, res.get("error")
+    # window 40x30 at ds_factor=2 -> 20x15
+    assert res["bands"]["red"].shape == (15, 20)
+    assert res["bounds"] == pytest.approx([10.03, 59.96, 10.07, 59.99], abs=1e-9)
+
+
+def test_windowed_read_no_overlap_returns_error(monkeypatch, scene, tmp_path):
+    red, nir, red_path, nir_path = scene
+    item = _FakeItem("s2-item", _SCENE_BOUNDS, {"red": str(red_path), "nir": str(nir_path)})
+    res = _fetch(monkeypatch, item, [20.0, 30.0, 21.0, 31.0], {"red": "red"}, ds_factor=1)
+    assert "error" in res
+    assert "无重叠" in res["error"]
+
+
+def test_windowed_read_projected_crs_reprojects_bbox(monkeypatch, tmp_path):
+    """Sentinel-2 L2A COGs are UTM: the WGS84 request bbox must be
+    transformed into the raster CRS before windowing, and the reported
+    bounds converted back to WGS84."""
+    import math
+    import rasterio
+    from rasterio.crs import CRS
+    from rasterio.transform import from_origin
+    from rasterio.warp import transform_bounds
+    from rasterio.windows import Window, from_bounds
+
+    path = tmp_path / "utm_band.tif"
+    width, height, px = 100, 80, 30.0
+    transform = from_origin(500000.0, 6640000.0, px, px)
+    rng = np.random.default_rng(3)
+    data = 100.0 + rng.random((height, width)) * 2000.0
+    with rasterio.open(
+        str(path), "w", driver="GTiff", height=height, width=width,
+        count=1, dtype="float64", crs="EPSG:32633", transform=transform,
+    ) as dst:
+        dst.write(data, 1)
+
+    # WGS84 bbox around a mid-scene UTM window.
+    wgs_bbox = list(transform_bounds(
+        CRS.from_epsg(32633), CRS.from_epsg(4326),
+        500000 + 30 * px, 6640000 - 40 * px, 500000 + 70 * px, 6640000 - 10 * px,
+    ))
+    item = _FakeItem("utm-item", wgs_bbox, {"red": str(path), "nir": str(path)})
+    res = _fetch(monkeypatch, item, wgs_bbox, {"red": "red", "nir": "nir"}, ds_factor=1)
+    assert "error" not in res, res.get("error")
+
+    # Expected window derived from the same reprojection primitives
+    # (transform_bounds -> from_bounds -> snap -> clip), read manually.
+    with rasterio.open(str(path)) as ds:
+        xmin, ymin, xmax, ymax = transform_bounds(
+            CRS.from_epsg(4326), ds.crs, *wgs_bbox, densify_pts=21)
+        win = from_bounds(xmin, ymin, xmax, ymax, ds.transform)
+        snap_eps = 1e-9
+        win = Window(math.floor(win.col_off + snap_eps),
+                     math.floor(win.row_off + snap_eps),
+                     math.ceil(win.width - snap_eps),
+                     math.ceil(win.height - snap_eps))
+        win = win.intersection(Window(0, 0, ds.width, ds.height))
+        r_win = ds.read(1, window=win)
+    # The reprojected bbox may expand the ideal window by at most ~1 px;
+    # it must never crop inside the originally requested UTM rect
+    # (col 30..70, row 10..40).
+    assert win.col_off <= 30 and win.row_off <= 10
+    assert win.col_off + win.width >= 70 and win.row_off + win.height >= 40
+    assert res["bands"]["red"].shape == (int(win.height), int(win.width))
+    np.testing.assert_array_equal(res["bands"]["red"], r_win)
+    # Reported bounds are WGS84 and land on the request bbox; the snapped
+    # window may expand the ideal rect by at most ~1 pixel (30 m ≈ 5.4e-4
+    # deg at lat 60) to guarantee full bbox coverage.
+    assert res["bounds"] == pytest.approx(wgs_bbox, abs=6e-4)
+
+
+# ─── SpectralRasterEngine: bounds flow from the actual data footprint ────
+
+
+@pytest.mark.asyncio
+async def test_engine_compute_index_uses_data_bounds(monkeypatch):
+    from app.services.rs.spectral_engine import SpectralRasterEngine
+    engine = SpectralRasterEngine()
+    data_bounds = [10.08, 59.92, 10.1, 60.0]
+
+    async def fake_fetch(**kwargs):
+        return {
+            "bands": {"red": np.full((2, 2), 0.2), "nir": np.full((2, 2), 0.6)},
+            "bounds": data_bounds,
+        }
+
+    monkeypatch.setattr(engine.stac, "fetch_stac_items_and_bands", fake_fetch)
+    res = await engine.compute_index([10.0, 59.9, 10.2, 60.1], "2024-01-01", "2024-01-02", "ndvi")
+    assert res.is_error is False
+    assert res.bounds == data_bounds  # 数据实际范围，而非请求 bbox
+
+
+@pytest.mark.asyncio
+async def test_engine_compute_index_falls_back_to_request_bbox(monkeypatch):
+    """Stac responses without a bounds key (no bands read) keep legacy bbox."""
+    from app.services.rs.spectral_engine import SpectralRasterEngine
+    engine = SpectralRasterEngine()
+    bbox = [10.0, 59.9, 10.2, 60.1]
+
+    async def fake_fetch(**kwargs):
+        return {"bands": {"red": np.full((2, 2), 0.2), "nir": np.full((2, 2), 0.6)}}
+
+    monkeypatch.setattr(engine.stac, "fetch_stac_items_and_bands", fake_fetch)
+    res = await engine.compute_index(bbox, "2024-01-01", "2024-01-02", "ndvi")
+    assert res.is_error is False
+    assert res.bounds == bbox
+
+
+@pytest.mark.asyncio
+async def test_engine_compute_terrain_uses_data_bounds(monkeypatch):
+    from app.services.rs.spectral_engine import SpectralRasterEngine
+    engine = SpectralRasterEngine()
+    data_bounds = [10.08, 59.92, 10.1, 60.0]
+
+    async def fake_fetch(**kwargs):
+        return {"bands": {"dem": np.zeros((4, 4))}, "cell_size_m": 30.0,
+                "bounds": data_bounds}
+
+    monkeypatch.setattr(engine.stac, "fetch_stac_items_and_bands", fake_fetch)
+    res = await engine.compute_terrain([10.0, 59.9, 10.2, 60.1], products=["slope"])
+    assert res.is_error is False
+    assert res.bounds == data_bounds

--- a/tests/unit/test_stac_windowed_read.py
+++ b/tests/unit/test_stac_windowed_read.py
@@ -135,8 +135,6 @@ def test_windowed_ndvi_matches_manual_window_read(monkeypatch, scene, tmp_path):
 def test_windowed_read_downsampled_shape_and_bounds(monkeypatch, scene, tmp_path):
     """out_shape thinning must apply within the window; bounds stay the
     window's outer footprint."""
-    import rasterio
-    from rasterio.windows import Window
     red, nir, red_path, nir_path = scene
     item = _FakeItem("s2-item", _SCENE_BOUNDS, {"red": str(red_path), "nir": str(nir_path)})
 

--- a/tests/unit/test_terrain_compass.py
+++ b/tests/unit/test_terrain_compass.py
@@ -155,8 +155,9 @@ def _write_dem(path, west, north, size_deg, height, width, crs="EPSG:4326"):
 @pytest.mark.asyncio
 async def test_stac_cell_size_applies_cos_lat_to_east_west(monkeypatch, tmp_path):
     """#379: at the STAC read site, a geographic DEM's x cell size must be
-    corrected by cos(lat) (AOI center latitude) — otherwise east-west slopes
-    are underestimated ~cos(lat). The y (meridian) cell size is unchanged."""
+    corrected by cos(lat) (read-window center latitude) — otherwise
+    east-west slopes are underestimated ~cos(lat). The y (meridian) cell
+    size is unchanged."""
     from app.services.rs.stac_client import StacClientPrimitive, stac_primitive
 
     dem_path = tmp_path / "dem.tif"
@@ -171,8 +172,10 @@ async def test_stac_cell_size_applies_cos_lat_to_east_west(monkeypatch, tmp_path
         bands_needed={"dem": "data"},
         ds_factor=1,
     )
-    assert "error" not in res
-    assert res["bands"]["dem"].shape == (20, 20)
+    assert "error" not in res, res.get("error")
+    # #381: 只读 bbox ∩ 影像足迹的窗口 (col 13..17, row 9..13 of the 20x20 tile)。
+    assert res["bands"]["dem"].shape == (4, 4)
+    assert res["bounds"] == pytest.approx([10.003, 59.997, 10.007, 60.001], abs=1e-9)
     assert res["cell_size_m"] == pytest.approx(0.001 * 111320.0, rel=1e-9)
     lat = (59.997 + 60.001) / 2.0
     assert res["cell_size_x_m"] == pytest.approx(
@@ -183,6 +186,8 @@ async def test_stac_cell_size_applies_cos_lat_to_east_west(monkeypatch, tmp_path
 async def test_stac_projected_dem_has_no_cos_lat_correction(monkeypatch, tmp_path):
     """Projected (UTM) DEMs are already in metres on both axes — no x
     correction and no cell_size_x_m key."""
+    from rasterio.crs import CRS
+    from rasterio.warp import transform_bounds
     from app.services.rs.stac_client import StacClientPrimitive, stac_primitive
 
     dem_path = tmp_path / "dem_utm.tif"
@@ -192,12 +197,16 @@ async def test_stac_projected_dem_has_no_cos_lat_correction(monkeypatch, tmp_pat
     monkeypatch.setattr(StacClientPrimitive, "_get_catalog",
                         lambda self: _FakeCatalog([item]))
 
+    # WGS84 bbox covering the UTM scene footprint.
+    wgs_bbox = list(transform_bounds(
+        CRS.from_epsg(32633), CRS.from_epsg(4326),
+        500000.0, 6639700.0, 500300.0, 6640000.0))
     res = await stac_primitive.fetch_stac_items_and_bands(
         collection="cop-dem-glo-30",
-        bbox=[10.0, 59.9, 10.1, 60.0],
+        bbox=wgs_bbox,
         bands_needed={"dem": "data"},
         ds_factor=1,
     )
-    assert "error" not in res
+    assert "error" not in res, res.get("error")
     assert res["cell_size_m"] == pytest.approx(30.0)
     assert "cell_size_x_m" not in res

--- a/tests/unit/test_terrain_compass.py
+++ b/tests/unit/test_terrain_compass.py
@@ -1,0 +1,203 @@
+"""Issue #379 regression tests: compass-convention aspect/hillshade and
+cos(lat)-corrected east-west DEM cell size.
+
+Aspect must be the downhill azimuth measured clockwise from north (0-360°),
+and hillshade must illuminate the hemisphere facing the configured sun
+azimuth (previously the mixed convention rotated the light ~90°). Geographic
+DEM cell sizes must shrink in x by cos(lat) so east-west slopes are not
+underestimated.
+"""
+import math
+
+import numpy as np
+import pytest
+
+from app.services.rs.band_math import compute_aspect, compute_hillshade, compute_slope
+
+CELL = 30.0
+
+
+def _rising_plane(direction: str, n: int = 16, slope_deg: float = 45.0) -> np.ndarray:
+    """Synthetic plane (row 0 = north, col 0 = west) whose elevation rises
+    toward ``direction`` ('e'/'n'/'s'/'w') at ``slope_deg`` from horizontal.
+    Cell size 30 m, so the per-cell elevation step is 30·tan(slope)."""
+    step = CELL * math.tan(math.radians(slope_deg))
+    coords = np.arange(n) * step
+    east = np.tile(coords, (n, 1)).astype(float)           # z grows with col
+    west = np.tile(coords[::-1], (n, 1)).astype(float)     # z shrinks with col
+    north = np.tile(coords[::-1], (n, 1)).T.astype(float)  # z shrinks with row (row 0 = north)
+    south = np.tile(coords, (n, 1)).T.astype(float)        # z grows with row
+    return {"e": east, "w": west, "n": north, "s": south}[direction]
+
+
+def test_aspect_is_compass_clockwise_from_north():
+    """#379: downhill aspect must be compass, clockwise from north:
+    east-rising -> 270 (downhill W), north-rising -> 180 (downhill S),
+    south-rising -> 0 (downhill N), west-rising -> 90 (downhill E).
+    The old arctan2(-dzdy, dzdx) returned the math angle (0/90/270/180)."""
+    expected = {"e": 270.0, "n": 180.0, "s": 0.0, "w": 90.0}
+    for direction, want in expected.items():
+        aspect = compute_aspect(_rising_plane(direction), CELL)
+        interior = aspect[1:-1, 1:-1]
+        assert np.all(np.isfinite(interior)), direction
+        assert float(interior.mean()) == pytest.approx(want, abs=1e-6), direction
+        assert np.abs(interior - want).max() < 1e-6, direction
+
+
+def test_aspect_flat_is_nan():
+    aspect = compute_aspect(np.full((9, 9), 1234.0), CELL)
+    assert np.all(np.isnan(aspect))
+
+
+def _expected_hillshade(aspect_deg: float, azimuth: float = 315.0,
+                        altitude: float = 45.0) -> float:
+    """Closed-form illumination of a 45° plane for the fixed compass model:
+    255·(sin(alt)cos(θ) + cos(alt)sin(θ)cos(az - aspect))."""
+    return 255.0 * (
+        math.sin(math.radians(altitude)) * math.cos(math.radians(45.0))
+        + math.cos(math.radians(altitude)) * math.sin(math.radians(45.0))
+        * math.cos(math.radians(azimuth - aspect_deg))
+    )
+
+
+def test_hillshade_illumination_hemispheres():
+    """#379 acceptance: with the sun at 315° (NW), the north-facing slope is
+    the bright hemisphere (~218) and the south-facing slope the dark one
+    (~37). The old mirrored convention returned ~37 for the north-facing
+    slope (light rotated ~90°)."""
+    # South-rising plane -> downhill aspect 0° (north-facing slope).
+    hs = compute_hillshade(_rising_plane("s"), CELL, azimuth=315, altitude=45)
+    assert float(hs[1:-1, 1:-1].mean()) == pytest.approx(218.0, abs=0.5)
+    # North-rising plane -> aspect 180° (south-facing slope).
+    hs = compute_hillshade(_rising_plane("n"), CELL, azimuth=315, altitude=45)
+    assert float(hs[1:-1, 1:-1].mean()) == pytest.approx(37.0, abs=0.5)
+
+
+def test_hillshade_matches_closed_form_compass_model():
+    """#379: hillshade equals the closed-form compass illumination for every
+    cardinal plane and both sun azimuths (315° NW and 45° NE) — no mirroring,
+    no rotation of the light source."""
+    aspects = {"e": 270.0, "n": 180.0, "s": 0.0, "w": 90.0}
+    for direction, aspect_deg in aspects.items():
+        for azimuth in (315.0, 45.0):
+            hs = compute_hillshade(_rising_plane(direction), CELL,
+                                   azimuth=azimuth, altitude=45)
+            got = float(hs[1:-1, 1:-1].mean())
+            assert got == pytest.approx(_expected_hillshade(aspect_deg, azimuth),
+                                        abs=0.1), (direction, azimuth)
+
+
+def test_slope_plane_recovers_angle():
+    """Regression: the Horn slope kernel must keep recovering the true plane
+    angle (unchanged by the #379 convention fixes)."""
+    for slope_deg in (15.0, 30.0, 45.0):
+        dem = _rising_plane("e", slope_deg=slope_deg)
+        slope = compute_slope(dem, CELL)
+        assert float(slope[1:-1, 1:-1].mean()) == pytest.approx(slope_deg, abs=1e-6)
+
+
+def test_cell_size_x_doubles_east_west_gradient():
+    """#379 (cos(lat) fix): a half-size x cell doubles the x gradient, so an
+    east-west plane's slope rises to arctan(2·tan θ); the default (no
+    cell_size_x) keeps the legacy cell_size behavior."""
+    dem = _rising_plane("e", slope_deg=30.0)
+    want = math.degrees(math.atan(2 * math.tan(math.radians(30.0))))
+    slope = compute_slope(dem, CELL, cell_size_x=CELL / 2.0)
+    assert float(slope[1:-1, 1:-1].mean()) == pytest.approx(want, abs=1e-6)
+    # Legacy call shape: aspect direction unchanged, defaults preserved.
+    aspect = compute_aspect(dem, CELL)
+    assert float(aspect[1:-1, 1:-1].mean()) == pytest.approx(270.0, abs=1e-6)
+    assert float(compute_slope(dem, CELL)[1:-1, 1:-1].mean()) == pytest.approx(30.0, abs=1e-6)
+
+
+# ─── STAC read-site cell size: cos(lat) on the longitude axis ─────────────
+
+
+class _FakeAsset:
+    def __init__(self, href: str):
+        self.href = href
+
+
+class _FakeItem:
+    def __init__(self, item_id: str, bbox, hrefs):
+        self.id = item_id
+        self.bbox = list(bbox)
+        self.assets = {key: _FakeAsset(href) for key, href in hrefs.items()}
+
+
+class _FakeSearch:
+    def __init__(self, items):
+        self._items = items
+
+    def items(self):
+        return self._items
+
+
+class _FakeCatalog:
+    def __init__(self, items):
+        self._items = items
+
+    def search(self, **kwargs):
+        return _FakeSearch(self._items)
+
+
+def _write_dem(path, west, north, size_deg, height, width, crs="EPSG:4326"):
+    import rasterio
+    from rasterio.transform import from_origin
+    transform = from_origin(west, north, size_deg, size_deg)
+    with rasterio.open(
+        str(path), "w", driver="GTiff", height=height, width=width,
+        count=1, dtype="float64", crs=crs, transform=transform,
+    ) as dst:
+        dst.write(np.zeros((height, width), dtype=np.float64), 1)
+
+
+@pytest.mark.asyncio
+async def test_stac_cell_size_applies_cos_lat_to_east_west(monkeypatch, tmp_path):
+    """#379: at the STAC read site, a geographic DEM's x cell size must be
+    corrected by cos(lat) (AOI center latitude) — otherwise east-west slopes
+    are underestimated ~cos(lat). The y (meridian) cell size is unchanged."""
+    from app.services.rs.stac_client import StacClientPrimitive, stac_primitive
+
+    dem_path = tmp_path / "dem.tif"
+    _write_dem(dem_path, west=9.99, north=60.01, size_deg=0.001, height=20, width=20)
+    item = _FakeItem("dem-item", [10.0, 59.99, 10.02, 60.01], {"data": str(dem_path)})
+    monkeypatch.setattr(StacClientPrimitive, "_get_catalog",
+                        lambda self: _FakeCatalog([item]))
+
+    res = await stac_primitive.fetch_stac_items_and_bands(
+        collection="cop-dem-glo-30",
+        bbox=[10.003, 59.997, 10.007, 60.001],
+        bands_needed={"dem": "data"},
+        ds_factor=1,
+    )
+    assert "error" not in res
+    assert res["bands"]["dem"].shape == (20, 20)
+    assert res["cell_size_m"] == pytest.approx(0.001 * 111320.0, rel=1e-9)
+    lat = (59.997 + 60.001) / 2.0
+    assert res["cell_size_x_m"] == pytest.approx(
+        0.001 * 111320.0 * math.cos(math.radians(lat)), rel=1e-9)
+
+
+@pytest.mark.asyncio
+async def test_stac_projected_dem_has_no_cos_lat_correction(monkeypatch, tmp_path):
+    """Projected (UTM) DEMs are already in metres on both axes — no x
+    correction and no cell_size_x_m key."""
+    from app.services.rs.stac_client import StacClientPrimitive, stac_primitive
+
+    dem_path = tmp_path / "dem_utm.tif"
+    _write_dem(dem_path, west=500000.0, north=6640000.0, size_deg=30.0,
+               height=10, width=10, crs="EPSG:32633")
+    item = _FakeItem("dem-utm", [10.0, 59.9, 10.1, 60.0], {"data": str(dem_path)})
+    monkeypatch.setattr(StacClientPrimitive, "_get_catalog",
+                        lambda self: _FakeCatalog([item]))
+
+    res = await stac_primitive.fetch_stac_items_and_bands(
+        collection="cop-dem-glo-30",
+        bbox=[10.0, 59.9, 10.1, 60.0],
+        bands_needed={"dem": "data"},
+        ds_factor=1,
+    )
+    assert "error" not in res
+    assert res["cell_size_m"] == pytest.approx(30.0)
+    assert "cell_size_x_m" not in res


### PR DESCRIPTION
## Summary

Two P2 GIS-correctness issues in the remote-sensing module (`app/services/rs/`), fixed in two commits:

### Fixes #379 — `compute_aspect` returned math angles; `compute_hillshade` rotated the light ~90°; DEM x cell size ignored cos(lat)

- **`compute_aspect`** (`band_math.py`): `arctan2(-dzdy, dzdx)` returned the math angle (counter-clockwise from east) instead of the documented compass downhill azimuth (clockwise from north). East-rising terrain gave 0° (true 270°), north-rising gave 90° (true 180°). Switched to the ESRI-equivalent `degrees(atan2(-dzdx, dzdy)) % 360` — verified on synthetic planes: E/N/S/W rise → 270/180/0/90. Flat cells keep NaN.
- **`compute_hillshade`**: fed the wrong aspect into `cos(az_rad - aspect_rad)` and mirrored the sun with `radians(360 - azimuth)`, rotating the light ~90°. With the sun at 315°, the north-facing slope returned 37 (dark) instead of ~218 (bright). Now uses the compass aspect (radians) with the un-mirrored azimuth in the same clockwise-from-north frame; verified against the closed-form illumination for all four cardinal planes at 315°/45°.
- **DEM x cell size**: geographic DEMs report degrees; the longitude cell size was converted at the equator rate (~111320 m/deg), underestimating east-west slopes by ~cos(lat). `stac_client` now also emits `cell_size_x_m = cell_size_m · cos(center_lat)` for geographic CRS only, and `compute_slope`/`compute_aspect`/`compute_hillshade` accept an optional `cell_size_x` (default `None` keeps legacy behavior) applied to the dzdx terms only.

### Fixes #381 — full-scene-tile reads stamped with the request AOI bbox

`_read_bands` read every band as the whole scene tile (only `out_shape` thinning, no `Window`), and `spectral_engine` attached the request AOI bbox to the full-tile arrays: statistics described the entire ~110 km Sentinel-2/COP-DEM tile while the rendered overlay was squeezed/shifted onto the wrong footprint (a 10980² ÷ 4 tile also wasted ~60 MB float64 per band).

- Each band is now read from the window **bbox ∩ item footprint**: the WGS84 request bbox is transformed into the raster CRS (Sentinel-2 L2A COGs are UTM), intersected with the dataset bounds, snapped to the pixel grid (floor offsets / ceil lengths, with a float-noise epsilon so pixel-aligned bboxes stay exact) and clipped to the scene.
- `out_shape` thinning applies within the window; the effective pixel size uses the actual window/out_shape ratio (was nominal `ds_factor`).
- The reported `bounds` are the resampled window's outer footprint reprojected to WGS84; `spectral_engine` uses them for `RasterAnalysisResult.bounds` (stats, `emit_raster_layer` MapLibre image source, `compute_ndvi`/`compute_vegetation_index` payloads), falling back to the request bbox when no bands were read.
- Band CRSs are validated per item (warn on mismatch; windows computed per band).

## Tests

- `tests/unit/test_terrain_compass.py` (new): synthetic E/N/S/W rising planes (cell 30 m) → aspect 270/180/0/90; hillshade bright/dark hemispheres (sun 315°/45°, north-facing slope ≈218); flat → NaN; slope plane recovery unchanged; `cell_size_x` gradient doubling; STAC read-site cos(lat) correction (geographic vs UTM DEM), all offline with a fake catalog + local GeoTIFFs.
- `tests/unit/test_stac_windowed_read.py` (new): synthetic COG + small bbox — windowed NDVI equals a manual window read exactly; result bounds match the data extent (not the request bbox); downsampled shape/bounds; no-overlap → error; UTM reprojection round-trip; engine-level bounds flow for `compute_index`/`compute_terrain` (incl. legacy bbox fallback).

Ran: `tests/test_critical_backend_correctness.py` (INDEX_FORMULAS contract), `tests/unit/{test_terrain_compass,test_stac_windowed_read,test_rs_service_module,test_spectral_engine,test_execution_offload,test_raster_env,test_cloud_geospatial_adapters,test_data_fabric_adapters,test_raster_cartography_converter,test_raster_math_hardening,test_domain_c_raster}.py`, `tests/{test_audit_simple_fixes,test_raster_route,test_cartography_service}.py` — **115 passed**.