### PR TITLE
fix(ui): real connectivity tests for LLM/RAG settings and correct session-switch state reset

### DIFF
--- a/app/api/routes/config.py
+++ b/app/api/routes/config.py
@@ -13,6 +13,8 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from pydantic import BaseModel
 from typing import Optional
 
+import httpx
+
 from app.api.routes.chat import get_engine, get_registry
 from app.tools.skills import load_skills
 from app.core.auth import require_admin
@@ -51,6 +53,20 @@ class LLMConfigRequest(BaseModel):
     api_key: Optional[str] = None
     use_prompt_caching: Optional[bool] = None
 
+
+class LLMTestRequest(BaseModel):
+    """连通性测试参数（#390）。字段全可选：缺省时使用引擎当前生效的配置。"""
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+    model: Optional[str] = None
+
+
+class RagTestRequest(BaseModel):
+    """知识库连通性测试参数（#390）。当前后端使用内置本地向量库，
+    address/collection 仅作展示用途，不影响后端行为。"""
+    address: Optional[str] = None
+    collection: Optional[str] = None
+
 @router.get("/llm")
 async def get_llm_config(_user: dict = Depends(require_admin)):
     """获取当前 LLM 配置（admin only）"""
@@ -78,6 +94,103 @@ async def update_llm_config(
         use_prompt_caching=req.use_prompt_caching
     )
     return {"status": "ok", "config": get_engine().get_config()}
+
+
+def _provider_error_detail(err: httpx.HTTPError) -> str:
+    """从上游 HTTP/传输错误里提取对用户可读的错误详情。
+
+    HTTPStatusError 优先取响应体的 ``error.message``（OpenAI 兼容错误
+    形状），取不到再退回状态文本；ConnectError 等传输错误直接转 str。
+    """
+    if isinstance(err, httpx.HTTPStatusError):
+        try:
+            body = err.response.json()
+            message = body.get("error", {}).get("message")
+            if isinstance(message, str) and message:
+                return message
+        except Exception:
+            pass
+        return f"上游返回 HTTP {err.response.status_code}"
+    return str(err) or "未知网络错误"
+
+
+@router.post("/llm/test")
+async def test_llm_config(
+    req: LLMTestRequest,
+    _user: dict = Depends(require_admin),
+):
+    """LLM 连通性测试（admin only，#390）。
+
+    向 provider 发一次最小补全请求，验证 base_url + api_key + model
+    组合真实可用。字段缺省时回退到引擎当前生效的配置（前端测试按钮
+    不携带 apiKey —— 真实 key 由服务端持有）。本端点不持久化任何配置。
+
+    失败返回 502 + 错误详情（不再有"永远成功"的假测试）；base_url
+    先过 SSRF 校验（与 POST /llm 同一套逻辑）。
+    """
+    engine = get_engine()
+    base_url = (req.base_url or engine.base_url or "").rstrip("/")
+    model = req.model or engine.model
+    api_key = req.api_key if req.api_key is not None else engine.api_key
+
+    if not base_url or not model:
+        raise HTTPException(status_code=400, detail="base_url 与 model 不能为空")
+    if not api_key:
+        raise HTTPException(status_code=400, detail="API Key 未配置，无法测试连通性")
+    try:
+        settings._validate_no_ssrf(base_url, field="base_url")
+    except ValueError as e:
+        logger.warning(f"base_url SSRF validation failed: {e}")
+        raise HTTPException(status_code=400, detail="base_url 校验失败: 不允许使用该 URL")
+
+    try:
+        from app.services.chat.llm_client import LLMConfig, test_llm_connection
+        cfg = LLMConfig(base_url=base_url, model=model, api_key=api_key)
+        await test_llm_connection(cfg)
+    except httpx.HTTPError as e:
+        logger.warning(f"LLM connectivity test failed: {e}")
+        raise HTTPException(status_code=502, detail=f"连接失败: {_provider_error_detail(e)}")
+    except Exception as e:
+        logger.exception("LLM connectivity test failed unexpectedly")
+        raise HTTPException(status_code=502, detail=f"连接测试失败: {e}")
+
+    return {"status": "ok", "detail": f"连接成功: {model}"}
+
+
+async def _check_rag_store() -> str:
+    """校验后端实际使用的知识库存储（当前为内置本地 FAISS 向量库）。
+
+    返回就绪描述；任何一步失败抛异常，由调用方转成 502 + 错误详情。
+    """
+    from app.services import rag_service
+    from app.services.rag.faiss_store import INDEX_DIR
+
+    os.makedirs(INDEX_DIR, exist_ok=True)
+    if not os.access(INDEX_DIR, os.W_OK):
+        raise RuntimeError(f"向量库目录不可写: {INDEX_DIR}")
+    metadata = rag_service._default_store.load_metadata()
+    chunks = len(metadata.get("chunks", [])) if isinstance(metadata, dict) else 0
+    return f"内置本地向量库（FAISS）就绪，已索引 {chunks} 个分块"
+
+
+@router.post("/rag/test")
+async def test_rag_config(
+    req: RagTestRequest,
+    _user: dict = Depends(require_admin),
+):
+    """知识库连通性测试（admin only，#390）。
+
+    当前后端检索使用内置本地 FAISS 向量库（无外部向量数据库依赖），
+    因此本端点校验该存储的真实健康状态（目录可写 + 元数据可读）。
+    请求中的 address/collection 仅作展示，后端当前不使用；响应返回
+    store 类型供前端如实展示。
+    """
+    try:
+        detail = await _check_rag_store()
+    except Exception as e:
+        logger.warning(f"RAG store health check failed: {e}")
+        raise HTTPException(status_code=502, detail=f"知识库不可用: {e}")
+    return {"status": "ok", "store": "local-faiss", "detail": detail}
 
 @router.get("/skills")
 async def list_skills(_user: dict = Depends(require_admin)):

