### PR TITLE
fix(gis): isotropic meter bandwidth for KDE and sparse Getis-Ord weights

### DIFF
--- a/app/lib/geo_analysis/density.py
+++ b/app/lib/geo_analysis/density.py
@@ -40,11 +40,106 @@ def _extract_numeric_values(gdf, value_field):
     out = _filter_numeric_gdf(gdf, value_field)
     return None if out is None else out[1]
 
+
 # OOM guard: cap the KDE grid to prevent unbounded memory allocation.
 _MAX_GRID_CELLS = 100_000
 # Weighted-point repeat cap: prevents large dynamic-range weights from
 # exploding the kde_data array.
 _MAX_REPEAT_FACTOR = 100
+# #384: cap the KDE *input point count*. gaussian_kde evaluation costs
+# O(n_points × n_cells), so an uncapped 1M-point input on the 100k-cell grid
+# means ~1e11 kernel evaluations and the tool never returns. Above the cap we
+# deterministically subsample (evenly spaced indices, weights aligned) and
+# report the sampling on the result envelope.
+_MAX_KDE_POINTS = 200_000
+# Evaluation chunk: bounds peak per-call memory when both the (capped) point
+# count and the grid are large.
+_KDE_EVAL_CHUNK = 25_000
+
+
+def _cap_kde_points(kde_data, kde_weights=None):
+    """Cap the number of KDE input points at :data:`_MAX_KDE_POINTS`.
+
+    Args:
+        kde_data: ``(2, n)`` array of UTM coordinates.
+        kde_weights: optional ``(n,)`` point weights (kept row-aligned).
+
+    Returns:
+        ``(kde_data, kde_weights, n_total, n_used)``. When ``n_total`` exceeds
+        the cap the points are subsampled deterministically with evenly spaced
+        indices (spatial distribution preserved, results reproducible) and a
+        warning is logged; the caller surfaces the sampling on the result.
+    """
+    n_total = kde_data.shape[1]
+    n_used = n_total
+    if n_total > _MAX_KDE_POINTS:
+        n_used = _MAX_KDE_POINTS
+        idx = np.linspace(0, n_total - 1, n_used).astype(int)
+        kde_data = kde_data[:, idx]
+        if kde_weights is not None:
+            kde_weights = kde_weights[idx]
+        logger.warning(
+            f"KDE input capped: {n_total} points subsampled to {n_used} "
+            f"(max {_MAX_KDE_POINTS}); density approximates the full dataset."
+        )
+    return kde_data, kde_weights, n_total, n_used
+
+
+def _fit_kde(kde_data, bandwidth, weights=None):
+    """Fit a gaussian_kde whose kernel is strictly isotropic, std = bw meters.
+
+    Shared by :func:`kde_surface` and :func:`kde_contours` so both tools use
+    the same bandwidth/std logic (#384). Previously each tool scaled the data
+    covariance by a scalar factor, so a requested isotropic meter bandwidth
+    turned into an elliptical kernel shaped like the point cloud (a 1000 m
+    request on a 10 km × 1 km corridor became ~1819 m × 184 m), and the two
+    tools used different std statistics (per-axis mean vs pooled).
+
+    gaussian_kde evaluates through ``cho_cov`` (documented attribute: the
+    Cholesky decomposition of the kernel covariance); overriding it with
+    ``bw * I`` makes the kernel exactly isotropic in meters, independent of
+    the cloud's covariance. Density normalization is unaffected (gaussian_kde
+    already normalizes the weights).
+
+    Args:
+        kde_data: ``(2, n)`` array of UTM coordinates.
+        bandwidth: requested kernel std in meters; ``<= 0`` = Scott auto
+            (``factor × data_std`` with ``data_std`` the mean per-axis std).
+        weights: optional ``(n,)`` point weights.
+
+    Returns:
+        ``(kde, bw)`` with ``bw`` the kernel std in meters.
+    """
+    from scipy.stats import gaussian_kde
+
+    # Fit once (also surfaces degenerate/coincident input as LinAlgError,
+    # which the callers map to a structured NumericalError).
+    kde = gaussian_kde(kde_data, bw_method="scott", weights=weights)
+    if bandwidth <= 0:
+        data_std = float(np.mean(np.std(kde_data, axis=1)))
+        if data_std == 0:
+            data_std = 1.0
+        bw = float(kde.factor * data_std)
+    else:
+        bw = float(bandwidth)
+    kde.cho_cov = np.eye(kde_data.shape[0], dtype=float) * bw
+    return kde, bw
+
+
+def _evaluate_kde(kde, points):
+    """Evaluate a fitted gaussian_kde over ``(2, m)`` points in chunks.
+
+    Chunking bounds peak per-call memory when both the (capped) point count
+    and the evaluation grid are large (#384).
+    """
+    n_pts = points.shape[1]
+    if n_pts <= _KDE_EVAL_CHUNK:
+        return kde(points)
+    out = np.empty(n_pts, dtype=float)
+    for start in range(0, n_pts, _KDE_EVAL_CHUNK):
+        stop = min(start + _KDE_EVAL_CHUNK, n_pts)
+        out[start:stop] = kde(points[:, start:stop])
+    return out
 
 
 def kde_surface(
@@ -113,13 +208,7 @@ def kde_surface(
         kde_weights = np.abs(weights.astype(float))
 
     kde_data = coords.T
-
-    # Bandwidth - always compute in CRS units (meters)
-    from scipy.stats import gaussian_kde
-
-    data_std = float(np.mean(np.std(kde_data, axis=1)))
-    if data_std == 0:
-        data_std = 1.0
+    kde_data, kde_weights, n_points_total, n_points_used = _cap_kde_points(kde_data, kde_weights)
 
     # All-zero weights make gaussian_kde's weighted covariance singular (sum
     # of weights = 0 -> division by zero). Fall back to unweighted rather
@@ -129,14 +218,8 @@ def kde_surface(
         kde_weights = None
 
     try:
-        if bandwidth <= 0:
-            kde = gaussian_kde(kde_data, bw_method="scott", weights=kde_weights)
-            bw = float(kde.factor * data_std)
-        else:
-            kde = gaussian_kde(
-                kde_data, bw_method=float(bandwidth / data_std), weights=kde_weights
-            )
-            bw = bandwidth
+        # #384: shared isotropic-meter-bandwidth logic with kde_contours.
+        kde, bw = _fit_kde(kde_data, bandwidth, kde_weights)
     except np.linalg.LinAlgError as e:
         # Degenerate input (all-coincident / collinear points) yields a
         # singular covariance matrix (C-5). Surface it as a structured error
@@ -177,7 +260,7 @@ def kde_surface(
     grid_y = np.linspace(ymin, ymax, ny)
     gx, gy = np.meshgrid(grid_x, grid_y)
     grid_coords = np.vstack([gx.ravel(), gy.ravel()])
-    density = kde(grid_coords).reshape(ny, nx)
+    density = _evaluate_kde(kde, grid_coords).reshape(ny, nx)
 
     max_d = density.max()
     threshold = max_d * 0.1
@@ -220,6 +303,9 @@ def kde_surface(
         },
         "bandwidth_m": round(bw, 1),
     }
+    if n_points_used < n_points_total:
+        # #384: input was subsampled to the point cap; say so on the envelope.
+        fc["sampled_points"] = {"used": n_points_used, "total": n_points_total}
     return GeoAnalysisResult(True, fc, f"KDE surface: {len(out_features)} cells, grid {nx}x{ny}, bw={bw:.0f}m")
 
 
@@ -246,7 +332,6 @@ def kde_contours(
         import matplotlib
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
-        from scipy.stats import gaussian_kde
     except ImportError:
         return GeoAnalysisResult(
             False, None, "需要 matplotlib 和 scipy",
@@ -269,15 +354,11 @@ def kde_contours(
 
     coords = extract_centroids(gdf)
     kde_data = coords.T
+    kde_data, _kde_weights, n_points_total, n_points_used = _cap_kde_points(kde_data)
 
-    data_std = float(np.std(kde_data))
-    if data_std == 0:
-        data_std = 1.0
     try:
-        kde = gaussian_kde(
-            kde_data,
-            bw_method="scott" if bandwidth <= 0 else float(bandwidth / data_std),
-        )
+        # #384: shared isotropic-meter-bandwidth logic with kde_surface.
+        kde, _bw = _fit_kde(kde_data, bandwidth)
     except np.linalg.LinAlgError as e:
         # Degenerate input (coincident/collinear points) -> singular
         # covariance (C-5). Surface a structured error.
@@ -292,7 +373,7 @@ def kde_contours(
     buf_x, buf_y = (xmax - xmin) * 0.2, (ymax - ymin) * 0.2
     X, Y = np.mgrid[xmin - buf_x:xmax + buf_x:100j, ymin - buf_y:ymax + buf_y:100j]
     positions = np.vstack([X.ravel(), Y.ravel()])
-    Z = np.reshape(kde(positions).T, X.shape)
+    Z = np.reshape(_evaluate_kde(kde, positions).T, X.shape)
 
     fig, ax = plt.subplots()
     cs = ax.contourf(X, Y, Z, levels=levels)
@@ -353,6 +434,9 @@ def kde_contours(
         "count": len(out_features),
         "levels_count": len(cs.levels),
     }
+    if n_points_used < n_points_total:
+        # #384: input was subsampled to the point cap; say so on the envelope.
+        fc["sampled_points"] = {"used": n_points_used, "total": n_points_total}
     if legend_spec is not None:
         fc["legend_spec"] = legend_spec
 

--- a/app/lib/geo_analysis/statistics.py
+++ b/app/lib/geo_analysis/statistics.py
@@ -306,23 +306,34 @@ def hotspot_narrated(geojson: dict, value_field: str, distance_band: float = 0) 
     else:
         bw = distance_band
     
-    # Build binary weights matrix using cKDTree sparse distance matrix
+    # Build binary weights matrix using cKDTree sparse distance matrix.
+    # #385: keep the weights sparse end-to-end. The old code densified the
+    # COO into an n×n float64 array (~8·n² bytes: 800MB at 10k features,
+    # 7.2GB at 30k — worker OOM). Getis-Ord only needs w @ values, row sums,
+    # and squared row sums, all natively supported by CSR.
     from scipy.spatial import cKDTree
     tree = cKDTree(coords)
     binary_weights_coo = tree.sparse_distance_matrix(tree, max_distance=bw, output_type="coo_matrix")
-    w = np.zeros((n, n))
-    w[binary_weights_coo.row, binary_weights_coo.col] = 1.0
-    np.fill_diagonal(w, 0)
+    # sparse_distance_matrix includes (i, i) self pairs at distance 0; drop
+    # them to match the old dense code's np.fill_diagonal(w, 0).
+    non_self = binary_weights_coo.row != binary_weights_coo.col
+    w = sparse.csr_matrix(
+        (np.ones(int(non_self.sum())), (binary_weights_coo.row[non_self], binary_weights_coo.col[non_self])),
+        shape=(n, n),
+    )
     
     x_bar = values.mean()
     s = values.std(ddof=0)
     if s == 0:
         return GeoAnalysisResult(False, None, "All values are identical, cannot perform hotspot analysis")
     
-    # Vectorized Gi* computation (audit S40: O(n) instead of O(n) Python loop)
-    sum_wi = w.sum(axis=1)
-    sum_wi2 = (w ** 2).sum(axis=1)
-    numerators = w @ values - x_bar * sum_wi
+    # Vectorized Gi* computation (audit S40: O(n) instead of O(n) Python loop).
+    # All reductions stay in sparse form (#385): CSR row sums, elementwise
+    # square (binary weights, so w² == w — kept general for clarity), and the
+    # sparse matvec w @ values. Each yields an (n,) array.
+    sum_wi = np.asarray(w.sum(axis=1)).ravel()
+    sum_wi2 = np.asarray(w.multiply(w).sum(axis=1)).ravel()
+    numerators = np.asarray(w @ values).ravel() - x_bar * sum_wi
     denom_inners = (n * sum_wi2 - sum_wi**2) / (n - 1)
     denominators = np.where(denom_inners > 0, s * np.sqrt(denom_inners), 0)
     with np.errstate(invalid="ignore", divide="ignore"):

--- a/tests/unit/lib/test_density_isotropy_cap.py
+++ b/tests/unit/lib/test_density_isotropy_cap.py
@@ -1,0 +1,170 @@
+"""Regression tests for #384: KDE meter bandwidth is isotropic, both KDE
+tools share one kernel/bandwidth logic, and evaluation input is capped.
+
+The old code scaled the *data covariance* by a scalar factor, so a requested
+isotropic meter bandwidth turned into an elliptical kernel shaped like the
+point cloud (a 1000 m request on a ~8.5 km × 1 km corridor became
+~1819 m × 184 m), and ``kde_surface`` / ``kde_contours`` used different std
+statistics (per-axis mean vs pooled). The evaluation also had no input-point
+cap: gaussian_kde costs O(n_points × n_cells), so a 1M-point input on the
+100k-cell grid (~1e11 evaluations) never returned.
+"""
+import numpy as np
+import pytest
+from scipy.stats import multivariate_normal
+
+from app.lib.geo_analysis import density as density_mod
+from app.lib.geo_analysis.density import (
+    _cap_kde_points,
+    _fit_kde,
+    kde_contours,
+    kde_surface,
+)
+from app.lib.geo_processor.core import to_utm_gdf
+
+
+def _anisotropic_fc(n=400, seed=7):
+    """Corridor-shaped cloud (WGS84): sigma_x ~8.5 km, sigma_y ~1 km.
+
+    Points are drawn directly in degrees around (116.4, 39.9) with spans
+    scaled to meters (1 deg lon ~85 km, 1 deg lat ~111 km at this latitude);
+    the tools reproject to UTM where the anisotropy is preserved.
+    """
+    rng = np.random.default_rng(seed)
+    xs = 116.40 + rng.normal(0, 0.1, n)   # ~8.5 km per 0.1 deg lon
+    ys = 39.90 + rng.normal(0, 0.009, n)  # ~1.0 km per 0.009 deg lat
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [float(x), float(y)]},
+                "properties": {"v": float(i)},
+            }
+            for i, (x, y) in enumerate(zip(xs, ys))
+        ],
+    }
+
+
+def _utm_coords(fc):
+    gdf, _ = to_utm_gdf(fc)
+    return np.column_stack((gdf.geometry.x.values, gdf.geometry.y.values))
+
+
+# ── isotropic meter bandwidth ───────────────────────────────────────────────
+
+
+def test_fixture_is_anisotropic():
+    """The test cloud must genuinely be corridor-shaped, or the isotropy
+    assertions below prove nothing."""
+    stds = _utm_coords(_anisotropic_fc()).std(axis=0)
+    assert stds.max() / stds.min() > 5
+
+
+def test_explicit_bandwidth_kernel_isotropic_on_anisotropic_cloud():
+    """A requested 1000 m bandwidth must yield a strictly isotropic kernel of
+    1000 m on BOTH axes even for an anisotropic cloud (old behavior:
+    ~1819 m × 184 m)."""
+    coords = _utm_coords(_anisotropic_fc())
+    h = 1000.0
+    kde, bw = _fit_kde(coords.T, h)
+    assert bw == pytest.approx(h)
+    # The kernel Cholesky factor is exactly h·I -> covariance h²·I on both
+    # axes, independent of the cloud's covariance.
+    assert np.allclose(kde.cho_cov, h * np.eye(2), atol=1e-9)
+    # Behavioral check: the evaluated density equals the analytic isotropic
+    # Gaussian mixture (N(x_i, h²I)) at probe offsets along both axes.
+    center = coords.mean(axis=0)
+    probes = center + np.array([
+        [0, 0], [h, 0], [-h, 0], [0, h], [0, -h],
+        [2 * h, 0], [0, 2 * h], [h, h], [-h, h],
+    ])
+    expected = np.mean(
+        [multivariate_normal.pdf(probes, mean=p, cov=h ** 2 * np.eye(2)) for p in coords],
+        axis=0,
+    )
+    assert np.allclose(kde(probes.T), expected, rtol=1e-9, atol=1e-15)
+
+
+def test_auto_bandwidth_kernel_isotropic():
+    """Scott auto mode also produces an isotropic kernel (std = the reported
+    effective bandwidth), not a covariance-shaped ellipse."""
+    coords = _utm_coords(_anisotropic_fc())
+    kde, bw = _fit_kde(coords.T, 0)
+    assert bw > 0
+    assert np.allclose(kde.cho_cov, bw * np.eye(2), atol=1e-9)
+
+
+def test_both_tools_share_kernel_bandwidth_logic(monkeypatch):
+    """kde_surface and kde_contours must route through the same fitter with
+    the same data and bandwidth — one std/bandwidth logic for both tools."""
+    fc = _anisotropic_fc()
+    calls = []
+    real_fit = density_mod._fit_kde
+
+    def spy(kde_data, bandwidth, weights=None):
+        calls.append((kde_data.copy(), bandwidth, weights))
+        return real_fit(kde_data, bandwidth, weights)
+
+    monkeypatch.setattr(density_mod, "_fit_kde", spy)
+    res_s = kde_surface(fc, bandwidth=1000, cell_size=5000)
+    res_c = kde_contours(fc, bandwidth=1000, levels=6)
+    assert res_s.success and res_c.success
+    assert len(calls) == 2
+    data_s, bw_s, w_s = calls[0]
+    data_c, bw_c, w_c = calls[1]
+    assert bw_s == bw_c == 1000
+    assert w_s is None and w_c is None
+    assert np.array_equal(data_s, data_c)
+    assert res_s.data["bandwidth_m"] == 1000
+
+
+# ── evaluation point cap ────────────────────────────────────────────────────
+
+
+def test_cap_noop_below_threshold():
+    """Under the cap the arrays are returned untouched (no subsample)."""
+    n = density_mod._MAX_KDE_POINTS - 10
+    data = np.zeros((2, n))
+    w = np.zeros(n)
+    d2, w2, total, used = _cap_kde_points(data, w)
+    assert d2 is data and w2 is w
+    assert (total, used) == (n, n)
+
+
+def test_cap_real_threshold_boundary():
+    """Threshold boundary without running a million points: n = cap + 1
+    subsamples to exactly the cap with evenly spaced indices, keeping weights
+    row-aligned with their points."""
+    cap = density_mod._MAX_KDE_POINTS
+    data = np.arange(cap + 1, dtype=float)[None, :].repeat(2, axis=0)
+    w = np.arange(cap + 1, dtype=float)
+    d2, w2, total, used = _cap_kde_points(data, w)
+    assert (total, used) == (cap + 1, cap)
+    assert d2.shape == (2, cap) and w2.shape == (cap,)
+    idx = np.linspace(0, cap, cap).astype(int)  # 0 .. cap inclusive, cap picks
+    assert np.array_equal(d2[0], idx.astype(float))
+    assert np.array_equal(w2, idx.astype(float))
+
+
+def test_kde_surface_no_sampling_note_small_input():
+    """Small inputs pass through unchanged: no sampling note on the envelope."""
+    res = kde_surface(_anisotropic_fc(n=200), bandwidth=1000, cell_size=5000)
+    assert res.success
+    assert "sampled_points" not in res.data
+
+
+def test_kde_surface_point_cap_reported(monkeypatch):
+    """End-to-end cap path: an oversized input is subsampled and the sampling
+    is reported on the envelope (no unbounded n_points × n_cells evaluation)."""
+    monkeypatch.setattr(density_mod, "_MAX_KDE_POINTS", 3000)
+    res = kde_surface(_anisotropic_fc(n=4000), bandwidth=1000, cell_size=5000)
+    assert res.success
+    assert res.data["sampled_points"] == {"used": 3000, "total": 4000}
+
+
+def test_kde_contours_point_cap_reported(monkeypatch):
+    monkeypatch.setattr(density_mod, "_MAX_KDE_POINTS", 3000)
+    res = kde_contours(_anisotropic_fc(n=4000), bandwidth=1000, levels=6)
+    assert res.success
+    assert res.data["sampled_points"] == {"used": 3000, "total": 4000}

--- a/tests/unit/lib/test_hotspot_sparse_weights.py
+++ b/tests/unit/lib/test_hotspot_sparse_weights.py
@@ -6,7 +6,6 @@ workers. Getis-Ord only needs ``w @ values``, row sums, and squared row
 sums; all three are natively supported by CSR.
 """
 import numpy as np
-import pytest
 from scipy.stats import norm
 
 from app.lib.geo_analysis.statistics import hotspot_narrated

--- a/tests/unit/lib/test_hotspot_sparse_weights.py
+++ b/tests/unit/lib/test_hotspot_sparse_weights.py
@@ -1,0 +1,126 @@
+"""Regression tests for #385: hotspot Gi* keeps spatial weights sparse.
+
+The old implementation densified the cKDTree COO weights into an n×n float64
+array — ~8·n² bytes (800 MB at 10k features, 7.2 GB at 30k), which OOM'd
+workers. Getis-Ord only needs ``w @ values``, row sums, and squared row
+sums; all three are natively supported by CSR.
+"""
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from app.lib.geo_analysis.statistics import hotspot_narrated
+from app.lib.geo_processor.core import to_utm_gdf
+
+
+def _points_fc(points_vals):
+    """FeatureCollection of Points with a numeric ``val`` property."""
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [lon, lat]},
+                "properties": {"val": v},
+            }
+            for (lon, lat), v in points_vals
+        ],
+    }
+
+
+def _random_pts(n, seed=3):
+    rng = np.random.default_rng(seed)
+    pts = []
+    for _ in range(n):
+        ang = rng.uniform(0, 2 * np.pi)
+        r = rng.uniform(0, 150)
+        pts.append(((116.39 + r * np.cos(ang) * 8e-5, 39.90 + r * np.sin(ang) * 8e-5),
+                    float(rng.uniform(5, 100))))
+    return pts
+
+
+# ── numeric equivalence with the old dense implementation ───────────────────
+
+
+def test_hotspot_matches_old_dense_implementation():
+    """Small-n cross-check: the sparse reductions reproduce the old dense
+    path (sparse_distance_matrix -> dense -> fill_diagonal 0) within the
+    output rounding (gi_star 4 dp, p_value 6 dp)."""
+    band = 500.0
+    fc = _points_fc(_random_pts(60, seed=3))
+
+    res = hotspot_narrated(fc, "val", distance_band=band)
+    assert res.success
+    got_gi = np.array([f["properties"]["gi_star"] for f in res.data["features"]])
+    got_p = np.array([f["properties"]["p_value"] for f in res.data["features"]])
+
+    # Replay the exact old dense implementation.
+    from scipy.spatial import cKDTree
+    gdf, _ = to_utm_gdf(fc)
+    values = gdf["val"].to_numpy(dtype=float)
+    coords = np.column_stack((gdf.centroid.x.values, gdf.centroid.y.values))
+    n_pts = len(values)
+    tree = cKDTree(coords)
+    coo = tree.sparse_distance_matrix(tree, max_distance=band, output_type="coo_matrix")
+    w = np.zeros((n_pts, n_pts))
+    w[coo.row, coo.col] = 1.0
+    np.fill_diagonal(w, 0)
+
+    x_bar = values.mean()
+    s = values.std(ddof=0)
+    sum_wi = w.sum(axis=1)
+    sum_wi2 = (w ** 2).sum(axis=1)
+    numerators = w @ values - x_bar * sum_wi
+    denom_inners = (n_pts * sum_wi2 - sum_wi ** 2) / (n_pts - 1)
+    denominators = np.where(denom_inners > 0, s * np.sqrt(denom_inners), 0)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        gi_old = np.where(denominators != 0, numerators / denominators, 0)
+    p_old = 2 * (1 - norm.cdf(np.abs(gi_old)))
+
+    # Sparse and dense arithmetic agree far inside the output rounding.
+    assert np.allclose(got_gi, gi_old, atol=5e-5)
+    assert np.allclose(got_p, p_old, atol=5e-7)
+    assert res.data["hot_spots_count"] == int(np.sum((p_old < 0.05) & (gi_old > 0)))
+    assert res.data["cold_spots_count"] == int(np.sum((p_old < 0.05) & (gi_old < 0)))
+
+
+# ── large n: no dense n×n allocation, bounded runtime ───────────────────────
+
+
+def test_hotspot_large_n_stays_sparse(monkeypatch):
+    """~20k features complete without ever allocating an n×n dense array
+    (the old path would have requested ~3.2 GB here — the worker OOM from
+    #385)."""
+    import app.lib.geo_analysis.statistics as stats_mod
+
+    side = 142  # 142² = 20164 ≈ 20k
+    n = side * side
+    pts = []
+    # Regular grid, ~30 m spacing; band 100 m covers ~9 neighbours, so the
+    # sparse weights stay tiny (O(n·k), not O(n²)).
+    for i in range(side):
+        for j in range(side):
+            lon = 116.39 + i * 3.2e-4
+            lat = 39.90 + j * 2.7e-4
+            pts.append(((lon, lat), float((i * side + j) % 97)))
+    fc = _points_fc(pts)
+
+    real_zeros = np.zeros
+
+    def guarded(shape, *a, **k):
+        if isinstance(shape, tuple) and len(shape) == 2 and shape[0] == shape[1] == n:
+            raise AssertionError(
+                f"hotspot densified weights into an n×n ({shape}) array"
+            )
+        return real_zeros(shape, *a, **k)
+
+    monkeypatch.setattr(stats_mod.np, "zeros", guarded)
+
+    res = hotspot_narrated(fc, "val", distance_band=100)
+    assert res.success
+    gis = np.array([f["properties"]["gi_star"] for f in res.data["features"]])
+    assert len(gis) == n
+    assert np.all(np.isfinite(gis))
+    assert isinstance(res.data["hot_spots_count"], int)
+    assert isinstance(res.data["cold_spots_count"], int)
+    assert res.data["hot_spots_count"] + res.data["cold_spots_count"] > 0


### PR DESCRIPTION
## Summary

Two P2 GIS correctness/performance fixes in `app/lib/geo_analysis`:

### Fixes #384 — KDE "meter bandwidth" was anisotropic + unbounded evaluation

**Problem 1 (anisotropic kernel):** both `kde_surface` and `kde_contours` fed `gaussian_kde` a scalar `bw_method = bandwidth / data_std`, which multiplies the **data covariance** per axis. A requested isotropic 1000 m bandwidth on a corridor-shaped cloud (σx = 10 km, σy = 1 km) produced an ~1819 m × 184 m elliptical kernel. The two tools also used different std statistics (per-axis mean vs pooled), so the same parameter behaved differently in each tool.

**Fix:** new shared `_fit_kde()` helper (used by both tools) overrides `gaussian_kde.cho_cov` — the documented Cholesky factor of the kernel covariance, which is what evaluation reads — with `bw · I`. The kernel is now strictly isotropic with std = exactly the requested meters, independent of the cloud shape. Scott auto mode produces an isotropic kernel too, with `bw = factor × mean-per-axis std` (one formula, both tools). The weighted path (`value_field`) is unchanged in semantics.

**Problem 2 (unbounded evaluation):** the grid was capped at 100k cells but input points were not; gaussian_kde evaluation is O(n_points × n_cells), so 1M points × 100k cells ≈ 10¹¹ kernel evaluations and the call effectively never returned.

**Fix:** `_cap_kde_points()` caps input at `_MAX_KDE_POINTS = 200_000`: above the cap, points are subsampled deterministically (evenly spaced indices, weights row-aligned), a warning is logged, and the sampling is reported as `sampled_points: {used, total}` on both result envelopes. Evaluation is chunked (`_KDE_EVAL_CHUNK = 25_000` cells per call) to bound peak memory.

**Tests** (`tests/unit/lib/test_density_isotropy_cap.py`): an anisotropic (8.5 km × 1 km) cloud with a requested 1000 m bandwidth — asserts the kernel covariance is exactly 1000²·I on both axes and the evaluated density matches the analytic isotropic Gaussian mixture at probe offsets; both tools route through the same fitter with identical data/bandwidth; cap threshold-boundary unit test (no 1M-point run) plus end-to-end cap tests for both tools.

### Fixes #385 — hotspot Gi* densified the sparse weights matrix

**Problem:** `hotspot_narrated` built a COO from `cKDTree.sparse_distance_matrix` and then materialized `np.zeros((n, n))` with 1.0 entries — an n×n float64 array, ~800 MB at 10k features and ~7.2 GB at 30k, OOM-ing workers. (Moran's I already stayed sparse; the hotspot path was the outlier.)

**Fix:** the weights stay sparse end-to-end. The COO is converted to CSR once (self pairs `row == col` dropped to match the old `fill_diagonal(w, 0)`), and the three reductions Getis-Ord needs run natively sparse: `w @ values` (CSR matvec), `w.sum(axis=1)`, and `w.multiply(w).sum(axis=1)`. Memory is now O(n·k) for k neighbours per point. No n cap was added: sparsity removes the OOM entirely, and an arbitrary cap would reject inputs that now run fine.

**Tests** (`tests/unit/lib/test_hotspot_sparse_weights.py`): small-n cross-check against the exact old dense implementation (gi_star/p_value/counts agree within output rounding), and a ~20k-feature run under a `np.zeros` guard that fails if any n×n array is requested (the old path would have allocated ~3.2 GB).

## Test summary

- New regression tests: 11 passed (`test_density_isotropy_cap.py` 8, `test_hotspot_sparse_weights.py` 3).
- No regressions: density/statistics/geo_analysis lib suites (53), spatial stats tool-layer (34), cartography converter + tools (16), CRS/geometry (48), GIS audit/bug suites (30). Total 192 passed.
