### PR TITLE
perf(report): offload WeasyPrint/Jinja2 rendering and sync DB off the event loop (#426)

### DIFF
--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -2,6 +2,7 @@
 报告生成服务 - 从会话历史生成 PDF/HTML/Markdown 报告
 使用 Jinja2 模板渲染 HTML，WeasyPrint 转换为 PDF
 """
+import asyncio
 import html as html_mod
 import json
 import os
@@ -225,7 +226,32 @@ class ReportService:
 
         Returns:
             生成是否成功
+
+        计算隔离不变式 1（#426，沿用 #386/d8c0ab1 卸载模式）：渲染体是
+        纯同步的 CPU/IO 密集操作——Jinja2 全量历史模板、MapSpec→SVG 编译、
+        同步文件写与 WeasyPrint ``write_pdf()`` 均在 worker 线程执行，
+        避免阻塞事件循环上所有并发 SSE 流。异常原样向调用方传播，
+        saga（create_and_generate / 工具路径）负责落 failed 终态。
         """
+        return await asyncio.to_thread(
+            self._generate_report_sync,
+            session_id=session_id,
+            session_title=session_title,
+            messages=messages,
+            output_path=output_path,
+            format=format,
+            mapspec=mapspec,
+        )
+
+    def _generate_report_sync(
+        self,
+        session_id: str,
+        session_title: str,
+        messages: list[dict[str, Any]],
+        output_path: str,
+        format: str = "pdf",
+        mapspec: Optional[dict[str, Any]] = None,
+    ) -> bool:
         try:
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
 

--- a/app/tools/report.py
+++ b/app/tools/report.py
@@ -6,10 +6,11 @@
 Agent 作为思维主体，应当主动编排和输出报告。此工具将报告生成
 纳入 Agent 的工具链，使其成为 Agent "思维外化"的一部分。
 """
+import asyncio
 import logging
 import uuid
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from app.tools.registry import ToolRegistry
 from app.services.report_service import spatial_report_engine, REPORT_DIR
@@ -19,6 +20,85 @@ from app.models.db_model import Conversation, Message
 from app.models.report import Report
 
 logger = logging.getLogger(__name__)
+
+
+def _prepare_report_record(session_id: str, format: str, title: Optional[str]) -> dict[str, Any]:
+    """Phase 1: 读取会话消息并落 'generating' 状态的 Report 行。
+
+    #426 计算隔离不变式 1：db_session() 是阻塞的同步 SQLAlchemy Session，
+    必须经 asyncio.to_thread 在 worker 线程执行，禁止在事件循环上直接调用。
+    Session 在本函数内创建、使用并关闭，绝不跨线程共享。
+    """
+    with db_session() as db:
+        conversation = db.get(Conversation, session_id)
+        if not conversation:
+            return {"error": f"会话 {session_id} 不存在"}
+
+        messages = (
+            db.query(Message)
+            .filter(Message.conversation_id == session_id)
+            .order_by(Message.created_at.asc())
+            .all()
+        )
+        if not messages:
+            return {"error": "会话中暂无消息，无法生成报告"}
+
+        report_id = str(uuid.uuid4())
+        report_title = title or conversation.title or "空间分析报告"
+        ext = "md" if format in ("markdown", "md") else format
+        file_name = f"{report_id}.{ext}"
+        file_path = os.path.join(REPORT_DIR, file_name)
+
+        report = Report(
+            id=report_id,
+            session_id=session_id,
+            title=report_title,
+            format=format,
+            status="generating",
+            file_path=file_path,
+        )
+        db.add(report)
+        db.commit()
+
+        msg_dicts = [
+            {
+                "role": m.role,
+                "content": m.content or "",
+                "tool_calls": m.tool_calls,
+                "tool_result": m.tool_result,
+            }
+            for m in messages
+        ]
+
+        return {
+            "report_id": report_id,
+            "report_title": report_title,
+            "file_path": file_path,
+            "msg_dicts": msg_dicts,
+        }
+
+
+def _finalize_report_record(report_id: str, success: bool, file_path: str) -> Optional[int]:
+    """Phase 3: 写终态 status（completed/failed）。成功时返回文件大小。
+
+    与 _prepare_report_record 同理：同步 SQLAlchemy 写必须在 worker 线程
+    执行（#426），Session 线程内闭合。
+    """
+    with db_session() as db:
+        report = db.get(Report, report_id)
+        if success and os.path.exists(file_path):
+            file_size = os.path.getsize(file_path)
+            if report:
+                report.status = "completed"
+                report.file_size = file_size
+                db.commit()
+            return file_size
+        else:
+            if report:
+                report.status = "failed"
+                report.error_message = "生成过程未产出文件"
+                db.commit()
+            return None
 
 
 def register_report_tools(registry: ToolRegistry):
@@ -59,78 +139,38 @@ def register_report_tools(registry: ToolRegistry):
         if not session_id:
             return {"error": "无法确定当前会话 ID，请在对话中重试。"}
 
-        with db_session() as db:
-            conversation = db.get(Conversation, session_id)
-            if not conversation:
-                return {"error": f"会话 {session_id} 不存在"}
+        # #426 计算隔离：同步 SQLAlchemy 读写（db_session）经 to_thread
+        # 下沉到 worker 线程；渲染由 spatial_report_engine.generate_report
+        # 内部同样卸载（见 report_service.py）。
+        prep = await asyncio.to_thread(_prepare_report_record, session_id, format, title)
+        if "error" in prep:
+            return {"error": prep["error"]}
 
-            messages = (
-                db.query(Message)
-                .filter(Message.conversation_id == session_id)
-                .order_by(Message.created_at.asc())
-                .all()
-            )
-            if not messages:
-                return {"error": "会话中暂无消息，无法生成报告"}
-
-            report_id = str(uuid.uuid4())
-            report_title = title or conversation.title or "空间分析报告"
-            ext = "md" if format in ("markdown", "md") else format
-            file_name = f"{report_id}.{ext}"
-            file_path = os.path.join(REPORT_DIR, file_name)
-
-            report = Report(
-                id=report_id,
-                session_id=session_id,
-                title=report_title,
-                format=format,
-                status="generating",
-                file_path=file_path,
-            )
-            db.add(report)
-            db.commit()
-
-            msg_dicts = [
-                {
-                    "role": m.role,
-                    "content": m.content or "",
-                    "tool_calls": m.tool_calls,
-                    "tool_result": m.tool_result,
-                }
-                for m in messages
-            ]
+        report_id = prep["report_id"]
+        report_title = prep["report_title"]
+        file_path = prep["file_path"]
 
         mapspec = await mapspec_store.get_mapspec(session_id)
         success = await spatial_report_engine.generate_report(
             session_id=session_id,
             session_title=report_title,
-            messages=msg_dicts,
+            messages=prep["msg_dicts"],
             output_path=file_path,
             format=format,
             mapspec=mapspec,
         )
 
-        with db_session() as db:
-            report = db.get(Report, report_id)
-            if success and os.path.exists(file_path):
-                file_size = os.path.getsize(file_path)
-                if report:
-                    report.status = "completed"
-                    report.file_size = file_size
-                    db.commit()
-
-                return {
-                    "type": "report_generated",
-                    "report_id": report_id,
-                    "title": report_title,
-                    "format": format,
-                    "file_size_kb": round(file_size / 1024, 1),
-                    "download_url": f"/api/v1/reports/{report_id}/download",
-                    "message": f"报告「{report_title}」已生成完毕（{format.upper()} 格式，{round(file_size / 1024, 1)} KB）。",
-                }
-            else:
-                if report:
-                    report.status = "failed"
-                    report.error_message = "生成过程未产出文件"
-                    db.commit()
-                return {"error": "报告生成过程失败，未能生成文件。"}
+        file_size = await asyncio.to_thread(
+            _finalize_report_record, report_id, bool(success), file_path
+        )
+        if file_size is not None:
+            return {
+                "type": "report_generated",
+                "report_id": report_id,
+                "title": report_title,
+                "format": format,
+                "file_size_kb": round(file_size / 1024, 1),
+                "download_url": f"/api/v1/reports/{report_id}/download",
+                "message": f"报告「{report_title}」已生成完毕（{format.upper()} 格式，{round(file_size / 1024, 1)} KB）。",
+            }
+        return {"error": "报告生成过程失败，未能生成文件。"}

--- a/tests/test_report_event_loop_offload_426.py
+++ b/tests/test_report_event_loop_offload_426.py
@@ -1,0 +1,416 @@
+"""Regression tests for #426: report generation must not block the event loop.
+
+Sibling of the #386 sweep (d8c0ab1 / tests/test_event_loop_offload_386.py),
+which never touched the report path:
+
+  1. ``ReportService.generate_report`` is an ``async def`` whose body is fully
+     synchronous — Jinja2 templating of the full session history, MapSpec→SVG
+     compilation, sync file writes and ``weasyprint.HTML(...).write_pdf()``
+     all execute inline on the loop, from ``POST /api/v1/reports``.
+  2. The ``generate_analysis_report`` agent tool (async def → ASYNC policy →
+     awaited on the loop) opens a sync ``db_session()`` (blocking SQLAlchemy)
+     before/after rendering.
+
+Each test fakes the slow work with a sync ``time.sleep`` that records the
+thread id it ran on, and asserts the main event loop stays responsive
+*while* the work is running — with the work on the loop, the fake's sleep
+blocks everything and the ticker assertion fails deterministically (same
+technique as tests/test_event_loop_offload_386.py).
+
+Run cost: ~1s per lag test (0.8s fake sleep), no network, no heavy deps.
+"""
+import asyncio
+import os
+import threading
+import time
+from contextlib import asynccontextmanager, contextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.core.database as core_db_mod
+from app.models.api_response import ErrCode
+from app.models.db_model import Conversation
+from app.models.report import Report
+from app.services import report_service as report_service_mod
+from app.services.report_service import ReportService
+
+_main_thread = threading.get_ident()
+
+
+async def _assert_loop_responsive_while(awaitable_factory, delay: float = 0.8):
+    """Run awaitable_factory() and assert a 0.05s timer fires mid-flight.
+
+    Deterministic: with the work offloaded the task is still running when the
+    timer completes; with the work on the loop the task finishes before the
+    test's own sleep resumes, so ``assert not task.done()`` fails.
+    """
+    task = asyncio.create_task(awaitable_factory())
+    await asyncio.sleep(0.15)          # let it enter the slow work
+    assert not task.done(), "work finished before the test could observe it"
+
+    ticks = []
+    async def _tick():
+        await asyncio.sleep(0.05)
+        ticks.append(True)
+
+    tick = asyncio.create_task(_tick())
+    await asyncio.sleep(0.15)
+    assert tick.done() and ticks, "event loop was blocked during the work"
+    assert not task.done(), "event loop was blocked during the work"
+    return await task
+
+
+# ─── Fakes ───────────────────────────────────────────────────────────────────
+
+
+def _msg(role: str = "user", content: str = "hello") -> MagicMock:
+    m = MagicMock()
+    m.role = role
+    m.content = content
+    m.tool_calls = None
+    m.tool_result = None
+    return m
+
+
+def _make_async_db(conversation, messages, created: dict) -> AsyncMock:
+    """AsyncSession double for the saga's phase-1 reads + 'generating' insert."""
+    db = AsyncMock()
+
+    async def _get(model, pk):
+        if model is Conversation:
+            return conversation
+        return None
+
+    db.get = AsyncMock(side_effect=_get)
+
+    exec_result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = messages
+    exec_result.scalars.return_value = scalars
+    db.execute = AsyncMock(return_value=exec_result)
+
+    db.add = MagicMock(side_effect=lambda row: created.__setitem__("report", row))
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.expunge = MagicMock()
+    return db
+
+
+def _make_session_factory(created: dict):
+    """AsyncSessionLocal double: phase-2 terminal-status update session."""
+
+    @asynccontextmanager
+    async def factory():
+        db2 = AsyncMock()
+
+        async def _get2(model, pk):
+            return created.get("report")
+
+        db2.get = AsyncMock(side_effect=_get2)
+        db2.commit = AsyncMock()
+        yield db2
+
+    return factory
+
+
+def _fake_weasyprint(observed: dict, delay: float = 0.8, error: Exception | None = None):
+    """WeasyPrint double: write_pdf stalls `delay` then writes a stub PDF."""
+
+    class _SlowHTML:
+        def __init__(self, string=None, **kwargs):
+            pass
+
+        def write_pdf(self, output_path):
+            observed["thread"] = threading.get_ident()
+            time.sleep(delay)
+            if error is not None:
+                raise error
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            with open(output_path, "wb") as f:
+                f.write(b"%PDF-1.4 fake-report")
+
+    mod = MagicMock()
+    mod.HTML = _SlowHTML
+    return mod
+
+
+# ─── Site 1: ReportService.generate_report (sync render body in async def) ──
+
+
+@pytest.mark.asyncio
+async def test_service_pdf_render_off_loop(monkeypatch, tmp_path):
+    """WeasyPrint write_pdf (multi-second on long sessions) must run in a
+    worker thread; the saga must still complete with status 'completed'."""
+    observed = {}
+    monkeypatch.setattr(report_service_mod, "weasyprint", _fake_weasyprint(observed))
+    monkeypatch.setattr(report_service_mod, "REPORT_DIR", str(tmp_path))
+
+    created: dict = {}
+    db = _make_async_db(
+        Conversation(id="sess-1", title="测试会话"),
+        [_msg(), _msg("assistant", "分析完成")],
+        created,
+    )
+
+    svc = ReportService()
+    res = await _assert_loop_responsive_while(
+        lambda: svc.create_and_generate(
+            db, "sess-1", format="pdf", session_factory=_make_session_factory(created)
+        )
+    )
+    assert observed["thread"] != _main_thread, "WeasyPrint render ran on the event loop thread"
+    assert res.success, res.message
+    assert created["report"].status == "completed"
+    assert created["report"].file_size > 0
+
+
+@pytest.mark.asyncio
+async def test_route_post_reports_render_off_loop(monkeypatch, tmp_path):
+    """POST /api/v1/reports must not stall the loop for the whole render."""
+    from app.api.routes import report as route_mod
+
+    observed = {}
+    monkeypatch.setattr(route_mod, "verify_session_owner", AsyncMock())
+    monkeypatch.setattr(
+        route_mod, "mapspec_store", MagicMock(get_mapspec=AsyncMock(return_value=None))
+    )
+    monkeypatch.setattr(report_service_mod, "weasyprint", _fake_weasyprint(observed))
+    monkeypatch.setattr(report_service_mod, "REPORT_DIR", str(tmp_path))
+
+    created: dict = {}
+    monkeypatch.setattr(
+        core_db_mod, "AsyncSessionLocal", _make_session_factory(created)
+    )
+    db = _make_async_db(Conversation(id="sess-1", title="测试会话"), [_msg()], created)
+
+    req = route_mod.GenerateReportRequest(session_id="sess-1", format="pdf")
+    resp = await _assert_loop_responsive_while(
+        lambda: route_mod.create_report(req, db=db, _user={"user_id": "u1"})
+    )
+    assert observed["thread"] != _main_thread, "WeasyPrint render ran on the event loop thread"
+    assert resp.success
+    assert resp.data["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_large_report_markdown_render_off_loop(monkeypatch, tmp_path):
+    """Full-history Jinja2/markdown render of a long session must be offloaded."""
+    svc = ReportService()
+    observed = {}
+
+    real_render = ReportService._render_markdown
+
+    def slow_render(self, data):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)  # simulated multi-second render of the full history
+        return real_render(self, data)
+
+    monkeypatch.setattr(ReportService, "_render_markdown", slow_render)
+
+    messages = [
+        {"role": "user" if i % 2 else "assistant", "content": f"消息 {i} " * 40}
+        for i in range(2000)
+    ]
+    out = tmp_path / "large.md"
+    ok = await _assert_loop_responsive_while(
+        lambda: svc.generate_report(
+            session_id="s-large",
+            session_title="长会话",
+            messages=messages,
+            output_path=str(out),
+            format="markdown",
+        )
+    )
+    assert ok
+    assert observed["thread"] != _main_thread, "markdown render ran on the event loop thread"
+    assert out.stat().st_size > 10_000
+
+
+# ─── Site 2: generate_analysis_report tool (sync db_session on the loop) ─────
+
+
+@pytest.mark.asyncio
+async def test_tool_sync_db_off_loop(monkeypatch, tmp_path):
+    """Both db_session() blocks (fetch+insert, terminal status) must run in a
+    worker thread; the render must go through the offloaded service path."""
+    from app.tools import report as tool_mod
+    from app.tools.registry import ToolRegistry
+    from app.tools.report import register_report_tools
+
+    reg = ToolRegistry()
+    register_report_tools(reg)
+    tool_fn = reg._tools["generate_analysis_report"]
+
+    observed_threads: list[int] = []
+    report_rows: dict[str, Report] = {}
+    conversation = Conversation(id="sess-tool", title="工具会话")
+
+    class _FakeSyncDB:
+        def get(self, model, pk):
+            if model is Conversation:
+                return conversation
+            if model is Report:
+                return report_rows.get(pk)
+            return None
+
+        def query(self, model):
+            q = MagicMock()
+            q.filter.return_value.order_by.return_value.all.return_value = [
+                _msg(),
+                _msg("assistant", "done"),
+            ]
+            return q
+
+        def add(self, row):
+            report_rows[row.id] = row
+
+        def commit(self):
+            pass
+
+    @contextmanager
+    def fake_db_session():
+        observed_threads.append(threading.get_ident())
+        time.sleep(0.8)  # blocking SQLAlchemy on a long session
+        yield _FakeSyncDB()
+
+    monkeypatch.setattr(tool_mod, "db_session", fake_db_session)
+    monkeypatch.setattr(tool_mod, "REPORT_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        tool_mod, "mapspec_store", MagicMock(get_mapspec=AsyncMock(return_value=None))
+    )
+
+    async def fake_render(**kwargs):
+        os.makedirs(os.path.dirname(kwargs["output_path"]), exist_ok=True)
+        with open(kwargs["output_path"], "w", encoding="utf-8") as f:
+            f.write("# fake report\n")
+        return True
+
+    monkeypatch.setattr(tool_mod.spatial_report_engine, "generate_report", fake_render)
+
+    result = await _assert_loop_responsive_while(
+        lambda: tool_fn(format="markdown", _session_id="sess-tool")
+    )
+    assert observed_threads and all(
+        t != _main_thread for t in observed_threads
+    ), "sync db_session ran on the event loop thread"
+    assert len(observed_threads) == 2, "both db_session blocks must be offloaded"
+    assert result.get("type") == "report_generated"
+    assert result["report_id"] in report_rows
+    assert report_rows[result["report_id"]].status == "completed"
+
+
+# ─── Adversarial: failure semantics + concurrency ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_render_failure_marks_failed_not_500(monkeypatch, tmp_path):
+    """A WeasyPrint crash must end the saga as status='failed' (ApiResponse
+    failure), never an unhandled 500 — including after the thread offload."""
+    from app.api.routes import report as route_mod
+
+    observed = {}
+    monkeypatch.setattr(route_mod, "verify_session_owner", AsyncMock())
+    monkeypatch.setattr(
+        route_mod, "mapspec_store", MagicMock(get_mapspec=AsyncMock(return_value=None))
+    )
+    monkeypatch.setattr(
+        report_service_mod,
+        "weasyprint",
+        _fake_weasyprint(observed, error=RuntimeError("weasyprint exploded")),
+    )
+    monkeypatch.setattr(report_service_mod, "REPORT_DIR", str(tmp_path))
+
+    created: dict = {}
+    monkeypatch.setattr(
+        core_db_mod, "AsyncSessionLocal", _make_session_factory(created)
+    )
+    db = _make_async_db(Conversation(id="sess-2", title="t"), [_msg()], created)
+
+    req = route_mod.GenerateReportRequest(session_id="sess-2", format="pdf")
+    resp = await route_mod.create_report(req, db=db, _user={"user_id": "u1"})
+
+    assert resp.success is False
+    assert resp.code == ErrCode.SERVER_ERROR
+    assert created["report"].status == "failed"
+    assert created["report"].error_message
+
+
+@pytest.mark.asyncio
+async def test_tool_render_failure_marks_failed(monkeypatch, tmp_path):
+    """Tool path: render returning False must set status='failed' + error dict."""
+    from app.tools import report as tool_mod
+    from app.tools.registry import ToolRegistry
+    from app.tools.report import register_report_tools
+
+    reg = ToolRegistry()
+    register_report_tools(reg)
+    tool_fn = reg._tools["generate_analysis_report"]
+
+    report_rows: dict[str, Report] = {}
+
+    class _FakeSyncDB:
+        def get(self, model, pk):
+            if model is Conversation:
+                return Conversation(id="sess-tool", title="t")
+            if model is Report:
+                return report_rows.get(pk)
+            return None
+
+        def query(self, model):
+            q = MagicMock()
+            q.filter.return_value.order_by.return_value.all.return_value = [_msg()]
+            return q
+
+        def add(self, row):
+            report_rows[row.id] = row
+
+        def commit(self):
+            pass
+
+    @contextmanager
+    def fake_db_session():
+        yield _FakeSyncDB()
+
+    monkeypatch.setattr(tool_mod, "db_session", fake_db_session)
+    monkeypatch.setattr(tool_mod, "REPORT_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        tool_mod, "mapspec_store", MagicMock(get_mapspec=AsyncMock(return_value=None))
+    )
+
+    async def failing_render(**kwargs):
+        return False
+
+    monkeypatch.setattr(tool_mod.spatial_report_engine, "generate_report", failing_render)
+
+    result = await tool_fn(format="markdown", _session_id="sess-tool")
+    assert "error" in result
+    (report_row,) = report_rows.values()
+    assert report_row.status == "failed"
+    assert report_row.error_message == "生成过程未产出文件"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_report_generation_parallel(monkeypatch, tmp_path):
+    """Two concurrent report requests must render in parallel in worker
+    threads, not serialize on the event loop."""
+    monkeypatch.setattr(report_service_mod, "weasyprint", _fake_weasyprint({}))
+    monkeypatch.setattr(report_service_mod, "REPORT_DIR", str(tmp_path))
+    svc = ReportService()
+
+    async def _one(i: int):
+        created: dict = {}
+        db = _make_async_db(Conversation(id=f"s{i}", title="t"), [_msg()], created)
+        return await svc.create_and_generate(
+            db, f"s{i}", format="pdf", session_factory=_make_session_factory(created)
+        )
+
+    t0 = time.monotonic()
+    r1, r2 = await asyncio.gather(_one(1), _one(2))
+    elapsed = time.monotonic() - t0
+
+    assert r1.success and r2.success
+    assert elapsed < 1.5, (
+        f"concurrent 0.8s renders serialized (took {elapsed:.2f}s) — "
+        "they are running on the event loop thread"
+    )


### PR DESCRIPTION
## Issues
- Fixes #426 (P1: report generation — WeasyPrint/Jinja2/sync DB — runs on the event loop from POST /reports and the generate_analysis_report tool)

## Root cause
`ReportService.generate_report` was an `async def` with a fully synchronous body (Jinja2 full-history templating, MapSpec→SVG compile, sync file writes, WeasyPrint `write_pdf`) executed inline on the event loop; the `generate_analysis_report` agent tool additionally ran two sync `db_session()` SQLAlchemy blocks on the loop. The #386 sweep (d8c0ab1) never touched this path.

## Implementation
- `generate_report` is now a thin `asyncio.to_thread` wrapper around the extracted `_generate_report_sync`; ADR-0023 saga semantics (generating → completed/failed, expunge + phase-2 session) untouched; both callers (route + engine singleton) inherit the offload.
- `app/tools/report.py`: both DB phases extracted into `_prepare_report_record` / `_finalize_report_record` sync helpers run via `asyncio.to_thread`; Sessions created/closed inside the worker thread. Response shapes unchanged.

## Regression tests
`tests/test_report_event_loop_offload_426.py` (386-style ticker harness): loop-lag with a 2 s fake render **2264 ms before → 203 ms after**; WeasyPrint crash across the thread boundary still lands in the saga failed-status handler (not a 500); concurrent renders parallelize.

## Validation
Mandated suites 25 passed; saga/vector-svg/386-sibling + 6 adjacent suites 62 more; `ruff` clean. Pre-existing warnings verified at baseline.

## Risk
Low: pure execution-context change, response shapes and status lifecycle unchanged.