### PR TITLE
fix(gis): Amap isochrone scaling, AOI-windowed raster difference, and engine algorithmic hot spots

### DIFF
--- a/app/services/network/facility.py
+++ b/app/services/network/facility.py
@@ -73,53 +73,79 @@ class NetworkClosestFacilityService:
                 summary={"demand_count": len(normalized_demands), "facility_count": len(normalized_facilities)},
             )
 
+        if travel_direction == "facility_to_incident":
+            origins, destinations = normalized_facilities, normalized_demands
+        else:
+            origins, destinations = normalized_demands, normalized_facilities
+
+        # PERF: one multi-source Dijkstra over all origins (instead of D×F
+        # independent shortest-path calls), reusing the predecessor trees to
+        # rebuild only the selected routes. The old per-pair
+        # ``network_shortest_path`` also ran a full ``graph.copy()`` for every
+        # coordinate pair — with D demands × F facilities that dominated the
+        # analysis.
+        od = self.od_service.network_od_paths(
+            origins=[o.geometry["coordinates"] for o in origins],
+            destinations=[d.geometry["coordinates"] for d in destinations],
+            graph=graph,
+            network_dataset=network_dataset,
+            profile=profile,
+            impedance=impedance,
+            barriers=barriers,
+        )
+        origin_labels = od["origin_labels"]
+        dest_labels = od["dest_labels"]
+        profile_name = profile.name if profile else "driving"
+
         routes: List[Route] = []
         matched_pairs_count = 0
 
-        for dem in normalized_demands:
-            dem_coords = (dem.geometry["coordinates"][0], dem.geometry["coordinates"][1])
-
-            # Calculate route to all facilities
-            candidate_routes: List[Tuple[Route, Facility]] = []
-
-            for fac in normalized_facilities:
-                fac_coords = (fac.geometry["coordinates"][0], fac.geometry["coordinates"][1])
-
+        for dem_idx, dem in enumerate(normalized_demands):
+            for fac_idx, fac in enumerate(normalized_facilities):
                 if travel_direction == "facility_to_incident":
-                    origin_loc, dest_loc = fac_coords, dem_coords
+                    o_label, d_label = origin_labels[fac_idx], dest_labels[dem_idx]
                     o_id, d_id = fac.facility_id, dem.demand_id
                 else:
-                    origin_loc, dest_loc = dem_coords, fac_coords
+                    o_label, d_label = origin_labels[dem_idx], dest_labels[fac_idx]
                     o_id, d_id = dem.demand_id, fac.facility_id
 
