### PR TITLE
fix(data-fabric): event-loop offload, truthful STAC, safe-where parser, real-session materialize (#425 #430 #431 #463)

### DIFF
--- a/app/api/routes/data_fabric.py
+++ b/app/api/routes/data_fabric.py
@@ -1,6 +1,7 @@
 """
 Enterprise Geospatial Data Fabric REST Routes
 """
+import asyncio
 import logging
 from typing import Dict, Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Header
@@ -170,6 +171,12 @@ async def create_data_source(
     GLOBAL source (org_id NULL, owner_id NULL) that then appeared in every
     anonymous user's list and was probe/sync-able by anyone. State-changing +
     outbound-request-triggering endpoints must not be unauthenticated.
+
+    Event-loop safety (#425, sibling of #386): the manager call drives a sync
+    remote probe AND an automatic full catalog sync (requests with 5-15s
+    timeouts). It runs in a worker thread via asyncio.to_thread — the injected
+    request-scoped Session is used only from that thread while awaited, the
+    same execution model FastAPI uses for plain ``def`` handlers.
     """
     try:
         # SSRF is always enforced at registration (ADR-0050 §5 P0). A previous
@@ -181,7 +188,8 @@ async def create_data_source(
         # unauthenticated requests — never persist it as an owner_id (no users
         # row with that id → FK violation on Postgres).
         user_id = _real_user_id(user)
-        source = data_fabric_manager.create_data_source(
+        source = await asyncio.to_thread(
+            data_fabric_manager.create_data_source,
             db=db,
             name=req.name,
             source_type=req.source_type,
@@ -295,6 +303,9 @@ async def probe_data_source(
     Requires authentication: probe triggers a server-side outbound HTTP request
     to the source endpoint — anonymous callers must not be able to initiate
     arbitrary outbound requests.
+
+    Event-loop safety (#425): the sync adapter probe (requests, 5s timeout)
+    runs in a worker thread; only the cheap DB read/commit stay on the loop.
     """
     s = db.query(DataSourceModel).filter(DataSourceModel.id == source_id).first()
     _require_tenant_owned(s, user)
@@ -308,7 +319,7 @@ async def probe_data_source(
         allow_private=s.connection_profile.get("allow_private", False),
     )
 
-    health_res = data_fabric_manager.probe_profile(profile)
+    health_res = await asyncio.to_thread(data_fabric_manager.probe_profile, profile)
     s.status = health_res.status
     db.commit()
 
@@ -325,11 +336,18 @@ async def sync_data_source_catalog(
 
     Requires authentication: sync triggers outbound requests against the source
     endpoint; anonymous callers must not initiate them.
+
+    Event-loop safety (#425): a full catalog sync blocks for its entire
+    duration (list_datasets at a 10s timeout plus a bounded describe pool
+    whose shutdown waits on the calling thread — minutes at thousands of
+    datasets). The whole manager call runs in a worker thread; the
+    request-scoped Session is used only from that thread while awaited (same
+    model FastAPI uses for plain ``def`` handlers).
     """
     s = db.query(DataSourceModel).filter(DataSourceModel.id == source_id).first()
     _require_tenant_owned(s, user)
     try:
-        items = data_fabric_manager.sync_catalog(db, source_id)
+        items = await asyncio.to_thread(data_fabric_manager.sync_catalog, db, source_id)
         return {
             "success": True,
             "synced_count": len(items),
@@ -480,11 +498,15 @@ async def preview_catalog_item(
 
     Requires authentication: preview triggers a server-side remote fetch against
     the source endpoint, so anonymous callers must not be able to initiate it.
+
+    Event-loop safety (#425): uses query_catalog_item_async so the blocking
+    adapter fetch runs off the loop (same pattern as materialize). Oversized
+    remote results surface as an actionable 413, not an unbounded payload.
     """
     try:
         _authorize_catalog_item(db, item_id, user)
         q_spec = QuerySpec(limit=limit)
-        q_res = data_fabric_manager.query_catalog_item(db, item_id, q_spec)
+        q_res = await data_fabric_manager.query_catalog_item_async(db, item_id, q_spec)
         return {
             "dataset_id": item_id,
             "features": q_res.features,
@@ -494,6 +516,9 @@ async def preview_catalog_item(
         }
     except HTTPException:
         raise
+    except ResultTooLargeError as e:
+        # Oversized remote result — actionable 413 with the shrink hint.
+        return JSONResponse(status_code=413, content={"success": False, **e.to_dict()})
     except Exception as e:
         logger.error(f"Catalog item preview failed for '{item_id}': {e}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))
@@ -510,13 +535,20 @@ async def query_catalog_item(
 
     Requires authentication: query runs a remote fetch against the source
     endpoint, so anonymous callers must not be able to initiate it.
+
+    Event-loop safety (#425): uses query_catalog_item_async so the blocking
+    adapter fetch runs off the loop (same pattern as materialize). Oversized
+    remote results surface as an actionable 413, not an unbounded payload.
     """
     try:
         _authorize_catalog_item(db, item_id, user)
-        q_res = data_fabric_manager.query_catalog_item(db, item_id, query_spec)
+        q_res = await data_fabric_manager.query_catalog_item_async(db, item_id, query_spec)
         return q_res.model_dump()
     except HTTPException:
         raise
+    except ResultTooLargeError as e:
+        # Oversized remote result — actionable 413 with the shrink hint.
+        return JSONResponse(status_code=413, content={"success": False, **e.to_dict()})
     except Exception as e:
         logger.error(f"Catalog item query failed for '{item_id}': {e}", exc_info=True)
         raise HTTPException(status_code=400, detail=str(e))

--- a/app/services/data_fabric/adapters/postgis_adapter.py
+++ b/app/services/data_fabric/adapters/postgis_adapter.py
@@ -28,6 +28,14 @@ MAX_QUERY_LIMIT = 10000
 # silently degrading to a no-op filter or splicing raw SQL.
 _SAFE_WHERE_OPS = ("LIKE", ">=", "<=", "!=", ">", "<", "=")
 _SAFE_WHERE_COLUMN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# #431: tokenize `identifier op value` from the left. The column prefix regex
+# (start-anchored, no $) grabs the identifier token, then the operator regex
+# (longest-first alternation so ">=" wins over ">") must immediately follow it.
+# Anchoring here — instead of scanning the whole expression with str.find — is
+# what keeps operator characters inside quoted VALUES (`name = 'a>b'`) from
+# capturing the operator scan.
+_SAFE_WHERE_COLUMN_PREFIX = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_SAFE_WHERE_OP_ANCHORED = re.compile(r"\s*(>=|<=|!=|>|<|=|LIKE)")
 
 
 def _parse_safe_where(expr: str) -> Tuple[str, List[Any]]:
@@ -42,29 +50,29 @@ def _parse_safe_where(expr: str) -> Tuple[str, List[Any]]:
         raise ValueError("Empty where expression")
 
     stripped = expr.strip()
-    # Find the operator by scanning left-to-right for the FIRST token that is
-    # an allowlisted operator. This avoids regex ambiguity with value content.
-    op_found = None
-    op_pos = None
-    for op in sorted(_SAFE_WHERE_OPS, key=len, reverse=True):
-        idx = stripped.find(op)
-        if idx > 0:
-            op_found = op
-            op_pos = idx
-            break
-    if op_found is None or op_pos is None:
+    # Tokenize from the LEFT: leading identifier, then the operator that must
+    # immediately follow it, then everything else is the value. The operator
+    # position is therefore determined by the COLUMN region only — a value
+    # containing `<`, `>`, `>=`, `<=` (e.g. `name = 'a>b'`) can no longer
+    # anchor the operator inside the quoted value and false-reject the filter
+    # (#431). Values are bound parameters, so this is purely a parse fix.
+    col_match = _SAFE_WHERE_COLUMN_PREFIX.match(stripped)
+    if col_match is None:
+        first_token = stripped.split()[0] if stripped.split() else stripped
+        raise ValueError(
+            f"Unsafe column name '{first_token}' in where expression: only [A-Za-z0-9_]+ allowed"
+        )
+    column = col_match.group(0)
+
+    op_match = _SAFE_WHERE_OP_ANCHORED.match(stripped[col_match.end():])
+    if op_match is None:
         raise ValueError(
             f"Unsupported where expression '{expr}': expected '<column> <op> <value>' "
             f"with op in {_SAFE_WHERE_OPS}"
         )
+    op_found = op_match.group(1)
+    value_raw = stripped[col_match.end() + op_match.end():].strip()
 
-    column = stripped[:op_pos].strip()
-    value_raw = stripped[op_pos + len(op_found):].strip()
-
-    if not _SAFE_WHERE_COLUMN.match(column):
-        raise ValueError(
-            f"Unsafe column name '{column}' in where expression: only [A-Za-z0-9_]+ allowed"
-        )
     if not value_raw:
         raise ValueError(f"Missing value in where expression '{expr}'")
 

--- a/app/services/data_fabric/adapters/stac_adapter.py
+++ b/app/services/data_fabric/adapters/stac_adapter.py
@@ -5,10 +5,10 @@ spatial/temporal pushdown filtering, and lazy streaming.
 """
 import time
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from urllib.parse import urljoin
 from app.services.data_fabric.base_adapter import GeospatialDataSourceAdapter
-from app.services.data_fabric.errors import classify_http_status
+from app.services.data_fabric.errors import SOURCE_UNREACHABLE, classify_http_status
 from app.services.data_fabric.security import DataFabricSecurity, make_safe_session
 from app.schemas.data_fabric_schema import (
     DatasetDescriptor,
@@ -160,7 +160,16 @@ class STACAdapter(GeospatialDataSourceAdapter):
         ]
 
     def list_datasets(self) -> List[Dict[str, Any]]:
-        """List available STAC collections."""
+        """List available STAC collections.
+
+        Truthfulness contract (#430): when a real endpoint is configured, any
+        discovery failure — unreachable, non-200, unparseable body, or a root
+        catalog without child links — returns an EMPTY list (mirroring the
+        ogc/wfs/arcgis adapters and this adapter's own query() path). The
+        synthetic fixtures are served ONLY on the explicit no-endpoint demo
+        path, and every entry is labeled ``source="synthetic-demo"`` so no
+        caller can mistake demo data for the remote's real datasets.
+        """
         if not self.endpoint:
             return self._list_synthetic_collections()
 
@@ -201,12 +210,19 @@ class STACAdapter(GeospatialDataSourceAdapter):
                         for cid in child_ids
                     ]
 
-            return self._list_synthetic_collections()
+            # Real endpoint configured but discovery yielded nothing
+            # truthful — empty list, NO synthetic fallback (#430).
+            logger.warning(
+                f"STAC list_datasets for '{self.endpoint}' returned no collections; "
+                f"registering an empty catalog"
+            )
+            return []
         except Exception as e:
-            logger.warning(f"STAC list_datasets fallback due to error: {e}")
-            return self._list_synthetic_collections()
+            logger.warning(f"STAC list_datasets failed for '{self.endpoint}': {e}")
+            return []
 
     def _list_synthetic_collections(self) -> List[Dict[str, Any]]:
+        """Explicit no-endpoint DEMO mode — labeled as such on every entry."""
         return [
             {
                 "id": coll_id,
@@ -214,13 +230,23 @@ class STACAdapter(GeospatialDataSourceAdapter):
                 "description": fixture["description"],
                 "license": fixture["license"],
                 "source_type": "stac",
+                # Explicit label so callers never mistake demo data for
+                # remote data (same contract as query()'s demo path).
+                "source": "synthetic-demo",
             }
             for coll_id, fixture in SYNTHETIC_STAC_FIXTURES.items()
         ]
 
     def describe(self, dataset_id: str) -> DatasetDescriptor:
-        """Fetch STAC collection descriptor metadata."""
-        if not self.endpoint or dataset_id in SYNTHETIC_STAC_FIXTURES:
+        """Fetch STAC collection descriptor metadata.
+
+        Truthfulness contract (#430): the synthetic fixtures are used ONLY in
+        explicit no-endpoint demo mode (and then labeled in metadata). With a
+        real endpoint configured, a failed descriptor fetch returns an honest
+        stub carrying a typed error and NO fabricated feature count — never
+        fixture metadata presented as the remote's data.
+        """
+        if not self.endpoint:
             fixture = SYNTHETIC_STAC_FIXTURES.get(dataset_id, SYNTHETIC_STAC_FIXTURES["landsat-8-c2-l2"])
             spatial_bbox = fixture["extent"]["spatial"]["bbox"][0]
             return DatasetDescriptor(
@@ -237,9 +263,13 @@ class STACAdapter(GeospatialDataSourceAdapter):
                     "extent": fixture["extent"],
                     "license": fixture["license"],
                     "item_count": fixture.get("item_count"),
+                    # Explicit label: this is demo data, not remote data.
+                    "source": "synthetic-demo",
                 },
             )
 
+        error_type: Optional[str] = None
+        error_message: Optional[str] = None
         try:
             safe_url = DataFabricSecurity.validate_url(self.endpoint, allow_private=self.allow_private)
             import requests
@@ -251,6 +281,11 @@ class STACAdapter(GeospatialDataSourceAdapter):
                 bbox = c.get("extent", {}).get("spatial", {}).get("bbox", [[-180.0, -90.0, 180.0, 90.0]])[0]
                 summaries = c.get("summaries", {})
                 fields = [{"name": k, "type": "property"} for k in summaries.keys()]
+                # Feature count: only what the source actually reports
+                # (`item_count`, used by several STAC implementations).
+                # Never fabricate a count the endpoint did not provide.
+                raw_count = c.get("item_count")
+                feature_count = int(raw_count) if isinstance(raw_count, (int, float)) else None
                 return DatasetDescriptor(
                     id=dataset_id,
                     title=c.get("title", dataset_id),
@@ -259,26 +294,29 @@ class STACAdapter(GeospatialDataSourceAdapter):
                     geometry_type="Polygon",
                     srs="EPSG:4326",
                     bbox=bbox,
-                    feature_count=10000,
+                    feature_count=feature_count,
                     fields=fields,
                     metadata={"extent": c.get("extent"), "license": c.get("license")},
                 )
+            error_type = classify_http_status(resp.status_code)
+            error_message = f"STAC collection fetch returned HTTP {resp.status_code}"
+            logger.warning(f"STAC describe for '{dataset_id}' failed: {error_message}")
         except Exception as e:
+            error_type = SOURCE_UNREACHABLE
+            error_message = f"STAC collection fetch failed: {e}"
             logger.warning(f"STAC describe error for '{dataset_id}': {e}")
 
-        # Fallback
-        fixture = SYNTHETIC_STAC_FIXTURES.get("landsat-8-c2-l2")
+        # Honest failure stub: no fixture fallback, no fabricated counts
+        # (#430). The typed error lets callers distinguish an unreachable
+        # source from an empty one.
         return DatasetDescriptor(
             id=dataset_id,
-            title=f"STAC Collection {dataset_id}",
-            description="STAC collection descriptor",
+            title=dataset_id,
+            description=f"STAC Collection {dataset_id} (descriptor unavailable)",
             source_type="stac",
-            geometry_type="Polygon",
-            srs="EPSG:4326",
-            bbox=fixture["extent"]["spatial"]["bbox"][0],
-            feature_count=100,
+            feature_count=None,
             fields=[],
-            metadata={},
+            metadata={"error_type": error_type, "error": error_message},
         )
 
     def preview(self, dataset_id: str, limit: int = 10) -> Dict[str, Any]:

--- a/app/services/data_fabric/manager.py
+++ b/app/services/data_fabric/manager.py
@@ -295,7 +295,13 @@ class DataFabricManager:
         )
 
         adapter = cls.get_adapter(conn_profile)
-        return adapter.query(item.name, query_spec)
+        result = adapter.query(item.name, query_spec)
+        # Resource guard (Section 22 / #425): only materialize enforced bounds
+        # before — the preview/query REST paths returned unbounded payloads
+        # (up to 10k features of arbitrary geometry, no byte cap). The guard
+        # does not trust the remote `limit` parameter (servers may ignore it).
+        enforce_result_bounds(result.features)
+        return result
 
     @classmethod
     async def query_catalog_item_async(
@@ -348,6 +354,11 @@ class DataFabricManager:
         result = await asyncio.to_thread(adapter.query, item.name, query_spec)
         if cancel_token is not None:
             cancel_token.raise_if_cancelled()
+        # Same resource guard as the sync path (#425): the preview/query REST
+        # routes ride this method after the offload fix, so their responses
+        # must respect the hard feature/byte bounds too. materialize() keeps
+        # its own (idempotent) enforcement before storing the ref.
+        enforce_result_bounds(result.features)
         return result
 
     @classmethod

--- a/frontend/components/layout/context-panel.tsx
+++ b/frontend/components/layout/context-panel.tsx
@@ -354,7 +354,10 @@ export function ContextPanel({
         {activeTab === 'project' && <ProjectTab />}
         {activeTab === 'layers' && <PanelErrorBoundary label="图层"><LayersTab /></PanelErrorBoundary>}
         {activeTab === 'analysis' && <AnalysisTab onSend={onSend} />}
-        {activeTab === 'data_sources' && <DataSourcesTab />}
+        {/* #463: sessionId/ownerToken are threaded into the Data Sources tab so
+            实例化至图层 materializes into the REAL conversation session instead of
+            the phantom 'default_session' (and the layer's ref is fetchable). */}
+        {activeTab === 'data_sources' && <DataSourcesTab sessionId={sessionId} ownerToken={ownerToken} />}
         {(activeTab === 'export_layout' || activeTab === 'exports') && <MapStudioTab />}
         {activeTab === 'tasks' && (
           <PanelErrorBoundary label="任务">

--- a/frontend/components/sidebar/data-sources-tab.test.tsx
+++ b/frontend/components/sidebar/data-sources-tab.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@/components/ui/toast', () => ({
   useToastStore: (selector: (s: typeof toastStore) => any) => selector(toastStore),
 }));
 
-const hudStore = { addLayer: vi.fn(), theme: 'dark' };
+const hudStore = { addLayer: vi.fn(), updateLayer: vi.fn(), theme: 'dark' };
 vi.mock('@/lib/store/useHudStore', () => ({
   useHudStore: (selector: (s: typeof hudStore) => any) => selector(hudStore),
 }));
@@ -38,6 +38,7 @@ vi.mock('@/lib/api/data-fabric', () => ({
     getCatalogItemDescriptor: vi.fn(),
     previewCatalogItem: vi.fn(),
     materializeCatalogItem: vi.fn(),
+    fetchRefGeoJSON: vi.fn(),
   },
 }));
 
@@ -172,5 +173,127 @@ describe('DataSourcesTab — catalog search debounce (A-F-08)', () => {
 
     expect(dataFabricApi.listDataSources).toHaveBeenCalledTimes(1);
     expect(listSpatialCatalog()).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #463 — materialize ("加载至地图") must target the REAL session and produce a
+// fetchable, renderable ref-backed layer (previously: a phantom
+// window.__WEBGIS_SESSION_ID__ global with zero writers sent
+// session_id='default_session' — 401 for anonymous users, false success +
+// invisible layer for authed ones).
+// ---------------------------------------------------------------------------
+
+import { ApiError } from '@/lib/api/transport';
+
+const materialize = () => vi.mocked(dataFabricApi.materializeCatalogItem);
+const fetchRef = () => vi.mocked(dataFabricApi.fetchRefGeoJSON);
+
+const GEOJSON = {
+  type: 'FeatureCollection' as const,
+  features: [
+    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
+    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
+  ],
+};
+
+async function renderWithCatalogItem(props?: { sessionId?: string | null; ownerToken?: string | null }) {
+  listSpatialCatalog().mockResolvedValue({
+    total: 1, limit: 50, offset: 0, items: [makeCatalogItem('cat1', '学校分布')],
+  });
+  render(<DataSourcesTab sessionId={props?.sessionId} ownerToken={props?.ownerToken} />);
+  const button = await screen.findByRole('button', { name: /加载至地图/ });
+  return button;
+}
+
+describe('DataSourcesTab — materialize session + layer wiring (#463)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(dataFabricApi.listDataSources).mockResolvedValue({ sources: [] });
+    listSpatialCatalog().mockResolvedValue(emptyCatalog());
+    materialize().mockResolvedValue({
+      success: true,
+      ref_id: 'ref:df-abc123',
+      feature_count: 2,
+      total_count: 2,
+      dataset_id: 'cat1',
+      source_id: 's1',
+      title: '学校分布',
+    });
+    fetchRef().mockResolvedValue(GEOJSON);
+  });
+
+  it('threads the real sessionId/ownerToken from props into the materialize request', async () => {
+    const button = await renderWithCatalogItem({ sessionId: 'sess-real-42', ownerToken: 'tok-7' });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(materialize()).toHaveBeenCalledTimes(1);
+    expect(materialize()).toHaveBeenCalledWith({
+      session_id: 'sess-real-42',
+      catalog_item_id: 'cat1',
+      ownerToken: 'tok-7',
+    });
+    // Never the phantom fallback id.
+    expect(materialize().mock.calls[0][0]?.session_id).not.toBe('default_session');
+  });
+
+  it('adds a fetchable ref-backed layer (source present, not skipped by the mapspec adapter) and hydrates it', async () => {
+    const button = await renderWithCatalogItem({ sessionId: 'sess-real-42' });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(hudStore.addLayer).toHaveBeenCalledTimes(1);
+    const layer = hudStore.addLayer.mock.calls[0][0];
+    expect(layer.id).toBe('df-cat1');
+    expect(layer._refId).toBe('ref:df-abc123');
+    // A placeholder FeatureCollection source keeps the layer renderable — the
+    // mapspec adapter skips sourceless layers outright (#463).
+    expect(layer.source).toBeDefined();
+    expect(layer.source.type).toBe('FeatureCollection');
+    expect(layer.source.metadata?.ref_id).toBe('ref:df-abc123');
+
+    // Fetch-on-demand hydrates the layer with the stored ref payload.
+    expect(fetchRef()).toHaveBeenCalledWith('ref:df-abc123', 'sess-real-42', expect.anything());
+    expect(hudStore.updateLayer).toHaveBeenCalledWith('df-cat1', { source: GEOJSON });
+  });
+
+  it('keeps the layer but warns when the ref payload fetch fails (no false silence)', async () => {
+    fetchRef().mockRejectedValue(new Error('boom'));
+    const button = await renderWithCatalogItem({ sessionId: 'sess-real-42' });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(hudStore.addLayer).toHaveBeenCalledTimes(1);
+    const toastCalls = toastStore.addToast.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(toastCalls.some((t: string) => t.includes('加载失败'))).toBe(true);
+  });
+
+  it('shows a clear login-required error on 401 instead of a raw status toast', async () => {
+    materialize().mockRejectedValue(new ApiError(401, 'Unauthorized', { detail: 'Not authenticated' }, 'req-1', 'DataFabric API error'));
+    const button = await renderWithCatalogItem({ sessionId: 'sess-real-42' });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(hudStore.addLayer).not.toHaveBeenCalled();
+    const messages = toastStore.addToast.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(messages.some((m: string) => m.includes('登录'))).toBe(true);
+    expect(messages.some((m: string) => m.includes('401'))).toBe(false);
+  });
+
+  it('blocks materialize with actionable guidance when no session exists', async () => {
+    const button = await renderWithCatalogItem({ sessionId: null });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(materialize()).not.toHaveBeenCalled();
+    expect(hudStore.addLayer).not.toHaveBeenCalled();
+    const messages = toastStore.addToast.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(messages.some((m: string) => m.includes('会话'))).toBe(true);
   });
 });

--- a/frontend/components/sidebar/data-sources-tab.tsx
+++ b/frontend/components/sidebar/data-sources-tab.tsx
@@ -4,6 +4,8 @@ import { useCallback, useRef, useState } from 'react';
 import { Database, Inbox, Layers, SearchX } from 'lucide-react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import { useToastStore } from '@/components/ui/toast';
+import { isApiError } from '@/lib/api/transport';
+import type { GeoJSONFeatureCollection } from '@/lib/types';
 import { dataFabricApi, type CatalogItem, type DatasetDescriptor, type QueryResult } from '@/lib/api/data-fabric';
 import { LoadingState } from '@/components/shared/loading-state';
 import { EmptyState } from '@/components/shared/empty-state';
@@ -24,7 +26,20 @@ export { CATALOG_SEARCH_DEBOUNCE_MS } from './data-sources/use-spatial-catalog';
 /** 子页签顺序即渲染顺序（V4 tablist 键盘导航用）。 */
 const SUBTABS: Array<'catalog' | 'sources'> = ['catalog', 'sources'];
 
-export function DataSourcesTab() {
+export interface DataSourcesTabProps {
+  /**
+   * #463: the REAL conversation session id (threaded from ContextPanel).
+   * Materialization writes session-store refs scoped to this id — the old
+   * `window.__WEBGIS_SESSION_ID__` global had zero writers repo-wide, so every
+   * request silently targeted a phantom 'default_session' (401 anonymous,
+   * invisible layer + cross-session ref pollution when authed).
+   */
+  sessionId?: string | null;
+  /** Anonymous-session ownership token riding X-Session-Token (SEC-08). */
+  ownerToken?: string | null;
+}
+
+export function DataSourcesTab({ sessionId, ownerToken }: DataSourcesTabProps) {
   const [activeSubTab, setActiveSubTab] = useState<'catalog' | 'sources'>('catalog');
   const [showAddForm, setShowAddForm] = useState(false);
 
@@ -56,6 +71,7 @@ export function DataSourcesTab() {
 
   const addToast = useToastStore((s) => s.addToast);
   const addLayer = useHudStore((s) => s.addLayer);
+  const updateLayer = useHudStore((s) => s.updateLayer);
 
   const { sources, loadingSources, refreshSources } = useDataSources();
   const {
@@ -129,29 +145,70 @@ export function DataSourcesTab() {
   };
 
   const handleMaterializeAndLoad = async (item: CatalogItem) => {
+    // #463: materialize writes into the CURRENT conversation's session store.
+    // Without a live session there is nothing to write into (and no way to
+    // fetch the ref back) — fail with actionable guidance instead of posting
+    // to a phantom 'default_session'.
+    if (!sessionId) {
+      addToast('暂无活动会话：请先在对话中发送一条消息创建会话，再实例化至图层', 'error');
+      return;
+    }
     setMaterializingId(item.id);
     try {
-      const activeSessionId = (window as unknown as { __WEBGIS_SESSION_ID__?: string }).__WEBGIS_SESSION_ID__ || 'default_session';
       const res = await dataFabricApi.materializeCatalogItem({
-        session_id: activeSessionId,
+        session_id: sessionId,
         catalog_item_id: item.id,
+        ownerToken,
       });
 
-      // Add to frontend HUD layers
+      // Add to frontend HUD layers as a REF-BACKED layer (same shape as the
+      // workspace-session restore path): the mapspec adapter skips sourceless
+      // layers outright, so carry a placeholder FeatureCollection holding the
+      // ref cursor in metadata, then hydrate on demand below. The materialized
+      // payload is always a GeoJSON FeatureCollection (see the backend
+      // materialize route), hence type 'vector' regardless of feature_type.
+      const layerId = `df-${item.id}`;
+      const placeholder: GeoJSONFeatureCollection = {
+        type: 'FeatureCollection',
+        features: [],
+        metadata: { ref_id: res.ref_id },
+      };
       addLayer({
-        id: `df-${item.id}`,
+        id: layerId,
         name: item.title || item.name,
-        type: item.feature_type === 'raster' ? 'raster' : 'vector',
+        type: 'vector',
         visible: true,
         opacity: 1,
         group: 'reference',
+        source: placeholder,
         _refId: res.ref_id,
         style: { color: '#16a34a' },
       });
 
       addToast(`成功按需实例化 ${res.feature_count} 个要素至图层`, 'success');
+
+      // Fetch-on-demand (#463): hydrate the layer with the stored payload so
+      // it actually renders. The ref lives in the real session, so the fetch
+      // carries the same session id / owner token as the materialize call.
+      try {
+        const geojson = await dataFabricApi.fetchRefGeoJSON(res.ref_id, sessionId, { ownerToken });
+        if (geojson && (geojson.type === 'FeatureCollection' || Array.isArray(geojson.features))) {
+          updateLayer(layerId, { source: geojson });
+        }
+      } catch {
+        // The layer exists and the ref was stored — only the immediate
+        // hydration failed (transient or ownership issue). Say so instead of
+        // faking success or silently leaving an invisible layer.
+        addToast('图层已创建，但引用数据加载失败，请稍后重试或刷新会话', 'warning');
+      }
     } catch (err) {
-      addToast(err instanceof Error ? err.message : '实例化失败', 'error');
+      if (isApiError(err) && err.status === 401) {
+        // The materialize route requires authentication — surface a clear
+        // login-required message instead of a raw 401 toast.
+        addToast('实例化需要登录：请先在 设置 → 账户 中登录后再试', 'error');
+      } else {
+        addToast(err instanceof Error ? err.message : '实例化失败', 'error');
+      }
     } finally {
       setMaterializingId(null);
     }

--- a/frontend/lib/api/data-fabric.ts
+++ b/frontend/lib/api/data-fabric.ts
@@ -13,6 +13,7 @@
 
 import { apiFetch } from './transport';
 import { fastGet, invalidateCache } from './get-fast-path';
+import type { GeoJSONFeatureCollection } from '../types';
 
 const DF_CREDENTIALS: RequestCredentials = 'include';
 const DF_LABEL = 'DataFabric API error';
@@ -286,5 +287,27 @@ export const dataFabricApi = {
       timeoutMs: 60_000,
       label: DF_LABEL,
     });
+  },
+
+  /**
+   * Fetch-on-demand for a materialized ref (#463): hydrate a `df-*` layer with
+   * the FeatureCollection stored in the session store under `refId`. Same
+   * endpoint/ownership model as the workspace-session layer-restore path
+   * (`use-workspace-session.ts`): session-scoped, owner-token protected.
+   */
+  async fetchRefGeoJSON(
+    refId: string,
+    sessionId: string,
+    opts?: { ownerToken?: string | null; signal?: AbortSignal }
+  ): Promise<GeoJSONFeatureCollection> {
+    return apiFetch<GeoJSONFeatureCollection>(
+      `/api/v1/layers/data/${encodeURIComponent(refId)}?session_id=${encodeURIComponent(sessionId)}`,
+      {
+        credentials: DF_CREDENTIALS,
+        ownerToken: opts?.ownerToken,
+        signal: opts?.signal,
+        label: DF_LABEL,
+      }
+    );
   },
 };

--- a/tests/test_event_loop_offload_425.py
+++ b/tests/test_event_loop_offload_425.py
@@ -1,0 +1,390 @@
+"""Regression tests for #425: Data Fabric routes must not run blocking sync
+remote I/O on the event loop (sibling of the #386 offload sweep).
+
+The five routes (create/probe/sync/preview/query) call sync manager methods
+that drive ``requests.Session`` adapters with 5-15s timeouts (and, for sync,
+a full catalog sync whose ThreadPoolExecutor shutdown waits on the calling
+thread). A slow or hung remote source therefore froze the single uvicorn event
+loop for the full timeout — every concurrent SSE chat stream stalled in
+lockstep. Only ``materialize`` was async-safe.
+
+Each test fakes the slow work with a sync ``time.sleep`` that records the
+thread id it ran on, and asserts the main event loop stays responsive WHILE
+the work is running — with the work on the loop, the fake's sleep blocks
+everything and the ticker assertion fails deterministically (same technique as
+tests/test_event_loop_offload_386.py).
+
+A second defect on the same path is covered here: the sync
+``query_catalog_item`` (preview/query routes) never enforced
+``enforce_result_bounds`` — only materialize did — so preview/query responses
+were unbounded.
+
+Run cost: ~1s per offload test (0.8s fake sleep), no network.
+"""
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.schemas.data_fabric_schema import DataFabricHealth, QueryResult
+
+_main_thread = threading.get_ident()
+
+
+async def _assert_loop_responsive_while(awaitable_factory, delay: float = 0.8):
+    """Run awaitable_factory() and assert a 0.05s timer fires mid-flight.
+
+    Deterministic: with the work offloaded the task is still running when the
+    timer completes; with the work on the loop the task finishes before the
+    test's own sleep resumes, so ``assert not task.done()`` fails.
+    """
+    task = asyncio.create_task(awaitable_factory())
+    await asyncio.sleep(0.15)          # let it enter the slow work
+    assert not task.done(), "work finished before the test could observe it"
+
+    ticks = []
+
+    async def _tick():
+        await asyncio.sleep(0.05)
+        ticks.append(True)
+
+    tick = asyncio.create_task(_tick())
+    await asyncio.sleep(0.15)
+    assert tick.done() and ticks, "event loop was blocked during the work"
+    assert not task.done(), "event loop was blocked during the work"
+    return await task
+
+
+# ─── shared fakes ────────────────────────────────────────────────────────────
+
+
+def _fake_source_row():
+    s = MagicMock()
+    s.id = "ds_test"
+    s.name = "Test Source"
+    s.source_type = "ogc_api"
+    s.endpoint_url = "https://example.com/ogc"
+    s.connection_profile = {"options": {}, "allow_private": False}
+    s.org_id = None
+    s.owner_id = "u1"
+    s.status = "unknown"
+    s.capabilities_json = []
+    return s
+
+
+def _fake_db_for_source():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = _fake_source_row()
+    return db
+
+
+def _fake_db_for_catalog_item():
+    """db whose query() yields a catalog item then its (tenant-owned) source."""
+    from app.models.data_fabric import CatalogItemModel
+
+    item = MagicMock()
+    item.id = "cat_ds_test_layer"
+    item.source_id = "ds_test"
+    item.name = "layer"
+    src = _fake_source_row()
+    item.data_source = src
+
+    db = MagicMock()
+
+    def _q(model):
+        m = MagicMock()
+        m.filter.return_value.first.return_value = item if model is CatalogItemModel else src
+        return m
+
+    db.query.side_effect = _q
+    return db
+
+
+_USER = {"user_id": "u1", "org_id": None}
+
+
+def _tiny_query_result(n_features=1):
+    return QueryResult(
+        dataset_id="cat_ds_test_layer",
+        features=[
+            {"type": "Feature", "geometry": None, "properties": {}} for _ in range(n_features)
+        ],
+        total_count=n_features,
+    )
+
+
+# ─── Site 1: create_data_source (probe + capabilities + full catalog sync) ──
+
+
+@pytest.mark.asyncio
+async def test_create_data_source_off_loop(monkeypatch):
+    """create_data_source drives a remote probe AND an auto catalog sync —
+    the whole manager call must run in a worker thread."""
+    from app.api.routes import data_fabric as route_mod
+    from app.services.data_fabric.manager import DataFabricManager
+
+    observed = {}
+
+    def _slow_create(**kwargs):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return _fake_source_row()
+
+    monkeypatch.setattr(DataFabricManager, "create_data_source", staticmethod(_slow_create))
+
+    req = route_mod.CreateDataSourceRequest(
+        name="Test OGC API Source",
+        source_type="ogc_api",
+        endpoint_url="https://example.com/ogc",
+        options={},
+    )
+    res = await _assert_loop_responsive_while(
+        lambda: route_mod.create_data_source(req, db=_fake_db_for_source(), user=dict(_USER))
+    )
+    assert observed["thread"] != _main_thread, "create_data_source ran on the event loop thread"
+    assert res["success"] is True
+    assert res["data_source"]["id"] == "ds_test"
+
+
+# ─── Site 2: probe_data_source (sync requests probe, 5s timeout) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_probe_data_source_off_loop(monkeypatch):
+    from app.api.routes import data_fabric as route_mod
+    from app.services.data_fabric.manager import DataFabricManager
+
+    observed = {}
+
+    def _slow_probe(profile):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return DataFabricHealth(status="healthy", message="OK", latency_ms=10.0)
+
+    monkeypatch.setattr(DataFabricManager, "probe_profile", staticmethod(_slow_probe))
+
+    res = await _assert_loop_responsive_while(
+        lambda: route_mod.probe_data_source("ds_test", db=_fake_db_for_source(), user=dict(_USER))
+    )
+    assert observed["thread"] != _main_thread, "probe ran on the event loop thread"
+    assert res["status"] == "healthy"
+
+
+# ─── Site 3: sync_data_source_catalog (full catalog sync) ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_data_source_catalog_off_loop(monkeypatch):
+    """sync_catalog blocks for the entire catalog sync (list_datasets 10s
+    timeout + describe pool shutdown(wait=True)) — must run off-loop."""
+    from app.api.routes import data_fabric as route_mod
+    from app.services.data_fabric.manager import DataFabricManager
+
+    observed = {}
+
+    def _slow_sync(db, source_id):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return []
+
+    monkeypatch.setattr(DataFabricManager, "sync_catalog", staticmethod(_slow_sync))
+
+    res = await _assert_loop_responsive_while(
+        lambda: route_mod.sync_data_source_catalog("ds_test", db=_fake_db_for_source(), user=dict(_USER))
+    )
+    assert observed["thread"] != _main_thread, "catalog sync ran on the event loop thread"
+    assert res["synced_count"] == 0
+
+
+# ─── Sites 4+5: preview / query (sync adapter.query with 10-30s timeouts) ────
+
+
+def _patch_query_paths(monkeypatch, observed):
+    """Patch BOTH query paths: the slow work itself (sync) and the async
+    wrapper that must offload it. Pre-fix routes call the sync method on the
+    loop (RED); post-fix routes await the async wrapper (GREEN)."""
+    from app.services.data_fabric.manager import DataFabricManager
+
+    def _slow_query(db, item_id, spec):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return _tiny_query_result(2)
+
+    async def _async_query(cls, db, item_id, spec, cancel_token=None):
+        return await asyncio.to_thread(_slow_query, db, item_id, spec)
+
+    monkeypatch.setattr(DataFabricManager, "query_catalog_item", staticmethod(_slow_query))
+    monkeypatch.setattr(
+        DataFabricManager, "query_catalog_item_async", classmethod(_async_query)
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_catalog_item_off_loop(monkeypatch):
+    from app.api.routes import data_fabric as route_mod
+
+    observed = {}
+    _patch_query_paths(monkeypatch, observed)
+
+    res = await _assert_loop_responsive_while(
+        lambda: route_mod.preview_catalog_item(
+            "cat_ds_test_layer", limit=10, db=_fake_db_for_catalog_item(), user=dict(_USER)
+        )
+    )
+    assert observed["thread"] != _main_thread, "preview query ran on the event loop thread"
+    assert len(res["features"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_query_catalog_item_route_off_loop(monkeypatch):
+    from app.api.routes import data_fabric as route_mod
+    from app.schemas.data_fabric_schema import QuerySpec
+
+    observed = {}
+    _patch_query_paths(monkeypatch, observed)
+
+    res = await _assert_loop_responsive_while(
+        lambda: route_mod.query_catalog_item(
+            "cat_ds_test_layer",
+            QuerySpec(limit=10),
+            db=_fake_db_for_catalog_item(),
+            user=dict(_USER),
+        )
+    )
+    assert observed["thread"] != _main_thread, "pushdown query ran on the event loop thread"
+    assert res["total_count"] == 2
+
+
+# ─── Secondary defect: result bounds on the preview/query path ───────────────
+
+
+def _patched_adapter_query(n_features):
+    from app.services.data_fabric.manager import DataFabricManager
+
+    class _FakeAdapter:
+        def query(self, name, spec):
+            return _tiny_query_result(n_features)
+
+        def health(self):
+            return DataFabricHealth(status="healthy", message="ok")
+
+    return staticmethod(lambda profile: _FakeAdapter()), DataFabricManager
+
+
+def test_query_catalog_item_enforces_result_bounds(monkeypatch):
+    """The sync query path (preview/query routes) must enforce
+    enforce_result_bounds — only materialize did before (#425)."""
+    from app.services.data_fabric.errors import ResultTooLargeError
+    from app.services.data_fabric.limits import max_features
+    from app.services.data_fabric.manager import DataFabricManager
+    from app.schemas.data_fabric_schema import QuerySpec
+
+    get_adapter, _ = _patched_adapter_query(max_features() + 1)
+    monkeypatch.setattr(DataFabricManager, "get_adapter", get_adapter)
+
+    with pytest.raises(ResultTooLargeError):
+        DataFabricManager.query_catalog_item(_fake_db_for_catalog_item(), "cat_ds_test_layer", QuerySpec(limit=10))
+
+
+def test_query_catalog_item_allows_bounded_results(monkeypatch):
+    from app.services.data_fabric.manager import DataFabricManager
+    from app.schemas.data_fabric_schema import QuerySpec
+
+    get_adapter, _ = _patched_adapter_query(3)
+    monkeypatch.setattr(DataFabricManager, "get_adapter", get_adapter)
+
+    res = DataFabricManager.query_catalog_item(
+        _fake_db_for_catalog_item(), "cat_ds_test_layer", QuerySpec(limit=10)
+    )
+    assert len(res.features) == 3
+
+
+def test_query_catalog_item_empty_result_passes(monkeypatch):
+    """Adversarial: an empty (failed/empty remote) result must pass through —
+    bounds guard rejects oversized payloads, never invents data."""
+    from app.services.data_fabric.manager import DataFabricManager
+    from app.schemas.data_fabric_schema import QuerySpec
+
+    get_adapter, _ = _patched_adapter_query(0)
+    monkeypatch.setattr(DataFabricManager, "get_adapter", get_adapter)
+
+    res = DataFabricManager.query_catalog_item(
+        _fake_db_for_catalog_item(), "cat_ds_test_layer", QuerySpec(limit=10)
+    )
+    assert res.features == []
+
+
+@pytest.mark.asyncio
+async def test_query_catalog_item_async_enforces_result_bounds(monkeypatch):
+    """The async path (used by the preview/query routes after the offload
+    fix, and by materialize) must enforce bounds too."""
+    from app.services.data_fabric.errors import ResultTooLargeError
+    from app.services.data_fabric.limits import max_features
+    from app.services.data_fabric.manager import DataFabricManager
+    from app.schemas.data_fabric_schema import QuerySpec
+
+    get_adapter, _ = _patched_adapter_query(max_features() + 1)
+    monkeypatch.setattr(DataFabricManager, "get_adapter", get_adapter)
+
+    with pytest.raises(ResultTooLargeError):
+        await DataFabricManager.query_catalog_item_async(
+            _fake_db_for_catalog_item(), "cat_ds_test_layer", QuerySpec(limit=10)
+        )
+
+
+@pytest.mark.asyncio
+async def test_preview_route_maps_result_too_large_to_413(monkeypatch):
+    """Adversarial: an oversized remote result on the preview path surfaces as
+    an actionable 413 (same contract as materialize), not a raw 400."""
+    from fastapi.responses import JSONResponse
+
+    from app.api.routes import data_fabric as route_mod
+    from app.services.data_fabric.errors import ResultTooLargeError
+    from app.services.data_fabric.manager import DataFabricManager
+
+    async def _raise_async(cls, db, item_id, spec, cancel_token=None):
+        raise ResultTooLargeError("query returned 999999 features (limit 1000)")
+
+    def _inert_sync(db, item_id, spec):
+        return _tiny_query_result(0)
+
+    monkeypatch.setattr(
+        DataFabricManager, "query_catalog_item_async", classmethod(_raise_async)
+    )
+    monkeypatch.setattr(DataFabricManager, "query_catalog_item", staticmethod(_inert_sync))
+    res = await route_mod.preview_catalog_item(
+        "cat_ds_test_layer", limit=10, db=_fake_db_for_catalog_item(), user=dict(_USER)
+    )
+    assert isinstance(res, JSONResponse)
+    assert res.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_query_route_maps_result_too_large_to_413(monkeypatch):
+    from fastapi.responses import JSONResponse
+
+    from app.api.routes import data_fabric as route_mod
+    from app.schemas.data_fabric_schema import QuerySpec
+    from app.services.data_fabric.errors import ResultTooLargeError
+    from app.services.data_fabric.manager import DataFabricManager
+
+    async def _raise_async(cls, db, item_id, spec, cancel_token=None):
+        raise ResultTooLargeError("query result ~99999999 bytes exceeds limit")
+
+    def _inert_sync(db, item_id, spec):
+        return _tiny_query_result(0)
+
+    monkeypatch.setattr(
+        DataFabricManager, "query_catalog_item_async", classmethod(_raise_async)
+    )
+    monkeypatch.setattr(DataFabricManager, "query_catalog_item", staticmethod(_inert_sync))
+    res = await route_mod.query_catalog_item(
+        "cat_ds_test_layer",
+        QuerySpec(limit=10),
+        db=_fake_db_for_catalog_item(),
+        user=dict(_USER),
+    )
+    assert isinstance(res, JSONResponse)
+    assert res.status_code == 413

--- a/tests/unit/test_data_fabric_postgis_where_431.py
+++ b/tests/unit/test_data_fabric_postgis_where_431.py
@@ -1,0 +1,110 @@
+"""Regression tests for #431: PostGIS _parse_safe_where must anchor operator
+detection to the COLUMN region, not scan the whole expression.
+
+Root cause: the operator was located via ``stripped.find(op)`` over the entire
+expression, so a quoted *value* containing ``>``, ``<``, ``>=`` or ``<=``
+(e.g. ``name = 'a>b'``) anchored the operator inside the value, the column
+slice failed the identifier regex, and the parser raised ``ValueError:
+Unsafe column name`` — valid filters were false-rejected. Values are bound
+parameters, so operator characters inside values carry zero injection risk.
+
+These tests are RED on the pre-fix parser and GREEN after the fix.
+"""
+import pytest
+
+from app.services.data_fabric.adapters.postgis_adapter import _parse_safe_where
+
+
+# ---------------------------------------------------------------------------
+# Valid filters whose VALUES contain operator characters (the #431 bug)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "expr, expected_sql, expected_param",
+    [
+        ("name = 'a>b'", '"name" = %s', "a>b"),
+        ("name = 'a<b'", '"name" = %s', "a<b"),
+        ("name = 'a>=b'", '"name" = %s', "a>=b"),
+        ("name = 'a<=b'", '"name" = %s', "a<=b"),
+        ("name = 'a!=b'", '"name" = %s', "a!=b"),
+        ("name = 'a=b'", '"name" = %s', "a=b"),
+        ("status = 'active<2'", '"status" = %s', "active<2"),
+        ("status = 'active>2'", '"status" = %s', "active>2"),
+        ("code >= 'x<y'", '"code" >= %s', "x<y"),
+        ("label != 'v>w'", '"label" != %s', "v>w"),
+        ("label <= 'v>=w'", '"label" <= %s', "v>=w"),
+        ("note LIKE '%a>b%'", '"note" LIKE %s', "%a>b%"),
+        ("note LIKE '%a>=b%'", '"note" LIKE %s', "%a>=b%"),
+        ("sym = '>'", '"sym" = %s', ">"),
+        ("sym = '<='", '"sym" = %s', "<="),
+        ('name = "a>b"', '"name" = %s', "a>b"),  # double-quoted value
+        ("name = '->arrow'", '"name" = %s', "->arrow"),  # operator char at value start
+    ],
+)
+def test_quoted_value_with_operator_chars_parses(expr, expected_sql, expected_param):
+    """A quoted value may legitimately contain every operator character."""
+    sql, params = _parse_safe_where(expr)
+    assert sql == expected_sql
+    assert params == [expected_param]
+
+
+def test_operator_in_value_does_not_confuse_real_operator():
+    """`pop > 100` and `name = 'a>b'` must both work — operator position is
+    determined by the column region, never by value content."""
+    assert _parse_safe_where("pop > 100") == ('"pop" > %s', [100])
+    assert _parse_safe_where("name = 'a>b'") == ('"name" = %s', ["a>b"])
+
+
+def test_no_space_forms_with_operator_chars_in_value():
+    """Tight forms (no whitespace around the operator) with operator chars in
+    the quoted value must still parse."""
+    sql, params = _parse_safe_where("name='a>b'")
+    assert sql == '"name" = %s'
+    assert params == ["a>b"]
+    sql2, params2 = _parse_safe_where("pop>100")
+    assert sql2 == '"pop" > %s'
+    assert params2 == [100]
+
+
+def test_long_column_name_not_eaten_by_operator_scan():
+    """A column like ``popularity`` must not be truncated by a ``<`` scan
+    hitting the value first (regression guard for the new parser)."""
+    sql, params = _parse_safe_where("popularity < 'x<y'")
+    assert sql == '"popularity" < %s'
+    assert params == ["x<y"]
+
+
+# ---------------------------------------------------------------------------
+# Genuinely unsafe inputs must stay rejected (no security regression)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "1=1",                      # injection attempt
+        "type = 'x' OR 1=1",        # conjunction inside value
+        "name; DROP TABLE users",   # statement injection
+        "type=(SELECT 1)",          # unquoted subquery
+        "x = (SELECT 1)",
+        "col == 5",                 # invalid operator
+        "",
+        "   ",
+        "= 5",                      # missing column
+        "col >",                    # missing value
+        "co l > 5",                 # space in identifier
+        "x = 1 UNION SELECT 2",     # unquoted union
+        "x = DROP",                 # unquoted keyword
+        "name = 'a' AND 1=1",       # quoted value + conjunction
+        "x' OR '1'='1",             # quote-break attempt
+    ],
+)
+def test_unsafe_expressions_still_rejected(expr):
+    with pytest.raises(ValueError):
+        _parse_safe_where(expr)
+
+
+def test_operator_chars_do_not_bypass_value_literal_checks():
+    """Operator chars in a value must not open a bypass for SQL structure:
+    an unquoted value containing a conjunction is still rejected."""
+    with pytest.raises(ValueError):
+        _parse_safe_where("name = a>b OR 1=1")

--- a/tests/unit/test_data_fabric_stac_truthfulness_430.py
+++ b/tests/unit/test_data_fabric_stac_truthfulness_430.py
@@ -1,0 +1,224 @@
+"""Regression tests for #430: the STAC adapter must fail truthfully.
+
+Contract (mirrors the adapter's own query() path and the ogc/wfs/arcgis
+adapters): when a real endpoint is configured and it fails (unreachable,
+non-200, empty catalog, missing child links, or any exception), discovery
+returns an EMPTY dataset list and describe returns an honest stub carrying a
+typed error — synthetic "landsat-8-c2-l2"/"cop-dem-30m" fixtures must never be
+registered as if they were the remote source's real datasets, and feature
+counts must never be fabricated. The synthetic fixtures survive ONLY on the
+explicit no-endpoint demo path, clearly labeled as such.
+
+These tests are RED on the pre-fix adapter and GREEN after the fix.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from app.schemas.data_fabric_schema import ConnectionProfile, DatasetDescriptor
+from app.services.data_fabric.adapters.stac_adapter import (
+    STACAdapter,
+    SYNTHETIC_STAC_FIXTURES,
+)
+from app.services.data_fabric.manager import DataFabricManager
+from app.services.data_fabric.metadata_cache import _describe_cache
+
+_ENDPOINT = "https://stac.example.com/v1"
+
+SYNTHETIC_IDS = set(SYNTHETIC_STAC_FIXTURES.keys())
+
+
+@pytest.fixture(autouse=True)
+def _clear_describe_cache():
+    _describe_cache.invalidate()
+    yield
+    _describe_cache.invalidate()
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else {}
+
+    def json(self):
+        return self._json
+
+
+def _adapter(endpoint: str = _ENDPOINT) -> STACAdapter:
+    return STACAdapter(ConnectionProfile(
+        source_type="stac",
+        endpoint_url=endpoint,
+        name="test_stac",
+    ))
+
+
+# ---------------------------------------------------------------------------
+# list_datasets: configured endpoint failure → [] (never synthetic ids)
+# ---------------------------------------------------------------------------
+
+def test_list_datasets_unreachable_returns_empty(monkeypatch):
+    def _conn_error(url, **kwargs):
+        raise requests.exceptions.ConnectionError("no route to host")
+
+    monkeypatch.setattr(requests, "get", _conn_error)
+    datasets = _adapter().list_datasets()
+    assert datasets == []
+    assert not SYNTHETIC_IDS & {d.get("id") for d in datasets}
+
+
+def test_list_datasets_server_error_returns_empty(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _FakeResp(status_code=503))
+    datasets = _adapter().list_datasets()
+    assert datasets == []
+
+
+def test_list_datasets_non_json_200_returns_empty(monkeypatch):
+    def _bad_json(url, **kwargs):
+        resp = _FakeResp(status_code=200)
+        resp.json = lambda: (_ for _ in ()).throw(ValueError("not json"))
+        return resp
+
+    monkeypatch.setattr(requests, "get", _bad_json)
+    assert _adapter().list_datasets() == []
+
+
+def test_list_datasets_empty_catalog_without_child_links_returns_empty(monkeypatch):
+    """/collections 200-but-empty and a root catalog with NO child links → []
+    (the old code fell back to synthetic fixtures here)."""
+    def _router(url, **kwargs):
+        if url.rstrip("/").endswith("/collections"):
+            return _FakeResp(200, {"collections": []})
+        return _FakeResp(200, {"links": [{"rel": "self", "href": "https://stac.example.com/v1"}]})
+
+    monkeypatch.setattr(requests, "get", _router)
+    datasets = _adapter().list_datasets()
+    assert datasets == []
+    assert not SYNTHETIC_IDS & {d.get("id") for d in datasets}
+
+
+def test_list_datasets_success_path_untouched(monkeypatch):
+    """/collections 200 with real collections still returns them."""
+    def _router(url, **kwargs):
+        assert url.rstrip("/").endswith("/collections"), "success path must not probe the root catalog"
+        return _FakeResp(200, {"collections": [
+            {"id": "sentinel-2-l2a", "title": "Sentinel-2 L2A", "description": "d", "license": "proprietary"},
+        ]})
+
+    monkeypatch.setattr(requests, "get", _router)
+    datasets = _adapter().list_datasets()
+    assert [d["id"] for d in datasets] == ["sentinel-2-l2a"]
+    assert not SYNTHETIC_IDS & {d.get("id") for d in datasets}
+
+
+def test_list_datasets_no_endpoint_demo_mode_labeled_synthetic():
+    """Explicit no-endpoint demo path keeps the fixtures AND labels them so no
+    caller can mistake demo data for remote data."""
+    datasets = _adapter(endpoint="").list_datasets()
+    ids = {d["id"] for d in datasets}
+    assert ids == SYNTHETIC_IDS
+    for entry in datasets:
+        assert entry.get("source") == "synthetic-demo"
+
+
+# ---------------------------------------------------------------------------
+# describe: no fixture fallback, no fabricated feature counts
+# ---------------------------------------------------------------------------
+
+def test_describe_endpoint_failure_returns_honest_stub(monkeypatch):
+    def _conn_error(url, **kwargs):
+        raise requests.exceptions.ConnectionError("no route to host")
+
+    monkeypatch.setattr(requests, "get", _conn_error)
+    desc = _adapter().describe("some-real-collection")
+    assert isinstance(desc, DatasetDescriptor)
+    assert desc.id == "some-real-collection"
+    # Never a fabricated count and never the fixture payload.
+    assert desc.feature_count is None
+    assert desc.title != SYNTHETIC_STAC_FIXTURES["landsat-8-c2-l2"]["title"]
+    assert desc.metadata.get("error")
+
+
+def test_describe_endpoint_error_status_is_typed(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _FakeResp(status_code=503))
+    desc = _adapter().describe("some-real-collection")
+    assert desc.feature_count is None
+    assert desc.metadata.get("error_type") == "SOURCE_BAD_RESPONSE"
+
+
+def test_describe_synthetic_id_with_configured_endpoint_is_not_fixture(monkeypatch):
+    """A REAL collection whose id collides with a synthetic fixture id must be
+    served from the endpoint, never from the built-in fixture."""
+    def _router(url, **kwargs):
+        return _FakeResp(200, {
+            "id": "landsat-8-c2-l2",
+            "title": "Real Landsat",
+            "description": "from the real endpoint",
+            "license": "PDDL",
+        })
+
+    monkeypatch.setattr(requests, "get", _router)
+    desc = _adapter().describe("landsat-8-c2-l2")
+    assert desc.title == "Real Landsat"
+    assert desc.feature_count is None  # not the fabricated 10000
+
+
+def test_describe_success_does_not_fabricate_feature_count(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _FakeResp(200, {
+        "id": "sentinel-2-l2a", "title": "Sentinel-2 L2A",
+    }))
+    desc = _adapter().describe("sentinel-2-l2a")
+    assert desc.title == "Sentinel-2 L2A"
+    assert desc.feature_count is None
+
+
+def test_describe_reports_item_count_when_source_provides_it(monkeypatch):
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _FakeResp(200, {
+        "id": "sentinel-2-l2a", "title": "Sentinel-2 L2A", "item_count": 4321,
+    }))
+    desc = _adapter().describe("sentinel-2-l2a")
+    assert desc.feature_count == 4321
+
+
+def test_describe_no_endpoint_demo_mode_labeled(monkeypatch):
+    desc = _adapter(endpoint="").describe("landsat-8-c2-l2")
+    assert desc.metadata.get("source") == "synthetic-demo"
+    # Demo fixtures may carry their fixture counts, but ONLY on this labeled path.
+    assert desc.feature_count == SYNTHETIC_STAC_FIXTURES["landsat-8-c2-l2"]["item_count"]
+
+
+# ---------------------------------------------------------------------------
+# sync_catalog level: failing endpoint registers ZERO catalog items
+# ---------------------------------------------------------------------------
+
+def _mock_db(ds_model):
+    db = MagicMock()
+    ds_q = MagicMock()
+    ds_q.filter.return_value.first.return_value = ds_model
+    cat_q = MagicMock()
+    cat_q.filter.return_value.all.return_value = []
+    db.query.side_effect = [ds_q, cat_q]
+    return db
+
+
+def test_sync_catalog_with_failing_stac_endpoint_registers_nothing(monkeypatch):
+    def _conn_error(url, **kwargs):
+        raise requests.exceptions.ConnectionError("no route to host")
+
+    monkeypatch.setattr(requests, "get", _conn_error)
+    ds = MagicMock()
+    ds.id = "src_stac"
+    ds.name = "stac"
+    ds.source_type = "stac"
+    ds.endpoint_url = _ENDPOINT
+    ds.connection_profile = {"options": {}, "allow_private": False}
+    db = _mock_db(ds)
+    monkeypatch.setattr(
+        DataFabricManager, "get_adapter", staticmethod(lambda profile: _adapter())
+    )
+
+    items = DataFabricManager.sync_catalog(db, "src_stac")
+
+    # Zero datasets registered; the trailing commit is an empty transaction.
+    assert items == []
+    db.add.assert_not_called()


### PR DESCRIPTION
## Issues
- Fixes #425 (P1 perf: data-fabric routes run blocking sync remote HTTP + full catalog syncs on the event loop; preview/query unbounded)
- Fixes #430 (P3: STAC adapter fabricates synthetic catalog entries/feature counts on endpoint failure)
- Fixes #431 (P3: PostGIS `_parse_safe_where` false-rejects valid filters whose values contain >, <, >=, <=)
- Fixes #463 (P2 UI: 实例化至图层 targets phantom `default_session`; layer never renders)

## Root causes
1. **#425** The #386 offload sweep (d8c0ab1) never converted the data-fabric route family: `create/probe/sync/preview/query` called sync manager methods (sync `requests` sessions, 5–15 s timeouts, full catalog sync) inline in `async def` handlers; sync `query_catalog_item` also skipped `enforce_result_bounds`.
2. **#430** `STACAdapter.list_datasets` fell back to built-in synthetic collections on every configured-endpoint failure; `describe` fabricated `feature_count=10000/100`.
3. **#431** Operator located via whole-string `find(op)` — anchors inside quoted values → false "Unsafe column name" rejects.
4. **#463** `window.__WEBGIS_SESSION_ID__` had zero writers (always `default_session`); materialized layer had no `source` → skipped by the mapspec adapter, never fetchable.

## Implementation
- preview/query → `query_catalog_item_async` (off-loop adapter fetch, same pattern as materialize); probe offloads `probe_profile`; create/sync offload the whole manager call via `asyncio.to_thread` (request-scoped Session used only from that worker thread while awaited — the FastAPI `def`-handler model).
- `enforce_result_bounds` now enforced on both sync and async query paths; `ResultTooLargeError` → actionable 413.
- STAC: endpoint failure → `[]` + typed warning (mirrors ogc/wfs/arcgis); describe failure → honest stub with `classify_http_status`; counts only from source-provided `item_count`; synthetic mode kept ONLY for the explicit no-endpoint demo path, labeled `source="synthetic-demo"`.
- PostGIS parser: start-anchored identifier token + immediately-following longest-first operator regex; value is the bound remainder. All SEC-06 unsafe rejections preserved.
- UI: ContextPanel threads real `sessionId`/`ownerToken` into DataSourcesTab; materialize hits the real session (401 → login-required toast, no session → actionable guidance); layer added with placeholder FeatureCollection + `metadata.ref_id` + `_refId`, hydrated via new `fetchRefGeoJSON` (`/layers/data/{refId}`) with explicit warning on hydration failure.

## Regression tests
- `tests/test_event_loop_offload_425.py` — 386-style event-loop-lag harness (11 tests)
- `tests/unit/test_data_fabric_stac_truthfulness_430.py` (13)
- `tests/unit/test_data_fabric_postgis_where_431.py` (36; all 28 pre-existing SEC-06 tests still pass)
- `frontend/components/sidebar/data-sources-tab.test.tsx` extended (8 tests)

## Risk
Low-medium: route behavior unchanged for healthy sources; new 413 only for genuinely oversized payloads; STAC demo mode callers must rely on the explicit no-endpoint path only.

## Validation
- Full fabric suite 153 passed; targeted suites 82 passed; `ruff check app tests` clean.
- Frontend: vitest 1359 passed (only the documented pre-existing `chat-tab.render-scope` baseline failure); `tsc --noEmit` clean.