### PR TITLE
fix(map): dual-scheme matchers and post-state verification for legacy imperative map commands

### DIFF
--- a/frontend/components/map/map-action-handler.test.tsx
+++ b/frontend/components/map/map-action-handler.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import { MapActionHandler } from './map-action-handler';
 import { makeMockMaplibreMap } from '@/test/__mocks__/maplibre-map';
+import { COMMAND_CATALOGUE } from '@/lib/map-commands/catalogue';
 import {
   notifyUserGestureStart,
   _resetCameraArbitrationForTests,
@@ -76,6 +77,7 @@ const mockSetBaseLayer = vi.fn();
 const mockSetPendingSystemMessage = vi.fn();
 const mockRemoveLayer = vi.fn();
 const mockUpdateLayer = vi.fn();
+const mockReorderLayers = vi.fn();
 const mockExport = vi.fn(async (): Promise<{ ok: boolean; error?: string }> => ({ ok: true }));
 const mockAddAnnotation = vi.fn((feature) => {
   mockAnnotationsStore.push(feature);
@@ -117,6 +119,7 @@ vi.mock('@/lib/store/useHudStore', async () => {
     setPendingSystemMessage: mockSetPendingSystemMessage,
     removeLayer: mockRemoveLayer,
     updateLayer: mockUpdateLayer,
+    reorderLayers: mockReorderLayers,
     get annotations() { return mockAnnotationsStore; },
     addAnnotation: mockAddAnnotation,
     clearAnnotations: mockClearAnnotations,
@@ -717,19 +720,55 @@ describe('MapActionHandler', () => {
     );
   });
 
-  it('handles APPLY_LAYER_FILTER correctly with parsed filter array', async () => {
+  it('handles APPLY_LAYER_FILTER correctly with parsed filter array (issue #393)', async () => {
     actions = [{
       command: 'APPLY_LAYER_FILTER',
       params: { layer_id: 'custom-layer', filter: '["==", "density", 10]' },
     }];
-
-    const map = mockGetMap();
+    // The map has MapSpec sublayers (`${id}__*`), not the bare id — the old code
+    // setFilter'd the bare id (a silent no-op) and acked succeeded anyway.
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'custom-layer__fill', type: 'fill' });
+    map.addLayer({ id: 'custom-layer__point', type: 'circle' });
+    mockGetMap.mockImplementation(() => map);
+    mockLayersStore = [{ id: 'custom-layer', name: 'Custom' }];
 
     await act(async () => {
       render(<MapActionHandler />);
     });
 
-    expect(map.setFilter).toHaveBeenCalledWith('custom-layer', ['==', 'density', 10]);
+    expect(map.setFilter).toHaveBeenCalledWith('custom-layer__fill', ['==', 'density', 10]);
+    expect(map.setFilter).toHaveBeenCalledWith('custom-layer__point', ['==', 'density', 10]);
+    // store sync: the reconcile re-emits layer.filter, so the filter survives
+    expect(mockUpdateLayer).toHaveBeenCalledWith('custom-layer', { filter: ['==', 'density', 10] });
+    expect(reportTerminalFn).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'APPLY_LAYER_FILTER' }),
+      'succeeded',
+      expect.objectContaining({ actual: { confirmed: true } }),
+    );
+    expect(popAction).toHaveBeenCalled();
+  });
+
+  it('APPLY_LAYER_FILTER with no matching target → failed ack target_not_found (no fake success)', async () => {
+    actions = [{
+      command: 'APPLY_LAYER_FILTER',
+      params: { layer_id: 'ghost', filter: ['==', 'density', 10] },
+    }];
+    const map = makeMockMaplibreMap(); // no layers on the map, none in the store
+    mockGetMap.mockImplementation(() => map);
+    mockLayersStore = [];
+
+    await act(async () => {
+      render(<MapActionHandler />);
+    });
+
+    expect(reportTerminalFn).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'APPLY_LAYER_FILTER' }),
+      'failed',
+      expect.objectContaining({ error: 'target_not_found' }),
+    );
+    expect(map.setFilter).not.toHaveBeenCalled();
+    expect(popAction).toHaveBeenCalled();
   });
 
   // ─── V3 terminal states (Harness–Map Interaction Closed Loop, design §6) ──
@@ -769,7 +808,7 @@ describe('MapActionHandler', () => {
     expect(popAction).toHaveBeenCalled();
   });
 
-  it('V3: void run → succeeded ack', async () => {
+  it('V3: explicit succeeded result → succeeded ack', async () => {
     actions = [{ command: 'clear_annotations', params: {} }];
 
     await act(async () => {
@@ -782,6 +821,31 @@ describe('MapActionHandler', () => {
       expect.any(Object),
     );
     expect(popAction).toHaveBeenCalled();
+  });
+
+  it('V3 (issue #393): void run → failed ack no_result, never a fake succeeded', async () => {
+    // Every catalogue command now returns an explicit MapCommandResult; a void
+    // return means the command forgot to report (or an unverifiable path
+    // slipped through) and must fail honestly — the old default converted the
+    // broken apply_layer_filter/heatmap commands into fake successes.
+    const original = (COMMAND_CATALOGUE as any).clear_annotations;
+    (COMMAND_CATALOGUE as any).clear_annotations = { requiredParams: () => true, run: () => undefined };
+    try {
+      actions = [{ command: 'clear_annotations', params: {} }];
+
+      await act(async () => {
+        render(<MapActionHandler />);
+      });
+
+      expect(reportTerminalFn).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'clear_annotations' }),
+        'failed',
+        expect.objectContaining({ error: 'no_result' }),
+      );
+      expect(popAction).toHaveBeenCalled();
+    } finally {
+      (COMMAND_CATALOGUE as any).clear_annotations = original;
+    }
   });
 
   it('V3: ack metadata carries started_at/finished_at/duration_ms', async () => {
@@ -1051,6 +1115,33 @@ describe('MapActionHandler', () => {
       expect.objectContaining({ error: 'target_not_found' }),
     );
     expect(map.moveLayer).not.toHaveBeenCalled();
+    expect(popAction).toHaveBeenCalled();
+  });
+
+  it('V3 (issue #393): REORDER_LAYER on a MapSpec `${id}__*` layer reorders the store durably', async () => {
+    actions = [{ command: 'REORDER_LAYER', params: { layer_id: 'analysis-result', position: 'top' } }];
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'analysis-result__fill', type: 'fill' });
+    map.addLayer({ id: 'analysis-result__point', type: 'circle' });
+    map.addLayer({ id: 'other__fill', type: 'fill' });
+    mockGetMap.mockImplementation(() => map);
+    mockLayersStore = [{ id: 'other' }, { id: 'analysis-result' }];
+
+    await act(async () => {
+      render(<MapActionHandler />);
+    });
+
+    // index 0 = topmost; the MapSpecRuntime reconcile applies the map z-order
+    // from this array — the legacy custom-only matcher failed target_not_found
+    expect(mockReorderLayers).toHaveBeenCalledWith([
+      { id: 'analysis-result' },
+      { id: 'other' },
+    ]);
+    expect(reportTerminalFn).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'REORDER_LAYER' }),
+      'succeeded',
+      expect.objectContaining({ actual: { store_updated: true } }),
+    );
     expect(popAction).toHaveBeenCalled();
   });
 

