### PR TITLE
test(map): complete the shared MapLibre mock surface with a coverage meta-test

### DIFF
--- a/frontend/components/map/map-action-handler.test.tsx
+++ b/frontend/components/map/map-action-handler.test.tsx
@@ -148,18 +148,13 @@ vi.mock('@/lib/map-kit/exporter', () => ({
 }));
 
 /**
- * Shared MapLibre mock + per-layer layout bookkeeping so the round-2 FIX-B
- * visibility verification (getLayoutProperty reflecting setLayoutProperty) can
- * be exercised end to end.
+ * The shared mock now owns the FIX-B layout bookkeeping itself:
+ * setLayoutProperty/setPaintProperty write into the target layer def and
+ * getLayoutProperty/getPaintProperty read it back (#404), so the round-2 FIX-B
+ * visibility verification can be exercised end to end without extra wrapping.
  */
 function mapWithLayoutBookkeeping() {
-  const map = makeMockMaplibreMap();
-  const layouts: Record<string, Record<string, unknown>> = {};
-  map.setLayoutProperty = vi.fn((id: string, prop: string, value: unknown) => {
-    layouts[id] = { ...(layouts[id] || {}), [prop]: value };
-  });
-  map.getLayoutProperty = vi.fn((id: string, prop: string) => layouts[id]?.[prop] ?? null);
-  return map;
+  return makeMockMaplibreMap();
 }
 
 describe('MapActionHandler', () => {
@@ -1306,12 +1301,18 @@ describe('MapActionHandler', () => {
     );
   });
 
-  it('V3 FIX-B: visibility update that cannot be verified on a store layer → store_updated', async () => {
+  it('V3 FIX-B: visibility update whose value does not stick on the map → store_updated', async () => {
     actions = [{ command: 'LAYER_VISIBILITY_UPDATE', params: { layer_id: 'poi', visible: false } }];
     mockLayersStore = [{ id: 'poi', name: 'POI Layer' }];
-    const map = makeMockMaplibreMap(); // no getLayoutProperty bookkeeping → verification fails
+    // The shared mock is stateful now (setLayoutProperty writes into the layer
+    // def), so "unverifiable" must simulate the real-world race the FIX-B
+    // guard exists for: the set did not take effect on the map (e.g. style
+    // still loading in real MapLibre). Keep getLayoutProperty stale — it must
+    // NOT reflect the 'none' that was just set.
+    const map = makeMockMaplibreMap();
     mockGetMap.mockImplementation(() => map);
     map._layers.push({ id: 'poi__main', type: 'circle', source: 'poi' });
+    map.getLayoutProperty = vi.fn(() => 'visible');
 
     await act(async () => {
       render(<MapActionHandler />);

--- a/frontend/components/map/map-panel.cartography-race.test.tsx
+++ b/frontend/components/map/map-panel.cartography-race.test.tsx
@@ -246,13 +246,10 @@ function repairAction(
 const noop = () => {};
 
 function freshMockMap() {
-  const map = makeMockMaplibreMap();
-  map.isStyleLoaded = vi.fn(() => true);
-  map.setTerrain = vi.fn();
-  map.getBounds = vi.fn(() => ({
-    getWest: () => 116.3, getSouth: () => 39.8, getEast: () => 116.5, getNorth: () => 40.0,
-  }));
-  return map;
+  // The shared mock ships isStyleLoaded (true), setTerrain and getBounds
+  // (default center [116.4, 39.9] ± 0.1° = the exact constants this helper
+  // used to hard-code); no per-test scaffolding needed anymore (#404).
+  return makeMockMaplibreMap();
 }
 
 /** A layer that triggers exactly one cartographic observation per fingerprint. */

--- a/frontend/components/map/map-panel.test.tsx
+++ b/frontend/components/map/map-panel.test.tsx
@@ -151,17 +151,11 @@ const noop = () => {};
 
 /** Shared mock map + the extra surface MapPanel/runtime/renderer needs. */
 function freshMockMap() {
-  const map = makeMockMaplibreMap();
-  map.isStyleLoaded = vi.fn(() => true);
-  map.setTerrain = vi.fn();
-  map.getBounds = vi.fn(() => ({
-    getWest: () => 116.3,
-    getSouth: () => 39.8,
-    getEast: () => 116.5,
-    getNorth: () => 40.0,
-  }));
-  map.queryRenderedFeatures = vi.fn((_point: unknown, _opts: unknown) => rmg.queryResults);
-  return map;
+  // The shared mock now ships isStyleLoaded (true), setTerrain, getBounds
+  // (derived from the default center) and queryRenderedFeatures; only the
+  // rendered-feature results stay test-driven, read lazily so each test's
+  // rmg.queryResults assignment is picked up per call.
+  return makeMockMaplibreMap({ renderedFeatures: () => rmg.queryResults });
 }
 
 function pointLayer(id: string, name: string, opts: { legend?: boolean } = {}): Layer {

--- a/frontend/test/__mocks__/maplibre-map.ts
+++ b/frontend/test/__mocks__/maplibre-map.ts
@@ -20,10 +20,27 @@ import { vi } from 'vitest';
  *   vi.fn, so both `expect(map._calls.addSource)` and
  *   `expect(map.addSource).toHaveBeenCalledWith(...)` styles work.
  *
+ * Completeness contract (issue #404): every MapLibre method the application
+ * code touches (frontend/lib + frontend/components) must exist on this mock —
+ * enforced by test/maplibre-mock-surface.test.ts, which statically scans the
+ * sources for `map.<method>` accesses. Before that contract, a missing method
+ * made any test walking such a path TypeError instead of asserting, so those
+ * paths (style-loaded gating, rendered-feature queries, bounds/viewport
+ * reading, canvas export, image bookkeeping, DPI management, controls and
+ * terrain) were silently untested.
+ *
+ * Style mutations are stateful, not just logged:
+ * - moveLayer actually reorders `_layers` (no beforeId → end of the array,
+ *   which is the top of the z-order);
+ * - setLayoutProperty/setPaintProperty write into the target layer def's
+ *   layout/paint, and getLayoutProperty/getPaintProperty read them back — so
+ *   render assertions can be written against the mock's style state.
+ *
  * Underscore-prefixed helpers are test-only and not part of the MapLibre API:
  * - `_fire(event, payload?)` — dispatch to registered once/on listeners;
  * - `_setViewport(partial)` — mutate the camera state;
- * - `_calls` / `_sources` / `_layers` / `_viewport` — introspection.
+ * - `_calls` / `_sources` / `_layers` / `_images` / `_terrain` / `_controls` /
+ *   `_viewport` — introspection.
  */
 
 export interface MockMapViewport {
@@ -45,6 +62,11 @@ export interface MockMapCallLog {
   moveLayer: Array<{ id: string; beforeId?: string | null }>;
   setFilter: Array<{ layerId: string; filter: unknown }>;
   setData: Array<{ id: string; data: unknown }>;
+  addControl: Array<{ control: unknown; position?: string | null }>;
+  setTerrain: Array<{ options: unknown }>;
+  queryRenderedFeatures: Array<{ geometry: unknown; params?: unknown }>;
+  setLayoutProperty: Array<{ layerId: string; name: string; value: unknown }>;
+  setPaintProperty: Array<{ layerId: string; name: string; value: unknown }>;
 }
 
 export interface MakeMockMaplibreMapOptions {
@@ -52,6 +74,60 @@ export interface MakeMockMaplibreMapOptions {
   zoom?: number;
   bearing?: number;
   pitch?: number;
+  /** `isStyleLoaded()` result — default true: tests assume the base style is
+   *  loaded synchronously unless they explicitly exercise the deferral path. */
+  styleLoaded?: boolean;
+  /** `queryRenderedFeatures()` results. Pass an array (fixed) or a zero-arg
+   *  function (lazy — re-read on every call, e.g. a mutable test registry). */
+  renderedFeatures?: unknown[] | (() => unknown[]);
+  /** `getBounds()` corners as [west, south, east, north]. Default derives from
+   *  center ± 0.1°, so the default viewport yields [116.3, 39.8, 116.5, 40.0]. */
+  bounds?: [number, number, number, number];
+}
+
+/** Minimal 2D-context stub (mirrors test/setup.ts) so drawing-heavy paths
+ *  (exporter composition) can run without a real GL/2D context. */
+const canvas2dContext: Record<string, unknown> = {
+  drawImage: () => {},
+  fillText: () => {},
+  fillRect: () => {},
+  createLinearGradient: () => ({ addColorStop: () => {} }),
+  beginPath: () => {},
+  moveTo: () => {},
+  lineTo: () => {},
+  closePath: () => {},
+  fill: () => {},
+  stroke: () => {},
+  strokeRect: () => {},
+  arc: () => {},
+  arcTo: () => {},
+  save: () => {},
+  restore: () => {},
+  translate: () => {},
+  rotate: () => {},
+  setLineDash: () => {},
+  measureText: () => ({ width: 50 }),
+  fillStyle: '',
+  strokeStyle: '',
+  lineWidth: 1,
+  font: '',
+  textAlign: 'left',
+};
+
+/** Canvas-like object returned by `getCanvas()`: real jsdom canvases cannot
+ *  `toBlob`, so the mock hands back a self-contained fake with the surface the
+ *  exporter actually uses (width/height, toBlob, toDataURL, getContext). */
+function makeCanvasLike() {
+  return {
+    width: 800,
+    height: 600,
+    toBlob: (cb: (blob: Blob | null) => void) => {
+      cb(new Blob(['mock-canvas'], { type: 'image/png' }));
+    },
+    toDataURL: () =>
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    getContext: () => canvas2dContext,
+  };
 }
 
 export function makeMockMaplibreMap(options: MakeMockMaplibreMapOptions = {}) {
@@ -72,6 +148,21 @@ export function makeMockMaplibreMap(options: MakeMockMaplibreMapOptions = {}) {
   // easeTo start an animation; jumpTo/moveend end it.
   let animating = false;
 
+  // Issue #404 additions: style/rendering state that the previously-closed mock
+  // surface never modeled (every one of these used to TypeError when reached).
+  const bounds: [number, number, number, number] = options.bounds ?? [
+    viewport.center[0] - 0.1,
+    viewport.center[1] - 0.1,
+    viewport.center[0] + 0.1,
+    viewport.center[1] + 0.1,
+  ];
+  const styleLoaded = options.styleLoaded ?? true;
+  const renderedFeatures = options.renderedFeatures ?? [];
+  let terrain: { source: string; exaggeration?: number } | null = null;
+  let pixelRatio = 1;
+  const images = new Set<string>();
+  const controls: Array<{ control: unknown; position?: string }> = [];
+
   const calls: MockMapCallLog = {
     flyTo: [],
     fitBounds: [],
@@ -84,6 +175,11 @@ export function makeMockMaplibreMap(options: MakeMockMaplibreMapOptions = {}) {
     moveLayer: [],
     setFilter: [],
     setData: [],
+    addControl: [],
+    setTerrain: [],
+    queryRenderedFeatures: [],
+    setLayoutProperty: [],
+    setPaintProperty: [],
   };
 
   const emit = (event: string, payload?: unknown) => {
@@ -137,13 +233,88 @@ export function makeMockMaplibreMap(options: MakeMockMaplibreMapOptions = {}) {
       calls.removeLayer.push(id);
     }),
     moveLayer: vi.fn((id: string, beforeId?: string | null) => {
+      // Stateful: actually reorder `_layers` (before my previous no-op, z-order
+      // assertions silently observed the stale order). No beforeId → end of the
+      // array = top of the z-order; beforeId → immediately before that layer.
+      const i = layers.findIndex((l) => l.id === id);
+      if (i >= 0) {
+        const [moved] = layers.splice(i, 1);
+        if (beforeId !== undefined && beforeId !== null) {
+          const j = layers.findIndex((l) => l.id === beforeId);
+          layers.splice(j >= 0 ? j : layers.length, 0, moved);
+        } else {
+          layers.push(moved);
+        }
+      }
       calls.moveLayer.push({ id, beforeId: beforeId ?? null });
     }),
     setFilter: vi.fn((layerId: string, filter: any) => {
       calls.setFilter.push({ layerId, filter });
     }),
-    setLayoutProperty: vi.fn(),
-    setPaintProperty: vi.fn(),
+    setLayoutProperty: vi.fn((layerId: string, name: string, value: unknown) => {
+      // Stateful: write into the target layer def so render assertions can read
+      // the value back through getLayoutProperty/getStyle (MapLibre semantics).
+      const layer = layers.find((l) => l.id === layerId);
+      if (layer) {
+        layer.layout = layer.layout ?? {};
+        layer.layout[name] = value;
+      }
+      calls.setLayoutProperty.push({ layerId, name, value });
+    }),
+    setPaintProperty: vi.fn((layerId: string, name: string, value: unknown) => {
+      const layer = layers.find((l) => l.id === layerId);
+      if (layer) {
+        layer.paint = layer.paint ?? {};
+        layer.paint[name] = value;
+      }
+      calls.setPaintProperty.push({ layerId, name, value });
+    }),
+    getLayoutProperty: vi.fn((layerId: string, name: string) => {
+      const layer = layers.find((l) => l.id === layerId);
+      // null when unset (real MapLibre resolves style defaults; the mock keeps
+      // the explicit-value contract only — enough for verification logic).
+      return layer?.layout?.[name] ?? null;
+    }),
+    getPaintProperty: vi.fn((layerId: string, name: string) => {
+      const layer = layers.find((l) => l.id === layerId);
+      return layer?.paint?.[name] ?? null;
+    }),
+
+    // ─── Rendering / style-state surface (issue #404) ──────────────────────
+    isStyleLoaded: vi.fn(() => styleLoaded),
+    getBounds: vi.fn(() => ({
+      getWest: () => bounds[0],
+      getSouth: () => bounds[1],
+      getEast: () => bounds[2],
+      getNorth: () => bounds[3],
+    })),
+    queryRenderedFeatures: vi.fn((geometry: unknown, params?: unknown) => {
+      calls.queryRenderedFeatures.push({ geometry, params });
+      // Configured features only — no spatial filtering (that is real MapLibre
+      // territory; tests drive the result set explicitly).
+      const features =
+        typeof renderedFeatures === 'function' ? renderedFeatures() : renderedFeatures;
+      return Array.isArray(features) ? features : [];
+    }),
+    getCanvas: vi.fn(() => makeCanvasLike()),
+    hasImage: vi.fn((id: string) => images.has(id)),
+    removeImage: vi.fn((id: string) => {
+      images.delete(id);
+    }),
+    getPixelRatio: vi.fn(() => pixelRatio),
+    setPixelRatio: vi.fn((ratio: number) => {
+      pixelRatio = ratio;
+    }),
+    addControl: vi.fn((control: unknown, position?: string) => {
+      controls.push({ control, position });
+      calls.addControl.push({ control, position: position ?? null });
+      return map;
+    }),
+    setTerrain: vi.fn((opts: { source: string; exaggeration?: number } | null) => {
+      terrain = opts ? { source: opts.source, exaggeration: opts.exaggeration } : null;
+      calls.setTerrain.push({ options: opts });
+      return map;
+    }),
 
     // ─── Camera ────────────────────────────────────────────────────────────
     flyTo: vi.fn((opts: any) => {
@@ -207,6 +378,9 @@ export function makeMockMaplibreMap(options: MakeMockMaplibreMapOptions = {}) {
     _calls: calls,
     _sources: sources,
     _layers: layers,
+    _images: images,
+    _terrain: terrain,
+    _controls: controls,
     _viewport: viewport,
     _setViewport(partial: Partial<MockMapViewport>) {
       if (partial.center) viewport.center = partial.center;

--- a/frontend/test/map-render-work-count.test.tsx
+++ b/frontend/test/map-render-work-count.test.tsx
@@ -146,15 +146,10 @@ vi.mock('@/components/map/map-decorations', () => ({
 }));
 
 function freshInstrumentedMap() {
+  // The shared mock ships isStyleLoaded (true), setTerrain and getBounds
+  // (default center [116.4, 39.9] ± 0.1° = the constants this helper used to
+  // hard-code); only the call counters remain per-test instrumentation.
   const map = makeMockMaplibreMap();
-  map.isStyleLoaded = vi.fn(() => true);
-  map.setTerrain = vi.fn();
-  map.getBounds = vi.fn(() => ({
-    getWest: () => 116.3,
-    getSouth: () => 39.8,
-    getEast: () => 116.5,
-    getNorth: () => 40.0,
-  }));
   const origGetStyle = map.getStyle;
   map.getStyle = vi.fn(() => {
     metrics.mapLibreGetStyleCalls += 1;

--- a/frontend/test/maplibre-mock-surface.test.ts
+++ b/frontend/test/maplibre-mock-surface.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Coverage meta-test for the shared MapLibre mock — issue #404 acceptance
+ * criterion.
+ *
+ * The mock used to be a closed object literal: any `map.<method>(...)` the
+ * application code calls that was NOT in the literal TypeError'd at runtime.
+ * Tests never walked those paths (they crashed), so entire feature branches —
+ * style-loaded gating (runtime.ts), rendered-feature queries (map-panel,
+ * map-kit/state), bounds/viewport reading (map-panel, runtime-evidence),
+ * canvas export (map-kit/exporter), image bookkeeping (map-kit/renderer), DPI
+ * management, controls and terrain — ran with zero coverage.
+ *
+ * This test statically scans frontend/lib + frontend/components (non-test
+ * sources) for every `map.<ident>` access (call sites and bare accesses, e.g.
+ * `typeof map.hasImage === 'function'` or passing `map.getLayoutProperty` as a
+ * value), and asserts the identifier exists as a function on the shared mock.
+ * The scan is deliberately a cheap regex over source text (per issue #404): it
+ * fails loudly the day someone calls a new MapLibre method without adding it
+ * to the mock, and it is trivially auditable.
+ *
+ * All map receivers in the app are named `map` (function params, or
+ * `mapRef.current?.getMap()` / `mapInstance.getMap()` results), so the regex
+ * `\bmap\.` captures the full runtime surface. False positives from the word
+ * boundary (e.g. `"map.png"` output paths) are covered by NON_API_WHITELIST
+ * below — every entry must state why it is not a MapLibre member.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { makeMockMaplibreMap } from './__mocks__/maplibre-map';
+
+const FRONTEND_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+// Application code only — tests may use their own stubs; the contract this
+// meta-test guards is the app's runtime surface, not test scaffolding.
+const SCAN_DIRS = ['lib', 'components'];
+
+/**
+ * Identifiers the scan can match that are NOT MapLibre members. Every entry
+ * must explain why it is exempt — adding entries without a real reason is how
+ * mock drift sneaks back in.
+ */
+const NON_API_WHITELIST: Record<string, string> = {
+  // Filesystem output path string literal — `path.join(args.outDir, "map.png")`
+  // in lib/mapspec-compiler/runtime-validate.ts. The word boundary before
+  // `map` holds inside the quoted string, so the access regex matches it;
+  // it is not a MapLibre member (unlike `map.getCanvas()` etc.).
+  png: 'string literal "map.png" (output file path) in lib/mapspec-compiler/runtime-validate.ts',
+};
+
+const ACCESS_RE = /\bmap\.([A-Za-z_][A-Za-z0-9_]*)/g;
+
+interface AccessSite {
+  file: string;
+  line: number;
+  kind: 'call' | 'access';
+}
+
+function collectAccesses(): Map<string, AccessSite[]> {
+  const found = new Map<string, AccessSite[]>();
+  const add = (name: string, site: AccessSite) => {
+    const list = found.get(name) ?? [];
+    list.push(site);
+    found.set(name, list);
+  };
+
+  for (const dir of SCAN_DIRS) {
+    const base = path.join(FRONTEND_ROOT, dir);
+    if (!fs.existsSync(base)) continue;
+    const walk = (dirPath: string): void => {
+      for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+        const full = path.join(dirPath, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (
+          /\.(ts|tsx)$/.test(entry.name) &&
+          !/\.(test|spec)\.[cm]?[jt]sx?$/.test(entry.name)
+        ) {
+          const src = fs.readFileSync(full, 'utf8');
+          ACCESS_RE.lastIndex = 0;
+          let m: RegExpExecArray | null;
+          while ((m = ACCESS_RE.exec(src)) !== null) {
+            const name = m[1];
+            const after = src.slice(ACCESS_RE.lastIndex);
+            const kind: AccessSite['kind'] =
+              after.startsWith('(') || after.startsWith('?.(') ? 'call' : 'access';
+            const line = src.slice(0, m.index).split('\n').length;
+            add(name, { file: full, line, kind });
+          }
+        }
+      }
+    };
+    walk(base);
+  }
+  return found;
+}
+
+describe('shared MapLibre mock covers the app-level MapLibre surface (#404)', () => {
+  it('every map.<method> the application source touches exists on the mock', () => {
+    const map = makeMockMaplibreMap();
+    const accesses = collectAccesses();
+
+    // Sanity: the scan must actually find the known surface, otherwise the
+    // meta-test silently guards nothing.
+    expect(accesses.size).toBeGreaterThan(10);
+    // (forEach rather than for-of: the test tsconfig targets ES3, where only
+    // array iteration is allowed without downlevelIteration.)
+    (['addLayer', 'getSource', 'queryRenderedFeatures', 'isStyleLoaded'] as const).forEach(
+      (mustFind) => {
+        expect(accesses.has(mustFind), `scan must still see ${mustFind}`).toBe(true);
+      },
+    );
+
+    const missing: string[] = [];
+    accesses.forEach((sites, name) => {
+      if (NON_API_WHITELIST[name]) return;
+      if (typeof map[name] !== 'function') {
+        const first = sites[0];
+        missing.push(
+          `${name} (${first.kind} at ${path.relative(FRONTEND_ROOT, first.file)}:${first.line})`,
+        );
+      }
+    });
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

`frontend/test/__mocks__/maplibre-map.ts` was a closed object literal. The application calls at least a dozen MapLibre methods the mock did not model (`addControl`, `setTerrain`, `queryRenderedFeatures`, `isStyleLoaded`, `getBounds`, `getCanvas`, `hasImage`, `removeImage`, `setPixelRatio`, `getPixelRatio`, `getLayoutProperty`, `getPaintProperty`). Any test walking those paths hit a `TypeError` instead of asserting — so the paths were **silently untested**. The most visible vector: `MapSpecRuntime.reconcile`/`reconcileAsync` gate on `map.isStyleLoaded()`, which returned `undefined` (falsy) in the mock, silently pushing every mock-based runtime test down the deferral/fallback branch.

This PR completes the shared mock surface and locks it in with a meta-test, per issue #404.

## Changes

### 1. Shared mock completed (`frontend/test/__mocks__/maplibre-map.ts`)
- **New methods with state semantics**:
  - `isStyleLoaded()` → `true` (configurable via `styleLoaded` option)
  - `queryRenderedFeatures()` → configured features (`renderedFeatures` option: fixed array or lazy zero-arg fn), call recorded in `_calls`
  - `getBounds()` → LngLatBounds-like `{getWest/getSouth/getEast/getNorth}`; defaults derive from center ± 0.1° (exactly the constants three test helpers used to hard-code), overridable via `bounds` option
  - `getCanvas()` → self-contained canvas-like (`width/height/toBlob/toDataURL/getContext`) — jsdom canvases can't `toBlob`, so `captureMapCanvas` becomes exercisable
  - `addControl`/`setTerrain` (recorded in `_calls`, state exposed via `_controls`/`_terrain`), `hasImage`/`removeImage` (backed by an `_images` set), `setPixelRatio`/`getPixelRatio`
  - `getLayoutProperty`/`getPaintProperty` (see below)
- **Stateful style mutations** (were log-only `vi.fn()`s):
  - `moveLayer` now actually reorders `_layers` (no `beforeId` → end = top of z-order); z-order assertions no longer silently observe the stale order
  - `setLayoutProperty`/`setPaintProperty` write into the target layer def's `layout`/`paint`; `getLayoutProperty`/`getPaintProperty` read them back — render assertions are now writable
- New `MakeMockMaplibreMapOptions`: `styleLoaded`, `renderedFeatures`, `bounds`.

### 2. Coverage meta-test (`frontend/test/maplibre-mock-surface.test.ts`)
- Statically scans `frontend/lib` + `frontend/components` (non-test sources) for every `map.<ident>` access (call sites and bare accesses like `typeof map.hasImage === 'function'` / passing `map.getLayoutProperty` as a value) and asserts each exists **as a function** on the mock.
- Regex-based by design (per issue #404): cheap, deterministic, fails loudly the day a new MapLibre method is called without being added to the mock.
- One-entry whitelist with justification: `png` — string literal `"map.png"` (output file path in `lib/mapspec-compiler/runtime-validate.ts`), not a MapLibre member.

### 3. Existing tests de-scaffolded onto the stateful mock
`map-panel.test.tsx`, `map-panel.cartography-race.test.tsx`, `map-render-work-count.test.tsx` no longer hand-patch `isStyleLoaded`/`setTerrain`/`getBounds`/`queryRenderedFeatures` (the shared mock ships them); `map-action-handler.test.tsx` drops its private layout-bookkeeping wrapper (`mapWithLayoutBookkeeping` now just returns the shared mock).

## Existing test gaps exposed & how they were handled

Changing the mock's behavior surfaced exactly one test whose green-ness depended on the mock's incompleteness:

- **`map-action-handler.test.tsx` — "visibility update that cannot be verified on a store layer → `store_updated`"**. Its premise was *"no getLayoutProperty bookkeeping → verification fails"*; with the stateful mock the FIX-B verification now legitimately succeeds (that is the point of the change). This was a **test-assumption error, not an app bug** — the FIX-B guard is supposed to verify successfully when the value sticks. Rewritten as **"visibility update whose value does not stick on the map → `store_updated`"**: it now simulates the real-world race the guard exists for (set did not take effect, e.g. style still loading) by keeping `getLayoutProperty` stale (`'visible'` instead of `'none'`). The assertions are unchanged — only the way the unverifiable state is produced.

No application-code bugs surfaced: all previously green behavior stays green.

## Verification
- `npm run typecheck` — clean (both `tsc --noEmit` and `tsc -p tsconfig.test.json`)
- `npx vitest run --reporter=dot` — **122 files / 1315 tests passed**, 3 skipped (pre-existing skips)
- `npx eslint` on all changed files — clean

Closes #404
