### PR TITLE
fix(mvt): geometry-aware cache byte budget and dataset-global raster tile normalization

### DIFF
--- a/app/services/mvt.py
+++ b/app/services/mvt.py
@@ -93,6 +93,19 @@ _IS_POINT = frozenset({"Point", "MultiPoint"})
 _IS_LINE = frozenset({"LineString", "MultiLineString"})
 _IS_POLY = frozenset({"Polygon", "MultiPolygon"})
 
+# ─── spatial index memory accounting (Issue #395) ────────────────────────────
+# Byte allowances used by build_spatial_index_entry's estimated_bytes. The old
+# flat heuristic (~350 B/feature) was only valid for points and simple
+# geometries; entries retain the raw feature dicts plus TWO shapely copies
+# (lon/lat and z0) of every geometry, and for complex polygons the Python
+# coordinate objects dominate (a 100k-vertex polygon is ~6-10 MB of Python
+# objects). Estimates are computed once at insert time — the cache LRU only
+# ever reads the resulting scalar, never re-estimates on get.
+_COORD_OBJ_BYTES = 64  # per counted vertex: ~2 Python floats (48 B) in the raw
+# dict + packed float64 storage (2 x 16 B) across the two shapely copies
+_FEATURE_OBJ_BYTES = 400  # feature/geometry/properties dict container overhead
+_GEOM_OBJ_BYTES = 256  # per shapely wrapper object (GEOS struct + Python), per copy
+
 # ─── optional shapely / numpy ───────────────────────────────────────────────
 try:  # pragma: no cover - exercised only in environments without shapely
     import numpy as np
@@ -1059,11 +1072,30 @@ def build_spatial_index_entry(key, data) -> SpatialIndexEntry:
         except Exception:  # pragma: no cover - defensive
             tree = None
 
-    # Calculate estimated memory footprint for size-aware cache budgeting
+    # Calculate estimated memory footprint for size-aware cache budgeting.
+    # Issue #395: the old per-feature constant (~350 B) under-counted complex
+    # polygons by 100x+ (a 100k-vertex polygon retains ~6-10 MB of Python
+    # coordinate objects + two shapely copies), so the byte LRU never actually
+    # capped memory. Estimate from the real payload instead: JSON structural
+    # bytes of the kept features (reusing the registry's walker) plus a
+    # per-vertex term counting BOTH retained shapely copies. Done once at
+    # insert time; the cache only stores the resulting scalar.
+    from app.tools.registry import _estimate_json_bytes  # local import: keep mvt's import graph light
+
+    vertex_count = 0
+    if _SHAPELY and geoms:
+        try:
+            vertex_count = int(shapely.get_num_coordinates(geoms).sum()) + int(
+                shapely.get_num_coordinates(geoms_lonlat).sum()
+            )
+        except Exception:  # pragma: no cover - defensive
+            vertex_count = 0
     est_bytes = (
-        len(kept) * 350
-        + len(geoms) * 200
-        + sum(200 for g in geoms_lonlat if g is not None)
+        _estimate_json_bytes(kept)
+        + vertex_count * _COORD_OBJ_BYTES
+        + len(kept) * _FEATURE_OBJ_BYTES
+        + len(geoms) * _GEOM_OBJ_BYTES
+        + len(geoms_lonlat) * _GEOM_OBJ_BYTES
         + len(bounds) * 80
         + 1024
     )

--- a/app/services/raster_tile_service.py
+++ b/app/services/raster_tile_service.py
@@ -47,16 +47,90 @@ _CRS_LESS_WARNED: "set[str]" = set()
 _CRS_LESS_WARNED_MAX = 4096
 
 
-def _normalize_channel(arr: np.ndarray, valid_mask: np.ndarray) -> np.ndarray:
-    """Normalize numeric array to 0-255 uint8 channel."""
+def _normalize_channel(
+    arr: np.ndarray,
+    valid_mask: np.ndarray,
+    vmin: Optional[float] = None,
+    vmax: Optional[float] = None,
+) -> np.ndarray:
+    """Normalize numeric array to 0-255 uint8 channel.
+
+    ``vmin``/``vmax`` are the dataset-global stretch bounds (see
+    ``_get_band_stats``); every tile of a raster shares them so adjacent
+    tiles render with one consistent stretch (no color seams). When omitted
+    (fallback), the per-tile min/max are used.
+    """
     if not valid_mask.any():
         return np.zeros_like(arr, dtype=np.uint8)