--- a/frontend/components/map/map-action-handler.tsx
+++ b/frontend/components/map/map-action-handler.tsx
@@ -129,9 +129,15 @@ export const MapActionHandler = React.memo(function MapActionHandler() {
         return;
       }
 
+      // Issue #393: every catalogue command now returns an explicit
+      // MapCommandResult (post-state verification is the FIX-B contract), so a
+      // void return is no longer evidence of success — it means the command
+      // forgot to report, or an unverifiable code path slipped through. Fail
+      // honestly instead of acking `succeeded` for a mutation that may never
+      // have landed (the old default silently converted the broken
+      // apply_layer_filter / heatmap commands into fake successes).
       if (result === undefined || result === null) {
-        // void run → succeeded (legacy fire-and-forget commands untouched).
-        finish('succeeded');
+        finish('failed', { error: 'no_result' });
         return;
       }
       if (result.status === 'failed') {

--- a/frontend/lib/map-commands/heatmapCommands.test.ts
+++ b/frontend/lib/map-commands/heatmapCommands.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { heatmapCommands } from './heatmapCommands';
+import type { MapCommandContext } from './types';
+import { makeMockMaplibreMap } from '@/test/__mocks__/maplibre-map';
+
+function makeCtx(map: any, params: Record<string, unknown> = {}): MapCommandContext {
+  return {
+    map,
+    popAction: () => {},
+    setDeferredPop: () => {},
+    safePop: () => {},
+    getHudState: () => ({}),
+    setSelectedBaseLayer: () => {},
+    command: 'add_heatmap_raster',
+    params,
+  } as unknown as MapCommandContext;
+}
+
+/**
+ * Issue #393: the three heatmap commands used to return void unconditionally —
+ * the dispatcher converted the void into a `succeeded` ack even when the
+ * renderer mount silently failed. They now verify the post-state (source +
+ * layer present) before claiming success.
+ */
+describe('heatmap commands (issue #393: post-state verification, no fake success)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('add_heatmap_raster', () => {
+    const params = {
+      image: 'data:image/png;base64,AAAA',
+      bbox: [116, 39, 117, 40],
+      opacity: 0.5,
+      layerId: 'rain',
+    };
+
+    it('acks confirmed:true only when the image source AND raster layer landed', () => {
+      const map = makeMockMaplibreMap();
+      const result = heatmapCommands.add_heatmap_raster.run(makeCtx(map, params));
+
+      expect(result).toEqual({ status: 'succeeded', result: { confirmed: true } });
+      expect(map.getSource('custom-rain')).toBeTruthy();
+      expect(map.getLayer('custom-rain')).toBeTruthy();
+    });
+
+    it('fails mutation_failed when the map never registers the mount', () => {
+      // getSource/getLayer always null — the renderer calls no-op → old code
+      // returned void → dispatcher acked succeeded. Now it must fail honestly.
+      const bareMap = {
+        getSource: vi.fn(() => null),
+        getLayer: vi.fn(() => null),
+        addSource: vi.fn(),
+        addLayer: vi.fn(),
+        getStyle: vi.fn(() => ({ layers: [], sources: {} })),
+        getCanvas: vi.fn(() => ({ width: 800, height: 600 })),
+        fitBounds: vi.fn(),
+        getCenter: vi.fn(() => ({ lng: 116, lat: 39 })),
+        getZoom: vi.fn(() => 5),
+      };
+      const result = heatmapCommands.add_heatmap_raster.run(makeCtx(bareMap, params));
+
+      expect(result).toEqual({ status: 'failed', error: 'mutation_failed' });
+    });
+
+    it('rejects missing payload data as invalid_params', () => {
+      const map = makeMockMaplibreMap();
+      expect(heatmapCommands.add_heatmap_raster.run(makeCtx(map, { bbox: [1, 2, 3, 4] })))
+        .toEqual({ status: 'failed', error: 'invalid_params' });
+      expect(heatmapCommands.add_heatmap_raster.run(makeCtx(map, { image: 'x' })))
+        .toEqual({ status: 'failed', error: 'invalid_params' });
+    });
+  });
+
+  describe('add_native_heatmap', () => {
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const params = { geojson, layerId: 'poi-heat', palette: 'magma', radius: 20 };
+
+    it('acks confirmed:true only when the source AND heatmap layer landed', () => {
+      const map = makeMockMaplibreMap();
+      const result = heatmapCommands.add_native_heatmap.run(makeCtx(map, params));
+
+      expect(result).toEqual({ status: 'succeeded', result: { confirmed: true } });
+      expect(map.getSource('custom-poi-heat')).toBeTruthy();
+      expect(map.getLayer('custom-poi-heat')).toBeTruthy();
+    });
+
+    it('fails mutation_failed when the mount did not land', () => {
+      const bareMap = {
+        getSource: vi.fn(() => null),
+        getLayer: vi.fn(() => null),
+        addSource: vi.fn(),
+        addLayer: vi.fn(),
+        removeLayer: vi.fn(),
+        getStyle: vi.fn(() => ({ layers: [], sources: {} })),
+      };
+      const result = heatmapCommands.add_native_heatmap.run(makeCtx(bareMap, params));
+
+      expect(result).toEqual({ status: 'failed', error: 'mutation_failed' });
+    });
+
+    it('rejects missing geojson as invalid_params', () => {
+      expect(heatmapCommands.add_native_heatmap.run(makeCtx(makeMockMaplibreMap(), {})))
+        .toEqual({ status: 'failed', error: 'invalid_params' });
+    });
+  });
+
+  describe('create_thematic_map', () => {
+    const geojson = { type: 'FeatureCollection', features: [] };
+    const style = { type: 'choropleth', field: 'pop', breaks: [0, 100], colors: ['#fff', '#000'] };
+    const params = { geojson, layerId: 'pop-theme', style, field: 'pop' };
+
+    it('acks confirmed:true only when the source AND thematic layer landed', () => {
+      const map = makeMockMaplibreMap();
+      const result = heatmapCommands.create_thematic_map.run(makeCtx(map, params));
+
+      expect(result).toEqual({ status: 'succeeded', result: { confirmed: true } });
+      expect(map.getSource('custom-pop-theme')).toBeTruthy();
+      expect(map.getLayer('custom-pop-theme')).toBeTruthy();
+    });
+
+    it('fails mutation_failed when the mount did not land', () => {
+      const bareMap = {
+        getSource: vi.fn(() => null),
+        getLayer: vi.fn(() => null),
+        addSource: vi.fn(),
+        addLayer: vi.fn(),
+        getStyle: vi.fn(() => ({ layers: [], sources: {} })),
+      };
+      const result = heatmapCommands.create_thematic_map.run(makeCtx(bareMap, params));
+
+      expect(result).toEqual({ status: 'failed', error: 'mutation_failed' });
+    });
+
+    it('rejects missing geojson/style as invalid_params', () => {
+      const map = makeMockMaplibreMap();
+      expect(heatmapCommands.create_thematic_map.run(makeCtx(map, { style })))
+        .toEqual({ status: 'failed', error: 'invalid_params' });
+      expect(heatmapCommands.create_thematic_map.run(makeCtx(map, { geojson })))
+        .toEqual({ status: 'failed', error: 'invalid_params' });
+    });
+  });
+});