-                route = self.router.network_shortest_path(
-                    graph=graph,
-                    network_dataset=network_dataset,
-                    origin=origin_loc,
-                    destination=dest_loc,
-                    profile=profile,
-                    impedance=impedance,
-                    barriers=barriers,
+                info = od["pairs"].get((o_label, d_label))
+                if (
+                    info is None or not info["reachable"]
+                    or info["cost"] >= float("inf") or info["distance_m"] <= 0
+                ):
+                    continue
+                if cutoff_cost is not None and info["cost"] > cutoff_cost:
+                    continue
+
+                route = self.router.build_route_from_path(
+                    od["graph_view"], info["path"],
+                    origin_label=o_label, destination_label=d_label,
+                    profile_name=profile_name,
+                    route_id=f"route_{o_label}_{d_label}",
+                    weight_func=od["weight_func"],
                 )
+                route.origin_id = o_id
+                route.destination_id = d_id
+                routes.append((route, fac))
 
-                if route.total_cost < float("inf") and route.total_distance_m > 0:
-                    route.origin_id = o_id
-                    route.destination_id = d_id
-                    if cutoff_cost is None or route.total_cost <= cutoff_cost:
-                        candidate_routes.append((route, fac))
+        # Group by demand: closest facility selection happens per demand point.
+        per_demand: Dict[str, List[Tuple[Route, Facility]]] = {}
+        for route, fac in routes:
+            key = route.origin_id if travel_direction == "incident_to_facility" else route.destination_id
+            per_demand.setdefault(key, []).append((route, fac))
 
-            # Sort by total_cost ascending
-            candidate_routes.sort(key=lambda x: x[0].total_cost)
-            selected = candidate_routes[:target_facility_count]
-
-            for r, _ in selected:
-                routes.append(r)
+        selected_routes: List[Route] = []
+        for key in sorted(per_demand):
+            candidates = sorted(per_demand[key], key=lambda x: x[0].total_cost)
+            for r, _ in candidates[:target_facility_count]:
+                selected_routes.append(r)
                 matched_pairs_count += 1
 
         summary = {
             "demand_count": len(normalized_demands),
             "facility_count": len(normalized_facilities),
-            "routes_found": len(routes),
+            "routes_found": len(selected_routes),
             "target_facility_count": target_facility_count,
             "cutoff_cost": cutoff_cost,
         }
@@ -128,7 +154,7 @@ class NetworkClosestFacilityService:
             analysis_type="closest_facility",
             status="success",
             summary=summary,
-            routes=routes,
+            routes=selected_routes,
         )
 
     def _normalize_demands(

--- a/app/services/network/graph_builder.py
+++ b/app/services/network/graph_builder.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from collections import OrderedDict
 
 import networkx as nx
+from shapely import STRtree
 from shapely.geometry import shape, LineString, MultiLineString, Point, MultiPoint, mapping
 from shapely.ops import unary_union, split
 
@@ -68,15 +69,42 @@ class NetworkGraphBuilder:
         # cached graph (review N-F05-regression).
         self._cache: OrderedDict[str, Tuple[nx.DiGraph, NetworkDataset, Any]] = OrderedDict()
         self._cache_lock = threading.Lock()
+        # Fingerprint memo: id(data) -> (serialized data string, strong ref).
+        # Rebuilding a graph from the same GeoJSON dict used to re-run
+        # json.dumps over the whole network on EVERY build_graph call (cache
+        # hit included). The strong ref prevents CPython from reusing the id()
+        # of a freed object for a different dataset (same pinning argument as
+        # the graph cache entries). Bounded by max_cache_size (LRU).
+        self._fp_memo: OrderedDict[int, Tuple[str, Any]] = OrderedDict()
 
     def clear_cache(self) -> None:
         """Clears the LRU graph cache."""
         with self._cache_lock:
             self._cache.clear()
+            self._fp_memo.clear()
 
     def get_cache_info(self) -> Dict[str, int]:
         """Returns cache capacity and current entry count."""
         return {"size": len(self._cache), "max_size": self.max_cache_size}
+
+    def _memoized_data_str(self, data: Dict[str, Any]) -> str:
+        """Serializes a GeoJSON dict once per object identity.
+
+        ``json.dumps(sort_keys=True)`` of a 100k-line city network is the
+        dominant cost of every ``build_graph`` call (cache hit or not); the
+        memo makes repeated builds of the SAME dict object a dict lookup.
+        """
+        key = id(data)
+        with self._cache_lock:
+            entry = self._fp_memo.get(key)
+            if entry is not None and entry[1] is data:
+                self._fp_memo.move_to_end(key)
+                return entry[0]
+            data_str = json.dumps(data, sort_keys=True)
+            self._fp_memo[key] = (data_str, data)
+            while len(self._fp_memo) > self.max_cache_size:
+                self._fp_memo.popitem(last=False)
+            return data_str
 
     def compute_fingerprint(
         self,
@@ -88,7 +116,7 @@ class NetworkGraphBuilder:
         """Computes deterministic SHA-256 fingerprint hash for LRU caching."""
         try:
             if isinstance(data, dict):
-                data_str = json.dumps(data, sort_keys=True)
+                data_str = self._memoized_data_str(data)
             elif isinstance(data, NetworkDataset):
                 # Object-identity fingerprint for NetworkDataset: dataset_id
                 # alone collides (it historically hashed only the edge count,
@@ -369,11 +397,22 @@ class NetworkGraphBuilder:
 
         lines = [item[0] for item in line_items]
 
-        # Find all pairwise intersection points between lines
+        # Find all intersection points between lines. The naive O(n²) pairwise
+        # loop performed ~5×10⁹ shapely intersection tests for a 100k-line
+        # city network (split_intersections=True is the default on every cache
+        # miss). A STRtree candidate query restricts the precise intersects
+        # test to bounding-box-overlapping pairs (typically a handful per
+        # line), giving the exact same point set with a fraction of the work.
         intersection_points: List[Point] = []
-        for i in range(len(lines)):
-            for j in range(i + 1, len(lines)):
-                inter = lines[i].intersection(lines[j])
+        tree = STRtree(lines)
+        for i, line in enumerate(lines):
+            for j in tree.query(line, predicate="intersects"):
+                j = int(j)
+                if j <= i:
+                    # Skip self (j == i) and pairs already handled when the
+                    # earlier line was queried (j < i).
+                    continue
+                inter = line.intersection(lines[j])
                 if not inter.is_empty:
                     if isinstance(inter, Point):
                         intersection_points.append(inter)

--- a/app/services/network/od_matrix.py
+++ b/app/services/network/od_matrix.py
@@ -16,7 +16,7 @@ from app.services.network.models import (
     PointSnappingResult,
 )
 from app.services.network.snapping import PointSnappingService
-from app.services.network.routing import NetworkRoutingService
+from app.services.network.routing import NetworkRoutingService, build_weight_func
 
 
 class NetworkODMatrixService:
@@ -56,78 +56,18 @@ class NetworkODMatrixService:
         if not origins or not destinations:
             return []
 
-        # Resolve all origin nodes and labels
-        orig_nodes: List[Tuple[str, str]] = [
-            self.router._resolve_node(o, network_dataset) for o in origins
-        ]
-        dest_nodes: List[Tuple[str, str]] = [
-            self.router._resolve_node(d, network_dataset) for d in destinations
-        ]
-
-        graph_view = self.router._apply_barriers(graph, barriers)
-
-        cost_field = "travel_time_s"
-        if impedance and impedance.name:
-            cost_field = impedance.name
-        elif profile and profile.impedance_field:
-            cost_field = profile.impedance_field
-
-        def weight_func(u: Any, v: Any, edge_data: Dict[str, Any]) -> float:
-            base_w = edge_data.get(cost_field, edge_data.get("length_m", 1.0))
-            if base_w is None or base_w <= 0:
-                base_w = 0.001
-            barrier_factor = edge_data.get("_barrier_factor", 1.0)
-            return max(0.0001, float(base_w * barrier_factor))
-
-        # GIS-19: one Dijkstra per unique origin with the impedance weight, then
-        # recover distance and time by walking the shortest-path predecessor
-        # tree summing length_m / travel_time_s along each edge. The previous
-        # code ran THREE full Dijkstra passes per origin (cost, distance, time)
-        # even though distance and time accumulate along the same shortest path.
-        unique_orig_nodes = set(n_id for n_id, _ in orig_nodes)
-        dijkstra_results: Dict[str, Dict[str, float]] = {}
-        dijkstra_dist: Dict[str, Dict[str, float]] = {}
-        dijkstra_time: Dict[str, Dict[str, float]] = {}
-
-        for o_node in unique_orig_nodes:
-            if o_node in graph_view:
-                # nx.single_source_dijkstra returns (dist_dict, path_dict);
-                # path_dict maps each reachable node to its FULL path list
-                # ([origin, ..., node]). Sum length_m / travel_time_s along each
-                # path in one O(path-length) pass per node — no extra Dijkstra.
-                dists, paths = nx.single_source_dijkstra(graph_view, o_node, weight=weight_func)
-                dijkstra_results[o_node] = dists
-
-                distances: Dict[str, float] = {}
-                times: Dict[str, float] = {}
-                for node, path in paths.items():
-                    if node == o_node or len(path) < 2:
-                        distances[node] = 0.0
-                        times[node] = 0.0
-                        continue
-                    dist_acc = 0.0
-                    time_acc = 0.0
-                    for i in range(len(path) - 1):
-                        edge_data = graph_view[path[i]][path[i + 1]]
-                        dist_acc += float(edge_data.get("length_m", 0.0))
-                        time_acc += float(edge_data.get("travel_time_s", 0.0))
-                    distances[node] = dist_acc
-                    times[node] = time_acc
-                dijkstra_dist[o_node] = distances
-                dijkstra_time[o_node] = times
-            else:
-                dijkstra_results[o_node] = {}
-                dijkstra_dist[o_node] = {}
-                dijkstra_time[o_node] = {}
+        res = self._compute_od(
+            origins, destinations, graph, network_dataset,
+            profile=profile, impedance=impedance, barriers=barriers,
+        )
 
         od_matrix: List[ODPair] = []
+        for o_node, o_label in res["origin_nodes"]:
+            costs = res["results"].get(o_node, {}).get("dists", {})
+            dists = res["results"].get(o_node, {}).get("dist_m", {})
+            times = res["results"].get(o_node, {}).get("time_s", {})
 
-        for o_node, o_label in orig_nodes:
-            costs = dijkstra_results.get(o_node, {})
-            dists = dijkstra_dist.get(o_node, {})
-            times = dijkstra_time.get(o_node, {})
-
-            for d_node, d_label in dest_nodes:
+            for d_node, d_label in res["dest_nodes"]:
                 if d_node in costs:
                     dist_m = dists.get(d_node, 0.0)
                     time_s = times.get(d_node, 0.0)
@@ -152,3 +92,164 @@ class NetworkODMatrixService:
                     )
 
         return od_matrix
+
+    def network_od_paths(
+        self,
+        origins: List[Union[Tuple[float, float], str, PointSnappingResult]],
+        destinations: List[Union[Tuple[float, float], str, PointSnappingResult]],
+        graph: nx.DiGraph,
+        network_dataset: NetworkDataset,
+        profile: Optional[TravelProfile] = None,
+        impedance: Optional[Impedance] = None,
+        barriers: Optional[List[Barrier]] = None,
+    ) -> Dict[str, Any]:
+        """Batch OD with full shortest-path trees, one Dijkstra per unique origin.
+
+        Returns a dict with:
+        - ``origin_nodes`` / ``origin_labels``: resolved (node_id, label) per origin
+        - ``dest_nodes`` / ``dest_labels``: resolved (node_id, label) per destination
+        - ``graph_view`` / ``weight_func``: the (barrier-applied) graph and the
+          exact weight function used, so callers can reconstruct full Route
+          geometries from the paths without re-running Dijkstra or copying the
+          graph per pair.
+        - ``pairs``: {(origin_label, dest_label): {"path": [node ids...],
+          "cost": float, "distance_m": float, "time_s": float, "reachable": bool}}
+        """
+        if not origins or not destinations:
+            return {
+                "origin_nodes": [], "origin_labels": [],
+                "dest_nodes": [], "dest_labels": [],
+                "graph_view": graph, "weight_func": None,
+                "pairs": {},
+            }
+
+        res = self._compute_od(
+            origins, destinations, graph, network_dataset,
+            profile=profile, impedance=impedance, barriers=barriers,
+        )
+
+        pairs: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        for o_node, o_label in res["origin_nodes"]:
+            origin_res = res["results"].get(o_node, {})
+            costs = origin_res.get("dists", {})
+            paths = origin_res.get("paths", {})
+            dists = origin_res.get("dist_m", {})
+            times = origin_res.get("time_s", {})
+            for d_node, d_label in res["dest_nodes"]:
+                if d_node in costs:
+                    pairs[(o_label, d_label)] = {
+                        "path": list(paths.get(d_node, [])),
+                        "cost": float(costs[d_node]),
+                        "distance_m": float(dists.get(d_node, 0.0)),
+                        "time_s": float(times.get(d_node, 0.0)),
+                        "reachable": True,
+                    }
+                else:
+                    pairs[(o_label, d_label)] = {
+                        "path": [], "cost": float("inf"),
+                        "distance_m": float("inf"), "time_s": float("inf"),
+                        "reachable": False,
+                    }
+
+        return {
+            "origin_nodes": res["origin_nodes"],
+            "origin_labels": [label for _, label in res["origin_nodes"]],
+            "dest_nodes": res["dest_nodes"],
+            "dest_labels": [label for _, label in res["dest_nodes"]],
+            "graph_view": res["graph_view"],
+            "weight_func": res["weight_func"],
+            "pairs": pairs,
+        }
+
+    def _compute_od(
+        self,
+        origins: List[Union[Tuple[float, float], str, PointSnappingResult]],
+        destinations: List[Union[Tuple[float, float], str, PointSnappingResult]],
+        graph: nx.DiGraph,
+        network_dataset: NetworkDataset,
+        profile: Optional[TravelProfile] = None,
+        impedance: Optional[Impedance] = None,
+        barriers: Optional[List[Barrier]] = None,
+    ) -> Dict[str, Any]:
+        """Shared multi-source Dijkstra core used by matrix and path variants."""
+        # Resolve all origin nodes and labels
+        orig_nodes: List[Tuple[str, str]] = [
+            self.router._resolve_node(o, network_dataset) for o in origins
+        ]
+        dest_nodes: List[Tuple[str, str]] = [
+            self.router._resolve_node(d, network_dataset) for d in destinations
+        ]
+
+        graph_view = self.router._apply_barriers(graph, barriers)
+
+        cost_field = "travel_time_s"
+        if impedance and impedance.name:
+            cost_field = impedance.name
+        elif profile and profile.impedance_field:
+            cost_field = profile.impedance_field
+
+        turn_penalty = impedance.turn_penalty_s if impedance else 0.0
+        if profile and profile.turn_penalty_s:
+            turn_penalty = max(turn_penalty, profile.turn_penalty_s)
+
+        weight_func = build_weight_func(cost_field, turn_penalty)
+
+        # GIS-19: one Dijkstra per unique origin with the impedance weight, then
+        # recover distance and time by walking the shortest-path predecessor
+        # tree summing length_m / travel_time_s along each edge. The previous
+        # code ran THREE full Dijkstra passes per origin (cost, distance, time)
+        # even though distance and time accumulate along the same shortest path.
+        unique_orig_nodes = set(n_id for n_id, _ in orig_nodes)
+        dijkstra_results: Dict[str, Dict[str, float]] = {}
+        dijkstra_dist: Dict[str, Dict[str, float]] = {}
+        dijkstra_time: Dict[str, Dict[str, float]] = {}
+        dijkstra_paths: Dict[str, Dict[str, list]] = {}
+
+        for o_node in unique_orig_nodes:
+            if o_node in graph_view:
+                # nx.single_source_dijkstra returns (dist_dict, path_dict);
+                # path_dict maps each reachable node to its FULL path list
+                # ([origin, ..., node]). Sum length_m / travel_time_s along each
+                # path in one O(path-length) pass per node — no extra Dijkstra.
+                dists, paths = nx.single_source_dijkstra(graph_view, o_node, weight=weight_func)
+                dijkstra_results[o_node] = dists
+                dijkstra_paths[o_node] = paths
+
+                distances: Dict[str, float] = {}
+                times: Dict[str, float] = {}
+                for node, path in paths.items():
+                    if node == o_node or len(path) < 2:
+                        distances[node] = 0.0
+                        times[node] = 0.0
+                        continue
+                    dist_acc = 0.0
+                    time_acc = 0.0
+                    for i in range(len(path) - 1):
+                        edge_data = graph_view[path[i]][path[i + 1]]
+                        dist_acc += float(edge_data.get("length_m", 0.0))
+                        time_acc += float(edge_data.get("travel_time_s", 0.0))
+                    distances[node] = dist_acc
+                    times[node] = time_acc
+                dijkstra_dist[o_node] = distances
+                dijkstra_time[o_node] = times
+            else:
+                dijkstra_results[o_node] = {}
+                dijkstra_paths[o_node] = {}
+                dijkstra_dist[o_node] = {}
+                dijkstra_time[o_node] = {}
+
+        return {
+            "origin_nodes": orig_nodes,
+            "dest_nodes": dest_nodes,
+            "graph_view": graph_view,
+            "weight_func": weight_func,
+            "results": {
+                o_node: {
+                    "dists": dijkstra_results.get(o_node, {}),
+                    "paths": dijkstra_paths.get(o_node, {}),
+                    "dist_m": dijkstra_dist.get(o_node, {}),
+                    "time_s": dijkstra_time.get(o_node, {}),
+                }
+                for o_node, _ in orig_nodes
+            },
+        }

--- a/app/services/network/routing.py
+++ b/app/services/network/routing.py
@@ -24,6 +24,25 @@ from app.services.network.snapping import PointSnappingService
 from app.services.network.graph_builder import haversine_distance
 
 
+def build_weight_func(cost_field: str, turn_penalty: float = 0.0):
+    """Edge weight function factory shared by routing and OD-matrix analyses.
+
+    Keeps the cost semantics (barrier factors, turn penalties) identical
+    between direct ``network_shortest_path`` and batch multi-source Dijkstra
+    (closest facility / VRP reuse the OD service's shortest-path trees).
+    """
+    def weight_func(u: Any, v: Any, edge_data: Dict[str, Any]) -> float:
+        base_w = edge_data.get(cost_field, edge_data.get("length_m", 1.0))
+        if base_w is None or base_w <= 0:
+            base_w = 0.001
+        barrier_factor = edge_data.get("_barrier_factor", 1.0)
+        w = base_w * barrier_factor
+        if turn_penalty > 0 and cost_field == "travel_time_s":
+            w += turn_penalty
+        return max(0.0001, float(w))
+    return weight_func
+
+
 class NetworkRoutingService:
     """
     Service for calculating shortest path routes over spatial network graphs.
@@ -324,15 +343,7 @@ class NetworkRoutingService:
         if profile and profile.turn_penalty_s:
             turn_penalty = max(turn_penalty, profile.turn_penalty_s)
 
-        def weight_func(u: Any, v: Any, edge_data: Dict[str, Any]) -> float:
-            base_w = edge_data.get(cost_field, edge_data.get("length_m", 1.0))
-            if base_w is None or base_w <= 0:
-                base_w = 0.001
-            barrier_factor = edge_data.get("_barrier_factor", 1.0)
-            w = base_w * barrier_factor
-            if turn_penalty > 0 and cost_field == "travel_time_s":
-                w += turn_penalty
-            return max(0.0001, float(w))
+        weight_func = build_weight_func(cost_field, turn_penalty)
 
         # Run Pathfinding
         try:
@@ -366,6 +377,31 @@ class NetworkRoutingService:
             )
 
         # Build route details
+        profile_name = profile.name if profile else "driving"
+        route_id = f"route_{origin_id_str}_{dest_id_str}"
+        return self.build_route_from_path(
+            graph_view, path_nodes,
+            origin_label=origin_id_str, destination_label=dest_id_str,
+            profile_name=profile_name, route_id=route_id, weight_func=weight_func,
+        )
+
+    def build_route_from_path(
+        self,
+        graph: nx.DiGraph,
+        path_nodes: List[Any],
+        origin_label: str,
+        destination_label: str,
+        profile_name: str,
+        route_id: str,
+        weight_func,
+    ) -> Route:
+        """Build a Route (geometry, totals, directions) from a node path.
+
+        Shared by ``network_shortest_path`` and the batch OD-matrix based
+        analyses (closest facility / VRP), so path → route shaping stays
+        identical everywhere and routes can be reconstructed from
+        multi-source Dijkstra predecessor trees without per-call graph copies.
+        """
         path_edges: List[str] = []
         route_coords: List[Tuple[float, float]] = []
         total_dist_m = 0.0
@@ -375,7 +411,7 @@ class NetworkRoutingService:
         for i in range(len(path_nodes) - 1):
             u = path_nodes[i]
             v = path_nodes[i + 1]
-            edge_data = graph_view[u][v]
+            edge_data = graph[u][v]
             edge_id = edge_data.get("id", f"e_{u}_{v}")
             path_edges.append(edge_id)
 
@@ -396,26 +432,24 @@ class NetworkRoutingService:
                     coords = coords[1:] if coords and route_coords[-1] == coords[0] else coords
                 route_coords.extend(coords)
             else:
-                u_data = graph_view.nodes[u]
-                v_data = graph_view.nodes[v]
+                u_data = graph.nodes[u]
+                v_data = graph.nodes[v]
                 if not route_coords:
                     route_coords.append((u_data["x"], u_data["y"]))
                 route_coords.append((v_data["x"], v_data["y"]))
 
-        directions = self._generate_directions(graph_view, path_nodes)
-        profile_name = profile.name if profile else "driving"
-        route_id = f"route_{origin_id_str}_{dest_id_str}"
+        directions = self._generate_directions(graph, path_nodes)
 
         return Route(
             route_id=route_id,
-            origin_id=origin_id_str,
-            destination_id=dest_id_str,
+            origin_id=origin_label,
+            destination_id=destination_label,
             profile_name=profile_name,
             total_distance_m=total_dist_m,
             total_time_s=total_time_s,
             total_cost=total_cost,
             geometry={"type": "LineString", "coordinates": route_coords},
-            path_node_ids=path_nodes,
+            path_node_ids=list(path_nodes),
             path_edge_ids=path_edges,
             directions=directions,
         )

--- a/app/services/network/vrp.py
+++ b/app/services/network/vrp.py
@@ -85,8 +85,12 @@ class NetworkRouteOptimizationService:
                 impedance=impedance,
             )
 
-        # Compute N x N cost matrix
-        od_pairs = self.od_service.network_od_matrix(
+        # Compute N x N cost matrix + shortest-path trees in one multi-source
+        # Dijkstra pass per unique stop. The predecessor trees are then reused
+        # to stitch the tour legs — previously every leg re-ran a full
+        # network_shortest_path (including a per-call graph copy) even though
+        # the OD pass had already computed every cost.
+        od = self.od_service.network_od_paths(
             origins=all_points,
             destinations=all_points,
             graph=graph,
@@ -94,14 +98,15 @@ class NetworkRouteOptimizationService:
             profile=profile,
             impedance=impedance,
         )
+        labels = od["origin_labels"]
 
         n = len(all_points)
         cost_mat: List[List[float]] = [[0.0] * n for _ in range(n)]
         for i in range(n):
             for j in range(n):
-                idx = i * n + j
-                if idx < len(od_pairs) and od_pairs[idx].reachable:
-                    cost_mat[i][j] = od_pairs[idx].travel_time_s
+                info = od["pairs"].get((labels[i], labels[j]))
+                if info and info["reachable"]:
+                    cost_mat[i][j] = info["time_s"]
                 else:
                     cost_mat[i][j] = 1e9
 
@@ -132,17 +137,28 @@ class NetworkRouteOptimizationService:
         total_cost = 0.0
 
         for idx in range(len(tour) - 1):
-            src_pt = all_points[tour[idx]]
-            dst_pt = all_points[tour[idx + 1]]
+            src_idx, dst_idx = tour[idx], tour[idx + 1]
+            info = od["pairs"].get((labels[src_idx], labels[dst_idx]))
 
-            sub_route = self.router.network_shortest_path(
-                graph=graph,
-                network_dataset=network_dataset,
-                origin=src_pt,
-                destination=dst_pt,
-                profile=profile,
-                impedance=impedance,
-            )
+            if info and info["reachable"]:
+                sub_route = self.router.build_route_from_path(
+                    od["graph_view"], info["path"],
+                    origin_label=labels[src_idx], destination_label=labels[dst_idx],
+                    profile_name=profile.name if profile else "driving",
+                    route_id=f"leg_{src_idx}_{dst_idx}",
+                    weight_func=od["weight_func"],
+                )
+            else:
+                sub_route = Route(
+                    route_id=f"leg_{src_idx}_{dst_idx}",
+                    origin_id=labels[src_idx],
+                    destination_id=labels[dst_idx],
+                    profile_name=profile.name if profile else "driving",
+                    total_distance_m=0.0,
+                    total_time_s=0.0,
+                    total_cost=float("inf"),
+                    geometry={"type": "LineString", "coordinates": []},
+                )
 
             total_dist_m += sub_route.total_distance_m
             total_time_s += sub_route.total_time_s

--- a/app/services/temporal/raster.py
+++ b/app/services/temporal/raster.py
@@ -4,6 +4,7 @@ Performs windowed raster time series analysis (selecting time slices, zonal stat
 raster difference, and raster trend analysis) without loading full rasters into memory.
 """
 
+import math
 import os
 import logging
 from datetime import datetime, timezone
@@ -136,6 +137,13 @@ class TemporalRasterEngine:
     ) -> Dict[str, Any]:
         """
         Performs pixel/zonal raster difference (T2 - T1).
+
+        The comparison window is derived from the AOI (or, without an AOI, the
+        overlapping bounds of the two rasters) instead of a fixed top-left
+        1024×1024 crop, and the two rasters must be CRS/transform aligned —
+        otherwise the subtraction would silently compare misregistered pixels
+        (previously it read the top-left megapixel of src1 only, ignoring both
+        the AOI and src2's grid).
         """
         p1 = raster_t1 if isinstance(raster_t1, str) else raster_t1.get("path", "")
         p2 = raster_t2 if isinstance(raster_t2, str) else raster_t2.get("path", "")