-    vmin, vmax = float(arr[valid_mask].min()), float(arr[valid_mask].max())
+    if vmin is None or vmax is None:
+        vmin = float(arr[valid_mask].min())
+        vmax = float(arr[valid_mask].max())
+    norm = np.zeros_like(arr, dtype=float)
     if vmax > vmin:
-        norm = np.clip((arr - vmin) / (vmax - vmin), 0.0, 1.0)
-    else:
-        norm = np.zeros_like(arr, dtype=float)
+        # Compute only over valid pixels: NaN/Inf in invalid positions must
+        # not propagate into the cast (callers replace invalid positions with
+        # 0 via np.where anyway).
+        norm[valid_mask] = np.clip((arr[valid_mask] - vmin) / (vmax - vmin), 0.0, 1.0)
     return (norm * 255).astype(np.uint8)
+
+
+# ─── per-raster global normalization stats (Issue #410) ─────────────────────
+# Per-tile min/max stretching gave adjacent tiles of the same raster
+# different stretches -> visible color seams at tile boundaries. Compute the
+# dataset-global (vmin, vmax) per band once per raster and reuse it for every
+# tile. Bounded LRU-ish dict; double-checked under a lock (worst case two
+# threads compute the same raster's stats concurrently, one wins — harmless).
+_STATS_CACHE: "Dict[str, Tuple[Tuple[float, float], ...]]" = {}
+_STATS_CACHE_LOCK = threading.Lock()
+_STATS_MAX_ENTRIES = 512
+# Longest-side cap for the decimated stats read: bounds the one-time cost even
+# for huge rasters. The approximation is fine — tiles need one CONSISTENT
+# stretch, not pixel-exact global extremes.
+_STATS_MAX_SIDE = 2048
+
+
+def _compute_band_stats(src, count: int) -> Tuple[Tuple[float, float], ...]:
+    """Dataset-wide (vmin, vmax) per band, skipping nodata/NaN pixels.
+
+    Reads the whole raster decimated to at most ``_STATS_MAX_SIDE`` pixels on
+    the longest side (masked=True so nodata never enters the min/max; NaN and
+    Inf values are additionally filtered — the NaN-nodata fix from #372 stays
+    intact because declared-nodata NaN is masked AND stray NaNs are skipped).
+    """
+    scale = min(1.0, _STATS_MAX_SIDE / float(max(src.width, src.height)))
+    out_shape = (
+        count,
+        max(1, int(round(src.height * scale))),
+        max(1, int(round(src.width * scale))),
+    )
+    data = src.read(indexes=tuple(range(1, count + 1)), out_shape=out_shape, masked=True)
+    arr = np.ma.getdata(data)
+    mask = np.ma.getmaskarray(data)
+    stats: "list[Tuple[float, float]]" = []
+    for b in range(count):
+        valid = np.isfinite(arr[b]) & ~mask[b]
+        if not valid.any():
+            stats.append((0.0, 0.0))
+            continue
+        stats.append((float(arr[b][valid].min()), float(arr[b][valid].max())))
+    return tuple(stats)
+
+
+def _get_band_stats(raster_path: str, src, count: int) -> Tuple[Tuple[float, float], ...]:
+    """Cached per-raster (vmin, vmax) per band (double-checked, lock-protected)."""
+    with _STATS_CACHE_LOCK:
+        stats = _STATS_CACHE.get(raster_path)
+    if stats is not None:
+        return stats
+    stats = _compute_band_stats(src, count)
+    with _STATS_CACHE_LOCK:
+        existing = _STATS_CACHE.get(raster_path)
+        if existing is not None:
+            return existing
+        if len(_STATS_CACHE) >= _STATS_MAX_ENTRIES:
+            _STATS_CACHE.clear()  # bounded working set; staleness is best-effort
+        _STATS_CACHE[raster_path] = stats
+    return stats
 
 
 _RASTER_TILE_CACHE: Dict[Tuple[str, int, int, int, int, str], bytes] = collections.OrderedDict()