--- a/frontend/lib/map-commands/heatmapCommands.ts
+++ b/frontend/lib/map-commands/heatmapCommands.ts
@@ -40,6 +40,15 @@ export const heatmapCommands: Record<string, CommandEntry> = {
       });
 
       navigation.fitBounds(map, bbox, 50);
+      // V3 round-2 FIX-B (issue #393): post-mutation verification — the image
+      // source and the raster layer must actually exist on the map before we
+      // claim success. The old body returned void unconditionally, so the
+      // dispatcher acked succeeded even when the mount silently failed.
+      if (!map.getSource?.(id) || !map.getLayer?.(id)) {
+        return { status: 'failed', error: 'mutation_failed' };
+      }
+      // V3: verifiable marker (heatmap raster add — harness convergence).
+      return { status: 'succeeded', result: { confirmed: true } };
     },
   },
 
@@ -61,6 +70,14 @@ export const heatmapCommands: Record<string, CommandEntry> = {
         radius,
         opacity: 0.8
       });
+      // V3 round-2 FIX-B (issue #393): post-mutation verification — both the
+      // source and the heatmap layer must exist before claiming success (was:
+      // unconditional void → fake succeeded ack).
+      if (!map.getSource?.(id) || !map.getLayer?.(id)) {
+        return { status: 'failed', error: 'mutation_failed' };
+      }
+      // V3: verifiable marker (native heatmap add — harness convergence).
+      return { status: 'succeeded', result: { confirmed: true } };
     },
   },
 
@@ -81,6 +98,14 @@ export const heatmapCommands: Record<string, CommandEntry> = {
       const id = `custom-${layerId || 'thematic-' + (field || Date.now())}`;
       renderer.addGeoJsonSource(map, id, geojson);
       renderer.addThematicLayer(map, id, geojson, style);
+      // V3 round-2 FIX-B (issue #393): post-mutation verification — the source
+      // and the thematic layer must exist before claiming success (was:
+      // unconditional void → fake succeeded ack).
+      if (!map.getSource?.(id) || !map.getLayer?.(id)) {
+        return { status: 'failed', error: 'mutation_failed' };
+      }
+      // V3: verifiable marker (thematic map mount — harness convergence).
+      return { status: 'succeeded', result: { confirmed: true } };
     },
   },
 };

--- a/frontend/lib/map-commands/layerCommands.test.ts
+++ b/frontend/lib/map-commands/layerCommands.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { layerCommands } from './layerCommands';
 import type { MapCommandContext } from './types';
 import * as renderer from '@/lib/map-kit/renderer';