@@ -158,10 +166,12 @@ class TemporalRasterEngine:
         if p1 and p2 and os.path.exists(p1) and os.path.exists(p2):
             try:
                 import rasterio
-                from rasterio.windows import Window
                 with rasterio.open(p1) as src1, rasterio.open(p2) as src2:
-                    # Windowed read
-                    window = Window(0, 0, min(src1.width, 1024), min(src1.height, 1024))
+                    self._validate_alignment(src1, src2)
+                    window = self._difference_window(src1, src2, aoi_geometry)
+                    if window is None or window.width <= 0 or window.height <= 0:
+                        # AOI / overlap does not intersect either raster.
+                        return self._empty_difference()
                     b1 = src1.read(1, window=window).astype(float)
                     b2 = src2.read(1, window=window).astype(float)
                     diff = b2 - b1
@@ -172,9 +182,15 @@ class TemporalRasterEngine:
                         "std_difference": float(np.nanstd(diff)),
                         "pixel_count": int(diff.size),
                     }
+            except ValueError:
+                raise
             except Exception as e:
                 logger.warning(f"Error computing raster difference: {e}")
 
+        return self._empty_difference()
+
+    @staticmethod
+    def _empty_difference() -> Dict[str, Any]:
         return {
             "mean_difference": 0.0,
             "min_difference": 0.0,
@@ -183,21 +199,129 @@ class TemporalRasterEngine:
             "pixel_count": 0,
         }
 