@@ -135,10 +209,26 @@ def render_raster_tile(
                 _set_cached_tile(key, res)
                 return res
 
-            # Perform windowed read from source file (O(win_size) memory)
+            # Perform windowed read from source file (O(win_size) memory).
+            # Issue #410: read ONLY the bands we render (max 3) — the previous
+            # full-band read decoded every band of a >3-band raster (~2x waste).
             count = min(src.count, 3)
+            indexes = tuple(range(1, count + 1))
             win_transform = rasterio.windows.transform(win, src.transform)
-            win_data = src.read(window=win)
+            win_data = src.read(indexes=indexes, window=win)
+
+            # Dataset-global stretch bounds (per band) so adjacent tiles share
+            # one normalization instead of per-tile min/max (seam fix, #410).
+            try:
+                stats = _get_band_stats(raster_path, src, count)
+            except Exception:
+                logger.debug(
+                    "[raster_tile_service] global stats unavailable for %s, "
+                    "falling back to per-tile normalization",
+                    raster_path,
+                    exc_info=True,
+                )
+                stats = None
 
             # Destination array for reproject
             dst_data = np.zeros((count, tile_size, tile_size), dtype=src.dtypes[0])
@@ -166,7 +256,8 @@ def render_raster_tile(
                 for c in range(3):
                     arr = dst_data[c]
                     valid_mask = np.isfinite(arr) & (arr != nodata_val) if np.issubdtype(arr.dtype, np.floating) else (arr != nodata_val)
-                    rgb[:, :, c] = np.where(valid_mask, _normalize_channel(arr, valid_mask), 0)
+                    stretch = stats[c] if stats is not None else ()
+                    rgb[:, :, c] = np.where(valid_mask, _normalize_channel(arr, valid_mask, *stretch), 0)
 
                 band_valid = (dst_data != nodata_val)
                 if finite_any is not None:
@@ -184,7 +275,8 @@ def render_raster_tile(
                     _set_cached_tile(key, res)
                     return res
 
-                gray = _normalize_channel(arr, valid_mask)
+                stretch = stats[0] if stats is not None else ()
+                gray = _normalize_channel(arr, valid_mask, *stretch)
                 alpha = np.where(valid_mask, 255, 0).astype(np.uint8)
                 rgba = np.dstack([gray, gray, gray, alpha])
                 img = Image.fromarray(rgba, "RGBA")

--- a/tests/unit/test_mvt_cache_memory_pressure.py
+++ b/tests/unit/test_mvt_cache_memory_pressure.py
@@ -1,7 +1,10 @@
 """Unit tests for MVT cache memory pressure bounds, lifecycle invalidation, and concurrency contracts."""
 
 import asyncio
+import math
+
 import pytest
+import shapely
 
 from app.services.mvt import (
     SingleFlightManager,
@@ -55,6 +58,76 @@ def test_spatial_index_cache_byte_budget_eviction():
     assert cache.total_bytes <= cache._max_bytes
     assert cache.get(("s1", "r3")) is not None
     assert cache.get(("s1", "r1")) is None  # r1 was evicted to enforce byte budget
+
+
+def _complex_polygon_fc(n_vertices: int) -> dict:
+    """Single-feature FC whose polygon ring has n_vertices distinct points.
+
+    A closed ring (first == last point per GeoJSON) holds n_vertices + 1
+    coordinates inside shapely; the ring is a regular polygon (no
+    self-intersections) around (116.0, 39.0).
+    """
+    ring = [
+        [
+            116.0 + 0.01 * math.cos(2 * math.pi * i / n_vertices),
+            39.0 + 0.01 * math.sin(2 * math.pi * i / n_vertices),
+        ]
+        for i in range(n_vertices)
+    ]
+    ring.append(ring[0])
+    return {
+        "type": "FeatureCollection",
+        "features": [{
+            "type": "Feature",
+            "geometry": {"type": "Polygon", "coordinates": [ring]},
+            "properties": {"id": 0, "name": "complex"},
+        }],
+    }
+
+
+def test_spatial_index_entry_estimate_scales_with_geometry_vertices():
+    """Issue #395: estimated_bytes reflects the real coordinate count, not a flat ~350 B/feature."""
+    n_vertices = 50_000
+    entry = build_spatial_index_entry(("s1", "r1"), _complex_polygon_fc(n_vertices))
+    assert len(entry.features) == 1
+
+    # Both retained shapely copies (lon/lat and z0) count the closed ring with
+    # its duplicated closing point: 2 x (n_vertices + 1) coordinates.
+    coords = int(shapely.get_num_coordinates(entry.geoms[0])) + int(
+        shapely.get_num_coordinates(entry.geoms_lonlat[0])
+    )
+    assert coords >= 2 * n_vertices
+
+    # The old heuristic charged this entry 1*350 + 2*200 + 80 + 1024 ≈ 1.8 KB
+    # (never evicted, yet real Python objects are ~6-10 MB per 100k vertices).
+    # The new estimate is coordinate-count-driven: at least ~50 B per real
+    # vertex, and within the same order of magnitude as the measured footprint.
+    assert entry.estimated_bytes >= coords * 50
+    assert entry.estimated_bytes >= 2 * 1024 * 1024  # MBs, not KBs
+    assert entry.estimated_bytes <= coords * 400  # sanity: not a 100x overcount
+    assert entry.estimated_bytes > 100_000
+
+
+def test_spatial_index_cache_byte_budget_evicts_complex_geometry():
+    """Issue #395: complex polygons are charged their true footprint, so the
+    byte budget actually evicts them (the 350 B/feature heuristic let a single
+    complex ref exceed the whole 256 MB cap 100x+)."""
+    fc = _complex_polygon_fc(50_000)
+
+    # One 50k-vertex entry alone costs ~8 MB; a 1 MB budget must not retain it.
+    cache = SpatialIndexCache(max_refs=100, max_bytes=1024 * 1024)
+    entry = cache.get_or_build(("s1", "r1"), lambda: build_spatial_index_entry(("s1", "r1"), fc))
+    assert entry.estimated_bytes > cache._max_bytes
+    assert cache.get(("s1", "r1")) is None  # evicted immediately
+    assert cache.total_bytes == 0
+
+    # Two entries under a 12 MB budget: second insert evicts the oldest LRU.
+    cache2 = SpatialIndexCache(max_refs=100, max_bytes=12 * 1024 * 1024)
+    cache2.get_or_build(("s1", "r1"), lambda: build_spatial_index_entry(("s1", "r1"), fc))
+    cache2.get_or_build(("s1", "r2"), lambda: build_spatial_index_entry(("s1", "r2"), fc))
+    assert cache2.total_bytes <= cache2._max_bytes
+    assert cache2.get(("s1", "r2")) is not None
+    assert cache2.get(("s1", "r1")) is None  # oldest evicted to stay in budget
 
 
 def test_spatial_index_cache_invalidate_ref_and_session():

--- a/tests/unit/test_raster_tile_service.py
+++ b/tests/unit/test_raster_tile_service.py
@@ -3,7 +3,6 @@ import io
 import os
 import tempfile
 import numpy as np
-import pytest
 import rasterio
 from rasterio.transform import from_bounds
 from PIL import Image

--- a/tests/unit/test_raster_tile_service.py
+++ b/tests/unit/test_raster_tile_service.py
@@ -1,7 +1,9 @@
 """Unit tests for raster tile streaming service (app/services/raster_tile_service.py)."""
+import io
 import os
 import tempfile
 import numpy as np
+import pytest
 import rasterio
 from rasterio.transform import from_bounds
 from PIL import Image
@@ -9,6 +11,7 @@ from PIL import Image
 from app.services.raster_tile_service import (
     tile_bounds_3857,
     _transparent_tile_png,
+    _normalize_channel,
     render_raster_tile,
 )
 
@@ -67,3 +70,155 @@ def test_render_raster_tile_synthetic_geotiff():
         assert img.mode == "RGBA"
     finally:
         os.unlink(path)
+
+
+def _write_dual_region_tiff(path: str) -> None:
+    """200x200 float32 GeoTIFF: left half 0, right half 1000, nodata top rows,
+    one stray NaN pixel inside the left half."""
+    width = height = 200
+    data = np.zeros((1, height, width), dtype=np.float32)
+    data[0, :, width // 2:] = 1000.0
+    data[0, :5, :] = -9999.0  # declared nodata
+    data[0, 20, 20] = np.nan  # NaN that is NOT the declared nodata
+    transform = from_bounds(116.0, 39.0, 117.0, 40.0, width, height)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=height,
+        width=width,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
+        nodata=-9999.0,
+    ) as dst:
+        dst.write(data)
+
+
+def test_render_uses_dataset_global_stretch_across_tiles(monkeypatch, tmp_path):
+    """Issue #410: all tiles of one raster normalize with the SAME
+    dataset-global min/max (no per-tile stretch -> no color seams), and
+    nodata/NaN pixels never enter the global stats."""
+    from app.services import raster_tile_service as svc
+
+    path = str(tmp_path / "dual_region.tif")
+    _write_dual_region_tiff(path)
+
+    seen = []
+    real_normalize = svc._normalize_channel
+
+    def spy(arr, valid_mask, *stretch):
+        seen.append(stretch)
+        return real_normalize(arr, valid_mask, *stretch)
+
+    monkeypatch.setattr(svc, "_normalize_channel", spy)
+
+    rendered = []
+    # Grid of tiles overlapping the raster footprint (z=8, Beijing area).
+    for x in range(209, 213):
+        for y in range(95, 100):
+            png = svc.render_raster_tile(path, z=8, x=x, y=y, tile_size=256)
+            img = Image.open(io.BytesIO(png))
+            if np.asarray(img)[:, :, 3].any():
+                rendered.append((x, y))
+
+    assert len(rendered) >= 2, "expected at least two non-transparent tiles"
+
+    # Every normalization across every tile used one identical stretch.
+    assert seen, "no normalization happened"
+    assert len(set(seen)) == 1
+    vmin, vmax = seen[0]
+    # Dataset-global stats over VALID data only: nodata row (-9999) and the
+    # stray NaN pixel are excluded from the min/max.
+    assert vmin == 0.0
+    assert vmax == 1000.0
+
+    # Stats are cached per raster path after the first render.
+    assert path in svc._STATS_CACHE
+
+
+def test_multiband_read_uses_indexes_not_all_bands(monkeypatch, tmp_path):
+    """Issue #410: src.read is called with indexes=(1,2,3) — a >3-band raster
+    is no longer decoded band-by-band (previously read ALL bands then sliced
+    [:3], ~2x decode waste for 4+ band rasters)."""
+    from app.services import raster_tile_service as svc
+
+    path = str(tmp_path / "four_band.tif")
+    width = height = 100
+    base = np.linspace(0.0, 1.0, width * height, dtype=np.float32).reshape(1, height, width)
+    data = np.repeat(base, 4, axis=0) * np.array([1.0, 100.0, 10000.0, 1e6]).reshape(4, 1, 1)
+    transform = from_bounds(116.0, 39.0, 117.0, 40.0, width, height)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=height,
+        width=width,
+        count=4,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
+        nodata=-9999.0,
+    ) as dst:
+        dst.write(data)
+
+    read_calls = []
+
+    class RecordingReader:
+        """Proxy around a real rasterio dataset that records read() calls."""
+
+        def __init__(self, src):
+            self._src = src
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self._src.close()
+
+        def __getattr__(self, name):
+            return getattr(self._src, name)
+
+        def read(self, *args, **kwargs):
+            read_calls.append((args, kwargs))
+            return self._src.read(*args, **kwargs)
+
+    real_open = rasterio.open
+    monkeypatch.setattr(
+        rasterio, "open",
+        lambda p, *a, **k: RecordingReader(real_open(p, *a, **k)),
+    )
+
+    png_bytes = svc.render_raster_tile(path, z=8, x=210, y=97, tile_size=256)
+    assert png_bytes.startswith(b"\x89PNG")
+    img = open_image_bytes(png_bytes)
+    assert img.size == (256, 256)
+    assert np.asarray(img)[:, :, 3].any()  # window actually overlaps the raster
+
+    assert read_calls, "no read() calls recorded"
+    for args, kwargs in read_calls:
+        assert "indexes" in kwargs, f"read() called without indexes: {args=} {kwargs=}"
+        assert kwargs["indexes"] == (1, 2, 3)
+
+    # Stats cache holds exactly the 3 rendered bands.
+    assert path in svc._STATS_CACHE
+    assert len(svc._STATS_CACHE[path]) == 3
+
+
+def test_normalize_channel_explicit_stretch():
+    """Issue #410: explicit dataset-global bounds override the per-tile min/max."""
+    arr = np.array([[0.0, 50.0], [100.0, 100.0]])
+    valid = np.ones_like(arr, dtype=bool)
+
+    local = _normalize_channel(arr, valid)  # per-tile stretch 0..100
+    assert local[0, 0] == 0
+    assert local[0, 1] == int(50 / 100 * 255)
+
+    global_ = _normalize_channel(arr, valid, 0.0, 200.0)  # global stretch 0..200
+    assert global_[0, 1] == int(50 / 200 * 255)
+    assert global_[1, 1] == int(100 / 200 * 255)  # not clipped to 255 by local max
+
+    # vmax == vmin -> zeros (constant band renders as 0).
+    flat = _normalize_channel(arr, valid, 5.0, 5.0)
+    assert (flat == 0).all()


### PR DESCRIPTION
## 概要

修复两个瓦片服务 issue,分支基于最新 master,两个独立 commit(`Fixes #395` / `Fixes #410`)。

## Issue #395 (P2) — MVT SpatialIndexCache 字节预算低估 100x+

`app/services/mvt.py` 的 `build_spatial_index_entry` 用 `~350 B/feature` 常数估算
`estimated_bytes`,只对点/简单几何有界。保留条目持有 (a) 原始 feature dicts、
(b) lon/lat shapely 几何、(c) z0 shapely 几何 —— 复杂多边形下 Python 坐标对象
主导(10 万顶点 ≈ 6-10 MB,预算只记 350 B),256 MB 字节 LRU 实际无法限制内存。

**修复(选风险低的估算方向,保留 features + 空间索引 + z0 geoms 的现有设计):**
- kept features 走 `_estimate_json_bytes`(registry 的结构化 JSON 字节估算);
- shapely 顶点总数计入,lon/lat 与 z0 两份都计(`shapely.get_num_coordinates`,
  按 ~64 B/顶点,对应 Python float 对象 + 两份 packed float64 存储);
- 保留 per-feature / per-geom 容器与 wrapper 开销项;
- 估算只在插入时一次完成,LRU 逻辑不变,get 不再重算。

实测:50k 顶点多边形条目 8,354,947 B(≈ 83 B/坐标,与真实占用同数量级),
旧启发式仅 ~1.8 KB。超预算条目现在真正被逐出。

## Issue #410 (P3) — 栅格瓦片逐瓦片归一化 + 全波段读取

`app/services/raster_tile_service.py`:
1. `_normalize_channel` 逐瓦片 min/max 拉伸 → 同层相邻瓦片色缝;
2. `src.read(window=win)` 读全部波段再切 `[:3]` → >3 波段栅格解码浪费 ~2x。

**修复:**
- 每个 raster 缓存一次全局(降采样上限 2048px,`_STATS_MAX_SIDE`)逐波段
  `(vmin, vmax)`,`_STATS_CACHE` 有界(512)且 double-checked + 锁保护;
  所有瓦片共用同一拉伸(无色缝)。nodata 经 `masked=True` read 排除,
  NaN/Inf 额外 `np.isfinite` 过滤(#372 NaN-nodata 修复不回归);
- `read` 传 `indexes=(1,2,3)`(count<3 时按实际波段数),不再全波段解码;
- 全局统计失败时回退原逐瓦片归一化(行为不变)。

## 测试

新增回归测试(合成数据,无网络):
- `tests/unit/test_mvt_cache_memory_pressure.py`:
  - `test_spatial_index_entry_estimate_scales_with_geometry_vertices` — 50k 顶点
    多边形,断言 est ≥ 真实顶点数×50B、≥2 MB、同数量级上界;
  - `test_spatial_index_cache_byte_budget_evicts_complex_geometry` — 复杂几何
    条目按真实占用入账,1 MB 预算立即逐出,共享预算按 LRU 逐出;
- `tests/unit/test_raster_tile_service.py`:
  - `test_render_uses_dataset_global_stretch_across_tiles` — 同一 raster 两个
    窗口的所有归一化调用用同一 (vmin, vmax) = (0, 1000);nodata 行与 NaN
    像素不进统计;stats 按路径缓存;
  - `test_multiband_read_uses_indexes_not_all_bands` — 4 波段栅格,所有
    `read()` 调用均带 `indexes=(1,2,3)`,stats 缓存恰 3 波段;
  - `test_normalize_channel_explicit_stretch` — 显式全局拉伸覆盖局部 min/max。

本地结果(全部通过):
- `test_mvt_cache_memory_pressure.py` + `test_raster_tile_service.py`: 16 passed
- `test_mvt_encoder.py` + `test_mvt_prepared_geometry.py` + `test_raster_route.py`: 69 passed
- `test_mvt_cache_pressure_benchmark.py` + `test_layer_api.py`: 18 passed
- `test_perf_harness_v2.py`(raster): 5 passed