--- a/app/services/chat/llm_client.py
+++ b/app/services/chat/llm_client.py
@@ -366,6 +366,39 @@ async def call_llm(
     return response.json()
 
 
+async def test_llm_connection(
+    cfg: LLMConfig,
+    timeout: httpx.Timeout = httpx.Timeout(connect=10.0, read=15.0, write=10.0, pool=5.0),
+) -> dict:
+    """连通性探针：向 provider 发一次最小补全请求并校验 HTTP 状态。
+
+    供 ``POST /api/v1/config/llm/test`` 使用（#390）：设置面板的
+    "Connectivity Test" 之前是前端 setTimeout 假成功，从不触达后端。
+    这里复用与生产调用相同的 payload/header 构造与连接池，但用短超时
+    让失败快速返回，而不是等生产路径的 120s。
+
+    失败（HTTP 非 2xx / 传输层错误）向上抛异常，由调用方转成带错误
+    详情的响应，绝不返回"假成功"。
+    """
+    headers = _build_headers(cfg)
+    payload = _build_payload(
+        cfg,
+        [{"role": "user", "content": "ping"}],
+        tools=None,
+        stream=False,
+    )
+    _key, prefix = _normalize_base_url(cfg.base_url)
+    client = await get_llm_http_client(cfg.base_url)
+    response = await client.post(
+        f"{prefix}/chat/completions",
+        headers=headers,
+        json=payload,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
 async def call_llm_stream(
     cfg: LLMConfig,
     messages: list[dict],

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -109,7 +109,22 @@ export default function Home() {
 
   const handleSelectSession = useCallback(
     (sid: string) => {
-      selectSession(sid, (restored) => setMessages(restored));
+      // #392: 失败/空会话时 hook 以 (messages, notice) 回传 —— notice 非空
+      // 说明恢复失败，渲染成单条错误提示（旧 transcript 已被重置，不再残留）。
+      selectSession(sid, (restored, notice) => {
+        setMessages(
+          notice
+            ? [
+                {
+                  id: `session-error-${Date.now()}`,
+                  role: 'assistant' as const,
+                  content: notice,
+                  timestamp: new Date(),
+                },
+              ]
+            : restored
+        );
+      });
       setHistoryOpen(false);
     },
     [selectSession, setMessages, setHistoryOpen]

--- a/frontend/components/settings/llm-config.test.tsx
+++ b/frontend/components/settings/llm-config.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// LlmConfig 只读展示服务端配置，不再读写 store —— 模块本身也不 import
+// useHudStore，无需 mock。
+
+import { LlmConfig } from './llm-config';
+
+// ── Response doubles（与 transport.test.ts / use-workspace-session.test.ts 同形）──
+const jsonOk = (body: unknown, status = 200) => ({
+  ok: true,
+  status,
+  statusText: 'OK',
+  json: () => Promise.resolve(body),
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+const jsonErr = (status: number, statusText: string, body: unknown) => ({
+  ok: false,
+  status,
+  statusText,
+  json: () => Promise.resolve(body),
+  text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+});
+
+const fetchMock = vi.fn();
+
+const SERVER_CONFIG = {
+  base_url: 'https://api.openai.com/v1',
+  model: 'gpt-4o',
+  api_key: '***abcd',
+  use_prompt_caching: true,
+};
+
+describe('LlmConfig connectivity test (#390)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('对失败端点渲染 error 状态并展示后端错误详情（不再假成功）', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonOk(SERVER_CONFIG)) // mount: GET /config/llm
+      .mockResolvedValueOnce(
+        jsonErr(502, 'Bad Gateway', { detail: '连接失败: 上游返回 HTTP 401' })
+      ); // POST /config/llm/test
+
+    const user = userEvent.setup();
+    render(<LlmConfig />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: /connectivity test/i }));
+
+    expect(await screen.findByText(/Connection Failed/)).toBeInTheDocument();
+    // 错误详情来自真实后端响应，渲染在 UI 上（不是不可达的死分支）
+    expect(screen.getByText(/连接失败: 上游返回 HTTP 401/)).toBeInTheDocument();
+
+    // 测试请求确实是 POST 到 /config/llm/test，且 body 为空
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(String(url)).toContain('/api/v1/config/llm/test');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({});
+  });
+
+  it('测试成功后渲染 Connection OK', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonOk(SERVER_CONFIG))
+      .mockResolvedValueOnce(jsonOk({ status: 'ok', detail: '连接成功: gpt-4o' }));
+
+    const user = userEvent.setup();
+    render(<LlmConfig />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: /connectivity test/i }));
+
+    expect(await screen.findByText('Connection OK')).toBeInTheDocument();
+  });
+
+  it('只读展示服务端配置，并说明前端保存不生效', async () => {
+    fetchMock.mockResolvedValueOnce(jsonOk(SERVER_CONFIG));
+
+    render(<LlmConfig />);
+
+    expect(await screen.findByText('https://api.openai.com/v1')).toBeInTheDocument();
+    expect(screen.getByText('gpt-4o')).toBeInTheDocument();
+    expect(screen.getByText('***abcd')).toBeInTheDocument();
+    expect(screen.getByText('已启用')).toBeInTheDocument(); // prompt caching
+    expect(screen.getByText(/前端保存不会生效/)).toBeInTheDocument();
+    // 只读展示 —— 没有可编辑输入框
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('非管理员读取服务端配置失败时给出明确提示', async () => {
+    fetchMock.mockResolvedValueOnce(jsonErr(403, 'Forbidden', { detail: 'Not enough permissions' }));
+
+    render(<LlmConfig />);
+
+    expect(
+      await screen.findByText('需要管理员权限才能查看服务端 LLM 配置')
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/components/settings/llm-config.tsx
+++ b/frontend/components/settings/llm-config.tsx
@@ -1,107 +1,123 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
-import { useHudStore } from '@/lib/store/useHudStore';
-import { STitle, SField, SButton } from '@/components/shared/section-title';
-import ToggleSwitch from '@/components/shared/toggle-switch';
+import React, { useState, useEffect, useCallback } from 'react';
+import { STitle } from '@/components/shared/section-title';
+import { apiFetch, isApiError, describeApiError } from '@/lib/api/transport';
+
+/** GET /api/v1/config/llm 返回的服务端 LLM 配置（api_key 已被服务端掩码）。 */
+interface ServerLlmConfig {
+  base_url: string;
+  model: string;
+  api_key: string;
+  use_prompt_caching: boolean;
+}
+
+type TestState = 'idle' | 'testing' | 'success' | 'error';
+
+/** 只读展示行：值来自服务端，前端不提供编辑（#390，见下）。 */
+function ReadOnlyRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="eyebrow">{label}</span>
+      <div className="flex h-control-lg w-full items-center rounded-sm border border-edge-subtle bg-surface-sunken px-2 font-mono text-body text-ink-disabled">
+        <span className="truncate">{value || '—'}</span>
+      </div>
+    </div>
+  );
+}
 
 export function LlmConfig() {
-  const llmConfigFull = useHudStore((s) => s.llmConfigFull);
-  const setLlmConfigFull = useHudStore((s) => s.setLlmConfigFull);
+  const [serverConfig, setServerConfig] = useState<ServerLlmConfig | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [testState, setTestState] = useState<TestState>('idle');
+  const [testDetail, setTestDetail] = useState<string | null>(null);
 
-  const [baseUrl, setBaseUrl] = useState(llmConfigFull.baseUrl);
-  const [apiKey, setApiKey] = useState(llmConfigFull.apiKey);
-  const [model, setModel] = useState(llmConfigFull.model);
-  const [caching, setCaching] = useState(llmConfigFull.caching);
-  const [testing, setTesting] = useState(false);
-  const [testResult, setTestResult] = useState<
-    'idle' | 'success' | 'error'
-  >('idle');
-  const [saved, setSaved] = useState(false);
-
-  const timersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
-
-  useEffect(() => {
-    const timers = timersRef.current;
-    return () => {
-      timers.forEach((t) => clearTimeout(t));
-      timers.clear();
-    };
+  const loadServerConfig = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const data = await apiFetch<ServerLlmConfig>('/api/v1/config/llm', {
+        label: 'LLM config load error',
+      });
+      setServerConfig(data);
+    } catch (err) {
+      setServerConfig(null);
+      setLoadError(
+        isApiError(err) && err.status === 403
+          ? '需要管理员权限才能查看服务端 LLM 配置'
+          : describeApiError(err, '无法读取服务端 LLM 配置')
+      );
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const addTimer = (cb: () => void, ms: number) => {
-    const id = setTimeout(() => {
-      timersRef.current.delete(id);
-      cb();
-    }, ms);
-    timersRef.current.add(id);
-    return id;
-  };
+  useEffect(() => {
+    loadServerConfig();
+  }, [loadServerConfig]);
 
-  const handleSave = () => {
-    setLlmConfigFull({ baseUrl, apiKey, model, caching });
-    setSaved(true);
-    addTimer(() => setSaved(false), 2000);
-  };
-
-  const handleTest = () => {
-    setTesting(true);
-    setTestResult('idle');
-    addTimer(() => {
-      setTesting(false);
-      setTestResult('success');
-      addTimer(() => setTestResult('idle'), 3000);
-    }, 1500);
-  };
+  const handleTest = useCallback(async () => {
+    setTestState('testing');
+    setTestDetail(null);
+    try {
+      // #390：真实连通性测试。body 留空 —— 测试服务端当前生效的配置，
+      // 真实 apiKey 由服务端持有，不会出现在请求里。之前这里是
+      // setTimeout 1.5s 后无条件 setTestState('success') 的假测试。
+      await apiFetch<{ status: string; detail?: string }>(
+        '/api/v1/config/llm/test',
+        { method: 'POST', body: {}, label: 'LLM connectivity test error' }
+      );
+      setTestState('success');
+    } catch (err) {
+      setTestState('error');
+      setTestDetail(
+        isApiError(err) && err.status === 403
+          ? '需要管理员权限才能测试连接'
+          : describeApiError(err, '连接失败')
+      );
+    }
+  }, []);
 
   return (
     <div className="flex flex-col gap-5">
       <STitle title="大模型配置" sub="LLM Model Settings" />
 
-      {/* Base URL */}
-      <SField
-        label="Base URL"
-        value={baseUrl}
-        onChange={setBaseUrl}
-        placeholder="https://api.openai.com/v1"
-      />
-
-      {/* API Key */}
-      <SField
-        label="API Key"
-        value={apiKey}
-        onChange={setApiKey}
-        type="password"
-        placeholder="sk-..."
-      />
-
-      {/* Model */}
-      <SField
-        label="Model"
-        value={model}
-        onChange={setModel}
-        placeholder="gpt-4o"
-      />
-
-      {/* Caching toggle */}
-      <div className="flex items-center justify-between py-1">
-        <div>
-          <div className="text-title font-medium text-ink">Prompt Caching</div>
-          <div className="text-body text-ink-muted">
-            Cache repeated prompts to reduce latency and token usage
-          </div>
-        </div>
-        <ToggleSwitch label="Prompt Caching" checked={caching} onChange={() => setCaching(!caching)} />
+      {/* #390：LLM 配置由服务端统一管理，前端保存从未被后端消费 ——
+          改为只读展示并在 UI 明说，不再假装前端设置有效。 */}
+      <div className="rounded-md border border-edge-subtle bg-surface-raised px-4 py-3 text-body text-ink-secondary">
+        LLM 配置由服务端统一管理，前端保存不会生效。如需修改，请使用管理员账号在服务端完成，之后点击「刷新配置」更新显示。
       </div>
+
+      {loading && <div className="text-body text-ink-muted">加载中…</div>}
+
+      {!loading && loadError && (
+        <div className="text-body font-medium text-status-critical">{loadError}</div>
+      )}
+
+      {!loading && serverConfig && (
+        <>
+          <ReadOnlyRow label="Base URL" value={serverConfig.base_url} />
+          <ReadOnlyRow label="Model" value={serverConfig.model} />
+          <ReadOnlyRow
+            label="API Key"
+            value={serverConfig.api_key || '（未配置）'}
+          />
+          <ReadOnlyRow
+            label="Prompt Caching"
+            value={serverConfig.use_prompt_caching ? '已启用' : '未启用'}
+          />
+        </>
+      )}
 
       {/* Connectivity test */}
       <div className="flex items-center gap-3">
         <button
           onClick={handleTest}
-          disabled={testing}
+          disabled={testState === 'testing'}
           className="inline-flex items-center gap-1.5 rounded-sm border border-edge-subtle bg-surface-sunken px-3 py-1 text-body font-medium text-ink-secondary transition-all hover:bg-surface-hover disabled:opacity-50"
         >
-          {testing ? (
+          {testState === 'testing' ? (
             <>
               <svg
                 className="animate-spin"
@@ -126,24 +142,24 @@ export function LlmConfig() {
             <>Connectivity Test</>
           )}
         </button>
-        {testResult === 'success' && (
-          <span className="text-body font-medium text-status-success">
-            Connection OK
-          </span>
-        )}
-        {testResult === 'error' && (
-          <span className="text-body font-medium text-status-critical">
-            Connection Failed
-          </span>
-        )}
+        <button
+          onClick={loadServerConfig}
+          disabled={loading}
+          className="inline-flex items-center gap-1.5 rounded-sm border border-edge-subtle bg-surface-sunken px-3 py-1 text-body font-medium text-ink-secondary transition-all hover:bg-surface-hover disabled:opacity-50"
+        >
+          刷新配置
+        </button>
       </div>
-
-      {/* Save */}
-      <div className="pt-2">
-        <SButton saved={saved} onClick={handleSave}>
-          {saved ? 'Saved' : 'Save'}
-        </SButton>
-      </div>
+      {testState === 'success' && (
+        <div className="text-body font-medium text-status-success">
+          Connection OK
+        </div>
+      )}
+      {testState === 'error' && (
+        <div className="text-body font-medium text-status-critical">
+          Connection Failed{testDetail ? `：${testDetail}` : ''}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/settings/rag-config.test.tsx
+++ b/frontend/components/settings/rag-config.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@/lib/store/useHudStore', () => ({
+  useHudStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      ragConfig: {
+        spatialWeight: 60,
+        topK: 5,
+        rerank: true,
+        vectorDb: '',
+        collection: 'geoagent',
+      },
+      setRagConfig: vi.fn(),
+      ragSpatial: [],
+      ragSemantic: [],
+    }),
+}));
+
+import { RagConfig } from './rag-config';
+
+// ── Response doubles（与 transport.test.ts 同形）──
+const jsonOk = (body: unknown, status = 200) => ({
+  ok: true,
+  status,
+  statusText: 'OK',
+  json: () => Promise.resolve(body),
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+const jsonErr = (status: number, statusText: string, body: unknown) => ({
+  ok: false,
+  status,
+  statusText,
+  json: () => Promise.resolve(body),
+  text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+});
+
+const fetchMock = vi.fn();
+
+describe('RagConfig connectivity test (#390)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('对失败端点渲染 error 状态并展示后端错误详情（不再假成功）', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonErr(502, 'Bad Gateway', { detail: '知识库不可用: index.faiss 损坏' })
+    );
+
+    const user = userEvent.setup();
+    render(<RagConfig />);
+
+    await user.click(screen.getByRole('button', { name: /test connection/i }));
+
+    expect(await screen.findByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText(/知识库不可用: index.faiss 损坏/)).toBeInTheDocument();
+
+    // 请求确实 POST 到 /config/rag/test，并携带展示字段
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/api/v1/config/rag/test');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ address: '', collection: 'geoagent' });
+  });
+
+  it('测试成功后渲染 Connected 并展示后端返回的存储详情', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonOk({ status: 'ok', store: 'local-faiss', detail: '内置本地向量库（FAISS）就绪，已索引 0 个分块' })
+    );
+
+    const user = userEvent.setup();
+    render(<RagConfig />);
+
+    await user.click(screen.getByRole('button', { name: /test connection/i }));
+
+    expect(await screen.findByText('Connected')).toBeInTheDocument();
+    expect(screen.getByText(/已索引 0 个分块/)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/settings/rag-config.tsx
+++ b/frontend/components/settings/rag-config.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import { STitle, SField, SButton } from '@/components/shared/section-title';
 import ToggleSwitch from '@/components/shared/toggle-switch';
+import { apiFetch, isApiError, describeApiError } from '@/lib/api/transport';
 
 export function RagConfig() {
   const ragConfig = useHudStore((s) => s.ragConfig);
@@ -17,6 +18,7 @@ export function RagConfig() {
   const [testResult, setTestResult] = useState<
     'idle' | 'success' | 'error'
   >('idle');
+  const [testDetail, setTestDetail] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
   const timersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
@@ -44,14 +46,35 @@ export function RagConfig() {
     addTimer(() => setSaved(false), 2000);
   };
 
-  const handleTestConnection = () => {
+  const handleTestConnection = async () => {
     setTesting(true);
     setTestResult('idle');
-    addTimer(() => {
-      setTesting(false);
+    setTestDetail(null);
+    try {
+      // #390：真实连通性测试。后端校验其实际使用的知识库存储
+      // （内置本地 FAISS 向量库）；address/collection 一并发送，
+      // 供后端在接入外部向量库时使用。之前这里是 setTimeout 1.2s
+      // 后无条件置 success 的假测试。
+      const data = await apiFetch<{ status: string; store?: string; detail?: string }>(
+        '/api/v1/config/rag/test',
+        {
+          method: 'POST',
+          body: { address: vectorDb, collection },
+          label: 'RAG connectivity test error',
+        }
+      );
       setTestResult('success');
-      addTimer(() => setTestResult('idle'), 3000);
-    }, 1200);
+      setTestDetail(data.detail ?? null);
+    } catch (err) {
+      setTestResult('error');
+      setTestDetail(
+        isApiError(err) && err.status === 403
+          ? '需要管理员权限才能测试连接'
+          : describeApiError(err, '连接失败')
+      );
+    } finally {
+      setTesting(false);
+    }
   };
 
   return (
@@ -231,12 +254,14 @@ export function RagConfig() {
             value={vectorDb}
             onChange={setVectorDb}
             placeholder="http://localhost:19530"
+            hint="仅供展示：当前后端使用内置本地向量库（FAISS），不依赖外部向量数据库。"
           />
           <SField
             label="Collection"
             value={collection}
             onChange={setCollection}
             placeholder="geoagent"
+            hint="仅供展示：保存不会改变后端检索行为。"
           />
           <div className="flex items-center gap-3">
             <button
@@ -257,6 +282,14 @@ export function RagConfig() {
               </span>
             )}
           </div>
+          {testResult === 'success' && testDetail && (
+            <div className="text-body text-ink-muted">{testDetail}</div>
+          )}
+          {testResult === 'error' && (
+            <div className="text-body font-medium text-status-critical">
+              {testDetail ? `连接失败：${testDetail}` : '连接失败'}
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/lib/api/transport.ts
+++ b/frontend/lib/api/transport.ts
@@ -134,6 +134,24 @@ export function isApiError(err: unknown): err is ApiError {
   return err instanceof ApiError;
 }
 
+/**
+ * 把请求错误转成对用户可读的描述（#390）：优先取 FastAPI `detail`，
+ * 网络层 TypeError 给固定文案，其余退回 fallback。供设置面板等
+ * 直接渲染错误状态的 UI 使用。
+ */
+export function describeApiError(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) {
+    const body = err.body as { detail?: unknown } | null;
+    if (body && typeof body === 'object' && typeof body.detail === 'string' && body.detail) {
+      return body.detail;
+    }
+    return `${fallback}（HTTP ${err.status}）`;
+  }
+  if (err instanceof TypeError) return '网络错误，无法连接服务器';
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
 /** Type guard for ApiTimeoutError. */
 export function isApiTimeoutError(err: unknown): err is ApiTimeoutError {
   return err instanceof ApiTimeoutError;

--- a/frontend/lib/hooks/use-workspace-session.test.ts
+++ b/frontend/lib/hooks/use-workspace-session.test.ts
@@ -21,6 +21,7 @@ const hudState = vi.hoisted(() => ({
   addLayer: vi.fn(),
   fetchAnalysisAssets: vi.fn().mockResolvedValue(undefined),
   clearResults: vi.fn(),
+  historyOpen: false,
 }));
 
 vi.mock('@/lib/store/useHudStore', () => ({
@@ -64,13 +65,14 @@ describe('useWorkspaceSession selectSession (F-09)', () => {
     fetchMock.mockReset();
     vi.stubGlobal('fetch', fetchMock);
     resetViewportSeq();
+    hudState.historyOpen = false;
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it('non-OK restore surfaces a typed ApiError and does not clobber state', async () => {
+  it('non-OK restore surfaces a typed ApiError and resets messages to empty', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonOk({ sessions: [] })) // mount: refreshSessions
       .mockResolvedValueOnce(jsonErr(404, 'Not Found', { detail: 'session not found' })); // restore
@@ -88,9 +90,12 @@ describe('useWorkspaceSession selectSession (F-09)', () => {
     expect(err.status).toBe(404);
     expect(err.body).toEqual({ detail: 'session not found' });
 
-    // no phantom history message, and no further restore work (map-state /
-    // layers / analysis assets) — a failed restore must not write state
-    expect(onRestore).not.toHaveBeenCalled();
+    // #392: 失败路径也无条件重置 transcript —— messages 清空 + 附错误提示，
+    // 上一会话的聊天不会残留到新会话身份下（was: onRestore 完全不调用）。
+    expect(onRestore).toHaveBeenCalledTimes(1);
+    expect(onRestore).toHaveBeenCalledWith([], expect.stringContaining('session not found'));
+    // 没有 phantom history message，且没有后续恢复工作（map-state /
+    // layers / analysis assets）—— 失败的恢复不得再写状态
     expect(fetchMock).toHaveBeenCalledTimes(2); // sessions list + restore only
     expect(fetchMock.mock.calls[1][0]).toContain('/api/v1/chat/sessions/bad-id');
     expect(hudState.fetchAnalysisAssets).not.toHaveBeenCalled();
@@ -112,7 +117,9 @@ describe('useWorkspaceSession selectSession (F-09)', () => {
     const err = errorSpy.mock.calls[0][1] as ApiError;
     expect(err.status).toBe(502);
     expect(err.body).toBe('<html>proxy error</html>');
-    expect(onRestore).not.toHaveBeenCalled();
+    // #392: 非 JSON 错误体 -> messages 同样被重置（detail 不可用时回退 HTTP 状态）
+    expect(onRestore).toHaveBeenCalledTimes(1);
+    expect(onRestore).toHaveBeenCalledWith([], expect.stringContaining('HTTP 502'));
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -320,5 +327,65 @@ describe('useWorkspaceSession selectSession (F-09)', () => {
     expect(onRestore).not.toHaveBeenCalled();
     // F-4: the result registry must also be cleared for the fresh session.
     expect(vi.mocked(hudState.clearResults)).toHaveBeenCalled();
+  });
+
+  it('#392: History 抽屉打开信号触发 refreshSessions（不再只 mount 拉一次）', async () => {
+    fetchMock.mockResolvedValue(jsonOk({ sessions: [{ id: 's1', title: '会话一' }] }));
+    const { rerender } = renderHook(() => useWorkspaceSession(vi.fn()));
+    // mount 拉取 settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // 模拟 store 的 historyOpen 翻转为 true（History 抽屉打开）
+    act(() => {
+      hudState.historyOpen = true;
+      rerender();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const lastCall = fetchMock.mock.calls[1];
+    expect(String(lastCall[0])).toContain('/api/v1/chat/sessions');
+  });
+
+  it('#392: 空会话恢复时无条件把 transcript 重置为空', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonOk({ sessions: [] }))
+      .mockResolvedValueOnce(jsonOk({ title: '空会话', messages: [] }))
+      .mockResolvedValueOnce(jsonOk({ map_state: null }));
+
+    const onRestore = vi.fn();
+    const { result } = renderHook(() => useWorkspaceSession(vi.fn()));
+    await act(async () => {
+      await result.current.selectSession('empty-session', onRestore);
+    });
+
+    // was: messages 为空时 onRestoreMessages 不被调用，上一会话的聊天
+    // 残留屏幕（sessionIdRef 已指向新会话）
+    expect(onRestore).toHaveBeenCalledTimes(1);
+    expect(onRestore).toHaveBeenCalledWith([]);
+  });
+
+  it('#392: 恢复失败时 messages 被重置为空并附错误提示（不静默）', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonOk({ sessions: [] }))
+      .mockResolvedValueOnce(jsonErr(500, 'Internal Server Error', { detail: 'db down' }));
+
+    const onRestore = vi.fn();
+    const { result } = renderHook(() => useWorkspaceSession(vi.fn()));
+    await act(async () => {
+      await result.current.selectSession('broken', onRestore);
+    });
+
+    expect(onRestore).toHaveBeenCalledTimes(1);
+    expect(onRestore).toHaveBeenCalledWith([], expect.stringContaining('db down'));
+    // 错误提示里明确说明恢复失败，而不是静默
+    const notice = onRestore.mock.calls[0][1] as string;
+    expect(notice).toContain('加载会话失败');
+    expect(notice).toContain('历史记录未恢复');
   });
 });

--- a/frontend/lib/hooks/use-workspace-session.ts
+++ b/frontend/lib/hooks/use-workspace-session.ts
@@ -18,6 +18,28 @@ import {
 
 const MAX_SESSION_OWNER_TOKENS = 128;
 
+/**
+ * #392: 把会话恢复失败转成对用户可见的提示文案。优先 FastAPI detail，
+ * 网络层 TypeError 给固定文案；"不静默"——失败必须在 UI 上有交代。
+ */
+function sessionLoadErrorNotice(err: unknown): string {
+  let detail: string;
+  if (isApiError(err)) {
+    const body = err.body as { detail?: unknown } | null;
+    detail =
+      body && typeof body === 'object' && typeof body.detail === 'string' && body.detail
+        ? body.detail
+        : `HTTP ${err.status}`;
+  } else if (err instanceof TypeError) {
+    detail = '网络错误，无法连接服务器';
+  } else if (err instanceof Error && err.message) {
+    detail = err.message;
+  } else {
+    detail = '未知错误';
+  }
+  return `加载会话失败：${detail}。历史记录未恢复，可开始新对话。`;
+}
+
 export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) => void) {
   const [sessionId, setSessionId] = useState<string>();
   const sessionIdRef = useRef<string | undefined>(undefined);
@@ -46,6 +68,8 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
   const setAiStatus = useHudStore((s) => s.setAiStatus);
   const clearTask = useHudStore((s) => s.clearTask);
   const clearResults = useHudStore((s) => s.clearResults);
+  // #392: History 抽屉开关信号 —— 打开时触发会话列表刷新（见下方 effect）。
+  const historyOpen = useHudStore((s) => s.historyOpen);
 
   // Sync sessionId state to ref
   useEffect(() => {
@@ -96,8 +120,15 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
     };
   }, [refreshSessions]);
 
+  // #392: 历史列表之前只在 mount 拉一次 —— 页面存活期内新建的会话
+  // 永远不出现在 History 抽屉、顶栏一直显示"新会话"直到整页刷新。
+  // History 抽屉打开（store 的 historyOpen 翻转为 true）时重新拉取。
+  useEffect(() => {
+    if (historyOpen) refreshSessions();
+  }, [historyOpen, refreshSessions]);
+
   const selectSession = useCallback(
-    async (sid: string, onRestoreMessages: (messages: any[]) => void) => {
+    async (sid: string, onRestoreMessages: (messages: any[], notice?: string) => void) => {
       // Cancel previous session restoration requests to avoid stale layer insertions
       sessionLoadAbortRef.current?.abort();
       const ctrl = new AbortController();
@@ -128,6 +159,10 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
       const token = sessionTokensRef.current.get(sid) ?? null;
       sessionTokenRef.current = token;
       setActiveToken(token);
+      // #392: 消息恢复是否已成功写入。仅当"消息 GET 本身"失败时才用
+      // 错误提示重置 transcript —— 若消息已恢复、只是后续 map-state /
+      // 图层恢复失败，不能把刚恢复的 transcript 再清掉。
+      let messagesRestored = false;
       try {
         // F-09：会话恢复必须校验 HTTP 状态。旧实现 res.json() 不检查 res.ok，
         // 404/500 的错误体被当作成功消费（JSON detail → 静默无消息；HTML 错误
@@ -140,21 +175,25 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
         );
         if (signal.aborted) return;
 
-        if (data.messages && data.messages.length > 0) {
-          const restored = data.messages.map((m: any) => ({
-            id: m.id,
-            role: m.role,
-            content: m.content,
-            timestamp: new Date(m.timestamp),
-          }));
+        // #392: 无条件恢复 —— 之前只在 messages 非空时调 onRestoreMessages，
+        // 空会话 / GET 失败时上一会话的完整聊天留在屏幕上而 sessionIdRef 已
+        // 指向新会话，下一条消息会在新会话身份下延续旧 transcript。
+        const restored = (data.messages ?? []).map((m: any) => ({
+          id: m.id,
+          role: m.role,
+          content: m.content,
+          timestamp: new Date(m.timestamp),
+        }));
+        if (restored.length > 0) {
           restored.push({
             id: `session-switch-${Date.now()}`,
             role: 'assistant' as const,
-            content: `已恢复历史会话「${data.title || '未命名'}」——共 ${data.messages.length} 条记录。可继续提问。`,
+            content: `已恢复历史会话「${data.title || '未命名'}」——共 ${data.messages?.length ?? 0} 条记录。可继续提问。`,
             timestamp: new Date(),
           });
-          onRestoreMessages(restored);
         }
+        onRestoreMessages(restored);
+        messagesRestored = true;
 
         // setSessionId 已在函数开头同步调用（审计 F38），这里不再重复
 
@@ -293,8 +332,13 @@ export function useWorkspaceSession(dispatchAction: (action: MapActionPayload) =
         // Log the failure (typed or not) so debugging surface is uniform;
         // AbortError stays silent because it's the expected outcome of
         // session-switch cancellation.
-        if (err?.name !== 'AbortError') {
-          devOnly.error('Load session failed:', err);
+        if (err?.name === 'AbortError') return;
+        devOnly.error('Load session failed:', err);
+        // #392: 消息 GET 失败 -> 无条件重置 transcript（否则上一会话的
+        // 聊天残留屏幕、下一条消息延续旧 transcript），并附错误提示，
+        // 不再静默吞掉失败。
+        if (!messagesRestored) {
+          onRestoreMessages([], sessionLoadErrorNotice(err));
         }
       }
     },

--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -7,6 +7,7 @@ config.py 之前没有任何路由级测试（只有 Settings 模块测试）。
 import os
 import pytest
 import pytest_asyncio
+import httpx
 from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
 
@@ -108,3 +109,220 @@ async def test_config_skills_refresh_requires_admin(app_and_client):
     _, client = app_and_client
     resp = await client.post("/api/v1/config/skills/refresh")
     assert resp.status_code == 401
+
+
+def _admin_headers():
+    from app.core.auth import create_access_token
+    admin_token = create_access_token({"sub": "a1", "username": "a", "role": "admin"})
+    return {"Authorization": f"Bearer {admin_token}"}
+
+
+# ─── #390: /config/llm/test 与 /config/rag/test 连通性测试 ──────────────
+
+
+@pytest.mark.asyncio
+async def test_config_llm_test_requires_admin(app_and_client):
+    """#390: /config/llm/test 必须 admin token，无 token -> 401。"""
+    _, client = app_and_client
+    resp = await client.post("/api/v1/config/llm/test", json={})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_config_llm_test_rejects_viewer(app_and_client):
+    """#390: viewer token -> 403。"""
+    from app.core.auth import create_access_token
+    viewer_token = create_access_token({"sub": "v1", "username": "v", "role": "viewer"})
+    _, client = app_and_client
+    resp = await client.post(
+        "/api/v1/config/llm/test",
+        json={},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_config_llm_test_success_with_engine_config(app_and_client, monkeypatch):
+    """#390: admin 空请求体 -> 用引擎当前生效配置做真实探针，成功返回 ok。
+
+    探针被替换为假实现，验证路由正确回退到引擎的 base_url/model/api_key
+    （前端测试按钮不携带 apiKey，真实 key 由服务端持有）。
+    """
+    from app.api.routes import chat as chat_routes
+
+    captured = {}
+
+    async def fake_test_llm_connection(cfg, timeout=httpx.Timeout(1)):
+        captured["cfg"] = cfg
+        return {"id": "probe"}
+
+    monkeypatch.setattr(
+        "app.services.chat.llm_client.test_llm_connection",
+        fake_test_llm_connection,
+    )
+    _, client = app_and_client
+    resp = await client.post(
+        "/api/v1/config/llm/test", json={}, headers=_admin_headers()
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "连接成功" in body["detail"]
+    cfg = captured["cfg"]
+    assert cfg.base_url == chat_routes.engine.base_url
+    assert cfg.model == chat_routes.engine.model
+    assert cfg.api_key == chat_routes.engine.api_key
+
+
+@pytest.mark.asyncio
+async def test_config_llm_test_honors_request_overrides(app_and_client, monkeypatch):
+    """#390: 显式传 base_url/model/api_key 时探针使用请求值而非引擎配置。"""
+    captured = {}
+
+    async def fake_test_llm_connection(cfg, timeout=httpx.Timeout(1)):
+        captured["cfg"] = cfg
+        return {}
+
+    monkeypatch.setattr(
+        "app.services.chat.llm_client.test_llm_connection",
+        fake_test_llm_connection,
+    )
+    _, client = app_and_client
+    resp = await client.post(
+        "/api/v1/config/llm/test",
+        json={"base_url": "https://example.com/v1", "model": "probe-model", "api_key": "k"},
+        headers=_admin_headers(),
+    )
+    assert resp.status_code == 200, resp.text
+    cfg = captured["cfg"]
+    assert cfg.base_url == "https://example.com/v1"
+    assert cfg.model == "probe-model"
+    assert cfg.api_key == "k"
+
+
+@pytest.mark.asyncio
+async def test_config_llm_test_connect_failure_returns_502(app_and_client, monkeypatch):
+    """#390: 传输层失败 -> 502 + 错误详情（不再是假成功）。"""
+    async def failing_probe(cfg, timeout=httpx.Timeout(1)):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(
+        "app.services.chat.llm_client.test_llm_connection",
+        failing_probe,
+    )
+    _, client = app_and_client
+    resp = await client.post(
+        "/api/v1/config/llm/test", json={}, headers=_admin_headers()
+    )
+    assert resp.status_code == 502
+    body = resp.json()
+    assert "连接失败" in body["detail"]
+    assert "connection refused" in body["detail"]
+
+
+@pytest.mark.asyncio
+async def test_config_llm_test_provider_error_detail(app_and_client, monkeypatch):
+    """#390: 上游 4xx 时返回 provider 的 error.message 作为详情。"""
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+
+    async def failing_probe(cfg, timeout=httpx.Timeout(1)):
+        raise httpx.HTTPStatusError(
+            "401 Unauthorized",
+            request=request,
+            response=httpx.Response(401, json={"error": {"message": "invalid api key"}}),
+        )
+
+    monkeypatch.setattr(
+        "app.services.chat.llm_client.test_llm_connection",
+        failing_probe,
+    )
+    _, client = app_and_client
+    resp = await client.post(
+        "/api/v1/config/llm/test", json={}, headers=_admin_headers()
+    )
+    assert resp.status_code == 502
+    assert "invalid api key" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_config_llm_test_ssrf_rejected(app_and_client, monkeypatch):
+    """#390: base_url 指向云元数据端点 -> 400（与 POST /llm 同一校验）。"""
+    called = {"probe": False}
+
+    async def fake_test_llm_connection(cfg, timeout=httpx.Timeout(1)):
+        called["probe"] = True
+        return {}
+
+    monkeypatch.setattr(
+        "app.services.chat.llm_client.test_llm_connection",
+        fake_test_llm_connection,
+    )
+    _, client = app_and_client
+    resp = await client.post(
+        "/api/v1/config/llm/test",
+        json={"base_url": "http://169.254.169.254/latest/meta-data", "model": "m"},
+        headers=_admin_headers(),
+    )
+    assert resp.status_code == 400
+    assert not called["probe"]  # SSRF 校验在探针之前，探针不得被调用
+
+
+@pytest.mark.asyncio
+async def test_config_llm_test_missing_api_key_rejected(app_and_client):
+    """#390: 引擎无 api_key 且请求未提供 -> 400，不向 provider 发请求。"""
+    from app.api.routes import chat as chat_routes
+    original = chat_routes.engine.api_key
+    chat_routes.engine.api_key = ""
+    try:
+        _, client = app_and_client
+        resp = await client.post(
+            "/api/v1/config/llm/test", json={}, headers=_admin_headers()
+        )
+        assert resp.status_code == 400
+        assert "API Key" in resp.json()["detail"]
+    finally:
+        chat_routes.engine.api_key = original
+
+
+@pytest.mark.asyncio
+async def test_config_rag_test_requires_admin(app_and_client):
+    """#390: /config/rag/test 必须 admin token，无 token -> 401。"""
+    _, client = app_and_client
+    resp = await client.post("/api/v1/config/rag/test", json={})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_config_rag_test_success(app_and_client, monkeypatch):
+    """#390: admin -> 校验内置本地向量库健康，返回 store 类型。"""
+    async def fake_check():
+        return "内置本地向量库（FAISS）就绪，已索引 3 个分块"
+
+    monkeypatch.setattr("app.api.routes.config._check_rag_store", fake_check)
+    _, client = app_and_client
+    resp = await client.post(
+        "/api/v1/config/rag/test",
+        json={"address": "http://localhost:19530", "collection": "geoagent"},
+        headers=_admin_headers(),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["store"] == "local-faiss"
+    assert "FAISS" in body["detail"]
+
+
+@pytest.mark.asyncio
+async def test_config_rag_test_failure_returns_502(app_and_client, monkeypatch):
+    """#390: 本地向量库不可用 -> 502 + 错误详情。"""
+    async def failing_check():
+        raise RuntimeError("index.faiss 损坏")
+
+    monkeypatch.setattr("app.api.routes.config._check_rag_store", failing_check)
+    _, client = app_and_client
+    resp = await client.post(
+        "/api/v1/config/rag/test", json={}, headers=_admin_headers()
+    )
+    assert resp.status_code == 502
+    assert "index.faiss" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Two P2 UI issues in the settings panel and session switching:

### Fixes #390 — LLM/RAG "Connectivity Test" was fake; saved LLM settings never consumed

**The bug:** both "Connectivity Test" buttons were `setTimeout` callbacks that flipped the UI to success after ~1.5s without ever hitting the backend — the `error` branch was unreachable dead UI. Meanwhile the LLM form's Save wrote `llmConfigFull` into the Zustand store, but nothing ever read it: the chat request body only carries `message` / `session_id` / `map_state` / `skill_name`.

**Backend (new endpoints, admin-only, same style as existing `/config/*` routes):**
- `POST /api/v1/config/llm/test` — minimal chat-completions probe against the provider (new `test_llm_connection()` in `app/services/chat/llm_client.py`, short timeout, reuses the pooled HTTP client). Request fields are optional: omitted values fall back to the engine's **live** config, so the real API key never leaves the server. `base_url` is SSRF-guarded like `POST /llm`. Failures return `502` with provider/transport error detail.
- `POST /api/v1/config/rag/test` — health-checks the backend's *actual* RAG store. The backend uses a built-in local FAISS vector store (no external vector DB dependency), so the endpoint verifies store health (metadata readable + index dir writable) and returns the store type; Address/Collection from the UI are display-only for now.
- 11 new route tests (auth 401/403, engine-config fallback, request overrides, connect failure → 502, provider `error.message` detail, SSRF rejection, missing API key, RAG success/failure).

**Frontend:**
- `llm-config.tsx`: Connectivity Test now POSTs to the backend and renders the real error detail; the form became a read-only display of the server config (fetched from `GET /api/v1/config/llm`, refresh button) with explicit copy that the frontend cannot change LLM config.
- `rag-config.tsx`: Test Connection now POSTs to the backend and renders errors; Address/Collection show honest hints.
- New component tests (mock fetch): failed endpoints render the error state, success renders OK/Connected.

**Wiring choice for the saved LLM settings (issue point 2):** the backend `ChatRequest` has **no** per-request LLM override — the engine is a process-global singleton and the Pi-bridge path ignores the legacy engine entirely. Adding per-request overrides would be a large, risky backend change. Per the issue's option B, the fields are now marked **"server-side config" read-only** and the UI says so explicitly (no longer pretending frontend saves work). The store slice `llmConfigFull`/`setLlmConfigFull` is kept for compatibility but is no longer wired to any editable UI.

### Fixes #392 — Session list never refreshed; failed/empty switch kept the previous transcript

**The bug:**
- (a) `refreshSessions` ran only on mount — sessions created while the page is alive never showed in the History drawer, and the top bar kept showing "新会话" until a full reload.
- (b) `selectSession` only called `onRestoreMessages` when the GET returned non-empty messages and swallowed fetch errors — on an empty session or a failed GET, the previous session's full transcript stayed on screen while `sessionIdRef` already pointed at the new session, so the next message continued the old transcript under the new identity.

**Fix:**
- (a) The hook subscribes to the store's `historyOpen` flag (the existing History-drawer open signal — the minimal wiring; `page.tsx` needs no changes) and refetches the session list each time the drawer opens.
- (b) Both empty and error paths now unconditionally call `onRestoreMessages`: empty sessions restore `[]`; a failed messages GET restores `[]` plus an error notice (FastAPI detail when available) passed as a second callback argument — `page.tsx` renders it as a single assistant message, so the failure is visible, not silent. A `messagesRestored` flag ensures a downstream map-state/layer restore failure does not wipe an already-restored transcript.

**Hook tests:** drawer-open signal triggers `refreshSessions`; empty restore resets to `[]`; failed GET resets messages to empty with the error notice (two pre-existing error-path tests updated to the new contract).

## Test summary

- Backend: `tests/test_config_routes.py` — 17 passed (11 new for #390); `tests/unit/test_llm_http_lifecycle.py` — 13 passed.
- Frontend: `npm run typecheck` clean; full `vitest run` — 1323 passed / 3 skipped; new settings component tests + updated hook tests stable across repeated runs.