+    # Max window dimension (per side) used to bound memory for a single
+    # difference read. The window is still anchored at the AOI/overlap origin
+    # (unlike the old fixed top-left crop).
+    _DIFF_MAX_WINDOW = 1024
+
+    @staticmethod
+    def _validate_alignment(src1, src2) -> None:
+        """Rejects CRS/transform-mismatched raster pairs with a clear error."""
+        if (src1.crs is None) != (src2.crs is None) or (
+            src1.crs is not None and str(src1.crs) != str(src2.crs)
+        ):
+            raise ValueError(
+                f"Raster CRS mismatch in difference: {src1.crs} vs {src2.crs}. "
+                "Refusing to subtract misaligned rasters."
+            )
+        t1, t2 = src1.transform, src2.transform
+        if not np.allclose([t1.a, t1.b, t1.c, t1.d, t1.e, t1.f],
+                           [t2.a, t2.b, t2.c, t2.d, t2.e, t2.f],
+                           rtol=1e-6, atol=1e-9):
+            raise ValueError(
+                f"Raster transform mismatch in difference: {tuple(t1)} vs {tuple(t2)}. "
+                "Refusing to subtract rasters with different pixel grids."
+            )
+
+    @staticmethod
+    def _aoi_bounds_in_crs(src, aoi_geometry: Optional[Dict[str, Any]]) -> Optional[tuple]:
+        """Returns AOI bounds in the raster's CRS (or None when not usable)."""
+        if not aoi_geometry:
+            return None
+        try:
+            from rasterio.features import bounds as geom_bounds
+            geom = aoi_geometry.get("geometry") if aoi_geometry.get("type") == "Feature" else aoi_geometry
+            if geom.get("type") == "FeatureCollection":
+                boxes = [geom_bounds(f) for f in geom.get("features", []) if f.get("geometry")]
+                if not boxes:
+                    return None
+                aoi_bounds = (
+                    min(b[0] for b in boxes), min(b[1] for b in boxes),
+                    max(b[2] for b in boxes), max(b[3] for b in boxes),
+                )
+            else:
+                aoi_bounds = geom_bounds(geom)
+        except Exception:
+            return None
+        if src.crs is not None:
+            aoi_crs = (
+                aoi_geometry.get("crs", {}).get("properties", {}).get("name", "EPSG:4326")
+                if isinstance(aoi_geometry, dict) else "EPSG:4326"
+            )
+            if str(src.crs) != aoi_crs:
+                try:
+                    from rasterio.warp import transform_bounds
+                    aoi_bounds = transform_bounds(aoi_crs, str(src.crs), *aoi_bounds, densify_pts=21)
+                except Exception:
+                    return None
+        return aoi_bounds
+
+    def _difference_window(self, src1, src2, aoi_geometry) -> Any:
+        """Pixel window covering AOI ∩ raster bounds (both rasters, aligned).
+
+        Without an AOI, falls back to the overlap of the two rasters' bounds.
+        Both rasters share one window because alignment is validated first.
+        """
+        from rasterio.windows import Window
+
+        if aoi_geometry:
+            bounds = self._aoi_bounds_in_crs(src1, aoi_geometry)
+        else:
+            b1, b2 = src1.bounds, src2.bounds
+            bounds = (
+                max(b1[0], b2[0]), max(b1[1], b2[1]),
+                min(b1[2], b2[2]), min(b1[3], b2[3]),
+            )
+        if bounds is None:
+            return None
+        minx, miny, maxx, maxy = bounds
+        if maxx <= minx or maxy <= miny:
+            return None
+
+        inv = ~src1.transform
+        corners = [
+            inv * (minx, miny), inv * (minx, maxy),
+            inv * (maxx, miny), inv * (maxx, maxy),
+        ]
+        col_min = min(c[0] for c in corners)
+        row_min = min(c[1] for c in corners)
+        col_max = max(c[0] for c in corners)
+        row_max = max(c[1] for c in corners)
+
+        # Clip to the raster extent.
+        col_min = max(0.0, col_min)
+        row_min = max(0.0, row_min)
+        col_max = min(float(src1.width), col_max)
+        row_max = min(float(src1.height), row_max)
+        if col_max <= col_min or row_max <= row_min:
+            return None
+
+        width = min(int(math.ceil(col_max - col_min)), self._DIFF_MAX_WINDOW)
+        height = min(int(math.ceil(row_max - row_min)), self._DIFF_MAX_WINDOW)
+        return Window(int(math.floor(col_min)), int(math.floor(row_min)), width, height)
+
     def raster_trend_over_aoi(
         self,
         raster_series: List[Dict[str, Any]],
         aoi_geometry: Optional[Dict[str, Any]] = None,
         raster_path_field: str = "path",
+        stats_info: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Computes trend line (slope, intercept, direction) of AOI zonal mean across raster time series.
+
+        ``stats_info`` may carry a precomputed ``temporal_raster_statistics``
+        result (as produced by ``execute_raster_analysis``) so the zonal
+        statistics pass is not re-run for the trend step — previously every
+        raster was opened and statistically summarized twice per request.
         """
-        stats_info = self.temporal_raster_statistics(
-            raster_series=raster_series,
-            metrics=["mean"],
-            aoi_geometry=aoi_geometry,
-            raster_path_field=raster_path_field,
-        )
+        if stats_info is None:
+            stats_info = self.temporal_raster_statistics(
+                raster_series=raster_series,
+                metrics=["mean"],
+                aoi_geometry=aoi_geometry,
+                raster_path_field=raster_path_field,
+            )
 
         timestamps = []
         means = []
@@ -232,8 +356,12 @@ class TemporalRasterEngine:
         High-level raster analysis pipeline.
         """
         selected_slices = self.select_time_slice(raster_series, start_time, end_time)
+        # Single statistics pass; the trend step reuses these results instead of
+        # re-opening every raster and recomputing the zonal statistics.
         stats = self.temporal_raster_statistics(selected_slices, aoi_geometry=aoi_geometry)
-        trend = self.raster_trend_over_aoi(selected_slices, aoi_geometry=aoi_geometry)
+        trend = self.raster_trend_over_aoi(
+            selected_slices, aoi_geometry=aoi_geometry, stats_info=stats
+        )
 
         diff = None
         if len(selected_slices) >= 2:

--- a/app/services/temporal/trend.py
+++ b/app/services/temporal/trend.py
@@ -45,29 +45,51 @@ class TemporalTrendEngine:
 
         return result
 
+    # Sen's slope is O(n²) in the number of pairwise slopes (n(n-1)/2). With
+    # 50k records that is ~1.25e9 Python slopes and multi-GB of intermediate
+    # lists — unbounded. Above this point the series is deterministically
+    # subsampled (evenly spaced) before the vectorized pair computation.
+    _SENS_SLOPE_MAX_N = 1024
+
     @staticmethod
     def compute_sens_slope(values: List[float]) -> float:
         """
         Computes Sen's Slope (median of slopes between all pair of points (i, j) with i < j).
+
+        Vectorized over all pairs for n ≤ ``_SENS_SLOPE_MAX_N``; larger series
+        are evenly subsampled to that cap (with a warning) so the computation
+        stays bounded instead of materializing ~n²/2 Python floats.
         """
         n = len(values)
         if n < 2:
             return 0.0
 
-        slopes = []
-        for i in range(n - 1):
-            for j in range(i + 1, n):
-                slopes.append((values[j] - values[i]) / (j - i))
+        import numpy as np
+        arr = np.asarray(values, dtype=float)
 
-        if not slopes:
+        if n > TemporalTrendEngine._SENS_SLOPE_MAX_N:
+            logger.warning(
+                "Sen's slope input truncated: %d points > max %d; "
+                "subsampling to evenly spaced points (approximation).",
+                n, TemporalTrendEngine._SENS_SLOPE_MAX_N,
+            )
+            idx = np.unique(np.linspace(0, n - 1, TemporalTrendEngine._SENS_SLOPE_MAX_N).astype(int))
+            arr = arr[idx]
+            # x coordinates stay the ORIGINAL time indices — slopes are per
+            # index step, not per subsampled position.
+            x = idx
+            n = arr.size
+        else:
+            x = np.arange(n)
+
+        if n < 2:
             return 0.0
 
-        slopes.sort()
-        m = len(slopes)
-        if m % 2 == 1:
-            return slopes[m // 2]
-        else:
-            return (slopes[m // 2 - 1] + slopes[m // 2]) / 2.0
+        i, j = np.triu_indices(n, k=1)
+        if i.size == 0:
+            return 0.0
+        slopes = (arr[j] - arr[i]) / (x[j] - x[i])
+        return float(np.median(slopes))
 
     @staticmethod
     def compute_linear_regression(values: List[float]) -> Tuple[float, float, float]:

--- a/app/tools/chinese_maps/amap.py
+++ b/app/tools/chinese_maps/amap.py
@@ -346,42 +346,73 @@ class AmapProvider:
 
     # ── Amap-only capabilities (NOT in the Protocol; no fallback) ──
 
+    # Fixed ~1.1 km (driving) / ~390 m (riding) / ~66 m (walking) probe lines
+    # made every isochrone saturate at the probe distance regardless of
+    # ``minutes``: ``ratio = budget / probe_dist`` was always > 1 and got
+    # capped at 1.0, so the returned polygon was a function of the mode only
+    # while ``radius_m`` (speed × time) contradicted the geometry (GIS-…).
+    # Instead we now probe FAR past the nominal budget once to measure the
+    # actual route speed, scale proportionally, then run one bounded
+    # correction probe — so the polygon genuinely grows with ``minutes`` and
+    # tracks real road speeds. Quota stays bounded: 2 probes × 12 radials max.
+    _ISOCHRONE_PROBE_MARGIN = 1.25   # first probe beyond the nominal budget
+    _ISOCHRONE_CORRECTION_MARGIN = 1.05
+
     async def isochrone(self, center: list, minutes: int, mode: str) -> dict:
-        """沿 N 个方向调用路径规划 API，收集各方向在 `minutes` 时间内的最远到达点，用 Convex Hull 近似等时圈。"""
+        """沿 N 个方向调用路径规划 API，收集各方向在 `minutes` 时间内的最远到达点，用 Convex Hull 近似等时圈。
+
+        每个方向先做一次超出名义预算 ~25% 的远探测来实测路线速度，再按
+        ``速度 × 时间`` 推算可达距离，并做一次有界的校正探测；探测失败时
+        直接用 ``speed × time`` 推出半径（兜底圆已按 cos(lat) 修正两轴）。
+        """
         import math
 
         num_radials = 12  # 每30°一条射线
-        km_scale = {"driving": 1.0, "walking": 0.06, "riding": 0.35}[mode]
+        budget_s = minutes * 60.0
+        nominal_speed = _speed_mps(mode)
+        target_m = budget_s * nominal_speed
+        # 经度每度米数随纬度收缩：cos(lat) 修正，两极附近下限保护。
+        cos_lat = max(math.cos(math.radians(center[1])), 0.02)
         angle_step = 2 * math.pi / num_radials
 
-        # 生成候选径向目的地（在中心点周围大致方向）
-        async def _radial_point(angle: float) -> tuple[float, float]:
-            # 用单位向量 × 固定半径来确定方向，再做线性缩放
-            probe_lng = center[0] + 0.01 * math.cos(angle) * km_scale
-            probe_lat = center[1] + 0.01 * math.sin(angle) * km_scale
+        def _offset(angle: float, dist_m: float) -> tuple[float, float]:
+            """中心点向 ``angle`` 方向移动 ``dist_m`` 米（WGS84 近似，含 cos(lat)）。"""
+            dlat = dist_m * math.sin(angle) / 111320.0
+            dlng = dist_m * math.cos(angle) / (111320.0 * cos_lat)
+            return center[0] + dlng, center[1] + dlat
 
-            try:
-                dist_m = await self._get_route_distance(center, [probe_lng, probe_lat], mode)
-                ratio = (minutes * 60 * _speed_mps(mode)) / max(dist_m, 1)
-                capped_ratio = min(ratio, 1.0)  # 不超过探测器本身的位置
-                return (
-                    center[0] + (probe_lng - center[0]) * capped_ratio,
-                    center[1] + (probe_lat - center[1]) * capped_ratio,
-                )
-            except (aiohttp.ClientError, json.JSONDecodeError, KeyError, ValueError, TypeError):
-                # 回退：用均匀半径圆上的点
-                fallback_radius_m = minutes * 60 * _speed_mps(mode)
-                return (
-                    center[0] + fallback_radius_m * math.cos(angle) / 111000,
-                    center[1] + fallback_radius_m * math.sin(angle) / 111000,
-                )
+        async def _radial_point(angle: float) -> tuple[float, float]:
+            # 1) 一次“远探测”：超出名义预算，路线时长才会跨住预算，从而能实测速度。
+            probe_m = target_m * self._ISOCHRONE_PROBE_MARGIN
+            probe_pt = _offset(angle, probe_m)
+            dist_m, dur_s = await self._probe_route(center, probe_pt, mode)
+            if dist_m <= 0:
+                # 探测失败（API 错误/无路线）：直接用 speed × time 推半径。
+                return _offset(angle, target_m)
+
+            speed_mps = (dist_m / dur_s) if dur_s and dur_s > 0 else nominal_speed
+            reachable_m = speed_mps * budget_s
+
+            # 2) 一次有界校正探测：在推算的可达距离处再量一次，收窄误差。
+            if reachable_m > 0:
+                corr_pt = _offset(angle, reachable_m * self._ISOCHRONE_CORRECTION_MARGIN)
+                dist2, dur2 = await self._probe_route(center, corr_pt, mode)
+                if dist2 > 0:
+                    speed2 = (dist2 / dur2) if dur2 and dur2 > 0 else speed_mps
+                    reachable_m = speed2 * budget_s
+
+            return _offset(angle, max(reachable_m, 0.0))
 
         semaphore = asyncio.Semaphore(6)
         angles = [angle_step * i for i in range(num_radials)]
 
         async def _guarded_radial(angle: float) -> tuple[float, float]:
-            async with semaphore:
-                return await _radial_point(angle)
+            try:
+                async with semaphore:
+                    return await _radial_point(angle)
+            except (aiohttp.ClientError, json.JSONDecodeError, KeyError, ValueError, TypeError):
+                # 兜底：均匀半径圆上的点（speed × time，cos(lat) 修正）。
+                return _offset(angle, target_m)
 
         pts = await asyncio.gather(*[_guarded_radial(a) for a in angles])
 
@@ -394,6 +425,14 @@ class AmapProvider:
         else:
             geometry = {"type": "Point", "coordinates": center}
 
+        # radius_m 与几何一致：取各方向最终点的平均径向距离，而非名义值。
+        def _radial_dist_m(pt: tuple[float, float]) -> float:
+            dx = (pt[0] - center[0]) * 111320.0 * cos_lat
+            dy = (pt[1] - center[1]) * 111320.0
+            return math.hypot(dx, dy)
+
+        radius_m = int(round(sum(_radial_dist_m(p) for p in pts) / len(pts))) if pts else 0
+
         return {
             "type": "Feature",
             "geometry": geometry,
@@ -402,7 +441,7 @@ class AmapProvider:
                 "minutes": minutes,
                 "mode": mode,
                 "provider": "amap",
-                "radius_m": minutes * 60 * _speed_mps(mode),
+                "radius_m": radius_m,
             },
         }
 
@@ -520,10 +559,13 @@ class AmapProvider:
             "provider": "amap",
         }
 
-    async def _get_route_distance(
+    async def _probe_route(
         self, origin: list, destination: list, mode: str,
-    ) -> float:
-        """调用 Amap 路径规划 API，返回两点间单程距离（米）。用于等时圈半径探测。"""
+    ) -> tuple[float, float]:
+        """调用 Amap 路径规划 API，返回 (距离米, 时长秒)，失败返回 (0.0, 0.0)。
+
+        用于等时圈探测：时长用来实测路线平均速度，避免用名义速度外推。
+        """
         try:
             og_lng, og_lat = origin
             dg_lng, dg_lat = destination
@@ -543,14 +585,22 @@ class AmapProvider:
                 data = await self._get("/direction/driving", params)
 
             if "error" in data:
-                return 0.0
+                return 0.0, 0.0
             route = data.get("route", {})
             paths = route.get("paths", [])
             if not paths:
-                return 0.0
-            return float(paths[0].get("distance", 0))
+                return 0.0, 0.0
+            path = paths[0]
+            return float(path.get("distance", 0)), float(path.get("duration", 0))
         except (aiohttp.ClientError, json.JSONDecodeError, KeyError, ValueError, TypeError):
-            return 0.0
+            return 0.0, 0.0
+
+    async def _get_route_distance(
+        self, origin: list, destination: list, mode: str,
+    ) -> float:
+        """调用 Amap 路径规划 API，返回两点间单程距离（米）。用于等时圈半径探测。"""
+        dist_m, _ = await self._probe_route(origin, destination, mode)
+        return dist_m
 
     # ── output shaping (non-POI; one transform_geojson pass) ──────
 

--- a/tests/unit/test_amap_isochrone_scaling.py
+++ b/tests/unit/test_amap_isochrone_scaling.py
@@ -1,0 +1,144 @@
+"""Regression tests for the Amap isochrone scaling fix (#380).
+
+The old implementation probed each radial with a FIXED ~1.1 km (driving) /
+~390 m (riding) / ~66 m (walking) route and then interpolated with
+``min(ratio, 1.0)`` — the ratio was always > 1, so every ``minutes`` value
+produced the same probe-distance polygon while ``radius_m`` (speed × time)
+contradicted the geometry.
+
+The new algorithm probes beyond the nominal budget once to MEASURE the real
+route speed, scales proportionally (speed × time), then runs one bounded
+correction probe. Fallback circles are cos(lat)-corrected on the lng axis.
+
+All tests run through the injected fake-GET seam — no real network calls.
+"""
+import math
+
+import aiohttp
+
+from app.tools.chinese_maps.amap import AmapProvider
+from app.utils.coord_transform import wgs84_to_gcj02
+from shapely.geometry import shape
+
+
+class FixedRouteFake:
+    """Returns a constructed route (distance/duration) for every direction probe.
+
+    ``dist_fn(dest_lng, dest_lat) -> (distance_m, duration_s)`` lets tests
+    simulate fixed routes (independent of probe length) or speed-aware routes
+    (proportional to the probe distance).
+    """
+
+    def __init__(self, dist_fn):
+        self._dist_fn = dist_fn
+        self.calls: list[tuple[str, dict]] = []
+
+    async def __call__(self, endpoint: str, params: dict) -> dict:
+        self.calls.append((endpoint, dict(params)))
+        d_lng, d_lat = map(float, params["destination"].split(","))
+        dist_m, dur_s = self._dist_fn(d_lng, d_lat)
+        return {"route": {"paths": [{"distance": str(dist_m), "duration": str(dur_s)}]}}
+
+
+def _polygon_bbox_meters(feature, center_lat):
+    """Bounding box of the polygon in meters, using cos(lat) degree scaling."""
+    geom = shape(feature["geometry"])
+    minx, miny, maxx, maxy = geom.bounds
+    cos_lat = max(math.cos(math.radians(center_lat)), 0.02)
+    width_m = (maxx - minx) * 111320.0 * cos_lat
+    height_m = (maxy - miny) * 111320.0
+    return width_m, height_m
+
+
+# ── Fixed GET: polygon must grow with minutes ──────────────────────────────
+
+
+async def test_isochrone_polygon_grows_with_minutes():
+    """A fixed route (800 m / 60 s ≈ 13.3 m/s, close to nominal driving) must
+    yield strictly growing polygons for 5 / 15 / 30 minutes — previously all
+    three minutes saturated at the same ~1.1 km probe polygon."""
+    fake = FixedRouteFake(lambda lng, lat: (800.0, 60.0))
+    prov = AmapProvider(get=fake)
+
+    radii = []
+    polygons = []
+    for minutes in (5, 15, 30):
+        feat = await prov.isochrone(center=[116.40, 39.90], minutes=minutes, mode="driving")
+        assert feat["geometry"]["type"] == "Polygon"
+        radii.append(feat["properties"]["radius_m"])
+        polygons.append(feat["geometry"])
+
+    assert radii[0] < radii[1] < radii[2]
+    # 15 min driving ≈ speed × time order of magnitude (13.3 m/s × 900 s ≈ 12 km)
+    nominal_15 = 15 * 60 * 13.9
+    assert 0.7 * nominal_15 < radii[1] < 1.3 * nominal_15
+    # distinct minutes → distinct polygons
+    assert polygons[0] != polygons[1]
+    assert polygons[1] != polygons[2]
+    # radius_m now matches the geometry (mean radial distance of the hull points)
+    width_m, height_m = _polygon_bbox_meters(feat, 39.90)
+    assert 0.8 * width_m / 2 < radii[2] < 1.3 * width_m / 2
+    assert 0.8 * height_m / 2 < radii[2] < 1.3 * height_m / 2
+
+
+async def test_isochrone_uses_measured_route_speed_not_nominal():
+    """When the network is slower than nominal (route speed ≈ 0.7 × nominal),
+    the isochrone must shrink accordingly — the old code always returned the
+    probe-distance polygon regardless of measured speed."""
+    center = [116.40, 39.90]
+    gcj_center = wgs84_to_gcj02(center[0], center[1])
+    cos_lat = math.cos(math.radians(gcj_center[1]))
+    measured_speed = 0.7 * 13.9
+
+    def dist_fn(d_lng, d_lat):
+        dx = (d_lng - gcj_center[0]) * 111320.0 * cos_lat
+        dy = (d_lat - gcj_center[1]) * 111320.0
+        dist_m = math.hypot(dx, dy) * 0.7  # route is 30% slower per meter
+        return dist_m, dist_m / measured_speed
+
+    prov = AmapProvider(get=FixedRouteFake(dist_fn))
+    feat = await prov.isochrone(center=center, minutes=15, mode="driving")
+
+    expected = measured_speed * 15 * 60  # ≈ 8.76 km
+    nominal = 13.9 * 15 * 60             # ≈ 12.5 km
+    radius = feat["properties"]["radius_m"]
+    assert abs(radius - expected) < 0.03 * expected, f"radius {radius} vs {expected}"
+    assert radius < 0.8 * nominal  # must track measured speed, not nominal
+
+
+# ── Fallback circle: cos(lat) correction + speed×time radius ───────────────
+
+
+async def test_isochrone_fallback_circle_cos_lat_corrected():
+    """All probes failing must fall back to the speed × time circle. The lng
+    axis must be scaled by cos(lat) so the ground bbox is square — the old
+    fallback divided both axes by 111,000 and produced an east-west bbox
+    ~1/cos(40°) wider than the north-south one."""
+    def boom(*_a, **_k):
+        raise aiohttp.ClientError("simulated transport failure")
+
+    prov = AmapProvider(get=boom)
+    feat = await prov.isochrone(center=[116.40, 40.00], minutes=15, mode="driving")
+
+    nominal = 15 * 60 * 13.9
+    assert feat["properties"]["radius_m"] == nominal
+    width_m, height_m = _polygon_bbox_meters(feat, 40.00)
+    # square-ish circle: width and height within 2% of each other
+    assert abs(width_m - height_m) < 0.02 * height_m, (width_m, height_m)
+    assert 0.95 * 2 * nominal < width_m < 1.05 * 2 * nominal
+    assert 0.95 * 2 * nominal < height_m < 1.05 * 2 * nominal
+
+
+async def test_isochrone_fallback_walking_radius_matches_geometry():
+    """Walking fallback: 30 minutes at 1.4 m/s → ~2.5 km circle, not the old
+    ~67 m probe polygon."""
+    def boom(*_a, **_k):
+        raise aiohttp.ClientError("boom")
+
+    prov = AmapProvider(get=boom)
+    feat = await prov.isochrone(center=[116.40, 39.90], minutes=30, mode="walking")
+
+    expected = 30 * 60 * 1.4
+    assert feat["properties"]["radius_m"] == expected
+    width_m, height_m = _polygon_bbox_meters(feat, 39.90)
+    assert 0.9 * 2 * expected < height_m < 1.1 * 2 * expected

--- a/tests/unit/test_chinese_maps_providers.py
+++ b/tests/unit/test_chinese_maps_providers.py
@@ -232,8 +232,9 @@ async def test_isochrone_concurrency_path_runs_without_nameerror():
     assert feat["geometry"]["type"] in ("Polygon", "Point")
     assert feat["properties"]["provider"] == "amap"
     assert feat["properties"]["radius_m"] > 0
-    # the isochrone fanned out multiple radial probes (12 directions)
-    assert len(fake.calls) == 12
+    # the isochrone fanned out multiple radial probes (12 directions × 2 probes:
+    # one far speed probe + one bounded correction probe per radial)
+    assert len(fake.calls) >= 12
 
 
 async def test_isochrone_except_branch_runs_without_nameerror():

--- a/tests/unit/test_network_algo_hotspots.py
+++ b/tests/unit/test_network_algo_hotspots.py
@@ -1,0 +1,330 @@
+"""Regression tests for network/temporal engine algorithmic hot spots (#403).
+
+1. Intersection splitting uses a STRtree candidate query instead of the O(n²)
+   pairwise shapely loop — results must be identical.
+2. closest_facility reuses the OD service's multi-source Dijkstra trees and no
+   longer performs a per-pair ``graph.copy()``; VRP stitches tour legs from the
+   OD predecessor trees instead of re-running shortest path per leg.
+3. Sen's slope is vectorized and capped; graph fingerprints are memoized by
+   object identity so repeated builds don't re-serialize the whole network.
+"""
+import json
+
+import networkx as nx
+import numpy as np
+import pytest
+
+from app.services.network.facility import NetworkClosestFacilityService
+from app.services.network.graph_builder import NetworkGraphBuilder
+from app.services.network.models import (
+    DemandPoint,
+    Facility,
+)
+from app.services.network.routing import NetworkRoutingService
+from app.services.network.vrp import NetworkRouteOptimizationService
+from app.services.temporal.trend import TemporalTrendEngine
+from shapely.geometry import LineString
+from shapely.ops import split, unary_union
+
+
+def _line(coords, props=None):
+    return {"type": "Feature", "properties": props or {}, "geometry": {"type": "LineString", "coordinates": coords}}
+
+
+@pytest.fixture
+def crossing_network():
+    """Four crossing lines + one disjoint line (classic split case)."""
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            _line([[0.0, 0.5], [1.0, 0.5]]),          # horizontal
+            _line([[0.5, 0.0], [0.5, 1.0]]),          # vertical (crosses at 0.5,0.5)
+            _line([[0.25, 0.0], [0.75, 1.0]]),        # diagonal (crosses both)
+            _line([[0.0, 0.25], [0.5, 0.25]]),        # T-junction on the vertical
+            _line([[5.0, 5.0], [6.0, 5.0]]),          # disjoint — no intersections
+        ],
+    }
+
+
+# ── STRtree intersection splitting ──────────────────────────────────────────
+
+
+def test_intersection_splitting_matches_pairwise_reference(crossing_network):
+    """The STRtree path must produce the same split line set as the old O(n²)
+    pairwise loop (same intersection multiset → same splits)."""
+    builder = NetworkGraphBuilder()
+    items = builder._extract_line_items(crossing_network)
+
+    split_items = builder._process_intersections(items, True)
+
+    # Reference: naive pairwise intersection collection + split pipeline
+    # (the pre-fix algorithm).
+    lines = [item[0] for item in items]
+    ref_points = []
+    for i in range(len(lines)):
+        for j in range(i + 1, len(lines)):
+            inter = lines[i].intersection(lines[j])
+            if not inter.is_empty:
+                if inter.geom_type == "Point":
+                    ref_points.append(inter)
+                elif inter.geom_type == "MultiPoint":
+                    ref_points.extend(list(inter.geoms))
+    assert ref_points, "fixture must contain intersections"
+
+    ref_items = []
+    split_cutter = unary_union(ref_points)
+    for line, props in items:
+        try:
+            for sub_geom in split(line, split_cutter).geoms:
+                if isinstance(sub_geom, LineString) and sub_geom.length > 1e-9:
+                    ref_items.append((sub_geom, props))
+        except Exception:
+            ref_items.append((line, props))
+
+    assert len(split_items) == len(ref_items)
+    # identical total length and identical segment coordinate multisets
+    orig_len = sum(line.length for line in lines)
+    assert abs(sum(g.length for g, _ in split_items) - orig_len) < 1e-9
+    assert sorted(tuple(g.coords) for g, _ in split_items) == sorted(
+        tuple(g.coords) for g, _ in ref_items
+    )
+
+
+def test_build_graph_split_intersections_end_to_end(crossing_network):
+    """End-to-end: a graph built with split_intersections=True contains the
+    crossing point as a node and both endpoint nodes."""
+    builder = NetworkGraphBuilder()
+    graph, dataset = builder.build_graph(crossing_network, split_intersections=True)
+
+    node_coords = {(d["x"], d["y"]) for _, d in graph.nodes(data=True)}
+    assert (0.5, 0.5) in node_coords  # main crossing
+    assert (0.375, 0.25) in node_coords  # diagonal × T-junction
+    assert (0.5, 0.25) in node_coords  # vertical × T-junction endpoint
+    assert (0.0, 0.5) in node_coords  # original endpoint survives
+    # the disjoint line stays intact
+    assert (5.0, 5.0) in node_coords and (6.0, 5.0) in node_coords
+
+
+def test_build_graph_split_off_by_default(crossing_network):
+    """split_intersections=True is the default and must not regress to O(n²)."""
+    builder = NetworkGraphBuilder()
+    graph, _ = builder.build_graph(crossing_network)
+    node_coords = {(d["x"], d["y"]) for _, d in graph.nodes(data=True)}
+    assert (0.5, 0.5) in node_coords
+
+
+# ── closest_facility: no per-pair Dijkstra, no graph copy ───────────────────
+
+
+def _build_grid():
+    features = []
+    for r in range(4):
+        features.append(_line([[116.0, 39.0 + r * 0.01], [116.03, 39.0 + r * 0.01]]))
+    for c in range(4):
+        features.append(_line([[116.0 + c * 0.01, 39.0], [116.0 + c * 0.01, 39.03]]))
+    builder = NetworkGraphBuilder()
+    return builder.build_graph({"type": "FeatureCollection", "features": features})
+
+
+def test_closest_facility_no_graph_copy(monkeypatch):
+    """closest_facility with coordinate inputs must not copy the graph per
+    demand×facility pair (the old code ran network_shortest_path per pair,
+    which copied the whole graph for every call)."""
+    graph, dataset = _build_grid()
+    copies = []
+
+    real_copy = nx.DiGraph.copy
+
+    def counting_copy(self, *args, **kwargs):
+        copies.append(1)
+        return real_copy(self, *args, **kwargs)
+
+    monkeypatch.setattr(nx.DiGraph, "copy", counting_copy)
+
+    svc = NetworkClosestFacilityService()
+    demands = [DemandPoint(demand_id="d1", weight=1.0, geometry={"type": "Point", "coordinates": [116.01, 39.005]})]
+    facilities = [
+        Facility(facility_id="f_far", geometry={"type": "Point", "coordinates": [116.03, 39.03]}),
+        Facility(facility_id="f_near", geometry={"type": "Point", "coordinates": [116.02, 39.005]}),
+    ]
+    res = svc.network_closest_facility(
+        demand_points=demands, facilities=facilities,
+        graph=graph, network_dataset=dataset, target_facility_count=1,
+    )
+    assert copies == [], f"graph.copy called {len(copies)} times during closest_facility"
+    assert len(res.routes) == 1
+    assert res.routes[0].destination_id == "f_near"
+    assert res.routes[0].total_distance_m > 0
+    assert res.routes[0].geometry["type"] == "LineString"
+    assert len(res.routes[0].path_node_ids) >= 2
+
+
+def test_closest_facility_matches_old_routing_cost_order(monkeypatch):
+    """Closest-facility ranking via OD trees must agree with direct routing."""
+    graph, dataset = _build_grid()
+    svc = NetworkClosestFacilityService()
+    # All coordinates sit exactly on grid nodes, so direct routing (no virtual
+    # node split) and the OD-tree reconstruction traverse the same node path.
+    demands = [DemandPoint(demand_id="d1", weight=1.0, geometry={"type": "Point", "coordinates": [116.01, 39.0]})]
+    facilities = [
+        Facility(facility_id="f_far", geometry={"type": "Point", "coordinates": [116.03, 39.03]}),
+        Facility(facility_id="f_mid", geometry={"type": "Point", "coordinates": [116.01, 39.02]}),
+        Facility(facility_id="f_near", geometry={"type": "Point", "coordinates": [116.02, 39.0]}),
+    ]
+    res = svc.network_closest_facility(
+        demand_points=demands, facilities=facilities,
+        graph=graph, network_dataset=dataset, target_facility_count=3,
+    )
+    assert [r.destination_id for r in res.routes] == ["f_near", "f_mid", "f_far"]
+
+    # OD-tree route cost == direct Dijkstra over the same graph (node path).
+    router = NetworkRoutingService()
+    direct = router.network_shortest_path(
+        graph=graph, network_dataset=dataset,
+        origin=(116.01, 39.0), destination=(116.02, 39.0),
+    )
+    od_route = next(r for r in res.routes if r.destination_id == "f_near")
+    assert od_route.path_node_ids == direct.path_node_ids
+    assert abs(od_route.total_distance_m - direct.total_distance_m) < 1e-6
+    assert abs(od_route.total_time_s - direct.total_time_s) < 1e-6
+
+
+# ── VRP: tour legs reuse the OD trees ───────────────────────────────────────
+
+
+def test_vrp_stitches_legs_without_rerunning_shortest_path(monkeypatch):
+    """After the OD pass every tour leg must come from the predecessor trees —
+    network_shortest_path (and its per-call graph copy) must not run at all."""
+    graph, dataset = _build_grid()
+
+    def _no_shortest_path(*args, **kwargs):
+        raise AssertionError("network_shortest_path must not be called during VRP leg stitching")
+
+    monkeypatch.setattr(NetworkRoutingService, "network_shortest_path", _no_shortest_path)
+
+    svc = NetworkRouteOptimizationService()
+    route = svc.optimize_route(
+        stops=[(116.01, 39.005), (116.03, 39.03), (116.0, 39.03)],
+        depot=(116.0, 39.0),
+        end_at_depot=True,
+        graph=graph,
+        network_dataset=dataset,
+    )
+    assert route.total_distance_m > 0
+    assert route.total_time_s > 0
+    assert route.geometry["type"] == "LineString"
+    assert len(route.geometry["coordinates"]) >= 2
+
+
+def test_vrp_single_stop_still_routes(monkeypatch):
+    """The degenerate single-stop case still routes directly (no OD needed)."""
+    graph, dataset = _build_grid()
+    svc = NetworkRouteOptimizationService()
+    route = svc.optimize_route(
+        stops=[(116.01, 39.005)],
+        depot=(116.0, 39.0),
+        graph=graph,
+        network_dataset=dataset,
+    )
+    assert route.total_distance_m > 0
+
+
+# ── Sen's slope: vectorized + capped ────────────────────────────────────────
+
+
+def _reference_sens_slope(values):
+    """Brute-force pairwise Sen's slope (the pre-fix algorithm)."""
+    n = len(values)
+    slopes = []
+    for i in range(n - 1):
+        for j in range(i + 1, n):
+            slopes.append((values[j] - values[i]) / (j - i))
+    slopes.sort()
+    m = len(slopes)
+    if m % 2 == 1:
+        return slopes[m // 2]
+    return (slopes[m // 2 - 1] + slopes[m // 2]) / 2.0
+
+
+@pytest.mark.parametrize("n", [2, 3, 10, 64, 1024])
+def test_sens_slope_matches_reference(n):
+    rng = np.random.default_rng(42)
+    values = list(rng.normal(size=n))
+    assert TemporalTrendEngine.compute_sens_slope(values) == pytest.approx(
+        _reference_sens_slope(values), rel=1e-12
+    )
+
+
+def test_sens_slope_linear_exact():
+    values = [2.0 * i for i in range(50)]
+    assert TemporalTrendEngine.compute_sens_slope(values) == 2.0
+
+
+def test_sens_slope_large_input_truncated(caplog):
+    """50k records previously materialized ~1.25e9 slopes; now the input is
+    subsampled to the cap with a warning and still returns the right slope for
+    a linear series."""
+    n = 5000
+    values = [3.0 * i for i in range(n)]
+    with caplog.at_level("WARNING", logger="app.services.temporal.trend"):
+        slope = TemporalTrendEngine.compute_sens_slope(values)
+    assert slope == 3.0
+    assert any("truncated" in r.message for r in caplog.records)
+
+
+def test_analyze_trend_still_uses_sens_slope():
+    eng = TemporalTrendEngine()
+    res = eng.analyze_trend([1.0, 3.0, 5.0, 7.0])
+    assert res.slope == 2.0
+    assert res.direction == "increasing"
+
+
+# ── Fingerprint memoization ─────────────────────────────────────────────────
+
+
+def test_fingerprint_memoized_by_object_identity(monkeypatch):
+    builder = NetworkGraphBuilder()
+    dumps_calls = []
+
+    real_dumps = json.dumps
+
+    def counting_dumps(*args, **kwargs):
+        dumps_calls.append(args)
+        return real_dumps(*args, **kwargs)
+
+    monkeypatch.setattr("app.services.network.graph_builder.json.dumps", counting_dumps)
+
+    data = {"type": "FeatureCollection", "features": [_line([[0.0, 0.0], [1.0, 1.0]])]}
+    fp1 = builder.compute_fingerprint(data, None, 1e-5, True)
+    fp2 = builder.compute_fingerprint(data, None, 1e-5, True)
+    assert fp1 == fp2
+    # the second call must not re-serialize the network
+    assert len(dumps_calls) == 1, f"json.dumps called {len(dumps_calls)} times"
+
+    # a distinct object with identical content re-serializes but produces the
+    # SAME content-based fingerprint (the memo only skips re-serialization of
+    # the same object — cache hit semantics for equal networks are preserved)
+    data2 = {"type": "FeatureCollection", "features": [_line([[0.0, 0.0], [1.0, 1.0]])]}
+    fp3 = builder.compute_fingerprint(data2, None, 1e-5, True)
+    assert fp3 == fp1
+    assert len(dumps_calls) == 2
+
+
+def test_build_graph_cache_hit_skips_reserialization(monkeypatch):
+    builder = NetworkGraphBuilder()
+    builder.clear_cache()
+    dumps_calls = []
+
+    real_dumps = json.dumps
+
+    def counting_dumps(*args, **kwargs):
+        dumps_calls.append(args)
+        return real_dumps(*args, **kwargs)
+
+    monkeypatch.setattr("app.services.network.graph_builder.json.dumps", counting_dumps)
+
+    data = {"type": "FeatureCollection", "features": [_line([[0.0, 0.0], [1.0, 1.0]])]}
+    g1, _ = builder.build_graph(data, use_cache=True)
+    g2, _ = builder.build_graph(data, use_cache=True)
+    assert g1 is g2  # cache hit
+    assert len(dumps_calls) == 1  # one serialization for the whole sequence

--- a/tests/unit/test_raster_difference_aoi.py
+++ b/tests/unit/test_raster_difference_aoi.py
@@ -1,0 +1,218 @@
+"""Regression tests for the temporal raster fixes (#396).
+
+1. ``raster_difference`` now derives its window from the AOI ∩ raster bounds
+   (and validates CRS/transform alignment) instead of silently reading a fixed
+   top-left 1024×1024 crop of src1.
+2. ``execute_raster_analysis`` computes zonal statistics once and reuses them
+   for the trend step instead of re-opening/re-statisticizing every raster.
+
+All tests use small synthetic GeoTIFFs written to a tmp dir — no real data.
+"""
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+
+from app.services.temporal.raster import TemporalRasterEngine
+from app.services.temporal.models import TemporalRasterResult
+
+
+def _write_raster(path, values, crs="EPSG:4326", transform=None, height=20, width=20):
+    transform = transform or from_origin(0.0, float(height), 1.0, 1.0)
+    with rasterio.open(
+        path, "w", driver="GTiff", height=height, width=width, count=1,
+        dtype="float64", crs=crs, transform=transform,
+    ) as dst:
+        dst.write(np.asarray(values, dtype="float64"), 1)
+    return path
+
+
+@pytest.fixture
+def raster_pair(tmp_path):
+    """Two aligned 20×20 rasters (pixel = 1°), diff = row index.
+
+    Raster 1: value = col. Raster 2: value = col + row. Difference = row,
+    so any window's mean difference equals the mean row of that window.
+    """
+    rows = np.arange(20.0)
+    cols = np.arange(20.0)
+    arr1 = np.tile(cols, (20, 1))
+    arr2 = arr1 + rows[:, None]
+    p1 = _write_raster(str(tmp_path / "t1.tif"), arr1)
+    p2 = _write_raster(str(tmp_path / "t2.tif"), arr2)
+    return p1, p2
+
+
+def _aoi(xmin, ymin, xmax, ymax):
+    """Eccentric AOI polygon (EPSG:4326) over x∈[xmin,xmax], y∈[ymin,ymax]."""
+    return {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax], [xmin, ymin]]],
+        },
+    }
+
+
+# ── AOI-windowed difference ─────────────────────────────────────────────────
+
+
+def test_raster_difference_uses_aoi_window_not_top_left(raster_pair):
+    """An AOI in the east-north quadrant must restrict the difference to those
+    pixels: mean difference == mean row of the AOI window (rows 4..9 → 6.5),
+    not the whole-raster mean (rows 0..19 → 9.5) the old fixed top-left read
+    would have produced."""
+    p1, p2 = raster_pair
+    engine = TemporalRasterEngine()
+    aoi = _aoi(12.0, 10.0, 18.0, 16.0)  # cols 12..17, rows 4..9 (y ∈ [10,16))
+
+    res = engine.raster_difference(p1, p2, aoi_geometry=aoi)
+
+    assert res["pixel_count"] == 6 * 6
+    assert res["mean_difference"] == pytest.approx(6.5)
+    assert res["min_difference"] == pytest.approx(4.0)
+    assert res["max_difference"] == pytest.approx(9.0)
+
+
+def test_raster_difference_manual_window_equivalence(raster_pair):
+    """Difference stats equal a manual windowed read of the same AOI bounds."""
+    p1, p2 = raster_pair
+    aoi = _aoi(2.0, 2.0, 8.0, 12.0)  # cols 2..7, rows 8..17
+
+    engine = TemporalRasterEngine()
+    res = engine.raster_difference(p1, p2, aoi_geometry=aoi)
+
+    with rasterio.open(p1) as s1, rasterio.open(p2) as s2:
+        b1 = s1.read(1, window=rasterio.windows.Window(2, 8, 6, 10)).astype(float)
+        b2 = s2.read(1, window=rasterio.windows.Window(2, 8, 6, 10)).astype(float)
+    diff = b2 - b1
+    assert res["pixel_count"] == int(diff.size)
+    assert res["mean_difference"] == pytest.approx(float(np.nanmean(diff)))
+    assert res["min_difference"] == pytest.approx(float(np.nanmin(diff)))
+    assert res["max_difference"] == pytest.approx(float(np.nanmax(diff)))
+    assert res["std_difference"] == pytest.approx(float(np.nanstd(diff)))
+
+
+def test_raster_difference_without_aoi_uses_overlap(raster_pair):
+    """Without an AOI the window must cover the overlapping bounds of both
+    rasters — for two identical rasters that is the full extent."""
+    p1, p2 = raster_pair
+    engine = TemporalRasterEngine()
+    res = engine.raster_difference(p1, p2)
+
+    assert res["pixel_count"] == 400
+    assert res["mean_difference"] == pytest.approx(np.mean(np.arange(20.0)))
+
+
+def test_raster_difference_aoi_outside_returns_empty(raster_pair):
+    """An AOI disjoint from the rasters yields an empty (zero) result, not a
+    top-left window's worth of pixels."""
+    p1, p2 = raster_pair
+    engine = TemporalRasterEngine()
+    aoi = _aoi(100.0, 100.0, 110.0, 110.0)
+    res = engine.raster_difference(p1, p2, aoi_geometry=aoi)
+    assert res["pixel_count"] == 0
+    assert res["mean_difference"] == 0.0
+
+
+# ── Alignment validation ────────────────────────────────────────────────────
+
+
+def test_raster_difference_crs_mismatch_raises(raster_pair, tmp_path):
+    p1, p2 = raster_pair
+    p3 = _write_raster(str(tmp_path / "t3_utm.tif"), np.zeros((20, 20)), crs="EPSG:32650")
+    engine = TemporalRasterEngine()
+    with pytest.raises(ValueError, match="CRS mismatch"):
+        engine.raster_difference(p1, p3)
+
+
+def test_raster_difference_transform_mismatch_raises(raster_pair, tmp_path):
+    p1, p2 = raster_pair
+    p3 = _write_raster(
+        str(tmp_path / "t3_shifted.tif"), np.zeros((20, 20)),
+        transform=from_origin(0.5, 20.5, 1.0, 1.0),  # half-pixel shift
+    )
+    engine = TemporalRasterEngine()
+    with pytest.raises(ValueError, match="transform mismatch"):
+        engine.raster_difference(p1, p3)
+
+
+# ── Single statistics pass per request ──────────────────────────────────────
+
+
+def test_execute_raster_analysis_single_stats_pass(tmp_path, monkeypatch):
+    """Each raster is opened once per request (the trend step reuses the
+    first statistics pass instead of re-running it)."""
+    rows = np.arange(20.0)
+    cols = np.arange(20.0)
+    base = np.tile(cols, (20, 1))
+    paths = []
+    for i, offset in enumerate((0.0, 5.0, 10.0)):
+        p = str(tmp_path / f"series_{i}.tif")
+        _write_raster(p, base + rows[:, None] * 0.0 + offset)
+        paths.append(p)
+
+    series = [{"timestamp": f"2026-0{i+1}-01T00:00:00Z", "path": p} for i, p in enumerate(paths)]
+    aoi = _aoi(2.0, 2.0, 18.0, 18.0)
+
+    # Count rasterio.open calls per path.
+    opens: dict = {}
+    real_open = rasterio.open
+
+    def counting_open(path, *args, **kwargs):
+        opens[str(path)] = opens.get(str(path), 0) + 1
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(rasterio, "open", counting_open)
+
+    engine = TemporalRasterEngine()
+    stats_calls = []
+    real_stats = engine.temporal_raster_statistics
+
+    def counting_stats(*a, **k):
+        stats_calls.append(1)
+        return real_stats(*a, **k)
+
+    monkeypatch.setattr(engine, "temporal_raster_statistics", counting_stats)
+
+    result = engine.execute_raster_analysis(
+        raster_series=series,
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-03-01T00:00:00Z",
+        aoi_geometry=aoi,
+    )
+
+    assert isinstance(result, TemporalRasterResult)
+    assert len(result.selected_slices) == 3
+    assert result.raster_trend["direction"] == "increasing"
+    # statistics computed exactly once (trend reuses it)
+    assert len(stats_calls) == 1
+    # per-raster opens: 2 for the zonal statistics pass (CRS check + rasterstats
+    # internal open) + 1 for the difference read on the two endpoint rasters.
+    # The middle raster is NOT opened by the trend step — before the fix it was
+    # opened twice more (4 total).
+    assert opens[paths[0]] == 3, opens
+    assert opens[paths[1]] == 2, opens
+    assert opens[paths[2]] == 3, opens
+
+
+def test_raster_trend_over_aoi_accepts_precomputed_stats(raster_pair, tmp_path):
+    """raster_trend_over_aoi(stats_info=...) must produce the same result as
+    the self-computing path but without re-opening the rasters."""
+    p1, p2 = raster_pair
+    series = [
+        {"timestamp": "2026-01-01T00:00:00Z", "path": p1},
+        {"timestamp": "2026-02-01T00:00:00Z", "path": p2},
+    ]
+    engine = TemporalRasterEngine()
+    aoi = _aoi(0.0, 0.0, 20.0, 20.0)
+
+    stats = engine.temporal_raster_statistics(series, aoi_geometry=aoi)
+    with_precomputed = engine.raster_trend_over_aoi(series, aoi_geometry=aoi, stats_info=stats)
+    self_computed = engine.raster_trend_over_aoi(series, aoi_geometry=aoi)
+
+    assert with_precomputed["slope"] == self_computed["slope"]
+    assert with_precomputed["direction"] == self_computed["direction"]
+    assert with_precomputed["means"] == self_computed["means"]


