### PR TITLE
fix(sse): sticky routing for k8s resume, gap-marker for truncated replay, legacy-engine heartbeat

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -310,29 +310,18 @@ async def _sse_batched(stream, max_events=_PI_BATCH_MAX_EVENTS, max_delay_s=_PI_
         raise
 
 
-def _split_sse_events(chunk: str) -> list[str]:
-    """Split a (possibly coalesced) SSE chunk into individual event blocks.
-
-    Every block built by :func:`sse_event` ends with ``\\n\\n`` and its JSON
-    ``data:`` payload never contains a literal blank line (json.dumps escapes
-    newlines), so splitting on ``\\n\\n`` is lossless — for both the legacy
-    engine's internal SSEBatcher coalescing and the route-boundary batcher.
-    """
-    return [part for part in chunk.split("\n\n") if part]
-
-
 async def _recorded(stream, buffer: TurnEventBuffer):
     """Wrap an SSE event stream, recording each event into the resume buffer
-    before it is yielded (DUP-1). Handles coalesced chunks transparently so the
-    buffer holds individual events (WITH their ``\\n\\n`` block terminator — the
-    buffer stores exact wire blocks, and a resume replays them verbatim) in
-    emission order, ids and all.
+    before it is yielded (DUP-1). Buffered entries are the EXACT wire chunks
+    the stream yields — including coalesced batches — and a replay re-splits
+    them per event (see ``TurnEventBuffer.replay_after``), so the buffer holds
+    individual event blocks in emission order, ids and all, WITHOUT this route
+    re-splitting first. #398: re-splitting at record time made a 1000-token
+    answer occupy 1000 of the 256 ring slots and silently evict its own head
+    within a single turn; recording the merged chunk keeps the ring small.
     """
     async for chunk in stream:
-        for event in _split_sse_events(chunk):
-            # _split_sse_events strips the terminator; restore it so a replay
-            # yields spec-correct, independently-framed SSE events.
-            buffer.record(event + "\n\n")
+        buffer.record(chunk)
         yield chunk
 
 
@@ -734,13 +723,18 @@ async def chat_stream(
                         })
                         buffer.record(session_event)
                         yield session_event