+import { makeMockMaplibreMap } from '@/test/__mocks__/maplibre-map';
 
 vi.mock('@/lib/map-kit/renderer', () => ({
   updateLayerStyle: vi.fn(),
@@ -111,5 +112,214 @@ describe('cartographic runtime repair command', () => {
     expect(result).toEqual({ status: 'failed', error: 'superseded_by_user' });
     expect(renderer.updateLayerStyle).not.toHaveBeenCalled();
     expect(updateLayer).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Issue #393: legacy imperative map commands must not silently no-op ───
+
+function layerCtx(map: any, layers: any[] = []) {
+  const updateLayer = vi.fn();
+  const reorderLayers = vi.fn();
+  const hud = { layers, updateLayer, reorderLayers };
+  const ctx = {
+    map,
+    popAction: () => {},
+    setDeferredPop: () => {},
+    safePop: () => {},
+    getHudState: () => hud,
+    setSelectedBaseLayer: () => {},
+    command: 'apply_layer_filter',
+    params: {},
+  } as unknown as MapCommandContext;
+  return { ctx, updateLayer, reorderLayers, hud };
+}
+
+describe('apply_layer_filter (issue #393: dual-scheme + store sync + verification)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('applies the filter to every `${id}__*` MapSpec sublayer and writes it back to the store', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'result__fill', type: 'fill' });
+    map.addLayer({ id: 'result__line', type: 'line' });
+    map.addLayer({ id: 'result__point', type: 'circle' });
+    const { ctx, updateLayer } = layerCtx(map, [{ id: 'result' }]);
+    ctx.params = { layer_id: 'result', filter: ['==', ['get', 'type'], 'mall'] };
+
+    const result = layerCommands.apply_layer_filter.run(ctx);
+
+    expect(result).toEqual({ status: 'succeeded', result: { confirmed: true } });
+    expect(map.setFilter).toHaveBeenCalledWith('result__fill', ['==', ['get', 'type'], 'mall']);
+    expect(map.setFilter).toHaveBeenCalledWith('result__line', ['==', ['get', 'type'], 'mall']);
+    expect(map.setFilter).toHaveBeenCalledWith('result__point', ['==', ['get', 'type'], 'mall']);
+    // store sync: the reconcile re-emits layer.filter, so a bare setFilter is
+    // never rolled back by the next reconcile
+    expect(updateLayer).toHaveBeenCalledWith('result', { filter: ['==', ['get', 'type'], 'mall'] });
+  });
+
+  it('still matches the legacy `custom-` scheme', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'custom-pop', type: 'fill' });
+    map.addLayer({ id: 'custom-pop-outline', type: 'line' });
+    const { ctx, updateLayer } = layerCtx(map);
+    ctx.params = { layer_id: 'pop', filter: ['>', ['get', 'pop'], 1000] };
+
+    const result = layerCommands.apply_layer_filter.run(ctx);
+
+    expect(result).toEqual({ status: 'succeeded', result: { confirmed: true } });
+    expect(map.setFilter).toHaveBeenCalledWith('custom-pop', ['>', ['get', 'pop'], 1000]);
+    expect(map.setFilter).toHaveBeenCalledWith('custom-pop-outline', ['>', ['get', 'pop'], 1000]);
+    expect(updateLayer).toHaveBeenCalledWith('pop', { filter: ['>', ['get', 'pop'], 1000] });
+  });
+
+  it('parses string filters and clears the store filter when the expression is null', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'result__fill', type: 'fill' });
+    const { ctx, updateLayer } = layerCtx(map, [{ id: 'result' }]);
+    ctx.params = { layer_id: 'result', filter: '["==", "density", 10]' };
+
+    const result = layerCommands.apply_layer_filter.run(ctx);
+    expect(result).toEqual({ status: 'succeeded', result: { confirmed: true } });
+    expect(map.setFilter).toHaveBeenCalledWith('result__fill', ['==', 'density', 10]);
+
+    // clearing: filter null → setFilter(null) + store cleared (null)
+    ctx.params = { layer_id: 'result', filter: null };
+    const cleared = layerCommands.apply_layer_filter.run(ctx);
+    expect(cleared).toEqual({ status: 'succeeded', result: { confirmed: true } });
+    expect(map.setFilter).toHaveBeenLastCalledWith('result__fill', null);
+    expect(updateLayer).toHaveBeenLastCalledWith('result', { filter: null });
+  });
+
+  it('fails target_not_found when neither scheme matches and the store has no layer', () => {
+    const map = makeMockMaplibreMap();
+    const { ctx, updateLayer } = layerCtx(map, []);
+    ctx.params = { layer_id: 'ghost', filter: ['==', 'x', 1] };
+
+    const result = layerCommands.apply_layer_filter.run(ctx);
+
+    expect(result).toEqual({ status: 'failed', error: 'target_not_found' });
+    expect(map.setFilter).not.toHaveBeenCalled();
+    expect(updateLayer).not.toHaveBeenCalled();
+  });
+
+  it('does not fake success when the filter never lands on the map (getFilter empty)', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'result__fill', type: 'fill' });
+    // setFilter records the call but the layer never reflects it (e.g. a raster
+    // layer that rejects filters) — verification must not ack success.
+    (map as any).getFilter = vi.fn(() => null);
+    const { ctx, updateLayer } = layerCtx(map, [{ id: 'result' }]);
+    ctx.params = { layer_id: 'result', filter: ['==', ['get', 'type'], 'mall'] };
+
+    const result = layerCommands.apply_layer_filter.run(ctx);
+
+    // store scheme matched → honest store_updated (non-converging), never confirmed
+    expect(result).toEqual({ status: 'succeeded', result: { store_updated: true } });
+    expect(updateLayer).not.toHaveBeenCalled();
+  });
+
+  it('fails mutation_failed when a custom-scheme layer rejects the filter', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'custom-pop', type: 'raster' });
+    (map as any).getFilter = vi.fn(() => null);
+    const { ctx } = layerCtx(map);
+    ctx.params = { layer_id: 'pop', filter: ['==', 'x', 1] };
+
+    const result = layerCommands.apply_layer_filter.run(ctx);
+
+    expect(result).toEqual({ status: 'failed', error: 'mutation_failed' });
+  });
+});
+
+describe('reorder_layer (issue #393: MapSpec `${id}__` layers reorder durably)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reorders a MapSpec layer via the store array (runtime owns map z-order)', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'analysis-result__fill', type: 'fill' });
+    map.addLayer({ id: 'analysis-result__point', type: 'circle' });
+    map.addLayer({ id: 'other__fill', type: 'fill' });
+    const { ctx, reorderLayers } = layerCtx(map, [
+      { id: 'other' },
+      { id: 'analysis-result' },
+    ]);
+    ctx.command = 'reorder_layer';
+    ctx.params = { layer_id: 'analysis-result', position: 'top' };
+
+    const result = layerCommands.reorder_layer.run(ctx);
+
+    // not the legacy target_not_found — the MapSpec layer IS reorderable
+    expect(result).toEqual({ status: 'succeeded', result: { store_updated: true } });
+    // index 0 = topmost; the runtime reconcile re-applies map z-order from this
+    expect(reorderLayers).toHaveBeenCalledWith([
+      { id: 'analysis-result' },
+      { id: 'other' },
+    ]);
+  });
+
+  it('honors bottom / up / down and before(below before_id) semantics', () => {
+    const mk = () => layerCtx(
+      makeMockMaplibreMap(),
+      [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+    );
+
+    let t = mk();
+    t.ctx.command = 'reorder_layer';
+    t.ctx.params = { layer_id: 'b', position: 'bottom' };
+    layerCommands.reorder_layer.run(t.ctx);
+    expect(t.reorderLayers).toHaveBeenCalledWith([{ id: 'a' }, { id: 'c' }, { id: 'b' }]);
+
+    t = mk();
+    t.ctx.params = { layer_id: 'c', position: 'up' };
+    layerCommands.reorder_layer.run(t.ctx);
+    expect(t.reorderLayers).toHaveBeenCalledWith([{ id: 'a' }, { id: 'c' }, { id: 'b' }]);
+
+    t = mk();
+    t.ctx.params = { layer_id: 'a', position: 'down' };
+    layerCommands.reorder_layer.run(t.ctx);
+    expect(t.reorderLayers).toHaveBeenCalledWith([{ id: 'b' }, { id: 'a' }, { id: 'c' }]);
+
+    t = mk();
+    t.ctx.params = { layer_id: 'a', position: 'before', before_id: 'c' };
+    layerCommands.reorder_layer.run(t.ctx);
+    expect(t.reorderLayers).toHaveBeenCalledWith([{ id: 'b' }, { id: 'c' }, { id: 'a' }]);
+  });
+
+  it('reorders store-only layers (reconcile has not mounted sublayers yet)', () => {
+    const map = makeMockMaplibreMap(); // no map layers at all
+    const { ctx, reorderLayers } = layerCtx(map, [{ id: 'a' }, { id: 'b' }]);
+    ctx.command = 'reorder_layer';
+    ctx.params = { layer_id: 'b', position: 'top' };
+
+    const result = layerCommands.reorder_layer.run(ctx);
+
+    expect(result).toEqual({ status: 'succeeded', result: { store_updated: true } });
+    expect(reorderLayers).toHaveBeenCalledWith([{ id: 'b' }, { id: 'a' }]);
+  });
+
+  it('fails target_not_found for before_id that does not exist', () => {
+    const { ctx, reorderLayers } = layerCtx(makeMockMaplibreMap(), [{ id: 'a' }, { id: 'b' }]);
+    ctx.command = 'reorder_layer';
+    ctx.params = { layer_id: 'b', position: 'before', before_id: 'ghost' };
+
+    const result = layerCommands.reorder_layer.run(ctx);
+
+    expect(result).toEqual({ status: 'failed', error: 'target_not_found' });
+    expect(reorderLayers).not.toHaveBeenCalled();
+  });
+
+  it('still reorders legacy custom layers on the map (regression)', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'custom-other', type: 'fill' });
+    map.addLayer({ id: 'custom-target', type: 'fill' });
+    map.addLayer({ id: 'custom-target-outline', type: 'line' });
+    const { ctx } = layerCtx(map);
+    ctx.command = 'reorder_layer';
+    ctx.params = { layer_id: 'target', position: 'top' };
+
+    const result = layerCommands.reorder_layer.run(ctx);
+
+    expect(result).toEqual({ status: 'succeeded', result: { confirmed: true } });
+    expect(map.moveLayer).toHaveBeenCalledWith('custom-target', undefined);
+    expect(map.moveLayer).toHaveBeenCalledWith('custom-target-outline', undefined);
   });
 });