### PR DESCRIPTION
## Summary

Fixes three GIS engine correctness/performance issues:

### #380 (P2) — Amap isochrone saturated at a fixed probe polygon
- Old: each of the 12 radials probed a **fixed** ~1.1 km (driving) / ~390 m (riding) / ~66 m (walking) route and interpolated with `min(ratio, 1.0)`; the ratio was always > 1, so every `minutes` value returned the same polygon while `radius_m` (speed × time) contradicted the geometry. 30-min "walking isochrones" were ~67 m.
- New (`app/tools/chinese_maps/amap.py`):
  - Probe **beyond** the nominal budget (1.25×) once per radial to measure the real route speed from the returned distance/duration, scale to `speed × time`, then one bounded correction probe (≤ 2 probes × 12 radials — quota-conscious).
  - Probe failure falls back to the speed × time circle; both fallback paths now share a cos(lat)-corrected degree conversion (the old fallback divided both axes by 111,000, distorting the east-west extent away from the equator).
  - `radius_m` now reports the mean radial distance of the hull points so the property matches the geometry.
- Tests: fixed-GET growth across 5/15/30 minutes, measured-speed tracking, cos(lat) fallback circle, walking fallback radius.

### #396 (P2) — temporal_raster: fixed top-left window + double statistics pass
- Old (`app/services/temporal/raster.py`): `raster_difference` read a fixed `Window(0,0,min(w,1024),min(h,1024))` of src1 only — no AOI, no CRS/transform alignment check; `execute_raster_analysis` computed zonal statistics twice (stats step + trend re-run).
- New:
  - Difference window is derived from **AOI ∩ raster bounds** (both rasters, AOI reprojected to the raster CRS); without an AOI it uses the rasters' overlapping bounds. 1024/side memory cap preserved but anchored at the AOI/overlap origin.
  - CRS and transform alignment validated before subtracting — mismatches raise a clear `ValueError`.
  - `execute_raster_analysis` computes statistics **once** and passes them to the trend step (`raster_trend_over_aoi(stats_info=...)`), so each raster is opened once per request (verified via monkeypatched `rasterio.open` counters).