-                    async for chunk in _sse_batched(
-                        _recorded(
+                    # #398: record OUTSIDE the route batcher so the buffer
+                    # holds the COALESCED chunks (up to 32 token events each)
+                    # instead of every single token event — a token-heavy turn
+                    # otherwise overflows the ring within one turn and
+                    # silently loses its own head. Replay re-splits per event.
+                    async for chunk in _recorded(
+                        _sse_batched(
                             pi_bridge.stream_prompt(
                                 req.message, session_id=pi_session_id
                             ),
-                            buffer,
-                        )
+                        ),
+                        buffer,
                     ):
                         yield chunk
                 except Exception as e:

--- a/app/services/chat/event_resume.py
+++ b/app/services/chat/event_resume.py
@@ -48,7 +48,12 @@ Semantics (documented contract, see ``app.api.routes.chat._resume_generator``):
     this guard removes the whole-turn replay, not the namespace sharing.
 
 Bounds: ``RESUME_MAX_EVENTS`` per turn (ring buffer — only the tail survives,
-which is exactly what a dropped connection missed),
+which is exactly what a dropped connection missed). Entries are the route's
+COALESCED wire chunks (each holding up to ~32 token events — the route
+records merged batches whole and re-splits only at replay time, #398), so the
+256-slot ring comfortably covers multi-thousand-token turns; when the ring
+still evicts events a client has not seen, a replay STARTS with an explicit
+``resume_gap`` marker event instead of a silently truncated turn (#398).
 ``RESUME_MAX_BUFFERS_PER_SESSION`` recent turn buffers per session key (F4: a
 queued second POST registers its buffer WITHOUT clobbering the live turn's),
 and ``RESUME_MAX_SESSIONS`` process-wide (oldest buffered session evicted
@@ -64,14 +69,16 @@ import asyncio
 from collections import deque
 from typing import Optional
 
-from app.utils.sse import _is_terminal_event, sse_event_id
+from app.utils.sse import _is_terminal_event, sse_event, sse_event_id
 
-# Ring-buffer depth per turn: the tail a dropped client missed. 256 events is
-# comfortably larger than any single turn can plausibly emit (token bursts +
-# structural events + a tool loop of map commands), so a dropped client never
-# misses un-replayed step_results / commands merely because the ring was too
-# small — while staying bounded per turn (Round-2 P3: was 64, which could
-# silently evict un-replayed step_results under a long multi-command turn).
+# Ring-buffer depth per turn: the tail a dropped client missed. Entries are
+# COALESCED wire chunks (the route records merged batches whole and re-splits
+# only at replay time — #398), so 256 slots hold up to ~256×32 token events
+# plus structural events: a multi-thousand-token turn fits without evicting
+# its own head (Round-2 P3: was 64 SINGLE events, which could silently evict
+# un-replayed step_results under a long multi-command turn). If the ring is
+# STILL too small for a pathological turn, :meth:`TurnEventBuffer.replay_after`
+# emits an explicit ``resume_gap`` marker instead of silently truncating.
 RESUME_MAX_EVENTS = 256
 # Process-wide cap on buffered sessions; oldest evicted first.
 RESUME_MAX_SESSIONS = 32
@@ -80,6 +87,30 @@ RESUME_MAX_SESSIONS = 32
 # of the live turn still finds it (matched by message + Last-Event-ID). Small
 # bound: a client only ever resumes the live turn or the most recent ones.
 RESUME_MAX_BUFFERS_PER_SESSION = 4
+
+# #398: event type of the synthesized gap marker a replay emits FIRST when the
+# ring evicted events the client has not seen (the turn's head was truncated).
+# The marker carries no ``id:`` — it is produced at replay time, not part of
+# the original turn's id sequence. The client may ignore it, but it can now
+# TELL a truncated replay from a complete turn (seenEventIds dedup can't).
+RESUME_GAP_EVENT_TYPE = "resume_gap"
+
+
+def _event_blocks(event_str: str) -> list[str]:
+    """Split a (possibly coalesced) SSE chunk into individual event blocks,
+    terminator stripped, empty parts dropped."""
+    return [p for p in event_str.split("\n\n") if p]
+
+
+def _highest_event_id(event_str: str) -> int | None:
+    """Highest ``id:`` across all event blocks inside a (possibly coalesced)
+    SSE chunk; ``None`` when the chunk carries no id at all."""
+    highest: int | None = None
+    for block in _event_blocks(event_str):
+        eid = sse_event_id(block)
+        if eid is not None and (highest is None or eid > highest):
+            highest = eid
+    return highest
 
 
 class TurnEventBuffer:
@@ -128,19 +159,35 @@ class TurnEventBuffer:
     def record(self, event_str: str, *, force_terminal: bool = False) -> None:
         """Record one emitted event (call before yielding it to the wire).
 
+        ``event_str`` may be a COALESCED chunk holding several ``id:``-stamped
+        events (the engine/route batchers merge token bursts; #398: the merged
+        chunk is recorded WHOLE so a token-heavy turn cannot evict its own
+        head from the ring — replay re-splits per event). ``last_id`` tracks
+        the HIGHEST id across the chunk. A terminal event may sit at the END
+        of a coalesced chunk (the batchers flush the batch that contains the
+        terminal); it is detected per block and stored as the turn's terminal.
         ``force_terminal=True`` marks a non-`_TERMINAL_EVENTS` event (e.g. the
         route's synthesized ``error``) as the turn's terminal anyway, so a
-        resume replays it as the ending instead of treating the turn as aborted.
+        resume replays it as the ending instead of treating the turn as
+        aborted.
         """
-        event_id = sse_event_id(event_str)
+        event_id = _highest_event_id(event_str)
         if event_id is not None:
             self.last_id = event_id
         self._events.append(event_str)
         if len(self._events) > self.max_events:
             self._events.popleft()
-        if force_terminal or _is_terminal_event(event_str):
+        if force_terminal:
             self.ended = True
             self.terminal_event = event_str
+        else:
+            terminal_block: Optional[str] = None
+            for block in _event_blocks(event_str):
+                if _is_terminal_event(block):
+                    terminal_block = block
+            if terminal_block is not None:
+                self.ended = True
+                self.terminal_event = terminal_block + "\n\n"
         self._version += 1
         self._notify()
 
@@ -191,13 +238,41 @@ class TurnEventBuffer:
     def replay_after(self, last_event_id: int) -> list[str]:
         """Buffered events with ``id > last_event_id``, in original order.
 
-        Events without an ``id:`` line (keepalive comments) are never replayed
-        — they carry no resume value and would be un-ordered in the sequence.
+        Buffered entries are (possibly coalesced) wire chunks — see
+        :meth:`record`; #398 records merged batches whole so a token-heavy
+        turn cannot evict its own head. Each entry is re-split here and
+        filtered PER EVENT, so resumption granularity is unchanged: a resume
+        still starts at exactly the missed id, ids intact, blocks re-framed
+        with their ``\\n\\n`` terminator. Events without an ``id:`` line
+        (keepalive comments) are never replayed — they carry no resume value.
+
+        When the ring evicted events the client has not seen (the first
+        retained event id exceeds ``last_event_id + 1``), the returned list
+        STARTS with a synthesized ``resume_gap`` marker event (no ``id:`` — it
+        is not part of the turn) describing the missing id range, so a resumed
+        client can tell a truncated replay from a complete turn instead of
+        silently missing the head (#398).
         """
-        return [
-            e for e in self._events
-            if (eid := sse_event_id(e)) is not None and eid > last_event_id
-        ]
+        out: list[str] = []
+        first_id: int | None = None
+        for entry in self._events:
+            for block in _event_blocks(entry):
+                eid = sse_event_id(block)
+                if eid is None:
+                    continue
+                if first_id is None:
+                    first_id = eid
+                if eid > last_event_id:
+                    out.append(block + "\n\n")
+        if first_id is not None and first_id > last_event_id + 1:
+            out.insert(0, sse_event(RESUME_GAP_EVENT_TYPE, {
+                "session_id": self.session_id,
+                "resumed": True,
+                "gap": True,
+                "missing_from": last_event_id + 1,
+                "missing_to": first_id - 1,
+            }))
+        return out
 
     def __len__(self) -> int:
         return len(self._events)
@@ -272,10 +347,17 @@ class TurnResumeRegistry:
 
         A buffer matches when the message is identical (same turn — the client
         re-POSTs the same message) and the Last-Event-ID is meaningful for it:
-        ``0`` means "from the beginning of this turn" (also matches a
-        never-started buffer holding no events yet), otherwise the id must not
-        lie beyond the buffer's highest recorded id (per-turn id scopes make
-        ids from a LATER turn meaningless for an earlier one).
+
+          * ``0`` means "from the beginning of this turn" — it matches ONLY
+            turns that are still ACTIVE (live, or queued and never started;
+            #398). An ended buffer matched by 0 would replay a PREVIOUS turn's
+            complete stream as if it were the current answer (the reconnect
+            may target a newer turn whose buffer never registered, or be
+            simply stale) — refuse instead of replaying the wrong turn's
+            events;
+          * otherwise the id must not lie beyond the buffer's highest recorded
+            id (per-turn id scopes make ids from a LATER turn meaningless for
+            an earlier one).
 
         Returns ``(buffer, False)`` on a unique match, ``(None, True)`` when
         MULTIPLE buffers match (ambiguous — e.g. two concurrent anonymous
@@ -283,12 +365,17 @@ class TurnResumeRegistry:
         safe rather than replay the wrong turn's events (cross-turn leak).
         ``(None, False)`` = plain miss.
         """
-        matches = [
-            b
-            for b in self._buffers.get(session_id, ())
-            if b.message == message
-            and (last_event_id == 0 or (b.last_id is not None and last_event_id <= b.last_id))
-        ]
+        matches: list[TurnEventBuffer] = []
+        for b in self._buffers.get(session_id, ()):
+            if b.message != message:
+                continue
+            if last_event_id == 0:
+                # #398: id 0 only addresses an ACTIVE turn (live or queued);
+                # an ended buffer must never be replayed from its start.
+                if not b.ended:
+                    matches.append(b)
+            elif b.last_id is not None and last_event_id <= b.last_id:
+                matches.append(b)
         if len(matches) == 1:
             return matches[0], False
         return None, len(matches) > 1

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -57,6 +57,69 @@ from app.lib.runtime.evidence import (
 
 logger = logging.getLogger(__name__)
 
+# ── #409: legacy engine token-stream heartbeat ───────────────────────────────
+# The provider read timeout (llm_client.call_llm_stream) is 180s — far longer
+# than the ~60s idle timeout of the SSE proxies in front of the API. A
+# silently stalled provider therefore used to hang the turn with no output
+# until the proxy killed the connection, discarding the partial answer.
+# `_stream_with_token_keepalive` wraps the provider iteration so a keep_alive
+# event is emitted after `_LLM_TOKEN_KEEPALIVE_S` of silence WITHOUT
+# cancelling the provider stream: ``asyncio.wait_for`` on ``__anext__`` would
+# cancel the httpx read and destroy the stream, so the provider generator runs
+# in its own pump task and only the queue wait is timed.
+_LLM_TOKEN_KEEPALIVE_S = 15.0
+_KEEPALIVE_EVENT: tuple[str, dict] = ("keep_alive", {"message": "ping"})
+_QUEUE_END = object()  # pump-completed sentinel
+
+
+async def _stream_with_token_keepalive(
+    stream: AsyncGenerator[tuple[str, dict], None],
+    timeout_s: float = _LLM_TOKEN_KEEPALIVE_S,
+) -> AsyncGenerator[tuple[str, dict], None]:
+    """Adapt an LLM provider event stream: when no item arrives within
+    ``timeout_s`` seconds, a keep_alive tuple is yielded instead (the caller
+    forwards it as an SSE ``keep_alive`` event) and the wait resumes. Provider
+    items are delivered in order, unchanged; provider exceptions are re-raised
+    in the consumer. The pump task owns the provider generator, so a timeout
+    never cancels the underlying HTTP read; the pump is cancelled in the
+    ``finally`` when the consumer exits early (disconnect).
+    """
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def _pump() -> None:
+        try:
+            async for item in stream:
+                queue.put_nowait(item)
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:  # noqa: BLE001 — re-raised in the consumer
+            queue.put_nowait(exc)
+        else:
+            queue.put_nowait(_QUEUE_END)
+
+    pump = asyncio.create_task(_pump())
+    try:
+        while True:
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout_s)
+            except asyncio.TimeoutError:
+                if pump.done() and queue.empty():
+                    return
+                yield _KEEPALIVE_EVENT
+                continue
+            if item is _QUEUE_END:
+                return
+            if isinstance(item, BaseException):
+                raise item  # type: ignore[misc]  # noqa: B904
+            yield item
+    finally:
+        if not pump.done():
+            pump.cancel()
+        try:
+            await pump
+        except BaseException:  # noqa: BLE001 — the pump's outcome is already surfaced
+            pass
+
 
 def _settle_cancel() -> None:
     """Mark the live turn's outcome CANCELLED on a cooperative cancel.
@@ -1307,25 +1370,56 @@ class ChatExecutionEngine:
                     token_batcher = SSEBatcher(max_events=32, max_delay_s=0.08)
                     _t_llm = time.perf_counter()
                     _ttft_ms: Optional[float] = None
-                    async for event_type, event_data in self._call_llm_stream(messages_with_context, tools):
-                        if event_type == "token":
-                            if _ttft_ms is None:
-                                _ttft_ms = (time.perf_counter() - _t_llm) * 1000.0
-                                if _ev is not None:
-                                    _ev.mark_first_event()
-                            streamed_content_parts.append(event_data["content"])
-                            token_batcher.push(sse_event("token", {
-                                "content": event_data["content"],
-                                "is_reasoning": event_data.get("is_reasoning", False),
-                                "session_id": session_id,
-                            }))
-                            async for chunk in token_batcher.drain():
-                                yield chunk
-                        elif event_type == "done":
-                            # 收尾：冲刷尾部 token，保证流式内容完整到达前端
-                            for chunk in token_batcher.flush():
-                                yield chunk
-                            assistant_msg = event_data["message"]
+                    # #409: heartbeat + lossless error path for the token
+                    # stream.
+                    #   - _stream_with_token_keepalive yields a keep_alive
+                    #     event after _LLM_TOKEN_KEEPALIVE_S of provider
+                    #     silence, so SSE proxies with a ~60s idle timeout
+                    #     don't kill a stalled-but-alive turn;
+                    #   - an exception mid-stream flushes the batched tokens
+                    #     BEFORE propagating, so the route's error event
+                    #     follows the partial content instead of replacing it
+                    #     (the tokens were already produced by the provider;
+                    #     dropping them silently lost client-visible content).
+                    try:
+                        async for event_type, event_data in _stream_with_token_keepalive(
+                            self._call_llm_stream(messages_with_context, tools),
+                            timeout_s=_LLM_TOKEN_KEEPALIVE_S,
+                        ):
+                            if event_type == "token":
+                                if _ttft_ms is None:
+                                    _ttft_ms = (time.perf_counter() - _t_llm) * 1000.0
+                                    if _ev is not None:
+                                        _ev.mark_first_event()
+                                streamed_content_parts.append(event_data["content"])
+                                token_batcher.push(sse_event("token", {
+                                    "content": event_data["content"],
+                                    "is_reasoning": event_data.get("is_reasoning", False),
+                                    "session_id": session_id,
+                                }))
+                                async for chunk in token_batcher.drain():
+                                    yield chunk
+                            elif event_type == "done":
+                                # 收尾：冲刷尾部 token，保证流式内容完整到达前端
+                                for chunk in token_batcher.flush():
+                                    yield chunk
+                                assistant_msg = event_data["message"]
+                            elif event_type == "keep_alive":
+                                # #409: provider silent for _LLM_TOKEN_KEEPALIVE_S
+                                # — heartbeat the wire so idle proxies don't kill
+                                # the stream (same event the tool-wave wait uses).
+                                yield sse_event("keep_alive", event_data)
+                    except Exception:
+                        # #409: mid-stream failure — flush the batched tokens
+                        # BEFORE the exception reaches the route (which yields
+                        # its error event after our stream), so the client sees
+                        # the partial answer, not just the error. A client
+                        # disconnect (CancelledError — BaseException) skips
+                        # this: the connection is gone, so the buffered tokens
+                        # are dropped with the generator frame.
+                        for chunk in token_batcher.flush():
+                            yield chunk
+                        raise
 
                     if _ev is not None:
                         _ev.add_llm_round(

--- a/deploy/k8s/02-api-deployment.yaml
+++ b/deploy/k8s/02-api-deployment.yaml
@@ -9,6 +9,15 @@ metadata:
     component: api
     environment: production
 spec:
+  # #377: SSE turn-resume buffers are process-local (app/services/chat/
+  # event_resume.py — no cross-replica store). A reconnect must land on the
+  # SAME pod that served the turn; the Service below pins clients with
+  # sessionAffinity: ClientIP and the ingress pins with an nginx cookie, so
+  # multi-replica HA does not break resume for existing turns. This is the
+  # WEAK fix (probability reduction — new pods / affinity expiry can still
+  # strand a resume with error {resumed: false}); the STRONG fix is an
+  # externalized resume store (e.g. Redis), tracked separately (not in this
+  # PR). Scaling remains safe for NEW turns.
   replicas: 2
   strategy:
     rollingUpdate:
@@ -136,6 +145,15 @@ metadata:
     component: api
 spec:
   type: ClusterIP
+  # #377: SSE turn-resume buffers are process-local (event_resume.py) — a
+  # reconnect MUST reach the same pod that ran the turn. ClientIP affinity
+  # pins one client to one pod for the session; without it a plain ClusterIP
+  # Service round-robins and ~50% of reconnects hit a replica that never saw
+  # the turn, failing the resume with error {resumed: false} (the client then
+  # stops auto-retrying per contract). WEAK fix: sticky routing only lowers
+  # the probability. STRONG fix (not in this PR): externalize the resume
+  # store (e.g. Redis) so any replica can serve any resume.
+  sessionAffinity: ClientIP
   ports:
   - port: 80
     targetPort: 3000

--- a/deploy/k8s/04-ingress.yaml
+++ b/deploy/k8s/04-ingress.yaml
@@ -10,6 +10,14 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/use-regex: "true"
+    # #377: sticky routing for SSE resume — the turn-resume buffers are
+    # process-local (event_resume.py), so a reconnect must reach the SAME pod
+    # that served the turn. nginx pins each client to one backend with a
+    # cookie (paired with the api Service's sessionAffinity: ClientIP). WEAK
+    # fix (probability reduction); the STRONG fix is an externalized resume
+    # store, tracked separately (not in this PR).
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "webgis_sse_resume"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   tls:

--- a/deploy/k8s/07-hpa.yaml
+++ b/deploy/k8s/07-hpa.yaml
@@ -11,6 +11,14 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: webgis-api
+  # #377: minReplicas >= 2 (HA) means a reconnect can land on a different pod.
+  # The api Service (sessionAffinity: ClientIP) + ingress (nginx cookie)
+  # carry sticky routing so SSE turn-resume stays on the pod that served the
+  # turn. This is the WEAK fix — resume buffers are process-local, so affinity
+  # expiry or pod replacement can still fail a resume with
+  # error {resumed: false}; the STRONG fix is an externalized resume store
+  # (e.g. Redis), tracked separately (not in this PR). Scaling up/down stays
+  # safe for new turns.
   minReplicas: 2
   maxReplicas: 10
   # K8S-06：加 scaleDown.stabilizationWindowSeconds=300。否则负载一回落

--- a/tests/test_adversarial_sse_chaos.py
+++ b/tests/test_adversarial_sse_chaos.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.api.routes import chat as chat_route
-from app.services.chat.event_resume import RESUME_MAX_EVENTS, TurnResumeRegistry
+from app.services.chat.event_resume import TurnResumeRegistry
 from app.utils.sse import sse_event, sse_event_id, sse_event_type
 
 
@@ -210,7 +210,11 @@ async def test_chaos_multi_session_interleaved_resumes(_pi_path):
 async def test_chaos_ring_buffer_overflow_with_interleaved_resumes(_pi_path):
     """Adversary: Turn generates 300 events (> RESUME_MAX_EVENTS=256).
     Multiple clients resume at different offsets (recent vs evicted).
-    Verifies ring buffer truncation is clean, monotonic, and bounded."""
+    Verifies merged-batch recording keeps the WHOLE turn replayable (#398:
+    the ring stores coalesced chunks — ~10 entries for 300 tokens — so the
+    head is never silently evicted; a stale resume gets the FULL missed tail
+    instead of a truncated answer)."""
+    from app.services.chat.event_resume import RESUME_GAP_EVENT_TYPE
 
     class _MassiveBridge:
         def __init__(self) -> None:
@@ -231,12 +235,18 @@ async def test_chaos_ring_buffer_overflow_with_interleaved_resumes(_pi_path):
     await t
     assert bridge.prompt_calls == 1
 
-    # Client A resumes with very old ID (e.g. 5) -> gets ring tail
+    # Client A resumes with very old ID (e.g. 5) -> FULL replay 6..302
+    # (merged-batch recording keeps the whole 300-token turn in the ring).
     rA, rtA = await _open_resume("massive", last_event_id=5, session_id="sess-massive")
     await rtA
-    assert len(rA) == RESUME_MAX_EVENTS
+    assert not any(_event_type(b) == RESUME_GAP_EVENT_TYPE for b in rA), (
+        "nothing was evicted — a full replay must carry no gap marker"
+    )
     idsA = [_event_id(b) for b in rA]
-    assert idsA == list(range(302 - RESUME_MAX_EVENTS + 1, 303))
+    assert idsA == list(range(6, 303)), (
+        f"#398: full replay 6..302 expected, got {idsA[:3]}..{idsA[-3:]} (len={len(idsA)})"
+    )
+    assert _event_type(rA[-1]) == "done"
 
     # Client B resumes with recent ID (e.g. 290) -> gets events 291..302
     rB, rtB = await _open_resume("massive", last_event_id=290, session_id="sess-massive")

--- a/tests/test_k8s_security.py
+++ b/tests/test_k8s_security.py
@@ -93,3 +93,51 @@ class TestK8sUploadsVolumeParity:
                 assert "ReadWriteMany" in modes, (
                     f"{path}: webgis-uploads-pvc accessModes={modes} 缺 ReadWriteMany"
                 )
+
+
+class TestK8sResumeStickyRouting:
+    """#377: SSE turn-resume buffers are process-local (event_resume.py), so
+    k8s must route a client's reconnect back to the pod that served the turn.
+    Without sticky routing, ~50% of resumes (replicas: 2, plain ClusterIP)
+    land on a replica that never saw the turn and fail with
+    ``error {resumed: false}`` — the client stops auto-retrying per contract.
+    """
+
+    def test_api_service_has_session_affinity(self):
+        """The api Service must pin clients to one pod (sessionAffinity:
+        ClientIP). This is the WEAK fix (probability reduction); the STRONG
+        fix — an externalized resume store — is tracked separately."""
+        services = [
+            doc for doc in _load_k8s("deploy/k8s/02-api-deployment.yaml")
+            if doc and doc.get("kind") == "Service"
+        ]
+        assert services, "no Service found in 02-api-deployment.yaml"
+        for doc in services:
+            if doc["metadata"]["name"] == "webgis-api-service":
+                assert doc["spec"].get("sessionAffinity") == "ClientIP", (
+                    "webgis-api-service must set sessionAffinity: ClientIP — "
+                    "SSE turn-resume buffers are process-local and a reconnect "
+                    "must land on the pod that served the turn"
+                )
+                return
+        raise AssertionError(
+            "webgis-api-service not found in deploy/k8s/02-api-deployment.yaml"
+        )
+
+    def test_ingress_has_sticky_affinity_annotation(self):
+        """The nginx ingress must pin each client to one backend with a cookie
+        so SSE reconnects (Last-Event-ID resumes) reach the serving pod."""
+        ingresses = [
+            doc for doc in _load_k8s("deploy/k8s/04-ingress.yaml")
+            if doc and doc.get("kind") == "Ingress"
+        ]
+        assert ingresses, "no Ingress found in 04-ingress.yaml"
+        for doc in ingresses:
+            ann = doc["metadata"].get("annotations", {})
+            assert ann.get("nginx.ingress.kubernetes.io/affinity") == "cookie", (
+                "webgis-ingress must set nginx.ingress.kubernetes.io/affinity: "
+                "cookie — SSE turn-resume buffers are process-local"
+            )
+            assert "nginx.ingress.kubernetes.io/session-cookie-name" in ann, (
+                "webgis-ingress must name its session affinity cookie"
+            )

--- a/tests/test_runtime_chaos_resume.py
+++ b/tests/test_runtime_chaos_resume.py
@@ -609,6 +609,57 @@ def test_registry_clear_session_purges_one_key():
     assert len(reg) == 1
 
 
+# ─── #398: Last-Event-ID 0 only addresses ACTIVE turns ──────────────────────
+
+
+def test_find_id_zero_matches_only_active_buffers():
+    """#398: ``Last-Event-ID: 0`` ("from the beginning") must match ONLY turns
+    that are still ACTIVE (live, or queued and never started). An ENDED buffer
+    with the same message must not be replayed from its start — a stale
+    reconnect (e.g. for a newer turn that never registered) would otherwise
+    get the PREVIOUS turn's complete stream replayed as if it were the current
+    answer."""
+    reg = TurnResumeRegistry()
+    live = TurnEventBuffer("s", "same msg")
+    ended = TurnEventBuffer("s", "same msg")
+    ended.record(sse_event("done", {"session_id": "s"}, event_id=7))  # terminal
+    reg.register("s", live)
+    reg.register("s", ended)
+
+    match, ambiguous = reg.find("s", "same msg", 0)
+    assert ambiguous is False
+    assert match is live, "id 0 must match the ACTIVE buffer, never the ended one"
+
+
+def test_find_id_zero_refuses_when_only_ended_buffer_matches():
+    """#398: when every same-message buffer is ENDED, ``last_event_id == 0``
+    is a plain miss (``error {resumed: false}`` at the route) — the stale
+    reconnect is refused instead of replaying the finished turn from scratch.
+    A NONZERO id still matches the same buffer normally."""
+    reg = TurnResumeRegistry()
+    ended = TurnEventBuffer("s", "same msg")
+    ended.record(sse_event("done", {"session_id": "s"}, event_id=7))
+    reg.register("s", ended)
+
+    assert reg.find("s", "same msg", 0) == (None, False), (
+        "id 0 must not match an ended buffer"
+    )
+    match, ambiguous = reg.find("s", "same msg", 3)
+    assert ambiguous is False
+    assert match is ended, "a nonzero id resumes an ended turn as before"
+
+
+def test_find_id_zero_still_matches_queued_never_started_buffer():
+    """A queued/never-started buffer (registered, zero events, NOT ended) keeps
+    matching ``last_event_id == 0`` — the F20 live-hold path is unchanged."""
+    reg = TurnResumeRegistry()
+    queued = TurnEventBuffer("s", "queued msg")
+    reg.register("s", queued)
+    match, ambiguous = reg.find("s", "queued msg", 0)
+    assert ambiguous is False
+    assert match is queued
+
+
 @pytest.mark.asyncio
 async def test_clear_session_route_purges_resume_buffers(_pi_path, monkeypatch, _pass_ownership):
     """P2 (round-2 review): DELETE /chat/sessions/{X} must purge X's resume

--- a/tests/test_sse_legacy_keepalive.py
+++ b/tests/test_sse_legacy_keepalive.py
@@ -1,0 +1,272 @@
+"""#409: legacy engine token-stream heartbeat + lossless error flush.
+
+Two defects on the legacy chat engine's LLM token loop:
+
+  - no keepalive during token streaming: the provider read timeout is 180s
+    (llm_client) while the SSE proxies in front of the API idle-kill at
+    ~60s, so a silently stalled provider hung the turn until the proxy
+    dropped the connection;
+  - the engine's internal SSEBatcher holds up to 31 un-flushed token events
+    and only flushed them on the next push — a mid-stream exception went
+    straight to the route's error event, silently dropping the buffered
+    partial answer.
+
+Deterministic: fake provider streams (no network); the keepalive timeout is
+monkeypatched to milliseconds so no wall-clock waits.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.api.routes import chat as chat_route
+from app.services.chat import execution_engine as ee_mod
+from app.services.chat.event_resume import TurnResumeRegistry
+from app.services.chat_engine import ChatEngine
+from app.tools.registry import ToolRegistry
+from app.utils.sse import sse_event_type
+
+
+def _event_type(block: str) -> str:
+    return sse_event_type(block)
+
+
+def _block_events(chunk: str) -> list[str]:
+    return [p for p in chunk.split("\n\n") if p]
+
+
+# ─── fixtures (mirror test_runtime_chaos_engine.py / test_sse_resume.py) ─────
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    """Real ChatEngine with DB/planner/title side effects stubbed."""
+    eng = ChatEngine(ToolRegistry())
+
+    async def fake_get_or_create_session(session_id, user_id=None):
+        return []
+
+    async def fake_maybe_plan(*a, **kw):
+        return None
+
+    monkeypatch.setattr(eng, "_get_or_create_session", fake_get_or_create_session)
+    monkeypatch.setattr(eng, "_maybe_plan", fake_maybe_plan)
+    monkeypatch.setattr(eng, "_generate_title", AsyncMock())
+    monkeypatch.setattr(eng, "_save_msg_async", AsyncMock())
+    return eng
+
+
+@pytest.fixture(autouse=True)
+def _fresh_resume_registry(monkeypatch):
+    """Isolate the process-local resume registry per test."""
+    monkeypatch.setattr(chat_route, "_turn_resume_registry", TurnResumeRegistry())
+    monkeypatch.setattr(
+        chat_route.AsyncHistoryService,
+        "get_session",
+        AsyncMock(return_value=MagicMock()),
+    )
+    yield
+
+
+@pytest.fixture
+def _legacy_path(monkeypatch):
+    """Force the legacy engine path; install the engine behind get_engine()."""
+
+    def _install(eng) -> None:
+        monkeypatch.setattr(chat_route, "USE_NEW_AGENT", False)
+        monkeypatch.setattr(chat_route, "get_engine", lambda: eng)
+
+    return _install
+
+
+# ─── _stream_with_token_keepalive (unit) ─────────────────────────────────────
+
+
+async def _collect(agen):
+    out = []
+    async for item in agen:
+        out.append(item)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_keepalive_helper_passthrough_without_stall():
+    """A provider that keeps producing never triggers a keepalive; items pass
+    through in order, unchanged."""
+    async def fast():
+        yield ("token", {"content": "a"})
+        yield ("done", {"message": {"content": "a"}})
+
+    items = await _collect(ee_mod._stream_with_token_keepalive(fast(), timeout_s=5))
+    assert items == [
+        ("token", {"content": "a"}),
+        ("done", {"message": {"content": "a"}}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_keepalive_helper_emits_heartbeat_during_stall():
+    """A provider silent longer than the timeout yields keep_alive tuples
+    (without cancelling the stream), then the real events continue in order."""
+    async def stalled():
+        yield ("token", {"content": "a"})
+        await asyncio.sleep(0.06)  # silence >> timeout
+        yield ("done", {"message": {"content": "a"}})
+
+    items = await _collect(ee_mod._stream_with_token_keepalive(stalled(), timeout_s=0.02))
+    kinds = [t for t, _ in items]
+    assert "keep_alive" in kinds, kinds
+    assert kinds[-1] == "done", "the real terminal must arrive after the heartbeats"
+    real = [d for t, d in items if t != "keep_alive"]
+    assert real == [{"content": "a"}, {"message": {"content": "a"}}]
+
+
+@pytest.mark.asyncio
+async def test_keepalive_helper_propagates_provider_exception():
+    """A provider exception is re-raised in the consumer (never swallowed by
+    the pump), even when it fires after a stall."""
+    async def exploding():
+        yield ("token", {"content": "x"})
+        await asyncio.sleep(0.05)
+        raise RuntimeError("provider down")
+
+    with pytest.raises(RuntimeError, match="provider down"):
+        await _collect(
+            ee_mod._stream_with_token_keepalive(exploding(), timeout_s=0.02)
+        )
+
+
+# ─── engine-level: heartbeat on stall ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_engine_token_stall_emits_keepalive_then_done(engine, monkeypatch):
+    """#409: the legacy engine's token loop emits an SSE keep_alive event when
+    the provider stays silent past the (monkeypatched, 20ms) timeout — the
+    idle proxy would otherwise kill the connection — and the real terminal
+    still arrives afterwards."""
+    monkeypatch.setattr(ee_mod, "_LLM_TOKEN_KEEPALIVE_S", 0.02)
+
+    async def stalled_stream(*args, **kwargs):
+        yield ("token", {"content": "a "})
+        await asyncio.sleep(0.06)  # stall past the heartbeat interval
+        yield ("done", {"message": {"content": "a"}})
+
+    monkeypatch.setattr(engine, "_call_llm_stream", stalled_stream)
+
+    events: list[str] = []
+    async for event in engine.chat_stream("测试", session_id="s-keepalive"):
+        events.append(event)
+
+    types = [_event_type(e) for e in events]
+    assert "keep_alive" in types, types
+    assert types.index("keep_alive") > types.index("task_start"), (
+        "the heartbeat must be emitted during the token stall"
+    )
+    assert types[-1] == "done"
+
+
+# ─── engine-level: mid-stream error flushes buffered tokens ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_engine_mid_stream_error_flushes_buffered_tokens(engine, monkeypatch):
+    """#409: a provider error mid-token-stream must not drop the already
+    buffered tokens — they are flushed (yielded) BEFORE the exception
+    propagates to the route, so the client's error event follows the partial
+    answer instead of replacing it."""
+    async def exploding_stream(*args, **kwargs):
+        for i in range(5):  # below the 32-event batch threshold → all buffered
+            yield ("token", {"content": f"t{i} "})
+        raise RuntimeError("provider exploded")
+
+    monkeypatch.setattr(engine, "_call_llm_stream", exploding_stream)
+
+    events: list[str] = []
+    with pytest.raises(RuntimeError, match="provider exploded"):
+        async for event in engine.chat_stream("测试", session_id="s-flush"):
+            events.append(event)
+
+    # The flush emits the 5 tokens as one coalesced chunk — count wire blocks.
+    blocks = [b for e in events for b in _block_events(e)]
+    types = [_event_type(b) for b in blocks]
+    assert types[0] == "task_start"
+    assert types.count("token") == 5, (
+        f"all buffered tokens must be flushed before the error, got {types}"
+    )
+
+
+# ─── route-level: tokens before error + replayable tail ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_route_mid_stream_error_delivers_tokens_then_error(
+    _legacy_path, engine, monkeypatch
+):
+    """#409 end-to-end through the chat route (legacy path): the client sees
+    the 5 buffered tokens BEFORE the terminal error, and the resume buffer
+    recorded the same tail so a reconnect replays tokens + error."""
+    async def exploding_stream(*args, **kwargs):
+        for i in range(5):
+            yield ("token", {"content": f"t{i} "})
+        raise RuntimeError("provider exploded")
+
+    monkeypatch.setattr(engine, "_call_llm_stream", exploding_stream)
+    _legacy_path(engine)
+
+    resp = await chat_route.chat_stream(
+        chat_route.ChatRequest(message="hi", session_id="s-route-flush", map_state=None),
+        _user={}, owner_token=None, db=None,
+    )
+    blocks: list[str] = []
+    async for chunk in resp.body_iterator:
+        blocks.extend(_block_events(chunk))
+
+    types = [_event_type(b) for b in blocks]
+    assert types[0] == "task_start"
+    assert types.count("token") == 5, types
+    assert types[-1] == "error", types
+    assert types.index("error") == len(types) - 1, "the error must terminate the stream"
+
+    # The resume buffer holds the same tail (tokens + error terminal): a
+    # reconnect replays the partial answer, not a fabricated done.
+    resumed_resp = await chat_route.chat_stream(
+        chat_route.ChatRequest(message="hi", session_id="s-route-flush", map_state=None),
+        _user={}, owner_token=None, db=None,
+        last_event_id_header=1,
+    )
+    resumed_blocks: list[str] = []
+    async for chunk in resumed_resp.body_iterator:
+        resumed_blocks.extend(_block_events(chunk))
+    resumed_types = [_event_type(b) for b in resumed_blocks]
+    assert resumed_types.count("token") == 5, resumed_types
+    assert resumed_types[-1] == "error", resumed_types
+
+
+@pytest.mark.asyncio
+async def test_route_token_stall_emits_keepalive(_legacy_path, engine, monkeypatch):
+    """#409 route-level: the keep_alive event crosses the route boundary on
+    the legacy path (a stalled provider stream stays alive on the wire)."""
+    monkeypatch.setattr(ee_mod, "_LLM_TOKEN_KEEPALIVE_S", 0.02)
+
+    async def stalled_stream(*args, **kwargs):
+        yield ("token", {"content": "a "})
+        await asyncio.sleep(0.06)
+        yield ("done", {"message": {"content": "a"}})
+
+    monkeypatch.setattr(engine, "_call_llm_stream", stalled_stream)
+    _legacy_path(engine)
+
+    resp = await chat_route.chat_stream(
+        chat_route.ChatRequest(message="hi", session_id="s-route-ka", map_state=None),
+        _user={}, owner_token=None, db=None,
+    )
+    blocks: list[str] = []
+    async for chunk in resp.body_iterator:
+        blocks.extend(_block_events(chunk))
+
+    types = [_event_type(b) for b in blocks]
+    assert "keep_alive" in types, types
+    assert types[-1] == "done"

--- a/tests/test_sse_resume.py
+++ b/tests/test_sse_resume.py
@@ -218,12 +218,13 @@ async def test_resume_replays_exactly_missed_events_in_order(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_resume_replay_bounded_to_ring_tail(monkeypatch):
-    """The resume buffer is a bounded ring (RESUME_MAX_EVENTS=256): a client
-    that fell far behind gets only the buffered tail, replayed in order — the
-    documented bound, never a duplicate or reordered event."""
-    from app.services.chat.event_resume import RESUME_MAX_EVENTS
-
+async def test_resume_replays_full_missed_tail_when_turn_exceeds_ring_size(monkeypatch):
+    """#398: the ring holds MERGED batch entries (the route records coalesced
+    chunks whole and re-splits only at replay time), so a 400-event turn
+    occupies ~14 of the 256 slots. Resuming from id 100 now delivers the
+    ENTIRE missed tail 101..404 — the old behavior re-split every token at
+    record time, overflowed the ring within one turn, and silently replayed a
+    truncated (but superficially complete) answer."""
     bridge = _BurstBridge(bursts=(196, 204))  # 400 events total
     await _collect_route(monkeypatch, bridge)
 
@@ -232,11 +233,135 @@ async def test_resume_replay_bounded_to_ring_tail(monkeypatch):
     )
     assert bridge_after.prompt_calls == 1
     resumed_ids = [_event_id(b) for b in resumed]
-    # Ring tail = the last 256 events (149..404); ids 101..148 were evicted.
-    assert len(resumed_ids) == RESUME_MAX_EVENTS, len(resumed_ids)
-    assert resumed_ids == list(range(149, 405)), (
-        f"replay must deliver the ring tail 149..404, got {resumed_ids[:3]}..{resumed_ids[-3:]}"
+    assert resumed_ids == list(range(101, 405)), (
+        f"merged-batch recording must allow FULL replay 101..404, got "
+        f"{resumed_ids[:3]}..{resumed_ids[-3:]} (len={len(resumed_ids)})"
     )
+    assert _event_type(resumed[0]) != "resume_gap", "nothing was evicted — no gap"
+    assert _event_type(resumed[-1]) == "done"
+
+
+# ─── 2b. #398: gap marker + merged-batch recording ───────────────────────────
+
+
+def test_replay_after_emits_gap_marker_when_head_evicted():
+    """#398: when the ring evicted events the client has not seen, the replay
+    STARTS with an explicit `resume_gap` marker (no id — synthesized at replay
+    time) describing the missing id range, instead of a silently truncated
+    turn the client would mistake for complete."""
+    from app.services.chat.event_resume import RESUME_GAP_EVENT_TYPE, TurnEventBuffer
+
+    buffer = TurnEventBuffer("s", "msg", max_events=8)
+    for i in range(1, 13):  # 12 events → ids 1..4 evicted
+        buffer.record(sse_event("token", {"content": f"t{i} "}, event_id=i))
+
+    blocks = buffer.replay_after(0)
+    assert _event_type(blocks[0]) == RESUME_GAP_EVENT_TYPE, _event_type(blocks[0])
+    assert _event_id(blocks[0]) is None, "the marker is not part of the turn's id sequence"
+    assert '"missing_from": 1' in blocks[0] and '"missing_to": 4' in blocks[0]
+    # The retained tail follows, ids intact and in order.
+    assert [_event_id(b) for b in blocks[1:]] == list(range(5, 13))
+
+
+def test_replay_after_no_marker_without_eviction():
+    """A replay with no evicted head carries no marker — the common case."""
+    from app.services.chat.event_resume import TurnEventBuffer
+
+    buffer = TurnEventBuffer("s", "msg", max_events=8)
+    for i in range(1, 6):
+        buffer.record(sse_event("token", {"content": "x"}, event_id=i))
+    blocks = buffer.replay_after(2)
+    assert [_event_id(b) for b in blocks] == [3, 4, 5]
+    assert not any(_event_type(b) == "resume_gap" for b in blocks)
+
+
+def test_replay_after_filters_per_event_inside_coalesced_chunk():
+    """#398: buffered entries may be coalesced chunks (route batchers merge up
+    to 32 token events); replay re-splits and filters per event so a resume
+    still starts at exactly the missed id."""
+    from app.services.chat.event_resume import TurnEventBuffer
+
+    chunk = "".join(
+        sse_event("token", {"content": f"t{i} "}, event_id=i) for i in range(1, 33)
+    )
+    buffer = TurnEventBuffer("s", "msg", max_events=64)
+    buffer.record(chunk)
+    buffer.record(sse_event("done", {"session_id": "s"}, event_id=33))
+    assert buffer.last_id == 33, "last_id must track the HIGHEST id in the chunk"
+    assert buffer.ended is True
+    assert _event_type(buffer.terminal_event) == "done"
+
+    blocks = buffer.replay_after(30)
+    assert [_event_id(b) for b in blocks] == [31, 32, 33], [
+        _event_id(b) for b in blocks
+    ]
+
+
+def test_record_detects_terminal_inside_coalesced_chunk():
+    """A terminal event may sit at the END of a coalesced batch (the batchers
+    flush the batch containing the terminal) — the buffer must still mark the
+    turn ended with that terminal, not treat the chunk as non-terminal."""
+    from app.services.chat.event_resume import TurnEventBuffer
+
+    chunk = "".join(
+        sse_event("token", {"content": "x"}, event_id=i) for i in range(1, 33)
+    ) + sse_event("done", {"session_id": "s"}, event_id=33)
+    buffer = TurnEventBuffer("s", "msg", max_events=64)
+    buffer.record(chunk)
+    assert buffer.ended is True
+    assert buffer.last_id == 33
+    assert _event_type(buffer.terminal_event) == "done"
+    assert sse_event_id(buffer.terminal_event) == 33
+
+
+@pytest.mark.asyncio
+async def test_resume_emits_gap_marker_when_ring_evicted_head(monkeypatch):
+    """#398 end-to-end: a turn that overflowed the ring resumes with an
+    explicit `resume_gap` marker FIRST (its head was evicted), then the
+    retained tail — the client can perceive the truncation instead of seeing
+    a superficially complete turn."""
+    from app.services.chat.event_resume import RESUME_GAP_EVENT_TYPE, TurnEventBuffer
+
+    class _SmallRingBuffer(TurnEventBuffer):
+        def __init__(self, session_id, message, max_events=256):
+            super().__init__(session_id, message, max_events=8)
+
+    monkeypatch.setattr(chat_route, "TurnEventBuffer", _SmallRingBuffer)
+
+    class _ManyStructuralBridge:
+        def __init__(self) -> None:
+            self.prompt_calls = 0
+
+        async def stream_prompt(self, message, session_id=None):
+            self.prompt_calls += 1
+            sid = session_id or "s"
+            yield sse_event("task_start", {"task_id": "t", "session_id": sid})
+            for i in range(10):
+                yield sse_event("token", {"content": f"t{i} ", "session_id": sid})
+                yield sse_event(
+                    "step_result",
+                    {"tool": "search_poi", "result": {"ok": True}, "session_id": sid},
+                )
+            yield sse_event("done", {"session_id": sid})
+
+    bridge = _ManyStructuralBridge()
+    blocks, _ = await _collect_route(monkeypatch, bridge)
+    assert len(blocks) == 22  # 1 task_start + 10×(token+step_result) + done
+
+    resumed, bridge_after = await _collect_route(
+        monkeypatch, bridge, last_event_id=1
+    )
+    assert bridge_after.prompt_calls == 1, "resume must not re-execute"
+    assert _event_type(resumed[0]) == RESUME_GAP_EVENT_TYPE, [
+        _event_type(b) for b in resumed
+    ]
+    assert _event_id(resumed[0]) is None
+    assert '"missing_from": 2' in resumed[0] and '"missing_to": 14' in resumed[0]
+    # Ring tail: the last 8 buffer entries (ids 15..22), replayed in order.
+    assert [_event_id(b) for b in resumed[1:]] == list(range(15, 23)), [
+        _event_id(b) for b in resumed
+    ]
+    assert _event_type(resumed[-1]) == "done"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Three SSE-related fixes on top of the process-local turn-resume mechanism (#371):

1. **#377 (P1, deploy): k8s multi-replica topology breaks process-local SSE resume** — sticky routing so a reconnect lands on the pod that served the turn.
2. **#398 (P3, resume): ring buffer truncation + `Last-Event-ID: 0` stale-buffer match** — merged-batch recording, explicit `resume_gap` marker, and id-0 restricted to active turns.
3. **#409 (P3, legacy engine): no heartbeat during token streaming + buffered tokens lost on mid-stream errors** — keepalive on provider silence and a lossless error flush.

## #377 — k8s sticky routing for SSE resume (WEAK fix)

The resume event ring + `TurnResumeRegistry` are **process-local** (`app/services/chat/event_resume.py` — cross-restart/replica persistence is a documented non-goal). With `replicas: 2` + a plain ClusterIP Service + a non-sticky ingress, a reconnect lands on the wrong pod ~50% of the time → `error {resumed: false}` → the client **stops auto-retrying per contract**.

What this PR does:
- `deploy/k8s/02-api-deployment.yaml`: `sessionAffinity: ClientIP` on `webgis-api-service` (client → pod pinning for the whole session).
- `deploy/k8s/04-ingress.yaml`: `nginx.ingress.kubernetes.io/affinity: cookie` + `session-cookie-name: webgis_sse_resume` (browser → backend pinning).
- Deployment / Service / HPA manifests: comments documenting the "resume depends on the same pod" constraint.
- `tests/test_k8s_security.py`: manifest assertions — the api Service **must** carry `sessionAffinity: ClientIP` and the ingress the cookie affinity annotations (regression guard).

**This is the weakest of the two fix tiers the issue allows.** Sticky routing only reduces the failure *probability*; it is not a guarantee (affinity expiry, pod replacement, scale-down can still strand a resume). The **strong fix — externalizing the resume store (e.g. Redis) so any replica can serve any resume — is explicitly NOT in this PR** and should be tracked as follow-up. `event_resume.py`'s process-local semantics are untouched (45+ resume tests depend on them).

## #398 — resume ring capacity + `Last-Event-ID: 0` semantics

**(1) Silent truncation.** The route re-split every coalesced token batch into single events at record time (`_recorded`), so a 1000-token answer occupied 1000 of the 256 ring slots and evicted its own head within one turn; `replay_after` then silently skipped the evicted head — a resumed client saw a truncated but superficially complete turn (frontend `seenEventIds` dedup can't detect it).

- `_recorded` now records the **coalesced wire chunk whole** (the Pi path records *outside* `_sse_batched`; the legacy engine's internal batcher already yielded merged chunks). A 1000-token turn now occupies ~33 of the 256 slots.
- `TurnEventBuffer.record` tracks the **highest** id in a chunk and detects a terminal event **inside** a coalesced chunk (the batchers flush the batch containing the terminal).
- `replay_after` re-splits each buffered chunk and filters **per event**, so resumption granularity is unchanged; when the ring still evicts unseen events, the replay now **starts with a synthesized `resume_gap` marker** (no `id:`; payload `{gap: true, missing_from, missing_to}`) — the client can perceive the truncation and may ignore the event.

**(2) `Last-Event-ID: 0` stale-buffer match.** `find()` matched id 0 against *any* same-message buffer, including older **ended** ones — a stale reconnect could get a previous turn's complete stream replayed as the current answer. id 0 now matches **only active (live/queued, not-ended) buffers**; when only ended buffers match it is a plain miss (`error {resumed: false}`). Nonzero ids resume ended turns exactly as before.

**Acceptance:** a >256-event turn resumes as a **full replay** (was: truncated); when the ring genuinely evicts, the replay carries the **gap marker**; `Last-Event-ID: 0` **never matches** an ended same-message buffer.

Tests: the two ring-boundary tests were updated to the new full-replay contract (they encoded the old silent-truncation behavior this issue declares defective); added gap-marker unit + route-level tests, chunk-filtering / terminal-in-chunk tests, and `find()` id-0 semantics tests.

## #409 — legacy engine heartbeat + lossless error flush

**(1) No heartbeat during token streaming.** Provider read timeout is 180s while the SSE proxies idle-kill at ~60s — a silently stalled provider hung the turn until the proxy dropped the connection. The token loop now wraps the provider iteration in `_stream_with_token_keepalive`: after `_LLM_TOKEN_KEEPALIVE_S` (15s) of silence a `keep_alive` SSE event is emitted and the wait resumes. The provider generator runs in its own pump task and only the queue wait is timed (`asyncio.wait_for` on `__anext__` would cancel the httpx read and destroy the stream); provider exceptions are re-raised in the consumer; the pump is cancelled on disconnect.

**(2) Buffered tokens lost on mid-stream errors.** The engine's internal `SSEBatcher` held up to 31 un-flushed token events and flushed only on the next push — an exception went straight to the route's `error` event, silently dropping the partial answer. The token loop now **flushes the batcher before re-raising**, so the route's `error` follows the partial content and the resume buffer records the same tail. Disconnect (`CancelledError`) deliberately skips the flush, matching the route batcher's existing semantics.

**Acceptance:** a stalled provider stream (>timeout, monkeypatched to ms in tests) yields `keep_alive` events; a mid-stream provider error delivers the buffered tokens **before** the error event (engine- and route-level).

## Test summary

- `tests/test_sse_resume.py`, `tests/test_adversarial_sse_chaos.py`, `tests/test_runtime_chaos_resume.py`: all pass with the new contract (39 baseline + new tests).
- New `tests/test_sse_legacy_keepalive.py` (7 tests) and `tests/test_k8s_security.py` additions (2 tests).
- Full affected sweep: **381 tests passed** across resume/chaos/engine/streaming/chat/api/k8s suites (no failures; heavy/perf/integration suites untouched).

## Commits

- `Fixes #377` — k8s sticky routing + manifest docs + assertions
- `Fixes #398` — merged-batch ring recording, gap marker, id-0 semantics
- `Fixes #409` — engine token-stream keepalive + lossless error flush

## Follow-up (explicitly not in this PR)

Externalize the resume store (Redis-backed event ring / registry) so any replica can serve any resume — this is the strong fix for #377 and would also make k8s horizontal scaling fully safe.