--- a/frontend/lib/map-commands/layerCommands.ts
+++ b/frontend/lib/map-commands/layerCommands.ts
@@ -470,84 +470,189 @@ export const layerCommands: Record<string, CommandEntry> = {
     // the old validator (layers/order arrays) matched no actual run contract
     requiredParams: (p) => typeof p.layer_id === 'string' && typeof p.position === 'string',
     run(ctx) {
-      const { map, params } = ctx;
+      const { map, params, getHudState } = ctx;
       const { layer_id, position, before_id } = params || {};
       // V3: silent no-ops become explicit failed results (design §6).
       if (!layer_id || typeof layer_id !== 'string' || !layer_id.trim() || layer_id === 'ref:' || layer_id === 'custom-') {
         return { status: 'failed', error: 'target_not_found' };
       }
       if (!position) return { status: 'failed', error: 'invalid_params' };
-      const style = map.getStyle();
-      const allLayers = style.layers || [];
-      const subIds = allLayers
-        .map((l: any) => l.id as string)
-        .filter((id: string) => id === `custom-${layer_id}` || id.startsWith(`custom-${layer_id}-`));
-      if (subIds.length === 0) return { status: 'failed', error: 'target_not_found' };
+      // Issue #393: tighten position validation up-front so neither scheme path
+      // mutates the map/store before discovering the request is malformed.
+      if (!['top', 'bottom', 'up', 'down', 'before'].includes(position)) {
+        return { status: 'failed', error: 'invalid_params' };
+      }
+      if (position === 'before' && !before_id) return { status: 'failed', error: 'invalid_params' };
 
-      // Snapshot custom layer IDs only (we ignore base style layers)
-      const customIds = allLayers
-        .map((l: any) => l.id as string)
-        .filter((id: string) => id.startsWith('custom-'));
+      // V3 round-2 FIX-B: resolve the target across BOTH id schemes (custom-…
+      // stack and store `…__…` sublayers). The old custom-only matcher never saw
+      // a MapSpec layer (`${id}__${sub}`) and failed target_not_found for every
+      // current layer.
+      const matched = matchMapLayers(map, layer_id);
+      const storeHasLayer = getHudState().layers?.some?.((l: any) => l.id === layer_id) ?? false;
+      if (matched.length === 0 && !storeHasLayer) return { status: 'failed', error: 'target_not_found' };
 
-      const firstSubIdx = customIds.indexOf(subIds[0]);
-      let beforeAnchor: string | undefined;
+      const customMatched = matched.filter((id) => isCustomSchemeMatch(layer_id, id));
+      const storeMatched = matched.filter((id) => isStoreSchemeMatch(layer_id, id));
 
-      if (position === 'top') {
-        beforeAnchor = undefined; // moveLayer with no anchor -> top
-      } else if (position === 'bottom') {
-        const bottomCandidate = customIds.find((id: string) => !subIds.includes(id));
-        beforeAnchor = bottomCandidate;
-      } else if (position === 'up') {
-        // Find next custom group above
-        for (let i = firstSubIdx - 1; i >= 0; i--) {
-          if (!subIds.includes(customIds[i])) {
-            // Place subIds before the layer that sits above customIds[i]
-            beforeAnchor = customIds[i];
-            break;
+      // 1. custom stack → legacy algorithm: move the group on the map within the
+      //    custom stack (the runtime does not own these layers).
+      let customMoved = false;
+      if (customMatched.length > 0) {
+        const style = map.getStyle();
+        const allLayers = style.layers || [];
+
+        // Snapshot custom layer IDs only (we ignore base style layers)
+        const customIds = allLayers
+          .map((l: any) => l.id as string)
+          .filter((id: string) => id.startsWith('custom-'));
+
+        const firstSubIdx = customIds.indexOf(customMatched[0]);
+        let beforeAnchor: string | undefined;
+
+        if (position === 'top') {
+          beforeAnchor = undefined; // moveLayer with no anchor -> top
+        } else if (position === 'bottom') {
+          const bottomCandidate = customIds.find((id: string) => !customMatched.includes(id));
+          beforeAnchor = bottomCandidate;
+        } else if (position === 'up') {
+          // Find next custom group above
+          for (let i = firstSubIdx - 1; i >= 0; i--) {
+            if (!customMatched.includes(customIds[i])) {
+              // Place customMatched before the layer that sits above customIds[i]
+              beforeAnchor = customIds[i];
+              break;
+            }
           }
-        }
-      } else if (position === 'down') {
-        for (let i = firstSubIdx + subIds.length; i < customIds.length; i++) {
-          if (!subIds.includes(customIds[i])) {
-            beforeAnchor = customIds[i + 1];
-            break;
+        } else if (position === 'down') {
+          for (let i = firstSubIdx + customMatched.length; i < customIds.length; i++) {
+            if (!customMatched.includes(customIds[i])) {
+              beforeAnchor = customIds[i + 1];
+              break;
+            }
           }
+        } else if (position === 'before' && before_id) {
+          const targetGroup = customIds.find((id: string) => id === `custom-${before_id}` || id.startsWith(`custom-${before_id}-`));
+          beforeAnchor = targetGroup;
         }
-      } else if (position === 'before' && before_id) {
-        const targetGroup = customIds.find((id: string) => id === `custom-${before_id}` || id.startsWith(`custom-${before_id}-`));
-        beforeAnchor = targetGroup;
+
+        try {
+          for (const id of customMatched) {
+            map.moveLayer(id, beforeAnchor);
+          }
+          customMoved = true;
+        } catch (e) {
+          devOnly.warn('[MapActionHandler] REORDER_LAYER failed:', e);
+          return { status: 'failed', error: 'reorder_failed' };
+        }
       }
 
-      try {
-        for (const id of subIds) {
-          map.moveLayer(id, beforeAnchor);
+      // 2. store-scheme → durable reorder of the HUD store's layers array (index
+      //    0 = topmost). The MapSpecRuntime derives the map z-order from that
+      //    array (adapter → spec → reconcile → renderer.syncLayerZOrder), so a
+      //    direct moveLayer on the sublayers would be reverted by the next
+      //    reconcile — reordering the store is the change that sticks.
+      let storeReordered = false;
+      if (storeHasLayer) {
+        const storeOrder = [...(getHudState().layers as any[])];
+        const fromIdx = storeOrder.findIndex((l: any) => l.id === layer_id);
+        if (fromIdx !== -1) {
+          const [moved] = storeOrder.splice(fromIdx, 1);
+          let toIdx: number;
+          if (position === 'top') {
+            toIdx = 0;
+          } else if (position === 'bottom') {
+            toIdx = storeOrder.length;
+          } else if (position === 'up') {
+            toIdx = Math.max(0, fromIdx - 1);
+          } else if (position === 'down') {
+            toIdx = Math.min(storeOrder.length, fromIdx + 1);
+          } else {
+            // position === 'before' (validated above): directly below before_id.
+            const beforeIdx = storeOrder.findIndex((l: any) => l.id === before_id);
+            if (beforeIdx === -1) return { status: 'failed', error: 'target_not_found' };
+            toIdx = beforeIdx + 1;
+          }
+          storeOrder.splice(toIdx, 0, moved);
+          getHudState().reorderLayers(storeOrder);
+          storeReordered = true;
         }
-      } catch (e) {
-        devOnly.warn('[MapActionHandler] REORDER_LAYER failed:', e);
-        return { status: 'failed', error: 'reorder_failed' };
       }
+
       // V3 round-2 FIX-B: post-mutation verification — the target sublayers
       // must still exist on the map (moveLayer on a stale style index is a
       // silent no-op otherwise).
       const layersAfter = ((map.getStyle?.()?.layers ?? []) as any[]).map((l: any) => l.id as string);
-      const targetGone = subIds.some(
+      const targetGone = matched.some(
         (id: string) => !map.getLayer?.(id) && !layersAfter.includes(id),
       );
-      if (targetGone) return { status: 'failed', error: 'mutation_failed' };
-      // V3: verifiable marker (layer reorder — harness convergence).
-      return { status: 'succeeded', result: { confirmed: true } };
+      if (targetGone) return nonConfirmableAck(storeMatched);
+
+      // V3: verifiable markers (layer reorder — harness convergence). Custom
+      // layers are verified synchronously (confirmed); store layers are owned by
+      // the runtime reconcile (store_updated — the backend treats it as
+      // non-converging until the next observation confirms the map z-order).
+      const result: Record<string, unknown> = {};
+      if (customMoved) result.confirmed = true;
+      if (storeReordered) result.store_updated = true;
+      return { status: 'succeeded', result };
     },
   },
 
   apply_layer_filter: {
     requiredParams: (p) => typeof p.layer_id === 'string' || typeof p.id === 'string',
     run(ctx) {
-      const { map, params } = ctx;
+      const { map, params, getHudState } = ctx;
       const { layer_id, filter } = params || {};
       // V3: missing target → explicit failed result (was a silent return).
       if (!layer_id) return { status: 'failed', error: 'target_not_found' };
-      // Apply MapLibre filter with fallback parser for simple string filters
-      map.setFilter(layer_id, parseFilter(filter) as any);
+
+      // V3 round-2 FIX-B: resolve the target across BOTH id schemes (custom-…
+      // stack and store `…__…` sublayers) before declaring a miss. The old code
+      // called setFilter on the bare id, which does not exist on a MapSpec map
+      // (`${id}__fill/__line/__point` are the real layer ids); MapLibre emits an
+      // ErrorEvent instead of throwing, so run() returned void and the dispatcher
+      // acked `succeeded` for a filter that never landed.
+      const matched = matchMapLayers(map, layer_id);
+      const storeHasLayer = getHudState().layers?.some?.((l: any) => l.id === layer_id) ?? false;
+      if (matched.length === 0 && !storeHasLayer) return { status: 'failed', error: 'target_not_found' };
+
+      const parsed = parseFilter(filter);
+      const storeMatched = matched.filter((id) => isStoreSchemeMatch(layer_id, id));
+
+      // Apply to every matched sublayer BEFORE touching the store — a failed map
+      // mutation must not leave a store-only filter that the next reconcile
+      // would force onto the map anyway.
+      if (matched.length > 0) {
+        for (const id of matched) {
+          if (!map.getLayer?.(id)) return nonConfirmableAck(storeMatched);
+          try {
+            map.setFilter(id, parsed as any);
+          } catch (e) {
+            // Raster layers reject filters — surface it instead of fake-acking.
+            devOnly.warn('[MapActionHandler] APPLY_LAYER_FILTER failed on layer:', id, e);
+            return nonConfirmableAck(storeMatched);
+          }
+        }
+        // FIX-B: the filter must actually be recorded on the layer — setFilter
+        // on an unsupported (raster) or stale id silently no-ops otherwise.
+        for (const id of matched) {
+          const live = map.getFilter?.(id);
+          if (parsed && !live) return nonConfirmableAck(storeMatched);
+        }
+      }
+
+      // Persist the filter on the store layer so the MapSpecRuntime reconcile
+      // keeps it (the adapter re-emits `layer.filter`; a bare setFilter would be
+      // rolled back). null/'' clears it — the backend documents that contract.
+      getHudState().updateLayer(layer_id, { filter: parsed ?? null });
+
+      if (matched.length === 0) {
+        // Store-only: the reconcile owns the map sublayers → honest store_updated.
+        return { status: 'succeeded', result: { store_updated: true } };
+      }
+      // V3: verifiable marker (layer filter — harness convergence).
+      return { status: 'succeeded', result: { confirmed: true } };
     },
   },
 };

--- a/frontend/lib/mapspec-runtime/adapter.test.ts
+++ b/frontend/lib/mapspec-runtime/adapter.test.ts
@@ -319,6 +319,52 @@ describe("MapSpec Runtime Adapter — hudStateToMapSpec (ADR-0036)", () => {
     });
   });
 
+  describe("layer.filter (issue #393: imperative APPLY_LAYER_FILTER survives reconcile)", () => {
+    it("ANDs the imperative filter with the $type base on every sublayer", () => {
+      const layer = baseLayer({
+        source: fc(polygonFeature(), lineFeature(), pointFeature()),
+        filter: [">", ["get", "pop"], 1000],
+      });
+      const spec = hudStateToMapSpec({ layers: [layer], processLayers: {}, activeFilters: {}, is3D: false });
+
+      const fill = spec.layers.find((l) => l.id === `L1${SUBLAYER_SEP}fill`)!;
+      const line = spec.layers.find((l) => l.id === `L1${SUBLAYER_SEP}line`)!;
+      const point = spec.layers.find((l) => l.id === `L1${SUBLAYER_SEP}point`)!;
+      expect(fill.filter).toEqual(["all", ["==", "$type", "Polygon"], [">", ["get", "pop"], 1000]]);
+      expect(line.filter).toEqual(["all", ["==", "$type", "LineString"], [">", ["get", "pop"], 1000]]);
+      expect(point.filter).toEqual(["all", ["==", "$type", "Point"], [">", ["get", "pop"], 1000]]);
+    });
+
+    it("combines the imperative filter with activeFilters range filters", () => {
+      const src = fc(polygonFeature({ score: 10 })) as any;
+      src.metadata = { field: "score" };
+      const layer = baseLayer({
+        source: src,
+        filter: ["==", ["get", "name"], "mall"],
+      });
+      const spec = hudStateToMapSpec({
+        layers: [layer],
+        processLayers: {},
+        activeFilters: { L1: [[0, 25]] },
+        is3D: false,
+      });
+      const fill = spec.layers.find((l) => l.type === "fill")!;
+      expect(fill.filter).toEqual([
+        "all",
+        ["==", "$type", "Polygon"],
+        ["==", ["get", "name"], "mall"],
+        ["any", ["all", [">=", ["get", "score"], 0], ["<", ["get", "score"], 25]]],
+      ]);
+    });
+
+    it("emits no filter clause when layer.filter is null (cleared)", () => {
+      const layer = baseLayer({ source: fc(polygonFeature()), filter: null });
+      const spec = hudStateToMapSpec({ layers: [layer], processLayers: {}, activeFilters: {}, is3D: false });
+      const fill = spec.layers.find((l) => l.type === "fill")!;
+      expect(fill.filter).toEqual(["==", "$type", "Polygon"]);
+    });
+  });
+
   describe("visibility", () => {
     it("marks all sublayers visibility:none when layer.visible=false", () => {
       const layer = baseLayer({ visible: false, source: fc(polygonFeature(), lineFeature(), pointFeature()) });

--- a/frontend/lib/mapspec-runtime/adapter.ts
+++ b/frontend/lib/mapspec-runtime/adapter.ts
@@ -212,11 +212,17 @@ export function hudStateToMapSpec(input: HudToSpecInput): MapSpec {
     const filterRanges = activeFilters[layer.id];
     const buildLayerFilter = (baseType: string): unknown[] => {
       const base: unknown[] = ["==", "$type", baseType];
+      const parts: unknown[] = [base];
+      // Issue #393: imperative filters (APPLY_LAYER_FILTER) are persisted on the
+      // store layer — without this merge the reconcile would emit only the $type
+      // base and silently roll the filter back. The imperative expression ANDs
+      // with the geometry-type base so each sublayer keeps its own $type guard.
+      if (layer.filter) parts.push(layer.filter);
       if (filterField && filterRanges) {
         const rangeFilters = filterRanges.map((range: number[]) => ["all", [">=", ["get", filterField], range[0]], ["<", ["get", filterField], range[1]]]);
-        return ["all", base, ["any", ...rangeFilters]];
+        parts.push(["any", ...rangeFilters]);
       }
-      return base;
+      return parts.length === 1 ? base : ["all", ...parts];
     };
 
     const color = layer.style?.color || "#16a34a";

--- a/frontend/lib/store/slices/layersSlice.ts
+++ b/frontend/lib/store/slices/layersSlice.ts
@@ -25,6 +25,11 @@ export const MAX_ANNOTATIONS = 500;
 
 const PRESENTATION_FIELDS = new Set([
   'visible', 'opacity', 'style', 'legend_spec', 'type', '_refId', '_mapspecLayerId',
+  // Issue #393: an imperative filter (APPLY_LAYER_FILTER) changes what the map
+  // shows without the backend's MapSpec knowing — the certified presentation is
+  // stale, so the attestation tags must be invalidated like any other
+  // presentation change (visible/style/opacity precedent).
+  'filter',
 ]);
 
 /**

--- a/frontend/lib/types/layer.ts
+++ b/frontend/lib/types/layer.ts
@@ -38,6 +38,10 @@ export interface Layer {
   group?: 'analysis' | 'base' | 'reference';
   source?: string | GeoJSONFeatureCollection | HeatmapRasterSource;
   style?: LayerStyle;
+  /** Imperative MapLibre filter expression (APPLY_LAYER_FILTER). Persisted on the
+   *  store layer so the MapSpecRuntime reconcile re-emits it (issue #393: a bare
+   *  map.setFilter is rolled back by the next reconcile). null/absent = no filter. */
+  filter?: unknown[] | null;
   _refId?: string;
   /** Data Plane: MVT tile URL template ({z}/{x}/{y}) for large ref layers. */
   _tileUrl?: string;

--- a/frontend/test/__mocks__/maplibre-map.ts
+++ b/frontend/test/__mocks__/maplibre-map.ts
@@ -64,6 +64,7 @@ export function makeMockMaplibreMap(options: MakeMockMaplibreMapOptions = {}) {
 
   const sources: Record<string, any> = {};
   const layers: Array<Record<string, any>> = [];
+  const filters: Record<string, unknown> = {};
   const onceListeners = new Map<string, Set<(...args: any[]) => void>>();
   const onListeners = new Map<string, Set<(...args: any[]) => void>>();
   // ROUND-2: track whether a camera animation is in flight so stop() can model
@@ -139,9 +140,14 @@ export function makeMockMaplibreMap(options: MakeMockMaplibreMapOptions = {}) {
     moveLayer: vi.fn((id: string, beforeId?: string | null) => {
       calls.moveLayer.push({ id, beforeId: beforeId ?? null });
     }),
+    // Issue #393: setFilter/getFilter bookkeeping — the mock stores the applied
+    // filter per layer so commands can run their post-mutation verification
+    // (a real MapLibre map records the expression; getFilter returns it).
     setFilter: vi.fn((layerId: string, filter: any) => {
+      filters[layerId] = filter ?? null;
       calls.setFilter.push({ layerId, filter });
     }),
+    getFilter: vi.fn((layerId: string) => filters[layerId] ?? null),
     setLayoutProperty: vi.fn(),
     setPaintProperty: vi.fn(),
 


### PR DESCRIPTION
## Fixes #393 — legacy imperative map commands were silent no-ops that acked success

### Root cause (single)
The four imperative map commands predate the MapSpec sublayer id scheme (`${id}__${sub}`), and the dispatcher treated a `void` return from `run()` as `succeeded`:

1. **`apply_layer_filter`** called `map.setFilter(layer_id, ...)` on the bare store id, which does not exist on a MapSpec map — only `${id}__fill/__line/__point` do. MapLibre fires an ErrorEvent instead of throwing, so `run()` returned `void` → dispatcher acked `succeeded`. The filter was never written back to the store either, so the next reconcile rolled any manual filter back.
2. **`add_heatmap_raster` / `add_native_heatmap` / `create_thematic_map`** mounted renderer layers then returned `void` unconditionally — no post-state check (unlike `add_layer`/`add_raster_layer` which have round-2 FIX-B verification).
3. **`reorder_layer`** only matched legacy `custom-` ids → for every current MapSpec layer it honestly failed `target_not_found` (so the AI-visible capability was dead).
4. Backend mints these commands (`app/tools/layer_manager.py` `apply_layer_filter`/`reorder_layer`, prompt recommends `apply_layer_filter` for "只看人口>1000的区域") — so the broken path was the recommended one.

### Changes

**`apply_layer_filter`** (frontend/lib/map-commands/layerCommands.ts)
- Dual-scheme matcher (`matchMapLayers`, same as `remove_layer`/`layer_visibility_update`): resolves both `custom-${id}…` and `${id}__*` sublayers, applies the parsed filter to **every** matched sublayer.
- **Store sync so reconcile keeps it**: the filter is persisted via `updateLayer(layer_id, { filter })` on a new optional `Layer.filter` field, and the MapSpec adapter (`mapspec-runtime/adapter.ts` `buildLayerFilter`) now ANDs `layer.filter` with the per-sublayer `$type` base — so the runtime reconcile re-emits it instead of rolling it back. `null`/empty clears.
- `filter` added to `PRESENTATION_FIELDS` in layersSlice so a filter change invalidates the mapspec attestation like any other presentation change.
- Post-state verification: `map.getFilter(id)` must reflect a requested filter, otherwise honest `store_updated` (store-scheme) / `mutation_failed` (custom) — never `confirmed`. Raster layers that reject filters are surfaced as failures instead of fake acks.

**Heatmap commands** (frontend/lib/map-commands/heatmapCommands.ts)
- All three now verify post-state (`map.getSource(id)` + `map.getLayer(id)`) before returning `{ confirmed: true }`; failures return `failed: mutation_failed`. Missing payload data already failed `invalid_params`.

**`reorder_layer`** (frontend/lib/map-commands/layerCommands.ts)
- Dual-scheme target resolution. Custom-`custom-` layers keep the legacy on-map move algorithm (unchanged behavior, FIX-B `targetGone` check retained).
- MapSpec layers are reordered **durably in the HUD store** (`reorderLayers`, index 0 = topmost): the MapSpecRuntime derives map z-order from the store array (`adapter → spec → reconcile → renderer.syncLayerZOrder`), so a direct `moveLayer` on runtime-owned sublayers would be reverted by the next reconcile. Ack is `{ store_updated: true }` (honest: the map z-order change is async, runtime-owned), with `confirmed` for verified custom moves.
- Position validation tightened up-front (`top/bottom/up/down/before`, `before` requires `before_id`) so malformed requests fail before mutating anything.

**Dispatcher** (frontend/components/map/map-action-handler.tsx)
- **Tradeoff decision (issue ask)**: after auditing the whole catalogue, every command now returns an explicit `MapCommandResult` on every code path (the four commands above were the last void-returning ones). We therefore flipped the void default: `void → failed:no_result` instead of `succeeded`.
  - *Why not keep `void → succeeded`?* It is exactly the root-cause hole — any future command that forgets to report would silently fake-ack again, and the FIX-B contract ("never a fabricated confirmed") is stronger at the dispatcher level.
  - *Why safe?* No currently-registered command can hit the void path (all return results/promises; verified by code audit + the new `no_result` regression test). If a future command intentionally wants fire-and-forget, it must explicitly return `{ status: 'succeeded' }`.
  - Conservative alternative considered and rejected: keeping `void → succeeded` with a comment — it preserves the hole for the next command that forgets.

### Tests
- `layerCommands.test.ts`: apply_layer_filter — `${id}__*` sublayer application + store write, legacy `custom-` scheme, string-filter parsing + null-clear, `target_not_found` on miss, no-fake-success when `getFilter` is empty (store_updated), custom `mutation_failed`; reorder_layer — MapSpec layer reorder via store (top), bottom/up/down/before semantics, store-only layers, missing `before_id`, custom-layer regression.
- `heatmapCommands.test.ts` (new): all three commands ack `confirmed` only when source+layer land, fail `mutation_failed` on a no-op mount, `invalid_params` on missing payload.
- `adapter.test.ts`: `layer.filter` survives reconcile — ANDed with `$type` base on every sublayer, combined with `activeFilters` ranges, `null` = cleared.
- `map-action-handler.test.tsx`: APPLY_LAYER_FILTER end-to-end (sublayer setFilter + store sync + succeeded ack), APPLY_LAYER_FILTER missing target → `target_not_found`, REORDER_LAYER on a MapSpec layer → store reordered + `store_updated` ack, and the dispatcher `void → failed:no_result` regression.
- `test/__mocks__/maplibre-map.ts`: mock now keeps `setFilter`/`getFilter` bookkeeping so verification runs against a real recording map.

### Verification
- `npm run typecheck` (both tsconfigs): clean.
- Targeted vitest (4 files, 108 tests): pass.
- Full `vitest run`: 122 files / 1340 tests pass (6 of 8 full runs fully green; 2 runs each had one unrelated @testing-library `waitFor` timeout flake in an untouched test file under parallel load — failing test not in the changed set, not reproducible in isolation; baseline master runs were green).
- ESLint on all changed files: clean.

### Backend
No backend changes needed: `layer_manager.py` already resolves refs to canonical store layer ids, which the frontend dual-scheme matchers now resolve correctly.
