### PR TITLE
fix(ai): keep persisted history API-valid for MiniMax XML tool calls and exclude subagent transcripts from parent history

### DIFF
--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -188,6 +188,13 @@ def _lock_in_use(lock: asyncio.Lock) -> bool:
 class ChatExecutionEngine:
     """Agent 对话与流式响应执行引擎"""
 
+    #: #407: P1「clearing」标记提升为注册表级（class 级共享）—— per-instance
+    #: 时父引擎的 clear_session 只抑制本实例的 _save_msg_async，与 in-flight
+    #: 子代理引擎（独立实例、共享父 session_id）竞争时子引擎仍会写库，产生
+    #: 行复活窗口。共享集合保证任一引擎实例发起 clear 后，所有实例对该会话
+    #: 的 DB 写都被抑制（_save_msg_async / _reject_if_clearing 读取同一集合）。
+    _clearing_sessions: set[str] = set()
+
     def __init__(
         self,
         tool_registry: ToolRegistry,
@@ -263,7 +270,9 @@ class ChatExecutionEngine:
         # for a marked session are refused cleanly. The task registry lets
         # clear_session quiesce the cancelled turn (bounded) before clearing
         # the marker.
-        self._clearing_sessions: set[str] = set()
+        # NOTE: the marker set itself is CLASS-level (registry-wide) since #407
+        # — see the class attribute above; nothing per-instance is assigned
+        # here.
         self._active_turn_tasks: dict[str, asyncio.Task] = {}
         self._clear_quiesce_timeout = float(_os.getenv("CLEAR_QUIESCE_TIMEOUT", "5.0"))
         # P1: bounded cancel-and-await budget for the cancel/finally cleanup
@@ -595,6 +604,20 @@ class ChatExecutionEngine:
 
     async def _save_msg_async(self, session_id: str, role: str, content: str, tool_calls=None, tool_result=None, tool_call_id=None, reasoning_content=None):
         """异步保存消息到数据库"""
+        if getattr(self, "is_subagent_engine", False):
+            # #407: 子代理是隔离的微会话 —— 它复用父 session_id（refs /
+            # map_state 父子原生互通，见 subagent.py 设计注释），但它的内部
+            # transcript（任务 prompt、每条 assistant 消息、tool_call/tool
+            # 响应）只属于子引擎自己的内存 LRU。一旦写进父会话 DB，重载 /
+            # LRU 逐出后父上下文会重新载入完整子代理轨迹，污染主对话且白耗
+            # token。父侧只通过 spawn_subagent 工具的 tool-result 消息拿到
+            # 最终摘要，因此子引擎的一切持久化在此抑制。
+            logger.debug(
+                "save_message suppressed for session %s: subagent engine "
+                "transcripts are never persisted to the parent conversation",
+                session_id,
+            )
+            return
         if session_id in self._clearing_sessions:
             # P1: clear_session 刚删了该会话的 conversation 行 —— 现在写入会
             # 复活历史（SQLite: FK off → 孤儿 Message 行；Postgres: FK →

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -967,7 +967,14 @@ class ChatExecutionEngine:
                     if standard_calls:
                         entry["tool_calls"] = standard_calls
                     messages.append(entry)
-                    await self._save_msg_async(session_id, "assistant", content_text, tc_list, reasoning_content=reasoning)
+                    # #376: 持久化行只带 standard_calls（XML 路径为空 → None）。
+                    # MiniMax XML 路径的工具响应从不落库（只作为内存中的合成
+                    # user 消息存在），若把解析出的 xml_calls 一并持久化，进程
+                    # 重启 / LRU 逐出后重放历史会得到没有配对 tool 响应的
+                    # assistant.tool_calls —— OpenAI 兼容 provider 拒绝后续
+                    # turn 的首次 LLM 调用，会话永久损坏。降级为普通文本
+                    # assistant 行，重放序列合法。
+                    await self._save_msg_async(session_id, "assistant", content_text, standard_calls or None, reasoning_content=reasoning)
 
                     tool_result_msgs: list[str] = []
                     # F28: 与流式路径（chat_stream 并行 wave）同款抢占式取消 ——
@@ -1359,7 +1366,10 @@ class ChatExecutionEngine:
                         if standard_calls:
                             entry["tool_calls"] = standard_calls
                         messages.append(entry)
-                        await self._save_msg_async(session_id, "assistant", content_text, tc_list, reasoning_content=reasoning)
+                        # #376: 同非流式路径 —— XML 工具响应不落库，assistant 行
+                        # 只带 standard_calls（XML 路径为 None），避免重放历史
+                        # 出现孤儿 assistant.tool_calls 损坏会话。
+                        await self._save_msg_async(session_id, "assistant", content_text, standard_calls or None, reasoning_content=reasoning)
 
                         tool_result_msgs: list[str] = []
 

--- a/app/services/history_service_async.py
+++ b/app/services/history_service_async.py
@@ -16,6 +16,7 @@ SEC-08：新建的匿名会话会生成 server-issued `owner_token`（secrets.to
 前端必须在后续请求的 `X-Session-Token` 头里回传该 token 才能访问该会话。
 认证会话与历史匿名会话（token 为 NULL）不受影响。
 """
+import json
 import logging
 import secrets
 from datetime import datetime, timezone
@@ -53,6 +54,15 @@ def _msg_to_llm_dict(m: Message) -> dict:
                 tc_copy = dict(tc)
                 tc_copy["function"] = dict(tc["function"])
                 tc_copy["function"]["name"] = normalize_tool_name(tc["function"]["name"])
+                args = tc_copy["function"].get("arguments")
+                if isinstance(args, dict):
+                    # #376: MiniMax XML 路径解析出的 arguments 以 dict 形式
+                    # 落库，而 OpenAI 兼容 API 的 tool_calls 契约要求 JSON
+                    # 字符串 —— 重放时统一规范化（标准 FC 路径本就是字符串，
+                    # 此处为 no-op）。
+                    tc_copy["function"]["arguments"] = json.dumps(
+                        args, ensure_ascii=False
+                    )
                 tool_calls.append(tc_copy)
             else:
                 tool_calls.append(tc)
@@ -62,6 +72,44 @@ def _msg_to_llm_dict(m: Message) -> dict:
     if m.reasoning_content:
         item["reasoning_content"] = m.reasoning_content
     return item
+
+
+def _strip_orphaned_tool_calls(llm_messages: list[dict]) -> list[dict]:
+    """#376 兜底防线：加载时剥除没有配对 tool 响应的 assistant tool_calls。
+
+    修复前的 MiniMax XML 工具调用路径把解析出的 tool_calls 随 assistant 消息
+    持久化，但工具响应只以内存中的合成 user 消息存在、从不落库 —— 进程重启
+    或 LRU 逐出后重放历史会得到孤儿 assistant.tool_calls，OpenAI 兼容 provider
+    拒绝后续 turn 的首次 LLM 调用，会话永久损坏。此函数在重放路径上把每条
+    「tool_calls 没有后随匹配 tool 响应」的 assistant 消息降级为普通文本
+    （content 保留，tool_calls 剥除）；无 id 的 tool_call 无法与响应配对，
+    同样剥除。幂等：已配对（存在对应 tool 响应）的 tool_call 原样保留。
+    只影响本次重放，不修改 DB 行。
+    """
+    answered = {
+        m.get("tool_call_id")
+        for m in llm_messages
+        if m.get("role") == "tool" and m.get("tool_call_id")
+    }
+    for m in llm_messages:
+        if m.get("role") != "assistant" or not m.get("tool_calls"):
+            continue
+        kept = []
+        for tc in m["tool_calls"]:
+            tc_id = tc.get("id") if isinstance(tc, dict) else None
+            if tc_id is None or tc_id not in answered:
+                continue  # 孤儿 / 无 id：API 层无法配对，剥除
+            kept.append(tc)
+        if kept:
+            m["tool_calls"] = kept
+        else:
+            m.pop("tool_calls", None)
+            logger.info(
+                "[history] stripped orphaned tool_calls from an assistant "
+                "message on replay (session history would otherwise be "
+                "rejected by the LLM API)"
+            )
+    return llm_messages
 
 
 class AsyncHistoryService(HistoryStoreProtocol):
@@ -94,7 +142,11 @@ class AsyncHistoryService(HistoryStoreProtocol):
             llm_messages.append({"role": "system", "content": system_prompt})
         if conv and conv.messages:
             sorted_msgs = sorted(conv.messages, key=lambda m: m.id)
-            llm_messages.extend([_msg_to_llm_dict(m) for m in sorted_msgs])
+            # #376: 重放前剥除孤儿 assistant tool_calls（修复历史损坏的会话；
+            # 新写入路径已在源头不持久化 XML tool_calls）。
+            llm_messages.extend(
+                _strip_orphaned_tool_calls([_msg_to_llm_dict(m) for m in sorted_msgs])
+            )
 
         return HistoryContext(
             session_id=session_id,

--- a/app/services/subagent.py
+++ b/app/services/subagent.py
@@ -215,7 +215,14 @@ class SubagentDispatcher:
             def __init__(self, schemas: list[dict]):
                 self._schemas = schemas
 
-            def select_schemas(self, _user_message: str, session_id: Optional[str] = None):
+            def select_schemas(
+                self,
+                _user_message: str,
+                session_id: Optional[str] = None,
+                declared_domains: Optional[set] = None,
+            ):
+                # declared_domains 是 ToolCatalog 现行接口（_select_tools 始终
+                # 传此 kwarg）；stub 固定返回白名单，忽略即可。
                 return self._schemas
 
             def reset_session(self, session_id: str) -> None:

--- a/tests/unit/test_issue376_xml_tool_call_history.py
+++ b/tests/unit/test_issue376_xml_tool_call_history.py
@@ -1,0 +1,260 @@
+"""Issue #376 回归测试：MiniMax XML 工具调用路径必须保持持久化历史 API-valid。
+
+修复前：XML 路径把解析出的 tool_calls 随 assistant 消息落库，但工具响应只
+作为内存中的合成 user 消息存在、从不持久化 —— 进程重启 / LRU 逐出后重放
+历史产生没有配对 tool 响应的 assistant.tool_calls，OpenAI 兼容 provider 拒绝
+后续 turn 的首次 LLM 调用，会话永久损坏。
+
+修复（两层）：
+- 写入路径（execution_engine）：XML 分支持久化的 assistant 行只带
+  standard_calls（XML 路径为空 → tool_calls=None，降级为普通文本行）；
+- 重放路径（history_service_async）：load_context 剥除孤儿 tool_calls
+  （兜底修复历史损坏的会话），并把 dict 型 arguments 规范化为 JSON 字符串。
+"""
+import json
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.services.chat_engine import ChatEngine
+from app.tools.registry import ToolRegistry, tool
+
+XML_TOOL_CONTENT = (
+    "开始分析\n"
+    'minimax:tool_call <invoke name="geocode"><parameter name="query">北京</parameter></invoke>'
+)
+
+
+@pytest.fixture
+def registry():
+    r = ToolRegistry()
+
+    @tool(r, name="geocode", description="Geocode")
+    def geocode(query: str) -> dict:
+        return {"lat": 39.9042, "lon": 116.4074, "name": "北京"}
+
+    return r
+
+
+def _assistant_saves(mock_save):
+    """提取所有 role='assistant' 的 _save_msg_async 调用。"""
+    return [
+        c for c in mock_save.call_args_list
+        if len(c.args) > 1 and c.args[1] == "assistant"
+    ]
+
+
+# ─── 非流式路径 ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chat_xml_tool_turn_persists_assistant_without_tool_calls(registry):
+    """非流式 XML 轮：assistant 行以 tool_calls=None 落库（XML 已剥除）。"""
+    engine = ChatEngine(registry)
+    resp1 = {"choices": [{"message": {"content": XML_TOOL_CONTENT}}]}  # 无 standard tool_calls
+    resp2 = {"choices": [{"message": {"content": "北京的坐标是 39.9042, 116.4074"}}]}
+
+    async def fake_load(session_id, user_id=None):
+        # F23：本环境无可用 DB，显式 stub 加载成功，否则会话不会进 _sessions 缓存
+        return [{"role": "system", "content": "sys"}]
+
+    with patch.object(engine, "_load_session_from_db", side_effect=fake_load):
+        with patch.object(engine, "_call_llm", new_callable=AsyncMock, side_effect=[resp1, resp2]):
+            with patch.object(engine, "_save_msg_async", new_callable=AsyncMock) as mock_save:
+                result = await engine.chat("北京的坐标在哪？", session_id="sess-376-xml")
+
+    assert "39.9042" in result["content"]  # 工具确实执行了
+
+    saves = _assistant_saves(mock_save)
+    assert len(saves) == 2  # XML 工具轮 + 最终回答轮
+    xml_round = saves[0]
+    assert xml_round.args[3] is None  # tool_calls 不落库（此前是 xml_calls 列表）
+    assert "minimax:tool_call" not in xml_round.args[2]  # XML 标签已从 content 剥除
+
+    # 内存 messages 里的 XML 轮 assistant 条目同样不带 tool_calls
+    for m in engine._sessions["sess-376-xml"]:
+        if m.get("role") == "assistant":
+            assert not m.get("tool_calls")
+
+
+# ─── 流式路径 ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_xml_tool_turn_persists_assistant_without_tool_calls(registry, monkeypatch):
+    """流式 XML 轮：assistant 行同样以 tool_calls=None 落库。"""
+    engine = ChatEngine(registry)
+
+    async def fake_stream_1(*args, **kwargs):
+        yield ("done", {"message": {"content": XML_TOOL_CONTENT}})
+
+    async def fake_stream_2(*args, **kwargs):
+        yield ("done", {"message": {"content": "北京的坐标是 39.9042, 116.4074"}})
+
+    async def fake_get_or_create_session(session_id, user_id=None):
+        return []
+
+    async def fake_maybe_plan(*a, **kw):
+        return None
+
+    async def fake_generate_title(*a, **kw):
+        return None
+
+    monkeypatch.setattr(engine, "_get_or_create_session", fake_get_or_create_session)
+    monkeypatch.setattr(engine, "_maybe_plan", fake_maybe_plan)
+    monkeypatch.setattr(engine, "_generate_title", fake_generate_title)
+
+    with patch.object(
+        engine, "_call_llm_stream", side_effect=[fake_stream_1(), fake_stream_2()]
+    ):
+        with patch.object(engine, "_save_msg_async", new_callable=AsyncMock) as mock_save:
+            events = []
+            async for event in engine.chat_stream("北京的坐标在哪？", session_id="sess-376-stream"):
+                events.append(event)
+
+    assert any("task_complete" in e for e in events)
+
+    saves = _assistant_saves(mock_save)
+    assert len(saves) == 2
+    xml_round = saves[0]
+    assert xml_round.args[3] is None  # tool_calls 不落库
+    assert "minimax:tool_call" not in xml_round.args[2]
+
+
+# ─── 重放路径：孤儿修复（兜底） ─────────────────────────────────
+
+
+def _conv_with_messages(msgs):
+    from app.models.db_model import Conversation
+
+    conv = Conversation(id="sess-376-repair")
+    conv.messages = msgs
+    return conv
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+    def scalar_one(self):
+        return self._rows[0]
+
+
+class _FakeDb:
+    """最小 AsyncSession 替身：get_or_create_conversation 的 SELECT 直接返回 conv。"""
+
+    def __init__(self, conv):
+        self._conv = conv
+
+    async def execute(self, stmt, *a, **k):
+        return _FakeResult([self._conv])
+
+    def add(self, *a, **k):
+        pass
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        pass
+
+    async def rollback(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_load_context_strips_orphaned_xml_tool_calls():
+    """修复前旧代码写入的行（XML tool_calls + 从不存在的 tool 响应）重放时被
+    降级为普通文本 —— 不再产生会拒绝后续 LLM 调用的孤儿 tool_calls。"""
+    from app.models.db_model import Message
+    from app.services.history_service_async import AsyncHistoryService
+
+    legacy_tc = [{
+        "id": "call_xml_1",
+        "type": "function",
+        "function": {"name": "geocode", "arguments": {"query": "北京"}},
+    }]
+    msgs = [
+        Message(id=1, role="user", content="北京的坐标在哪？"),
+        Message(id=2, role="assistant", content="开始分析", tool_calls=legacy_tc),
+    ]
+    svc = AsyncHistoryService(db=_FakeDb(_conv_with_messages(msgs)))
+    ctx = await svc.load_context("sess-376-repair")
+
+    assistant = [m for m in ctx.llm_messages if m["role"] == "assistant"][0]
+    assert "tool_calls" not in assistant  # 孤儿 tool_calls 被剥除
+    assert assistant["content"] == "开始分析"  # content 保留
+
+
+@pytest.mark.asyncio
+async def test_load_context_keeps_paired_tool_calls_and_normalizes_arguments():
+    """已配对的 tool_calls 原样保留；dict 型 arguments 规范化为 JSON 字符串。"""
+    from app.models.db_model import Message
+    from app.services.history_service_async import AsyncHistoryService
+
+    tc = [{
+        "id": "call_xml_1",
+        "type": "function",
+        "function": {"name": "geocode", "arguments": {"query": "北京"}},
+    }]
+    msgs = [
+        Message(id=1, role="user", content="北京的坐标在哪？"),
+        Message(id=2, role="assistant", content="开始分析", tool_calls=tc),
+        Message(id=3, role="tool", content='{"lat": 39.9042}', tool_call_id="call_xml_1"),
+    ]
+    svc = AsyncHistoryService(db=_FakeDb(_conv_with_messages(msgs)))
+    ctx = await svc.load_context("sess-376-paired")
+
+    assistant = [m for m in ctx.llm_messages if m["role"] == "assistant"][0]
+    kept = assistant["tool_calls"]
+    assert len(kept) == 1
+    assert isinstance(kept[0]["function"]["arguments"], str)  # dict → JSON 字符串
+    assert json.loads(kept[0]["function"]["arguments"]) == {"query": "北京"}
+
+    tool = [m for m in ctx.llm_messages if m["role"] == "tool"][0]
+    assert tool["tool_call_id"] == "call_xml_1"
+
+
+@pytest.mark.asyncio
+async def test_load_context_keeps_only_answered_tool_calls():
+    """部分配对：只保留有 tool 响应的 tool_call，孤儿剥除。"""
+    from app.models.db_model import Message
+    from app.services.history_service_async import AsyncHistoryService
+
+    tc = [
+        {"id": "call_1", "type": "function", "function": {"name": "geocode", "arguments": '{"query": "北京"}'}},
+        {"id": "call_2", "type": "function", "function": {"name": "geocode", "arguments": '{"query": "上海"}'}},
+    ]
+    msgs = [
+        Message(id=1, role="user", content="两城"),
+        Message(id=2, role="assistant", content="开始", tool_calls=tc),
+        Message(id=3, role="tool", content="ok", tool_call_id="call_2"),
+    ]
+    svc = AsyncHistoryService(db=_FakeDb(_conv_with_messages(msgs)))
+    ctx = await svc.load_context("sess-376-partial")
+
+    assistant = [m for m in ctx.llm_messages if m["role"] == "assistant"][0]
+    assert [t["id"] for t in assistant["tool_calls"]] == ["call_2"]
+
+
+@pytest.mark.asyncio
+async def test_load_context_keeps_standard_fc_sequence_untouched():
+    """标准 OpenAI FC 序列（字符串 arguments + tool 响应）原样重放，不回归。"""
+    from app.models.db_model import Message
+    from app.services.history_service_async import AsyncHistoryService
+
+    tc = [{"id": "call_1", "type": "function", "function": {"name": "geocode", "arguments": '{"query": "北京"}'}}]
+    msgs = [
+        Message(id=1, role="user", content="北京的坐标在哪？"),
+        Message(id=2, role="assistant", content="", tool_calls=tc),
+        Message(id=3, role="tool", content='{"lat": 39.9042}', tool_call_id="call_1"),
+    ]
+    svc = AsyncHistoryService(db=_FakeDb(_conv_with_messages(msgs)))
+    ctx = await svc.load_context("sess-376-standard")
+
+    assistant = [m for m in ctx.llm_messages if m["role"] == "assistant"][0]
+    assert assistant["tool_calls"] == tc  # 原样保留
+    assert [m["role"] for m in ctx.llm_messages] == ["user", "assistant", "tool"]

--- a/tests/unit/test_issue407_subagent_persistence.py
+++ b/tests/unit/test_issue407_subagent_persistence.py
@@ -93,7 +93,6 @@ async def test_subagent_repair_orphaned_tool_calls_does_not_persist(registry):
 
     内存 repair 照常（消息配对补齐，子引擎自己的上下文保持合法），但绝不写库。
     """
-    import asyncio
 
     from app.services.subagent import SubagentDispatcher, select_tools_for_subagent
 

--- a/tests/unit/test_issue407_subagent_persistence.py
+++ b/tests/unit/test_issue407_subagent_persistence.py
@@ -1,0 +1,156 @@
+"""Issue #407 回归测试：子代理内部 transcript 绝不持久化进父会话 DB 历史。
+
+修复前：SubagentDispatcher 用 parent_session_id 跑子引擎，子代理每条内部
+消息（任务 prompt、assistant 消息、tool_call/tool 响应）都经 _save_msg_async
+写进父会话 DB 行 —— 重载 / LRU 逐出后父上下文包含完整子代理 transcript。
+
+修复（两层）：
+- 子代理引擎（is_subagent_engine=True）的 _save_msg_async 整体抑制持久化；
+- 「clearing」标记提升为注册表级（class 级共享）：任一引擎实例 clear_session
+  后，其他实例（含 in-flight 子引擎）对该会话的 DB 写同样被抑制。
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.tools.registry import ToolRegistry
+
+
+@pytest.fixture
+def registry():
+    r = ToolRegistry()
+    r.register("buffer_analysis", "buf", func=lambda **_: {}, tier=1)
+    return r
+
+
+def _recording_history(saved: list):
+    """记录 save_message 的 AsyncHistoryService 替身（load_context 返回空历史）。"""
+    from app.services.history_store_protocol import HistoryContext
+
+    class _RecordingHistory:
+        def __init__(self, db=None):
+            self.db = db
+
+        async def load_context(self, **kwargs):
+            return HistoryContext(
+                session_id=kwargs.get("session_id", ""),
+                owner_token=None,
+                user_id=None,
+                llm_messages=[],
+                raw_conversation=None,
+            )
+
+        async def save_message(
+            self,
+            session_id,
+            role,
+            content,
+            tool_calls=None,
+            tool_result=None,
+            tool_call_id=None,
+            reasoning_content=None,
+        ):
+            saved.append((session_id, role, content))
+
+    return _RecordingHistory
+
+
+# ─── 子代理不写父会话 DB ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subagent_turn_does_not_persist_to_parent_db_history(registry):
+    """真实子引擎跑一轮完整工具回合：父会话 DB 历史零写入。"""
+    from app.services.subagent import SubagentDispatcher, select_tools_for_subagent
+
+    parent_sid = "parent-sess-407-sub"
+    saved: list = []
+
+    dispatcher = SubagentDispatcher(registry, parent_session_id=parent_sid)
+    sub_engine = dispatcher._build_sub_engine(
+        select_tools_for_subagent(registry), max_rounds=5,
+    )
+    assert sub_engine.is_subagent_engine is True
+
+    resp1 = {"choices": [{"message": {"content": "调用工具", "tool_calls": [
+        {"id": "call_1", "function": {"name": "buffer_analysis", "arguments": '{"radius": 10}'}},
+    ]}}]}
+    resp2 = {"choices": [{"message": {"content": "子任务完成，生成 ref:data-abc。"}}]}
+
+    with patch.object(sub_engine, "_call_llm", new_callable=AsyncMock, side_effect=[resp1, resp2]):
+        with patch(
+            "app.services.chat.execution_engine.AsyncHistoryService",
+            _recording_history(saved),
+        ):
+            result = await sub_engine.chat("子任务：批量统计", session_id=parent_sid)
+
+    assert "子任务完成" in result["content"]  # 子代理正常跑完
+    assert saved == []  # 子代理内部消息（user/assistant/tool）从不写进父会话 DB
+
+
+@pytest.mark.asyncio
+async def test_subagent_repair_orphaned_tool_calls_does_not_persist(registry):
+    """取消/断连路径的孤儿 repair（_repair_orphaned_tool_calls 的 DB 写）同样被抑制。
+
+    内存 repair 照常（消息配对补齐，子引擎自己的上下文保持合法），但绝不写库。
+    """
+    import asyncio
+
+    from app.services.subagent import SubagentDispatcher, select_tools_for_subagent
+
+    parent_sid = "parent-sess-407-repair"
+    saved: list = []
+
+    dispatcher = SubagentDispatcher(registry, parent_session_id=parent_sid)
+    sub_engine = dispatcher._build_sub_engine(
+        select_tools_for_subagent(registry), max_rounds=5,
+    )
+
+    messages = [
+        {"role": "user", "content": "任务"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "call_orphan_1", "function": {"name": "buffer_analysis", "arguments": "{}"}},
+        ]},
+    ]
+    with patch(
+        "app.services.chat.execution_engine.AsyncHistoryService",
+        _recording_history(saved),
+    ):
+        await sub_engine._repair_orphaned_tool_calls(parent_sid, messages)
+
+    # 内存 repair 照常补齐（子引擎上下文合法），DB 零写入
+    assert messages[-1]["role"] == "tool"
+    assert messages[-1]["tool_call_id"] == "call_orphan_1"
+    assert saved == []
+
+
+# ─── clearing 标记注册表级共享 ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clearing_marker_is_registry_wide(registry):
+    """任一实例标记 clearing 后，其他实例（如 in-flight 子引擎）写库被抑制。"""
+    from app.services.chat.execution_engine import SessionClearingError
+    from app.services.chat_engine import ChatEngine
+
+    e1 = ChatEngine(registry)
+    e2 = ChatEngine(registry)
+    sid = "sess-407-clear"
+    saved: list = []
+
+    try:
+        e1._clearing_sessions.add(sid)
+        assert sid in e2._clearing_sessions  # 注册表级共享（同一集合）
+
+        with patch(
+            "app.services.chat.execution_engine.AsyncHistoryService",
+            _recording_history(saved),
+        ):
+            await e2._save_msg_async(sid, "user", "hello")  # 其他实例的写被抑制
+            await e2._save_msg_async("sess-407-other", "user", "hi")  # 非 clearing 会话照常
+
+        assert saved == [("sess-407-other", "user", "hi")]
+
+        with pytest.raises(SessionClearingError):
+            e2._reject_if_clearing(sid)  # 新 turn 拒绝（跨实例生效）
+    finally:
+        e1._clearing_sessions.discard(sid)  # 清掉共享标记，避免泄漏到其他测试


### PR DESCRIPTION
## 概述

修复两个会话历史持久化缺陷：P1 #376（MiniMax XML 工具调用把孤儿 tool_calls 持久化，重启后会话永久损坏）与 P3 #407（子代理内部 transcript 写进父会话 DB 历史，重载后重新进入父上下文）。

分支 `fix/chat-persistence`，两个 commit（`Fixes #376`、`Fixes #407`），基于最新 master，未动 master。

---

## Fixes #376 — MiniMax XML tool_calls 持久化损坏会话

**问题**：XML 工具调用路径把解析出的 `tool_calls` 随 assistant 消息落库（`execution_engine.py` 非流式 `_chat_locked` 与流式 `chat_stream` 两条保存路径），但工具响应只作为内存中的合成 user 消息存在、从不持久化。进程重启 / LRU 逐出后 `load_context` 原样重放 `msg.tool_calls`，产生没有配对 tool 响应的 `assistant.tool_calls` —— OpenAI 兼容 provider 拒绝后续每个 turn 的第一次 LLM 调用，会话永久损坏。次要问题：XML `arguments` 以 dict 落库，而 API 契约要求 JSON 字符串。

**修复（两层防线，流式 + 非流式）**：
- **写入路径**：XML 分支持久化的 assistant 行只带 `standard_calls`（XML 路径为空 → `tool_calls=None`），降级为普通文本行，重放序列合法；标准 FC 路径行为不变。
- **重放路径**（兜底 + 修复历史损坏数据）：
  - `load_context` 经新的 `_strip_orphaned_tool_calls` 剥除没有配对 tool 响应的 assistant `tool_calls`（已配对的原样保留，部分配对只保留有响应的项）；
  - `_msg_to_llm_dict` 把 dict 型 `arguments` 规范化为 JSON 字符串（标准字符串路径为 no-op）。

**测试**（`tests/unit/test_issue376_xml_tool_call_history.py`，5 个用例）：
- 非流式 / 流式 XML 工具轮：assistant 行以 `tool_calls=None` 落库、XML 标签从 content 剥除、工具真实执行；
- `load_context`：孤儿 tool_calls 剥除（content 保留）、配对保留且 arguments 规范化为 JSON 字符串、部分配对只保留已响应项、标准 FC 序列原样重放（无回归）。

---

## Fixes #407 — 子代理 transcript 污染父会话历史

**问题**：`SubagentDispatcher` 用 `parent_session_id` 跑子引擎，子代理每条内部消息（任务 prompt、assistant 消息、tool_call/tool 响应）都经 `_save_msg_async` 写进父会话 DB 行；内存 LRU 隔离但 DB 不隔离，重载 / 逐出后父上下文包含完整子代理轨迹。次要：`_clearing_sessions` 是 per-engine-instance 的，父 `clear_session` 与 in-flight 子代理竞争时不抑制子引擎写入（行复活窗口）。

**修复**：
- 子代理引擎（`is_subagent_engine=True`）的 `_save_msg_async` 整体抑制持久化 —— 子代理仍是隔离微会话（复用父 session_id 保持 refs/map_state 父子互通），但内部 transcript 只活在子引擎自己的内存 LRU；父侧只通过 spawn_subagent 工具的 tool-result 消息拿到最终摘要。取消 / 断连路径的孤儿 repair 同样被抑制（内存 repair 照常，子引擎自己的上下文保持合法）。
- `_clearing_sessions` 提升为注册表级（class 级共享）：任一引擎实例 `clear_session` 后，其他实例（含 in-flight 子引擎）对该会话的 DB 写与新 turn 拒绝都生效。
- 顺带修复 `_FrozenCatalog.select_schemas` 签名缺失 `declared_domains` kwarg —— 真实子引擎回合此前会直接 TypeError，spawn_subagent 无法端到端工作。

**测试**（`tests/unit/test_issue407_subagent_persistence.py`，3 个用例）：
- 真实子引擎完整工具回合（mock LLM）：父会话 DB 历史零写入；
- 孤儿 repair 路径：内存补齐照常、DB 零写入；
- clearing 标记跨实例共享：其他实例写库被抑制、非 clearing 会话照常落库。

---

## 测试摘要

- 新增回归测试：9 passed（376: 5，407: 3 + 1 在 376 文件外的 load_context 部分配对该文件内）。
- 相关既有套件（engine / history / subagent / session 等 12 个文件 + 整个 tests/unit + chat/history 顶层套件）：1711 passed, 2 skipped；唯一失败 `tests/unit/test_harness_dispatch_hook.py::test_harness_disabled_by_default` 在干净的 base（`git stash` 后）上同样失败 —— 环境相关，与本次改动无关。