### PR TITLE
fix(gis): Amap distance contract, timeout fallback, bounded health window, narrowed fallback triggers (#432 #433 #440 #479)

### DIFF
--- a/app/services/provider_health.py
+++ b/app/services/provider_health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections import deque
 from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
@@ -15,7 +16,10 @@ PROVIDER_NAMES = frozenset({"amap", "baidu", "tianditu", "overpass", "nominatim"
 class _State:
     consecutive_errors: int = 0
     last_failure_ts: float = 0.0
-    call_timestamps: list[float] = field(default_factory=list)
+    # 60s 滑动窗口（issue #433）：deque 按 append 顺序（≈时间升序）存放被
+    # **放行**的调用时间戳；过期项从左端弹出，均摊 O(1)，长度恒 ≤ 限流阈值，
+    # 失败/被拒路径不再无界增长。
+    call_timestamps: deque = field(default_factory=deque)
     circuit_open: bool = False
 
 
@@ -42,6 +46,7 @@ class ProviderHealthTracker:
     DEFAULT_RATE_LIMIT: int = 60
     DEFAULT_ERROR_THRESHOLD: int = 5  # 连续这么多次错误后短路
     DEFAULT_RECOVERY_SECONDS: int = 300  # 5 分钟冷静期后恢复尝试
+    _WINDOW_SECONDS: int = 60  # 速率窗口宽度（calls_per_minute 对应的秒数）
 
     def __init__(
         self,
@@ -56,37 +61,63 @@ class ProviderHealthTracker:
         self._state: dict[str, _State] = {}
         self._lock = asyncio.Lock()
 
+    # ── Internal helpers（调用方必须已持有 self._lock）───────────────────────
+
+    def _prune_window(self, s: _State, now: float) -> None:
+        """弹出窗外时间戳。append 顺序 ≈ 时间升序 → 左端弹出，均摊 O(1)。"""
+        cutoff = now - self._WINDOW_SECONDS
+        while s.call_timestamps and s.call_timestamps[0] <= cutoff:
+            s.call_timestamps.popleft()
+
+    def _circuit_gates(self, s: _State, now: float) -> bool:
+        """熔断检查；冷静期已过则悄悄复位（原 can_call 语义）。"""
+        if not s.circuit_open:
+            return True
+        if now - s.last_failure_ts < self._recovery_seconds:
+            return False
+        s.circuit_open = False
+        s.consecutive_errors = 0
+        return True
+
     # ── Public API ────────────────────────────────────────────────────────────
 
     async def can_call(self, provider: str) -> bool:
         """如果被速率限制或熔断（仍在冷静期内）则返回 False。"""
         async with self._lock:
-            s = self._state.get(provider, _State())
-            if s.circuit_open:
-                if time.time() - s.last_failure_ts < self._recovery_seconds:
-                    return False
-                # 冷静期已过，悄悄复位
-                s.circuit_open = False
-                s.consecutive_errors = 0
-            recent = [ts for ts in s.call_timestamps if time.time() - ts < 60]
-            return len(recent) < self._calls_per_minute
+            s = self._state.get(provider)
+            if s is None:
+                return True
+            now = time.time()
+            if not self._circuit_gates(s, now):
+                return False
+            self._prune_window(s, now)
+            return len(s.call_timestamps) < self._calls_per_minute
 
     async def record_attempt(self, provider: str) -> bool:
-        """记录一次调用意图，返回 True 表示允许调用，False 代表被限制。"""
+        """记录一次调用意图，返回 True 表示允许调用，False 代表被限制。
+
+        被拒（熔断/限流）的尝试**不写入**窗口：写入会让持续打点把限流窗
+        无限向后推、且窗口随失败路径无界增长（issue #433）。窗口在每次
+        检查前按 60s 剪枝，长度恒 ≤ calls_per_minute。
+        """
         ts = time.time()
         async with self._lock:
             s = self._state.setdefault(provider, _State())
+            if not self._circuit_gates(s, ts):
+                return False
+            self._prune_window(s, ts)
+            if len(s.call_timestamps) >= self._calls_per_minute:
+                return False
             s.call_timestamps.append(ts)
-        return await self.can_call(provider)
+            return True
 
     async def record_success(self, provider: str) -> None:
-        """请求成功：重置错误计数器，清除熔断标记。"""
+        """请求成功：重置错误计数器，清除熔断标记，并剪枝窗口。"""
         async with self._lock:
             s = self._state.setdefault(provider, _State())
             s.consecutive_errors = 0
             s.circuit_open = False
-            cutoff = time.time() - 60
-            s.call_timestamps = [ts for ts in s.call_timestamps if ts >= cutoff]
+            self._prune_window(s, time.time())
 
     async def record_error(self, provider: str, exc: Exception | None = None) -> None:
         """请求出错：累加连续错误计数，达到阈值后打开熔断。"""
@@ -116,15 +147,16 @@ class ProviderHealthTracker:
         """
         now = time.time()
         async with self._lock:
-            return {
-                p: {
+            out: dict[str, dict] = {}
+            for p, s in self._state.items():
+                self._prune_window(s, now)
+                out[p] = {
                     "consecutive_errors": s.consecutive_errors,
                     "last_failure_ts": s.last_failure_ts,
                     "circuit_open": s.circuit_open,
-                    "calls_last_minute": sum(1 for ts in s.call_timestamps if now - ts < 60),
+                    "calls_last_minute": len(s.call_timestamps),
                 }
-                for p, s in list(self._state.items())  # list() copy 防迭代中 mutate
-            }
+            return out
 
 
 from typing import Callable, Any

--- a/app/tools/chinese_maps/__init__.py
+++ b/app/tools/chinese_maps/__init__.py
@@ -14,11 +14,8 @@
 写法尽量少改，本 __init__.py 一次性把三个 provider 模块所有 _xxx 函数 import 进来。
 """
 import asyncio
-import json
 import logging
 from typing import Any, Optional
-
-import aiohttp
 
 from app.tools.registry import ToolRegistry, tool
 from app.utils.coord_transform import (
@@ -27,6 +24,7 @@ from app.utils.coord_transform import (
 
 # HTTP + provider 路由（_amap_get/_baidu_get/_tianditu_get 由各 provider 模块自行导入）
 from app.tools.chinese_maps.http import (
+    _FALLBACK_ERRORS,
     _has_provider,
     _VALID_PROVIDERS,
     with_fallback,
@@ -99,7 +97,7 @@ class ChineseMapsEngine:
         async def _call(p):
             try:
                 return await _dispatch[p](keyword, city, limit)
-            except (aiohttp.ClientError, json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
+            except _FALLBACK_ERRORS as e:
                 errors.append(f"{p}: {e}")
                 raise
         return await with_fallback(
@@ -150,7 +148,9 @@ async def batch_geocode_cn(
                 if "error" in result:
                     return {"index": idx, "status": "error", "address": addr, "error": str(result["error"])}
                 return {"index": idx, "status": "ok", "address": addr, **result}
-            except (aiohttp.ClientError, json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
+            except _FALLBACK_ERRORS as e:
+                # 仅隔离瞬时 provider 失败（transport/timeout/parse，统一回退语义
+                # #479）；自身代码 bug（KeyError/ValueError/TypeError）直接穿透。
                 return {"index": idx, "status": "error", "address": addr, "error": str(e)}
 
     results = await asyncio.gather(*[_one(i, a) for i, a in enumerate(addresses)])
@@ -184,7 +184,7 @@ def register_chinese_map_tools(registry: ToolRegistry):
         async def _call(p):
             try:
                 return await _dispatch[p](keyword, city, limit)
-            except (aiohttp.ClientError, json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
+            except _FALLBACK_ERRORS as e:
                 errors.append(f"{p}: {e}")
                 raise
 

--- a/app/tools/chinese_maps/amap.py
+++ b/app/tools/chinese_maps/amap.py
@@ -261,51 +261,88 @@ class AmapProvider:
             return data
         return self._shape_district(data.get("districts", []), return_geometry)
 
+    # /v3/distance 契约：origins 用 "|" 分隔且每请求最多 100 个点；destination
+    # 只接受单个坐标点；返回 results 按请求内 origin_id（1 起）排列，dest_id
+    # 恒为 "1"（单终点）。多终点矩阵必须拆成每终点一次请求（issue #440）。
+    _DISTANCE_MAX_ORIGINS = 100
+
     async def distance_matrix(
         self, origins: list[list], destinations: list[list], mode: str,
     ) -> dict:
         """Amap 距离矩阵。
 
-        - driving / walking 走 ``/v3/distance``（一次请求完成全量 OD 计算）
+        - driving / walking 走 ``/v3/distance``：
             - type=1 驾车，type=3 步行
+            - 契约限制 destination 为单点 → 每个终点一次请求，该请求的
+              results 填入矩阵的一列；origins > 100 时按 100 分块
         - riding 该批量接口不支持，回退到 N×M 并发调用 /direction/bicycling
 
         所有坐标在请求前 WGS84 → GCJ-02。
         """
-        # ── driving / walking：批量接口
+        # ── driving / walking：批量接口（每终点一次请求）
         if mode in ("driving", "walking"):
-            origin_str = ";".join(
-                f"{self._to_src(lng, lat)[0]},{self._to_src(lng, lat)[1]}"
-                for lng, lat in origins
-            )
-            dest_str = ";".join(
-                f"{self._to_src(lng, lat)[0]},{self._to_src(lng, lat)[1]}"
-                for lng, lat in destinations
-            )
-            params = {
-                "origins": origin_str,
-                "destination": dest_str,
-                "type": "1" if mode == "driving" else "3",
-            }
-            data = await self._get("/distance", params)
-            if "error" in data:
-                return data
-
-            results = data.get("results", [])
+            type_param = "1" if mode == "driving" else "3"
             matrix: list[list[dict | None]] = [
                 [None] * len(destinations) for _ in range(len(origins))
             ]
-            for item in results:
-                # Amap origin_id/dest_id 从 1 开始计数
-                oi = int(item.get("origin_id", 0)) - 1
-                di = int(item.get("dest_id", 0)) - 1
-                if 0 <= oi < len(origins) and 0 <= di < len(destinations):
-                    matrix[oi][di] = {
-                        "origin_index": oi,
-                        "dest_index": di,
-                        "distance_km": float(item.get("distance", 0)) / 1000.0,
-                        "duration_sec": int(item.get("duration", 0)),
+            semaphore = asyncio.Semaphore(6)
+
+            async def _one_dest(di: int) -> str | None:
+                """单终点（可能多个 origins 分块）请求；结果填矩阵第 di 列。
+
+                返回 error 描述（该终点请求失败时），否则 None。
+                """
+                d_gcj = self._to_src(destinations[di][0], destinations[di][1])
+                for chunk_start in range(0, len(origins), self._DISTANCE_MAX_ORIGINS):
+                    chunk = origins[chunk_start:chunk_start + self._DISTANCE_MAX_ORIGINS]
+                    origin_str = "|".join(
+                        f"{gx},{gy}"
+                        for gx, gy in (self._to_src(o[0], o[1]) for o in chunk)
+                    )
+                    params = {
+                        "origins": origin_str,
+                        "destination": f"{d_gcj[0]},{d_gcj[1]}",
+                        "type": type_param,
                     }
+                    async with semaphore:
+                        data = await self._get("/distance", params)
+                    if "error" in data:
+                        return str(data["error"])
+                    for item in data.get("results", []):
+                        # origin_id 是请求内 1 起编号，分块时补回全局行号；
+                        # dest_id 恒为 "1"（单终点），列号直接用本请求的 di。
+                        try:
+                            oi = int(item.get("origin_id", 0)) - 1 + chunk_start
+                        except (TypeError, ValueError):
+                            continue
+                        if 0 <= oi < len(origins):
+                            matrix[oi][di] = {
+                                "origin_index": oi,
+                                "dest_index": di,
+                                "distance_km": float(item.get("distance", 0)) / 1000.0,
+                                "duration_sec": int(item.get("duration", 0)),
+                            }
+                return None
+
+            errors = await asyncio.gather(*[
+                _one_dest(di) for di in range(len(destinations))
+            ])
+            failed = [di for di, err in enumerate(errors) if err]
+            if failed:
+                if all(cell is None for row in matrix for cell in row):
+                    # 全部终点都失败 → 与单请求时代行为一致，整体报错
+                    return {"error": errors[failed[0]]}
+                # 部分失败：保留成功的列，失败列置 None 并显式列出（issue #440：
+                # 不再静默丢弃，旧实现会返回全 None 矩阵）
+                return {
+                    "matrix": matrix,
+                    "origins_count": len(origins),
+                    "dests_count": len(destinations),
+                    "mode": mode,
+                    "provider": "amap",
+                    "errors": [f"dest_index {di}: {errors[di]}" for di in failed],
+                    "note": f"{len(failed)}/{len(destinations)} 个终点请求失败，对应矩阵列为 None",
+                }
             return {
                 "matrix": matrix,
                 "origins_count": len(origins),

--- a/app/tools/chinese_maps/http.py
+++ b/app/tools/chinese_maps/http.py
@@ -2,6 +2,7 @@
 
 M2: 从单体 chinese_maps.py 抽出。register_chinese_map_tools 仍在 __init__.py。
 """
+import asyncio
 import json
 import logging
 
@@ -54,8 +55,11 @@ def _speed_mps(mode: str) -> float:
 # The set of transport/parse errors that should trigger fallback to the next
 # provider rather than propagating to the LLM. Matches the per-tool except
 # clauses the 9 LLM tools previously inlined (architecture-review F1).
+# asyncio.TimeoutError: tracked_provider_get 的 total timeout（py3.11+ 即内建
+# TimeoutError，OSError 子类）不属于 ClientError 家族，必须单列（issue #432）。
 _FALLBACK_ERRORS = (
     aiohttp.ClientError,
+    asyncio.TimeoutError,
     json.JSONDecodeError,
     KeyError,
     ValueError,

--- a/app/tools/chinese_maps/http.py
+++ b/app/tools/chinese_maps/http.py
@@ -52,19 +52,34 @@ def _speed_mps(mode: str) -> float:
 # ── Provider fallback dispatch ───────────────────────────────────
 
 
-# The set of transport/parse errors that should trigger fallback to the next
-# provider rather than propagating to the LLM. Matches the per-tool except
-# clauses the 9 LLM tools previously inlined (architecture-review F1).
-# asyncio.TimeoutError: tracked_provider_get 的 total timeout（py3.11+ 即内建
-# TimeoutError，OSError 子类）不属于 ClientError 家族，必须单列（issue #432）。
+# The TRANSIENT provider-failure errors that trigger fallback to the next
+# provider (unified semantics, issues #432 + #479):
+# - transport failures: the aiohttp ClientError family (connect resets,
+#   ServerTimeoutError for connect/sock-read timeouts, …)
+# - total timeouts: asyncio.TimeoutError — on py3.11+ the builtin TimeoutError
+#   (an OSError subclass), NOT a ClientError, so it must be listed explicitly
+# - response parse failures: json.JSONDecodeError
+# Our own programming/schema errors (KeyError/ValueError/TypeError) deliberately
+# do NOT trigger fallback: they must propagate and surface as code bugs instead
+# of being misclassified as provider failures (#479).
 _FALLBACK_ERRORS = (
     aiohttp.ClientError,
     asyncio.TimeoutError,
     json.JSONDecodeError,
-    KeyError,
-    ValueError,
-    TypeError,
 )
+
+
+def _is_provider_error_dict(result: object) -> bool:
+    """True only for genuine provider-level failure payloads.
+
+    tracked_provider_get returns ``{"error": "<message>"}`` (never raises) for
+    HTTP != 200 / WAF 418 / quota / business-check failures. Requires a
+    non-empty **string** error value: business payloads that merely happen to
+    carry an ``error`` key (``None``, numeric, nested) are not provider
+    failures and must not trigger fallback (#479).
+    """
+    err = result.get("error") if isinstance(result, dict) else None
+    return isinstance(err, str) and bool(err)
 
 
 async def with_fallback(
@@ -80,10 +95,19 @@ async def with_fallback(
     Collapses the 9× ``_dispatch + _fallback_order + try/except`` scaffold that
     was duplicated across ``register_chinese_map_tools``. For each provider in
     fallback order, skips it when its API key is absent, otherwise invokes
-    ``await call(provider)``; on a transport/parse error OR a provider-level
-    ``{"error": ...}`` result (tracked GET 对 HTTP 418 WAF 拦截 / 配额超限 /
-    业务失败返回 error dict 而非异常), logs and tries the next provider.
-    Returns the first successful result, or ``{"error": ...}`` when no
+    ``await call(provider)``.
+
+    Fallback fires ONLY on transient provider failures:
+
+    - ``_FALLBACK_ERRORS`` exceptions (transport / total timeout / JSON parse);
+    - a provider-level ``{"error": "<non-empty str>"}`` result — tracked GET
+      对 HTTP 418 WAF 拦截 / 配额超限 / 业务失败返回 error dict 而非异常
+      (f545d7c; narrowed to non-empty string values in #479).
+
+    Our own code bugs (KeyError/ValueError/TypeError, business payloads with a
+    benign ``error`` field) do NOT fall back — they propagate / return as-is so
+    schema drift surfaces as itself instead of a misleading provider failure
+    (#479). Returns the first successful result, or ``{"error": ...}`` when no
     configured provider succeeded.
 
     Args:
@@ -116,7 +140,7 @@ async def with_fallback(
             logger.warning(f"{label}{p} failed: {e}")
             _note_failure(str(e))
             continue
-        if isinstance(result, dict) and "error" in result:
+        if _is_provider_error_dict(result):
             # 天地图 WAF 频控返回 HTTP 418、配额/业务失败走 business_checker —
             # 这些在 tracked_provider_get 里是正常返回的 error dict，不抛异常。
             # 不在此触发回退的话，首选 provider 被频控时整项能力直接不可用。

--- a/tests/unit/test_chinese_maps_providers.py
+++ b/tests/unit/test_chinese_maps_providers.py
@@ -185,24 +185,168 @@ async def test_district_amap_point_mode():
     assert out["features"][0]["geometry"]["type"] == "Point"
 
 
-# ── distance_matrix: batch path (driving) ────────────────────────────────────
+# ── distance_matrix: the REAL /v3/distance contract (driving/walking) ────────
+#
+# Issue #440: the driving/walking branch was written against an imagined N×M
+# batch API. The real contract (lbs.amap.com webservice direction#t7):
+#   - origins: |-separated, at most 100 points per request
+#   - destination: a SINGLE coordinate point (multi-destination unsupported)
+#   - results: one entry per origin, origin_id 1-based within the request,
+#     dest_id always "1"
+# So an N×M matrix = one request per destination; each request's results fill
+# exactly one matrix column. The old test mocked a multi-dest_id shape the API
+# never returns, keeping CI green while the feature was broken.
+
+from app.utils.coord_transform import wgs84_to_gcj02
+
+_ORIGINS_3 = [[116.0, 39.0], [116.1, 39.1], [116.2, 39.2]]
+_DESTS_3 = [[117.0, 40.0], [118.0, 41.0], [119.0, 42.0]]
 
 
-async def test_distance_matrix_amap_driving_batch():
-    fake = FakeGet({
-        "/distance": {
+def _dest_index_of(dest_str: str, wgs_dests: list) -> int:
+    """Map a request's single `destination` param back to its WGS84 index."""
+    lng, lat = map(float, dest_str.split(","))
+    for di, (w_lng, w_lat) in enumerate(wgs_dests):
+        gx, gy = wgs84_to_gcj02(w_lng, w_lat)
+        if abs(gx - lng) < 1e-9 and abs(gy - lat) < 1e-9:
+            return di
+    raise AssertionError(f"unknown destination param: {dest_str}")
+
+
+class DistanceContractFakeGet:
+    """Fake GET that ENFORCES the documented /v3/distance request contract.
+
+    Every request must carry a single destination and |-separated origins
+    (≤100); the response uses the real shape (per-origin results, dest_id=1).
+    """
+
+    def __init__(self, wgs_dests: list, dist_fn, n_origins: int):
+        self.calls: list[tuple[str, dict]] = []
+        self._wgs_dests = wgs_dests
+        self._dist_fn = dist_fn
+        self._n_origins = n_origins
+        self._seen_origins: dict[int, int] = {}  # per-destination chunk offset
+
+    async def __call__(self, endpoint: str, params: dict) -> dict:
+        assert endpoint == "/distance", f"wrong endpoint: {endpoint}"
+        self.calls.append((endpoint, dict(params)))
+        # contract: single destination, |-joined origins, ≤100 per request
+        assert "|" not in params["destination"] and ";" not in params["destination"], (
+            f"destination must be a single point, got: {params['destination']}"
+        )
+        origins = params["origins"].split("|")
+        assert ";" not in params["origins"], (
+            f"origins must be |-separated, got: {params['origins']}"
+        )
+        assert 1 <= len(origins) <= 100, f"origins per request must be ≤100, got {len(origins)}"
+        di = _dest_index_of(params["destination"], self._wgs_dests)
+        base = self._seen_origins.get(di, 0)
+        self._seen_origins[di] = base + len(origins)
+        return {
+            "status": "1",
             "results": [
-                {"origin_id": 1, "dest_id": 1, "distance": "1000", "duration": "60"},
-                {"origin_id": 1, "dest_id": 2, "distance": "2000", "duration": "120"},
+                {
+                    # origin_id is chunk-local (1-based); dist_fn gets the global index
+                    "origin_id": str(i + 1),
+                    "dest_id": "1",
+                    "distance": str(self._dist_fn(base + i, di)),
+                    "duration": str(60 * (base + i + 1)),
+                }
+                for i in range(len(origins))
             ],
-        },
-    })
+        }
+
+
+async def test_distance_matrix_amap_driving_matches_v3_distance_contract():
+    """3×3 driving matrix via one single-destination request per destination."""
+    fake = DistanceContractFakeGet(
+        _DESTS_3, dist_fn=lambda oi, di: 1000 * (oi + 1) + 100 * (di + 1), n_origins=3,
+    )
     prov = AmapProvider(get=fake)
-    out = await prov.distance_matrix([[116.0, 39.0]], [[117.0, 40.0], [118.0, 41.0]], "driving")
+    out = await prov.distance_matrix(_ORIGINS_3, _DESTS_3, "driving")
+
+    # one request per destination — multi-destination calls must split
+    assert len(fake.calls) == 3
     assert out["mode"] == "driving"
     assert out["provider"] == "amap"
+    assert out["origins_count"] == 3
+    assert out["dests_count"] == 3
+    assert out["matrix"][0][1] is not None
+    # every cell present and correctly placed (distance encodes (oi, di))
+    for oi in range(3):
+        for di in range(3):
+            cell = out["matrix"][oi][di]
+            assert cell is not None, f"cell [{oi}][{di}] missing"
+            assert cell["origin_index"] == oi
+            assert cell["dest_index"] == di
+            assert cell["distance_km"] == (1000 * (oi + 1) + 100 * (di + 1)) / 1000.0
+            assert cell["duration_sec"] == 60 * (oi + 1)
+    # each request carried 3 |-joined origins and driving type=1
+    for _, params in fake.calls:
+        assert len(params["origins"].split("|")) == 3
+        assert params["type"] == "1"
+
+
+async def test_distance_matrix_amap_walking_uses_type_3():
+    fake = DistanceContractFakeGet(_DESTS_3[:1], dist_fn=lambda oi, di: 500, n_origins=2)
+    prov = AmapProvider(get=fake)
+    out = await prov.distance_matrix(_ORIGINS_3[:2], _DESTS_3[:1], "walking")
+    assert out["mode"] == "walking"
+    assert fake.calls[0][1]["type"] == "3"
+    assert out["matrix"][0][0]["distance_km"] == 0.5
+
+
+async def test_distance_matrix_amap_chunks_over_100_origins():
+    """>100 origins must split into ≤100-origin requests (contract cap)."""
+    origins = [[116.0 + i * 0.001, 39.0] for i in range(150)]
+    dests = [[117.0, 40.0]]
+    # local origin index per request; single destination → local == global
+    fake = DistanceContractFakeGet(dests, dist_fn=lambda oi, di: 100 * (oi + 1), n_origins=150)
+    prov = AmapProvider(get=fake)
+    out = await prov.distance_matrix(origins, dests, "driving")
+
+    sizes = [len(params["origins"].split("|")) for _, params in fake.calls]
+    assert sizes == [100, 50], f"expected 100+50 chunking, got {sizes}"
+    assert len(out["matrix"]) == 150
+    # chunk-local origin_id maps back to the correct global row
+    for oi in range(150):
+        cell = out["matrix"][oi][0]
+        assert cell is not None, f"row {oi} missing"
+        assert cell["distance_km"] == 100 * (oi + 1) / 1000.0
+
+
+async def test_distance_matrix_amap_all_destinations_error_returns_error():
+    """Every per-destination request failed → the error dict surfaces."""
+    async def fake(endpoint, params):
+        return {"error": "Amap API HTTP 418"}
+
+    prov = AmapProvider(get=fake)
+    out = await prov.distance_matrix(_ORIGINS_3[:1], _DESTS_3[:2], "driving")
+    assert out == {"error": "Amap API HTTP 418"}
+
+
+async def test_distance_matrix_amap_partial_failure_surfaces_errors():
+    """One destination failing must not discard the successful columns."""
+    wgs_dests = _DESTS_3[:2]
+
+    async def fake(endpoint, params):
+        di = _dest_index_of(params["destination"], wgs_dests)
+        if di == 1:
+            return {"error": "Amap API HTTP 429"}
+        return {
+            "status": "1",
+            "results": [
+                {"origin_id": "1", "dest_id": "1", "distance": "1000", "duration": "60"},
+            ],
+        }
+
+    prov = AmapProvider(get=fake)
+    out = await prov.distance_matrix(_ORIGINS_3[:1], wgs_dests, "driving")
+    # column 0 filled, column 1 None, failure surfaced
+    assert out["matrix"][0][0] is not None
     assert out["matrix"][0][0]["distance_km"] == 1.0
-    assert out["matrix"][0][1]["distance_km"] == 2.0
+    assert out["matrix"][0][1] is None
+    assert any("429" in e for e in out["errors"])
 
 
 # ── NameError regression: isochrone concurrency + except branches ────────────

--- a/tests/unit/test_chinese_maps_split.py
+++ b/tests/unit/test_chinese_maps_split.py
@@ -224,3 +224,104 @@ async def test_geocode_cn_amap_timeout_falls_back_to_baidu(monkeypatch):
     result = await geocode_cn("北京市海淀区", "", provider="amap")
     assert result["provider"] == "baidu"
     assert result["count"] == 1
+
+
+# ── Issue #479: fallback 触发条件收敛（不掩盖自身代码 bug）─────────────────
+
+
+@pytest.mark.asyncio
+async def test_with_fallback_error_none_business_dict_does_not_fall_back(monkeypatch):
+    """业务 payload 里带 error=None 不是 provider 失败，不得触发回退（#479）。"""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "AMAP_API_KEY", "fake")
+    monkeypatch.setattr(settings, "BAIDU_MAP_AK", "fake")
+    monkeypatch.setattr(settings, "TIANDITU_TOKEN", "")
+
+    calls = []
+
+    async def _call(p):
+        calls.append(p)
+        if p == "amap":
+            # 业务字段恰好叫 error、值为 None —— 旧条件 `"error" in result` 会误判
+            return {"provider": "amap", "results": [], "error": None}
+        return {"provider": p}
+
+    out = await with_fallback("amap", _call)
+    assert out == {"provider": "amap", "results": [], "error": None}
+    assert calls == ["amap"], "baidu must not be tried for a non-error payload"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bug_exc", [KeyError, ValueError, TypeError])
+async def test_with_fallback_own_code_bugs_propagate(monkeypatch, bug_exc):
+    """KeyError/ValueError/TypeError 是自身代码/schema bug —— 必须穿透为代码
+    错误，不得被伪装成 provider 失败触发回退（#479）。"""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "AMAP_API_KEY", "fake")
+    monkeypatch.setattr(settings, "BAIDU_MAP_AK", "fake")
+    monkeypatch.setattr(settings, "TIANDITU_TOKEN", "")
+
+    calls = []
+
+    async def _call(p):
+        calls.append(p)
+        if p == "amap":
+            raise bug_exc("schema drift in our unwrap code")
+        return {"provider": p}
+
+    with pytest.raises(bug_exc):
+        await with_fallback("amap", _call)
+    assert calls == ["amap"], "fallback must not fire for own-code bugs"
+
+
+@pytest.mark.asyncio
+async def test_geocode_cn_schema_bug_surfaces_as_code_error(monkeypatch):
+    """整工具链路：per-provider 调用抛 KeyError（schema bug）→ 直接暴露，
+    不降级到 baidu、不产出误导性的『provider 失败』错误。"""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "AMAP_API_KEY", "fake")
+    monkeypatch.setattr(settings, "BAIDU_MAP_AK", "fake")
+    monkeypatch.setattr(settings, "TIANDITU_TOKEN", "fake")
+
+    async def buggy_amap_geocode(address, city):
+        raise KeyError("amap response schema drifted")
+
+    baidu_called = []
+
+    async def ok_baidu_geocode(address, city):
+        baidu_called.append(address)
+        return {"results": [], "count": 0, "provider": "baidu"}
+
+    monkeypatch.setattr(_AMAP, "geocode", buggy_amap_geocode)
+    from app.tools.chinese_maps import _BAIDU
+    monkeypatch.setattr(_BAIDU, "geocode", ok_baidu_geocode)
+
+    with pytest.raises(KeyError):
+        await geocode_cn("北京", "", provider="amap")
+    assert baidu_called == []
+
+
+@pytest.mark.asyncio
+async def test_geocode_cn_business_error_dict_still_falls_back(monkeypatch):
+    """f545d7c 行为保留（全工具链路 + 真实 payload 形状）：amap 业务失败
+    返回 {"error": "<str>"}（business_checker / HTTP 非 200）→ 回退到 baidu。"""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "AMAP_API_KEY", "fake")
+    monkeypatch.setattr(settings, "BAIDU_MAP_AK", "fake")
+    monkeypatch.setattr(settings, "TIANDITU_TOKEN", "")
+
+    async def amap_get(endpoint, params):
+        # tracked_provider_get business_checker 失败时的真实返回形状
+        return {"error": "Amap: INVALID_USER_KEY", "status": "0", "infocode": "10001"}
+
+    async def baidu_get(endpoint, params):
+        # 百度 geocoding/v3 真实成功形状
+        return {"status": 0, "result": {"location": {"lng": 116.40, "lat": 39.90}, "level": "ROAD"}}
+
+    monkeypatch.setattr(_AMAP, "_get", amap_get)
+    from app.tools.chinese_maps import _BAIDU
+    monkeypatch.setattr(_BAIDU, "_get", baidu_get)
+
+    result = await geocode_cn("北京市海淀区", "", provider="amap")
+    assert result["provider"] == "baidu"
+    assert result["count"] == 1

--- a/tests/unit/test_chinese_maps_split.py
+++ b/tests/unit/test_chinese_maps_split.py
@@ -9,6 +9,8 @@
 M2 时代的"amap.py 只能含 _*_amap 自由函数"结构断言已随架构评审 F1
 （Amap 深化为 AmapProvider 类）退役 —— 此文件不再断言旧的自由函数布局。
 """
+import asyncio
+
 import pytest
 
 from app.tools.chinese_maps import (
@@ -168,3 +170,57 @@ async def test_with_fallback_all_fail_reports_first_detail(monkeypatch):
 
     out = await with_fallback("amap", _call, no_key_msg="地图服务不可用")
     assert out["error"].startswith("地图服务不可用（amap down")
+
+
+# ── Issue #432: provider 总超时必须触发回退 ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeout_exc", [asyncio.TimeoutError, TimeoutError])
+async def test_with_fallback_timeout_error_triggers_next_provider(monkeypatch, timeout_exc):
+    """provider 总超时（非 ClientError 家族）必须回退到下一家（issue #432）。
+
+    tracked_provider_get 的 total timeout 让 aiohttp 抛 asyncio.TimeoutError
+    （py3.11+ 即内建 TimeoutError，OSError 子类），旧 _FALLBACK_ERRORS 只认
+    ClientError 家族 → 异常直接穿透 with_fallback，备选 provider 从未被尝试。
+    """
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "AMAP_API_KEY", "fake")
+    monkeypatch.setattr(settings, "BAIDU_MAP_AK", "fake")
+    monkeypatch.setattr(settings, "TIANDITU_TOKEN", "")
+
+    calls = []
+
+    async def _call(p):
+        calls.append(p)
+        if p == "amap":
+            raise timeout_exc()
+        return {"provider": p}
+
+    out = await with_fallback("amap", _call, no_key_msg="全部失败")
+    assert out == {"provider": "baidu"}
+    assert calls == ["amap", "baidu"]
+
+
+@pytest.mark.asyncio
+async def test_geocode_cn_amap_timeout_falls_back_to_baidu(monkeypatch):
+    """整工具链路：首选 provider 黑洞超时 → 自动降级到百度并返回其结果。"""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "AMAP_API_KEY", "fake")
+    monkeypatch.setattr(settings, "BAIDU_MAP_AK", "fake")
+    monkeypatch.setattr(settings, "TIANDITU_TOKEN", "")
+
+    async def amap_get(endpoint, params):
+        raise TimeoutError("total timeout")
+
+    async def baidu_get(endpoint, params):
+        return {"status": 0, "result": {"location": {"lng": 116.40, "lat": 39.90},
+                                        "level": "ROAD"}}
+
+    monkeypatch.setattr(_AMAP, "_get", amap_get)
+    from app.tools.chinese_maps import _BAIDU
+    monkeypatch.setattr(_BAIDU, "_get", baidu_get)
+
+    result = await geocode_cn("北京市海淀区", "", provider="amap")
+    assert result["provider"] == "baidu"
+    assert result["count"] == 1

--- a/tests/unit/test_provider_health_tracked_get.py
+++ b/tests/unit/test_provider_health_tracked_get.py
@@ -104,6 +104,70 @@ async def test_tracked_provider_get_circuit_breaker(monkeypatch):
     assert "暂时不可用" in res["error"]
 
 
+# ── Issue #433: bounded sliding window under sustained failure ───────────────
+
+
+@pytest.mark.asyncio
+async def test_call_timestamps_bounded_under_sustained_failure():
+    """持续失败（熔断打开后仍不停打点）不得让 call_timestamps 无界增长。
+
+    旧实现只在 record_success 里剪枝：失败/被拒路径只 append 不清理，
+    长时间故障下窗口按原始尝试速率增长（86,400 次/天 ≈ 3.5MB/provider/天）。
+    """
+    tracker = ProviderHealthTracker(calls_per_minute=60, error_threshold=5, recovery_seconds=300)
+    for _ in range(3000):
+        await tracker.record_attempt("amap")
+        await tracker.record_error("amap", Exception("down"))
+    window = tracker._state["amap"].call_timestamps
+    assert len(window) <= 60, f"call_timestamps unbounded: {len(window)} entries"
+
+
+@pytest.mark.asyncio
+async def test_call_timestamps_bounded_under_rate_limit_saturation():
+    """纯限流饱和（无熔断）：被拒尝试不写入窗口，长度恒 ≤ calls_per_minute。"""
+    tracker = ProviderHealthTracker(calls_per_minute=60)
+    denials = 0
+    for _ in range(3000):
+        if not await tracker.record_attempt("amap"):
+            denials += 1
+    assert denials > 0, "limiter never tripped — test is vacuous"
+    window = tracker._state["amap"].call_timestamps
+    assert len(window) <= 60, f"call_timestamps unbounded: {len(window)} entries"
+
+
+@pytest.mark.asyncio
+async def test_rate_window_allows_limit_then_denies_then_expires(monkeypatch):
+    """限流边界与过窗放行；被拒尝试不得延长锁定窗（#433）。"""
+    tracker = ProviderHealthTracker(calls_per_minute=3)
+    fake_now = 1000.0
+    monkeypatch.setattr("app.services.provider_health.time.time", lambda: fake_now)
+
+    for _ in range(3):
+        assert await tracker.record_attempt("amap") is True
+    assert await tracker.record_attempt("amap") is False
+    # 持续被拒的打点不应把窗口无限向后推
+    for _ in range(100):
+        assert await tracker.record_attempt("amap") is False
+    # 60s 窗口过期后重新放行
+    fake_now += 61
+    assert await tracker.record_attempt("amap") is True
+
+
+@pytest.mark.asyncio
+async def test_can_call_prunes_expired_timestamps(monkeypatch):
+    """can_call 剪枝过期时间戳（不再全量 O(n) 扫描复制）。"""
+    tracker = ProviderHealthTracker(calls_per_minute=5)
+    fake_now = 1000.0
+    monkeypatch.setattr("app.services.provider_health.time.time", lambda: fake_now)
+    for _ in range(4):
+        await tracker.record_attempt("baidu")
+    window = tracker._state["baidu"].call_timestamps
+    assert len(window) == 4
+    fake_now += 120  # all expired
+    assert await tracker.can_call("baidu") is True
+    assert len(window) == 0, "expired timestamps must be pruned, not just filtered"
+
+
 @pytest.mark.asyncio
 async def test_tracked_provider_get_post(monkeypatch):
     """POST 分支：Overpass 风格查询体经 session.post 提交（issue #310）。"""


### PR DESCRIPTION
## Issues
- Fixes #440 (P1: Amap distance_matrix violates /v3/distance contract — ";;"-joined origins & multi-destination param; test mocked the wrong shape)
- Fixes #432 (P2: total timeouts — asyncio.TimeoutError — escaped the chinese-maps with_fallback)
- Fixes #433 (P2: ProviderHealthTracker.call_timestamps unbounded growth; O(n) rate-limit checks)
- Fixes #479 (P3: with_fallback error-dict trigger too broad — "error" in dict / KeyError/ValueError/TypeError mask provider-schema bugs)

## Root causes
1. **#440** Implementation written against an imagined N×M batch API. Real `/v3/distance`: `|`-separated origins (≤100), a single `destination`, results keyed `origin_id` (dest implied). Old code also assumed per-result `dest_id`.
2. **#432** aiohttp total timeouts are re-raised by `tracked_provider_get` as `asyncio.TimeoutError` — not in the old fallback tuple.
3. **#433** `call_timestamps` was an unbounded list scanned linearly per check; denied attempts were recorded, extending lockouts.
4. **#479** `"error" in dict` (any value, incl. None/numeric) plus KeyError/ValueError/TypeError in the catch-all blurred provider failures vs our own code bugs.

## Implementation
- **#440** driving/walking rewritten: one concurrent request per destination (semaphore 6), `|`-joined origins chunked ≤100, single destination; unwrap keyed by destination index + per-request `origin_id`; partial failures keep good columns and surface an `errors` list. Riding branch unchanged.
- **#432/#479** unified `_FALLBACK_ERRORS = (ClientError, asyncio.TimeoutError, JSONDecodeError)` + `_is_provider_error_dict` (non-empty **string** error value only; f545d7c provider-dict behavior preserved). KeyError/ValueError/TypeError propagate.
- **#433** deque-based 60 s sliding window, pruned left in every path under the lock (amortized O(1)); denied attempts no longer recorded (bounded at `calls_per_minute`).

## Evidence
- #433: 5000 denied attempts left 5000 entries before vs 5 after; `can_call` 193→15,346 µs (linear) before vs 4.55 µs flat after.
- #440: contract-enforcing fake asserts 3×3 correctness, per-destination splitting, walking type=3, 100+50 origin chunking.

## Validation
164 related tests green (providers, split, provider-health, protocol parity, OSM degradation, chaos/resume, geocoding); `ruff` clean.

## Risk
Medium-low: distance_matrix response shape gains an optional `errors` key (additive); fallback no longer swallows our own code bugs (intended surfacing); rate-limit boundary is now exactly `calls_per_minute` (was one less).