### PR TITLE
perf(api): offload blocking parse/PDF/KDF/DB/Celery work off the event loop

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -7,6 +7,7 @@ S41: token refresh + logout (backend-only)。
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -160,11 +161,14 @@ async def register(
     if existing.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="username 或 email 已被占用")
 
+    # 计算隔离不变式 1：scrypt (N=2^14, ~50-150ms) 是 CPU 密集 KDF ——
+    # 在 async 路由上直接算会阻塞事件循环（#386）。注册/登录各只此一处。
+    password_hash = await asyncio.to_thread(hash_password, req.password)
     user = User(
         id=str(uuid.uuid4()),
         username=req.username,
         email=req.email,
-        password_hash=hash_password(req.password),
+        password_hash=password_hash,
         full_name=req.full_name,
         role="viewer",
         is_active=True,
@@ -202,7 +206,9 @@ async def login(
     user = result.scalar_one_or_none()
     # 即使用户不存在也跑一遍假 verify 以防止时序侧信道泄漏用户存在性
     # 审计 P1：使用模块级随机 dummy hash，避免固定 dummy 导致的时序差异。
-    valid = verify_password(req.password, user.password_hash if user else _DUMMY_STORED)
+    # 计算隔离不变式 1：scrypt verify 是 CPU 密集 KDF，offload 到线程（#386）。
+    stored_hash = user.password_hash if user else _DUMMY_STORED
+    valid = await asyncio.to_thread(verify_password, req.password, stored_hash)
     if not user or not valid:
         raise HTTPException(status_code=401, detail="用户名或密码错误")
     if not user.is_active:

--- a/app/api/routes/jobs.py
+++ b/app/api/routes/jobs.py
@@ -18,6 +18,7 @@ main.py 中先 include，比依赖同文件内的定义顺序更难写错。
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -240,7 +241,10 @@ async def retry_job(
         # 状态已是 queued —— 现在必须真的把任务重新交给 worker。
         # 只改状态而不入队会留下一个永远不推进的 job（比不提供 retry 更糟）。
         try:
-            async_result = celery_app.send_task(
+            # 计算隔离不变式 1：send_task publish 是 broker socket I/O，
+            # offload 到线程（#386）。
+            async_result = await asyncio.to_thread(
+                celery_app.send_task,
                 spec["task"],
                 args=list(spec.get("args") or []),
                 kwargs={**(spec.get("kwargs") or {}), "job_id": int(record.id)},

--- a/app/api/routes/map.py
+++ b/app/api/routes/map.py
@@ -8,6 +8,7 @@
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form
 from pydantic import BaseModel
 from typing import Optional, Any
+import asyncio
 import json
 import logging
 import os
@@ -194,6 +195,27 @@ async def upload_map_export(
     }
 
 
+def _render_pdf_to_file(
+    filename: str, content: bytes,
+    title: Optional[str], subtitle: Optional[str],
+    author: Optional[str], scale_text: Optional[str],
+) -> None:
+    """reportlab 渲染 + 同步文件写 —— 纯同步 CPU/socket 无关 IO，必须在
+    worker 线程执行（计算隔离不变式 1）。ValueError 原样上抛给路由做 400。"""
+    from app.lib.cartography.pdf_renderer import generate_map_pdf
+
+    pdf_bytes = generate_map_pdf(
+        img_bytes=content,
+        title=title,
+        subtitle=subtitle,
+        author=author,
+        scale_text=scale_text,
+    )
+    pdf_path = os.path.join(EXPORT_DIR, filename)
+    with open(pdf_path, "wb") as f:
+        f.write(pdf_bytes)
+
+
 @router.post("/export/pdf", tags=["地图制图"])
 async def export_map_as_pdf(
     file: UploadFile = File(...),
@@ -216,23 +238,17 @@ async def export_map_as_pdf(
         if len(content) > MAX_EXPORT_SIZE:
             raise HTTPException(status_code=413, detail="文件过大，上限 50MB")
 
-        from app.lib.cartography.pdf_renderer import generate_map_pdf
-
+        pdf_filename = f"map_export_{int(time.time())}_{uuid.uuid4().hex[:12]}.pdf"
+        # 计算隔离不变式 1：reportlab 渲染（含 ≤50MB 图嵌入）+ 同步文件写在
+        # worker 线程执行，避免阻塞事件循环上所有并发 SSE 流（#386）。
+        loop = asyncio.get_running_loop()
         try:
-            pdf_bytes = generate_map_pdf(
-                img_bytes=content,
-                title=title,
-                subtitle=subtitle,
-                author=author,
-                scale_text=scale_text,
+            await loop.run_in_executor(
+                None, _render_pdf_to_file,
+                pdf_filename, content, title, subtitle, author, scale_text,
             )
         except ValueError as val_err:
             raise HTTPException(status_code=400, detail=str(val_err))
-
-        pdf_filename = f"map_export_{int(time.time())}_{uuid.uuid4().hex[:12]}.pdf"
-        pdf_path = os.path.join(EXPORT_DIR, pdf_filename)
-        with open(pdf_path, "wb") as f:
-            f.write(pdf_bytes)
 
     except HTTPException:
         raise

--- a/app/api/routes/project.py
+++ b/app/api/routes/project.py
@@ -1,12 +1,13 @@
 """
 Project Workspace, Persistent Workflow, Spatial Data Quality & Lineage API Endpoints
 """
+import asyncio
 import logging
 from typing import Dict, Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
-from app.core.database import get_db
+from app.core.database import get_db, SessionLocal
 from app.core.auth import actor_ids, get_current_user, get_current_user_optional
 from app.services.project_service import ProjectService
 from app.services.workflow_engine import WorkflowEngine
@@ -30,6 +31,24 @@ from app.schemas.pagination import Page, clamp_pagination
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/projects", tags=["Project Workspace"])
+
+
+async def _run_workflow_engine(engine_method, **kwargs) -> Any:
+    """把 WorkflowEngine 协程整体 offload 到 worker 线程执行（#386）。
+
+    引擎每步都做同步 SQLAlchemy I/O（db.execute / flush / commit），直接 await
+    在 async 路由上会阻塞整个事件循环 —— 卡住所有并发 SSE 流。WorkflowEngine
+    方法是 async def（内部 await 工具 dispatch），因此在 worker 线程里用
+    asyncio.run 起独立事件循环执行。
+
+    并发安全：sync Session 非线程安全，绝不跨线程共享 —— 在 worker 线程内
+    新建 Session、同一线程内使用并关闭。
+    """
+    def _worker() -> Any:
+        with SessionLocal() as thread_db:
+            return asyncio.run(engine_method(thread_db, **kwargs))
+
+    return await asyncio.to_thread(_worker)
 
 
 @router.post("", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
@@ -242,8 +261,8 @@ async def run_workflow(
     tool_registry = get_tool_registry()
 
     try:
-        run = await WorkflowEngine.execute_workflow_run(
-            db=db,
+        run = await _run_workflow_engine(
+            WorkflowEngine.execute_workflow_run,
             workflow_id=workflow_id,
             tool_registry=tool_registry,
             input_bindings=req.input_bindings,
@@ -395,9 +414,14 @@ async def replay_run(
         raise HTTPException(status_code=404, detail="Project not found")
     tool_registry = get_tool_registry()
     try:
-        return await WorkflowEngine.replay_run(
-            db=db, prior_run_id=run_id, tool_registry=tool_registry, mode=req.mode,
-            user_id=user_id, org_id=org_id, expected_project_id=project_id,
+        return await _run_workflow_engine(
+            WorkflowEngine.replay_run,
+            prior_run_id=run_id,
+            tool_registry=tool_registry,
+            mode=req.mode,
+            user_id=user_id,
+            org_id=org_id,
+            expected_project_id=project_id,
         )
     except ValueError as e:
         raise HTTPException(status_code=404 if "not found" in str(e) else 409, detail=str(e))
@@ -422,9 +446,13 @@ async def resume_run(
         raise HTTPException(status_code=404, detail="Project not found")
     tool_registry = get_tool_registry()
     try:
-        return await WorkflowEngine.resume_run(
-            db=db, prior_run_id=run_id, tool_registry=tool_registry,
-            user_id=user_id, org_id=org_id, expected_project_id=project_id,
+        return await _run_workflow_engine(
+            WorkflowEngine.resume_run,
+            prior_run_id=run_id,
+            tool_registry=tool_registry,
+            user_id=user_id,
+            org_id=org_id,
+            expected_project_id=project_id,
             allow_rerun=req.allow_rerun,
         )
     except ValueError as e:

--- a/app/api/routes/task.py
+++ b/app/api/routes/task.py
@@ -1,4 +1,5 @@
 """Task API Route - 任务状态查询与取消"""
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from typing import Optional
@@ -194,7 +195,9 @@ async def get_celery_task_status(
     backend 不可用（无 Redis）时进度仍然可读，因为事实源已经在数据库里。
     """
     await _verify_celery_owner(db, task_id, _user.get("user_id", ""), owner_token)
-    payload = TaskQueueService.get_task_status(task_id)
+    # 计算隔离不变式 1：AsyncResult.info/.ready() 是 Celery result backend 的
+    # socket I/O，前端每 3s 轮询 —— 直接在循环上执行会卡住所有 SSE 流（#386）。
+    payload = await asyncio.to_thread(TaskQueueService.get_task_status, task_id)
 
     job = await DurableJobStore.get_by_celery_id(db, task_id)
     if job is not None:
@@ -229,5 +232,6 @@ async def revoke_celery_task(
         await db.commit()
         cancellation_registry.cancel(str(job.id), "cancelled by user")
 
-    revoked = TaskQueueService.revoke_task(task_id)
+    # 计算隔离不变式 1：control.revoke 是 broker socket I/O，offload 到线程（#386）。
+    revoked = await asyncio.to_thread(TaskQueueService.revoke_task, task_id)
     return {"revoked": revoked, "task_id": task_id}

--- a/app/api/routes/upload.py
+++ b/app/api/routes/upload.py
@@ -30,6 +30,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _load_geojson_features(path: Path) -> list:
+    """流式解析 GeoJSON 的 features —— 同步 CPU+IO 密集（50MB 上限），
+    必须在 worker 线程执行（计算隔离不变式 1）。"""
+    with open(path, "rb") as f:
+        return list(ijson.items(f, "features.item"))
+
+
 async def _verify_session_owner(db, session_id: Optional[str], user_id) -> None:
     """跨租户守卫：若 upload 关联了 session_id，会话必须属于调用方（审计 S42）。
 
@@ -320,8 +327,11 @@ async def get_upload_geojson(upload_id: int, _user: dict = Depends(get_current_u
             detail=f"GeoJSON 文件过大（{file_size / 1024 / 1024:.1f}MB > {MAX_VECTOR_SIZE / 1024 / 1024:.0f}MB 限制），请通过 /layers/data/{{ref_id}} 分片读取",
         )
 
-    with open(geojson_path, "rb") as f:
-        features = list(ijson.items(f, "features.item"))
+    # 计算隔离不变式 1：ijson 解析 50MB GeoJSON 是同步 CPU 工作，直接在
+    # async def 里执行会阻塞整个事件循环（#386）。照抄本文件上传路径的
+    # run_in_executor 模式，把解析扔到默认 threadpool。
+    loop = asyncio.get_running_loop()
+    features = await loop.run_in_executor(None, _load_geojson_features, geojson_path)
     return {"type": "FeatureCollection", "features": features}
 
 

--- a/app/services/explorer/orchestrator.py
+++ b/app/services/explorer/orchestrator.py
@@ -63,15 +63,18 @@ class ExplorerOrchestrator:
             explorer_validate_task.s(),
         )
 
-        # 提交任务
-        result = task_chain.apply_async()
+        # 提交任务 — 计算隔离不变式 1：apply_async 是 broker socket I/O，
+        # offload 到 worker 线程（#386），避免阻塞事件循环上的 SSE 流。
+        def _submit_chain() -> str:
+            result = task_chain.apply_async()
+            # F-06 fix: traverse parent chain to find the root (first) task ID
+            # so stream_progress can poll from the beginning of the pipeline
+            root_result = result
+            while getattr(root_result, "parent", None) is not None:
+                root_result = root_result.parent
+            return root_result.id
 
-        # F-06 fix: traverse parent chain to find the root (first) task ID
-        # so stream_progress can poll from the beginning of the pipeline
-        root_result = result
-        while getattr(root_result, "parent", None) is not None:
-            root_result = root_result.parent
-        celery_task_id = root_result.id
+        celery_task_id = await asyncio.to_thread(_submit_chain)
 
         # 审计 S42：记录任务所有权
         if user_id:
@@ -82,12 +85,13 @@ class ExplorerOrchestrator:
         return celery_task_id
 
     async def get_task_status(self, task_id: str) -> dict:
-        """查询任务状态"""
-        return self.task_queue.get_task_status(task_id)
+        """查询任务状态 — AsyncResult 读 result backend 是 socket I/O，
+        SSE stream_progress 每秒轮询，必须 offload（#386）。"""
+        return await asyncio.to_thread(self.task_queue.get_task_status, task_id)
 
     async def abort_task(self, task_id: str) -> bool:
-        """中止任务"""
-        return self.task_queue.revoke_task(task_id)
+        """中止任务 — control.revoke 是 broker socket I/O，offload（#386）。"""
+        return await asyncio.to_thread(self.task_queue.revoke_task, task_id)
 
     async def stream_progress(
         self,

--- a/app/services/task_queue.py
+++ b/app/services/task_queue.py
@@ -30,6 +30,21 @@ celery_app.conf.update(
     enable_utc=True,
     task_track_started=True,
     task_time_limit=3600,  # 1小时超时
+    # #386：broker/backend 的 socket 超时压到 1-2s —— 前端每 3s 轮询任务状态，
+    # Redis 不可达/慢响应时若长时间挂起，轮询请求会堆满事件循环线程池并卡住
+    # 所有并发 SSE 流。2s 超时让 /tasks/status 在 backend 不可用时快速降级
+    # 为 UNKNOWN（get_task_status 已捕获所有异常），而不是阻塞 120s。
+    broker_connection_timeout=2,
+    broker_transport_options={
+        "socket_connect_timeout": 2,
+        "socket_timeout": 2,
+    },
+    redis_socket_timeout=2,
+    redis_socket_connect_timeout=2,
+    result_backend_transport_options={
+        "socket_connect_timeout": 2,
+        "socket_timeout": 2,
+    },
     # ADR-0052: worker 崩溃语义。
     #   acks_late=True             → 执行完成后才 ack
     #   reject_on_worker_lost=False→ 不主动 requeue：重投会重复执行不可逆的 GIS

--- a/tests/test_event_loop_offload_386.py
+++ b/tests/test_event_loop_offload_386.py
@@ -208,7 +208,6 @@ async def test_register_kdf_off_loop(monkeypatch):
 @pytest.mark.asyncio
 async def test_login_kdf_off_loop(monkeypatch):
     """verify_password (scrypt, dummy-hash path doubled) must run in a worker thread."""
-    from datetime import datetime, timezone
 
     from app.api.routes import auth as auth_mod
     from app.models.db_model import User

--- a/tests/test_event_loop_offload_386.py
+++ b/tests/test_event_loop_offload_386.py
@@ -1,0 +1,384 @@
+"""Regression tests for #386: async routes must not do blocking sync work on the event loop.
+
+The surviving sites (baseline 971eb05) block every concurrent SSE chat stream:
+
+  1. 50MB GeoJSON parsed with ijson in ``get_upload_geojson``
+  2. reportlab PDF render + sync file write in ``export_map_as_pdf``
+  3. scrypt KDF (N=2^14 ≈ 50-150ms) in register/login
+  4. sync SQLAlchemy Session driven by WorkflowEngine in run/replay/resume
+  5. Celery broker/backend socket I/O (status polling every 3s, send_task,
+     apply_async, revoke)
+
+Each test fakes the slow work with a sync time.sleep (or an async sleep inside
+the worker-thread loop for the engine) that records the thread id it ran on,
+and asserts the main event loop stays responsive *while* the work is running —
+with the work on the loop, the fake's sleep would block everything and the
+final ``assert not task.done()`` fails deterministically (same technique as
+tests/unit/test_execution_offload.py).
+
+Run cost: ~1s per test (0.8s fake sleep), no network, no heavy deps.
+"""
+import asyncio
+import threading
+import time
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_main_thread = threading.get_ident()
+
+
+async def _assert_loop_responsive_while(awaitable_factory, delay: float = 0.8):
+    """Run awaitable_factory() and assert a 0.05s timer fires mid-flight.
+
+    Deterministic: with the work offloaded the task is still running when the
+    timer completes; with the work on the loop the task finishes before the
+    test's own sleep resumes, so ``assert not task.done()`` fails.
+    """
+    task = asyncio.create_task(awaitable_factory())
+    await asyncio.sleep(0.15)          # let it enter the slow work
+    assert not task.done(), "work finished before the test could observe it"
+
+    ticks = []
+    async def _tick():
+        await asyncio.sleep(0.05)
+        ticks.append(True)
+
+    tick = asyncio.create_task(_tick())
+    await asyncio.sleep(0.15)
+    assert tick.done() and ticks, "event loop was blocked during the work"
+    assert not task.done(), "event loop was blocked during the work"
+    return await task
+
+
+# ─── Site 1: upload.py get_upload_geojson (ijson parse of ≤50MB GeoJSON) ─────
+
+
+@pytest.mark.asyncio
+async def test_upload_geojson_parse_off_loop(monkeypatch, tmp_path):
+    """ijson features parse must run in a worker thread, not on the loop."""
+    from app.api.routes import upload as upload_mod
+
+    observed = {}
+
+    class _SlowIjson:
+        def items(self, f, prefix):
+            def _gen():
+                observed["thread"] = threading.get_ident()
+                time.sleep(0.8)
+                yield {"type": "Feature", "properties": {}, "geometry": None}
+            return _gen()
+
+    monkeypatch.setattr(upload_mod, "ijson", _SlowIjson())
+    monkeypatch.setattr(upload_mod.settings, "DATA_DIR", str(tmp_path))
+
+    geojson_path = tmp_path / "data.geojson"
+    geojson_path.write_text('{"type": "FeatureCollection", "features": []}')
+
+    fake_record = MagicMock()
+    fake_record.id = 1
+    fake_record.session_id = None  # 匿名会话，跳过所有权校验
+    fake_record.file_type = "vector"
+    fake_record.filename = str(geojson_path)
+    fake_result = MagicMock()
+    fake_result.scalar_one_or_none.return_value = fake_record
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(return_value=fake_result)
+    monkeypatch.setattr(upload_mod, "_verify_session_owner", AsyncMock())
+
+    @asynccontextmanager
+    async def fake_async_db_session():
+        yield fake_db
+
+    monkeypatch.setattr(upload_mod, "async_db_session", fake_async_db_session)
+
+    result = await _assert_loop_responsive_while(
+        lambda: upload_mod.get_upload_geojson(1, {"user_id": "test-user"})
+    )
+    assert observed["thread"] != _main_thread, "ijson parse ran on the event loop thread"
+    assert result["type"] == "FeatureCollection"
+    assert len(result["features"]) == 1
+
+
+# ─── Site 2: map.py export_map_as_pdf (reportlab render + sync file write) ────
+
+
+@pytest.mark.asyncio
+async def test_pdf_render_off_loop(monkeypatch, tmp_path):
+    """generate_map_pdf + file write must run in a worker thread."""
+    import io
+
+    from fastapi import UploadFile
+
+    from app.api.routes import map as map_mod
+
+    observed = {}
+
+    def _slow_render(img_bytes, **kwargs):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return b"%PDF-1.4 fake"
+
+    monkeypatch.setattr(
+        "app.lib.cartography.pdf_renderer.generate_map_pdf", _slow_render
+    )
+    monkeypatch.setattr(map_mod, "EXPORT_DIR", str(tmp_path))
+    monkeypatch.setattr(map_mod, "_set_export_owner", lambda *a, **k: None)
+
+    file = UploadFile(file=io.BytesIO(b"png-bytes"), filename="map.png")
+    try:
+        res = await _assert_loop_responsive_while(
+            lambda: map_mod.export_map_as_pdf(file, title="t", _user={"user_id": "u1"})
+        )
+        assert res["format"] == "pdf"
+        assert observed["thread"] != _main_thread, "PDF render ran on the event loop thread"
+        assert (tmp_path / res["filename"]).exists()
+    finally:
+        await file.close()
+
+
+@pytest.mark.asyncio
+async def test_pdf_render_value_error_still_400(monkeypatch, tmp_path):
+    """Renderer ValueError must still map to HTTP 400 after offloading."""
+    import io
+
+    from fastapi import HTTPException, UploadFile
+
+    from app.api.routes import map as map_mod
+
+    def _raise_value_error(img_bytes, **kwargs):
+        raise ValueError("无法解析图片数据")
+
+    monkeypatch.setattr(
+        "app.lib.cartography.pdf_renderer.generate_map_pdf", _raise_value_error
+    )
+    monkeypatch.setattr(map_mod, "EXPORT_DIR", str(tmp_path))
+
+    file = UploadFile(file=io.BytesIO(b"not-an-image"), filename="bad.png")
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await map_mod.export_map_as_pdf(file, _user={"user_id": "u1"})
+        assert exc_info.value.status_code == 400
+    finally:
+        await file.close()
+
+
+# ─── Site 3: auth.py scrypt KDF (hash_password / verify_password) ────────────
+
+
+@pytest.mark.asyncio
+async def test_register_kdf_off_loop(monkeypatch):
+    """hash_password (scrypt N=2^14) must run in a worker thread."""
+    from app.api.routes import auth as auth_mod
+
+    observed = {}
+
+    def _slow_hash(pw):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return "scrypt$16384$8$1$00$00"
+
+    monkeypatch.setattr(auth_mod, "hash_password", _slow_hash)
+    monkeypatch.setattr(auth_mod, "_allow_public_register", lambda: True)
+    monkeypatch.setattr(auth_mod, "_get_client_ip", lambda request: "1.2.3.4")
+
+    class _Limiter:
+        async def is_allowed(self, *a, **k):
+            return True
+
+    monkeypatch.setattr(auth_mod, "get_rate_limiter", AsyncMock(return_value=_Limiter()))
+
+    fake_result = MagicMock()
+    fake_result.scalar_one_or_none.return_value = None  # 无重名用户
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(return_value=fake_result)
+    fake_db.add = MagicMock()  # 同步调用点，避免未 await 的 coroutine 告警
+
+    req = auth_mod.RegisterRequest(
+        username="tester", email="t@example.com", password="secret123"
+    )
+    resp = await _assert_loop_responsive_while(
+        lambda: auth_mod.register(req, MagicMock(), db=fake_db)
+    )
+    assert observed["thread"] != _main_thread, "scrypt hash ran on the event loop thread"
+    assert resp.access_token
+
+
+@pytest.mark.asyncio
+async def test_login_kdf_off_loop(monkeypatch):
+    """verify_password (scrypt, dummy-hash path doubled) must run in a worker thread."""
+    from datetime import datetime, timezone
+
+    from app.api.routes import auth as auth_mod
+    from app.models.db_model import User
+
+    observed = {}
+
+    def _slow_verify(pw, stored):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return True
+
+    monkeypatch.setattr(auth_mod, "verify_password", _slow_verify)
+    monkeypatch.setattr(auth_mod, "_get_client_ip", lambda request: "1.2.3.4")
+
+    class _Limiter:
+        async def is_allowed(self, *a, **k):
+            return True
+
+    monkeypatch.setattr(auth_mod, "get_rate_limiter", AsyncMock(return_value=_Limiter()))
+
+    user = User(
+        id="u1",
+        username="tester",
+        email="t@example.com",
+        full_name=None,
+        role="viewer",
+        is_active=True,
+        token_version=0,
+        password_hash="scrypt$16384$8$1$00$00",
+        last_login=None,
+        login_count=None,
+    )
+    fake_result = MagicMock()
+    fake_result.scalar_one_or_none.return_value = user
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(return_value=fake_result)
+
+    req = auth_mod.LoginRequest(identifier="tester", password="secret123")
+    resp = await _assert_loop_responsive_while(
+        lambda: auth_mod.login(req, MagicMock(), db=fake_db)
+    )
+    assert observed["thread"] != _main_thread, "scrypt verify ran on the event loop thread"
+    assert resp.access_token
+    assert user.login_count == 1
+    assert user.last_login is not None
+
+
+# ─── Site 4: project.py workflow engine (sync Session driver) ────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_engine_off_loop(monkeypatch):
+    """WorkflowEngine.execute_workflow_run must run in a worker thread with a
+    Session created in that same thread (never shared cross-thread)."""
+    from app.api.routes import project as route_mod
+    from app.schemas.project_schema import WorkflowRunRequest
+
+    observed = {}
+
+    async def _slow_engine(db, **kwargs):
+        observed["thread"] = threading.get_ident()
+        observed["session_id"] = id(db)
+        await asyncio.sleep(0.8)  # 只阻塞 worker 线程自己的事件循环
+        return {"id": "wfrun_test_1", "status": "completed"}
+
+    monkeypatch.setattr(
+        route_mod.WorkflowEngine, "execute_workflow_run", staticmethod(_slow_engine)
+    )
+    monkeypatch.setattr(route_mod, "get_tool_registry", lambda: object())
+
+    class _FakeProjectService:
+        @staticmethod
+        def get_project_with_auth(**kwargs):
+            return {"id": "proj_1"}
+
+    monkeypatch.setattr(route_mod, "ProjectService", _FakeProjectService)
+
+    injected_db = MagicMock()
+    req = WorkflowRunRequest(input_bindings={"aoi": "Haidian"}, start_from_step=None)
+    res = await _assert_loop_responsive_while(
+        lambda: route_mod.run_workflow(
+            "proj_1", "wf_1", req,
+            db=injected_db,
+            user={"user_id": "u1", "org_id": None},
+        )
+    )
+    assert res["status"] == "completed"
+    assert observed["thread"] != _main_thread, "workflow engine ran on the event loop thread"
+    assert observed["session_id"] != id(injected_db), (
+        "engine reused the request-injected Session across threads"
+    )
+
+
+# ─── Site 5: Celery broker/backend socket I/O ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_celery_status_poll_off_loop(monkeypatch):
+    """AsyncResult.info/.ready() (frontend polls every 3s) must run off-loop."""
+    from app.api.routes import task as task_mod
+
+    observed = {}
+
+    def _slow_status(tid):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return {"task_id": tid, "status": "SUCCESS", "result": None, "progress": 100}
+
+    monkeypatch.setattr(
+        task_mod.TaskQueueService, "get_task_status", staticmethod(_slow_status)
+    )
+    monkeypatch.setattr(task_mod, "_verify_celery_owner", AsyncMock())
+    monkeypatch.setattr(
+        task_mod.DurableJobStore, "get_by_celery_id", AsyncMock(return_value=None)
+    )
+
+    payload = await _assert_loop_responsive_while(
+        lambda: task_mod.get_celery_task_status(
+            "celery-1", db=AsyncMock(), _user={"user_id": "u1"}, owner_token=None
+        )
+    )
+    assert payload["status"] == "SUCCESS"
+    assert observed["thread"] != _main_thread, "Celery backend read ran on the event loop thread"
+
+
+@pytest.mark.asyncio
+async def test_explorer_submit_and_status_off_loop(monkeypatch):
+    """Orchestrator apply_async + AsyncResult read (SSE stream polls 1s) off-loop."""
+    import app.services.explorer.orchestrator as orch_mod
+    from app.services.explorer.models import SearchContext
+    from app.services.explorer.orchestrator import ExplorerOrchestrator
+
+    orch = ExplorerOrchestrator()
+    observed = {}
+
+    def _slow_submit():
+        observed["submit_thread"] = threading.get_ident()
+        time.sleep(0.8)
+        root = MagicMock()
+        root.id = "celery_root_1"
+        root.parent = None
+        return root
+
+    def _slow_status(tid):
+        observed["status_thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return {"task_id": tid, "status": "PROGRESS", "result": {"meta": {}}, "progress": 50}
+
+    # start_exploration 内部 `chain(...)` 后 apply_async —— 用假 chain 注入慢提交。
+    monkeypatch.setattr(
+        orch_mod, "chain", lambda *tasks: MagicMock(apply_async=_slow_submit)
+    )
+    monkeypatch.setattr(
+        orch, "task_queue",
+        MagicMock(get_task_status=_slow_status, revoke_task=lambda tid: True),
+    )
+
+    # apply_async + parent 遍历必须 off-loop。
+    task_id = await _assert_loop_responsive_while(
+        lambda: orch.start_exploration(
+            "query", SearchContext(query="q", expected_data_type="poi_list"),
+            session_id="s1", user_id="u1",
+        )
+    )
+    assert task_id == "celery_root_1"
+    assert observed["submit_thread"] != _main_thread, "apply_async ran on the event loop thread"
+
+    # get_task_status（SSE stream_progress 每秒轮询）同样 off-loop。
+    status = await _assert_loop_responsive_while(
+        lambda: orch.get_task_status(task_id)
+    )
+    assert status["progress"] == 50
+    assert observed["status_thread"] != _main_thread, "AsyncResult read ran on the event loop thread"


### PR DESCRIPTION
## Summary

Fixes #386 (P2): async routes did sync CPU/socket work directly on the single uvicorn event loop, stalling every concurrent SSE chat stream. Baseline 971eb05 still exhibits all five sites; this PR offloads each one while keeping response/error semantics identical.

### Per site

| # | Site | Fix |
|---|------|-----|
| 1 | `app/api/routes/upload.py` `get_upload_geojson` | 50MB GeoJSON ijson parse moved to `_load_geojson_features` + `loop.run_in_executor` — same pattern as the upload path's `parse_vector` |
| 2 | `app/api/routes/map.py` `export_map_as_pdf` | reportlab render (≤50MB embedded image) + sync `open(...,"wb")` write moved into `_render_pdf_to_file`, executed in default threadpool; renderer `ValueError` still maps to HTTP 400 |
| 3 | `app/api/routes/auth.py` register/login | scrypt KDF (N=2^14 ≈ 50–150ms; doubled on failed login via dummy verify) wrapped in `asyncio.to_thread` — only the KDF, DB/session work stays async |
| 4 | `app/api/routes/project.py` run/replay/resume | `WorkflowEngine` coroutine (per-step sync Session execute/flush/commit + tool dispatch) run via `asyncio.run` inside `asyncio.to_thread` (`_run_workflow_engine`). A **fresh Session is created, used, and closed in the worker thread** — never shared cross-thread (Session is not thread-safe). 404/409/500 semantics unchanged |
| 5 | Celery broker/backend socket I/O | `asyncio.to_thread` at: `task.py` `get_celery_task_status` (AsyncResult.info/.ready(), polled every 3s) + `revoke_celery_task` (control.revoke); `jobs.py` retry `send_task` publish; explorer orchestrator `start_exploration` `apply_async` + parent-chain traversal, plus `get_task_status`/`abort_task` wrappers (SSE `stream_progress` polls them every 1s) |

### Bonus: Celery socket timeouts (`app/services/task_queue.py`)

Broker/backend timeouts tightened to 2s (`broker_connection_timeout`, `broker_transport_options.socket_*`, `redis_socket_timeout`, `redis_socket_connect_timeout`, `result_backend_transport_options.socket_*`). A dead/slow Redis now degrades `/tasks/status` polling to `UNKNOWN` in ~2s (existing catch-all in `get_task_status`) instead of hanging up to the 120s redis default.

### Tests

`tests/test_event_loop_offload_386.py` — 8 loop-blocking detection tests covering all five sites: a slow fake records the thread it ran on; the test asserts (a) a 0.05s timer fires on the main loop mid-work (loop not blocked) and (b) the work ran on a non-event-loop thread. Same deterministic technique as `tests/unit/test_execution_offload.py`. Includes an HTTP-400-preserved test for the PDF renderer ValueError path and a check that the workflow engine gets a fresh Session in the worker thread.

### Verification

- New tests: 8 passed
- Related sweep (upload/auth/task/jobs/project/workflow/explorer/map/pdf/celery, incl. `tests/jobs/`): **476 passed** — no regressions