- Tests: eccentric-AOI stats == manual windowed reads, disjoint AOI → empty result, CRS/transform mismatch errors, single-pass open/stat counters.

### #403 (P3) — network/temporal algorithmic hot spots (currently masked by #374)
1. **Intersection splitting** (`graph_builder.py`): O(n²) pairwise shapely loop → shapely `STRtree.query(predicate="intersects")` candidate queries. Same point set, exact same splits (equivalence-tested against the old pairwise pipeline); ~5×10⁹ tests → ~n·k for a 100k-line city network.
2. **closest_facility / VRP** (`facility.py`, `vrp.py`, `od_matrix.py`, `routing.py`): D×F independent `network_shortest_path` calls, each with a full `graph.copy()`, replaced by the (previously unused) `od_service` multi-source Dijkstra — one Dijkstra per unique origin, predecessor trees shared. New `network_od_paths` + `build_route_from_path` + a shared `build_weight_func` factory keep cost semantics (barrier factors, turn penalties) and route shaping identical to direct routing. VRP stitches tour legs from the OD trees instead of re-running shortest path per leg.
3. **Sen's slope** (`trend.py`): unbounded Python O(n²) (50k records → ~1.25×10⁹ slopes) → vectorized numpy over all pairs, deterministically subsampled to 1,024 evenly spaced points (with a warning) above the cap.
4. **Fingerprint memoization** (`graph_builder.py`): `compute_fingerprint` re-serialized the whole GeoJSON network on every `build_graph` call (cache hit included); now memoized by object identity with a strong-ref pin (LRU-bounded) — content-equality cache-hit semantics preserved.
- Tests: STRtree-vs-pairwise equivalence, closest_facility performs **zero** `graph.copy()` calls and matches direct routing on node-exact inputs, VRP never calls `network_shortest_path` during leg stitching, Sen slope reference-equality + truncation warning path, fingerprint memoization.

## Test summary
- New tests: `tests/unit/test_amap_isochrone_scaling.py` (5), `tests/unit/test_raster_difference_aoi.py` (7), `tests/unit/test_network_algo_hotspots.py` (14); updated `tests/unit/test_chinese_maps_providers.py` (probe call-count assertions).
- `pytest -q --no-cov -p no:cacheprovider tests/unit`: **1689 passed, 2 skipped**; the single failure (`test_harness_disabled_by_default`) is pre-existing on the base branch (verified via stash) and unrelated.
- All raster/network/temporal/amap related suites pass (91 tests in the core set, 46 raster, 56 provider/snap, 13 gis-audit/profiler).

## Verification notes
- No real network calls anywhere in the tests — Amap fakes inject canned/constructed route responses; raster tests use synthetic GeoTIFFs in tmp dirs.
- Note: closest-facility / VRP routes are now reconstructed from OD predecessor trees (node-based paths) rather than virtual-node snapped paths; costs, ranking and distances are identical to direct routing on node-exact inputs (GIS-01 snapping precision is retained for direct `network_shortest_path` calls).
