### PR TITLE
fix(network): reverse-split fraction, admissible A*, cutoff OD matrices, mid-edge OD snapping, turn penalties, zero-distance facilities, overlap split, isochrone scan (#443 #446 #447 #449 #453 #455 #456 #457)

### DIFF
--- a/app/lib/geo_analysis/network.py
+++ b/app/lib/geo_analysis/network.py
@@ -3,7 +3,7 @@ import networkx as nx
 import geopandas as gpd
 import numpy as np
 from shapely.geometry import Point, LineString, MultiLineString, mapping
-from shapely.ops import unary_union
+from shapely.ops import unary_union, substring
 from app.lib.geo_processor.core import GeoAnalysisResult
 from app.lib.geo_processor.core import to_utm_gdf
 # ADR-0052: 协作式取消检查点。cancellable() 在 chunk 边界读一次 contextvar，
@@ -49,11 +49,13 @@ def calculate_isochrones(network_geojson: dict | str, facility_points: dict | st
         if utm_crs != fac_crs:
             gdf_facilities = gdf_facilities.to_crs(utm_crs)
         
-        # Build NetworkX graph (MultiGraph to preserve parallel edges)
+        # Build NetworkX graph (MultiGraph to preserve parallel edges).
+        # #443: iterate the geometry GeoSeries directly — the previous
+        # ``iterrows()`` materialized a pandas (Geo)Series per feature, which
+        # dominated the call on 20k+ feature networks (only .geometry is used).
         G = nx.MultiGraph()
-        
-        for idx, row in gdf_network.iterrows():
-            geom = row.geometry
+
+        for geom in gdf_network.geometry:
             # GIS-P3-4: MultiLineString roads must contribute every part —
             # skipping them silently understated isochrone coverage.
             if isinstance(geom, MultiLineString):
@@ -91,6 +93,10 @@ def calculate_isochrones(network_geojson: dict | str, facility_points: dict | st
         from scipy.spatial import cKDTree
         node_tree = cKDTree(nodes_arr)
 
+        # EdgeView-parity lookup (see the per-facility scan below): node ->
+        # insertion order. Built once — it is invariant across facilities.
+        node_order = {n: i for i, n in enumerate(G.nodes)}
+
         # Road-width buffer for the network-constrained polygonization. The
         # previous ``MultiPoint(reachable_nodes).convex_hull`` enclosed rivers,
         # parks and any road-network hole in the convex envelope of reachable
@@ -124,42 +130,71 @@ def calculate_isochrones(network_geojson: dict | str, facility_points: dict | st
             # edges (one endpoint beyond the cutoff) are clipped at the
             # travel-budget fraction so the polygon does not over-extend past
             # the last reachable point (review C).
-            from shapely.ops import substring
+            #
+            # Issue #443: this used to scan ALL E graph edges per facility
+            # (O(F x E) Python-level iteration plus per-edge shapely substring
+            # clipping on boundary edges; measured 7.2 s for a tiny-budget
+            # query over a 19.8k-edge grid with F=2, dominated by that scan
+            # plus the iterrows() graph build). An edge is reachable iff at
+            # least one endpoint is in the cutoff-bounded Dijkstra set, so
+            # the scan walks the adjacency of the reachable nodes only — in
+            # G.nodes order with undirected-(u, v, key) dedup, reproducing
+            # networkx's EdgeView traversal exactly, so the reachable-edge
+            # sets, clipping and polygons are IDENTICAL to the full scan.
+            # Per-facility Dijkstra trees are kept deliberately: the output
+            # is one polygon per facility, which a merged multi-source tree
+            # cannot produce.
             reachable_edges = []
-            for u, v, edata in cancellable(G.edges(data=True), every=1024):
-                eg = edata.get("geometry")
-                if eg is None:
-                    continue
-                du = lengths.get(u)
-                dv = lengths.get(v)
-                if du is None and dv is None:
-                    continue
-                du_ok = du is not None and du <= max_dist
-                dv_ok = dv is not None and dv <= max_dist
-                if du_ok and dv_ok:
-                    reachable_edges.append(eg)  # fully within budget
-                    continue
-                # Partially reachable: clip at the budget fraction(s).
-                try:
-                    w = edata.get("weight") or eg.length
-                    if w <= 0:
-                        w = eg.length or 1.0
-                    if du_ok:
-                        frac = min(1.0, max(0.0, (max_dist - du) / w))
-                        if frac > 0:
-                            seg = substring(eg, 0.0, frac, normalized=True)
-                            if not seg.is_empty:
-                                reachable_edges.append(seg)
-                    if dv_ok:
-                        frac = min(1.0, max(0.0, (max_dist - dv) / w))
-                        if frac > 0:
-                            seg = substring(eg, 1.0 - frac, 1.0, normalized=True)
-                            if not seg.is_empty:
-                                reachable_edges.append(seg)
-                except Exception:
-                    # Clipping failed (degenerate geometry / topology): fall
-                    # back to the full edge rather than drop it.
-                    reachable_edges.append(eg)
+            seen_edge = set()
+            # EdgeView-parity: networkx yields each undirected edge as
+            # (earlier-in-node-order endpoint, later) on first encounter; the
+            # clipping below assumes u is the geometry's start node, so the
+            # orientation must match the pre-fix G.edges scan exactly.
+            reachable_nodes_ordered = [n for n in G.nodes if n in lengths]
+            for u0 in cancellable(reachable_nodes_ordered, every=1024):
+                for v0, keys in G[u0].items():
+                    for key, edata in keys.items():
+                        if (u0, v0, key) in seen_edge:
+                            continue
+                        seen_edge.add((u0, v0, key))
+                        seen_edge.add((v0, u0, key))
+                        eg = edata.get("geometry")
+                        if eg is None:
+                            continue
+                        if node_order[u0] < node_order[v0]:
+                            u, v = u0, v0
+                        else:
+                            u, v = v0, u0
+                        du = lengths.get(u)
+                        dv = lengths.get(v)
+                        if du is None and dv is None:
+                            continue
+                        du_ok = du is not None and du <= max_dist
+                        dv_ok = dv is not None and dv <= max_dist
+                        if du_ok and dv_ok:
+                            reachable_edges.append(eg)  # fully within budget
+                            continue
+                        # Partially reachable: clip at the budget fraction(s).
+                        try:
+                            w = edata.get("weight") or eg.length
+                            if w <= 0:
+                                w = eg.length or 1.0
+                            if du_ok:
+                                frac = min(1.0, max(0.0, (max_dist - du) / w))
+                                if frac > 0:
+                                    seg = substring(eg, 0.0, frac, normalized=True)
+                                    if not seg.is_empty:
+                                        reachable_edges.append(seg)
+                            if dv_ok:
+                                frac = min(1.0, max(0.0, (max_dist - dv) / w))
+                                if frac > 0:
+                                    seg = substring(eg, 1.0 - frac, 1.0, normalized=True)
+                                    if not seg.is_empty:
+                                        reachable_edges.append(seg)
+                        except Exception:
+                            # Clipping failed (degenerate geometry / topology): fall
+                            # back to the full edge rather than drop it.
+                            reachable_edges.append(eg)
 
             reachable = True
             if reachable_edges:

--- a/app/services/network/engine.py
+++ b/app/services/network/engine.py
@@ -116,8 +116,13 @@ class NetworkGraphEngine:
         profile: Optional[TravelProfile] = None,
         impedance: Optional[Impedance] = None,
         barriers: Optional[List[Barrier]] = None,
+        cutoff_s: Optional[float] = None,
     ) -> List[ODPair]:
-        """Calculates batch N x M origin-destination cost matrix."""
+        """Calculates batch N x M origin-destination cost matrix.
+
+        ``cutoff_s`` bounds the per-origin Dijkstra in the active impedance's
+        cost units (#449); pairs beyond it are returned unreachable.
+        """
         if graph is None:
             graph, _ = self.builder.build_graph(network_dataset, profile=profile)
         return self.od_service.network_od_matrix(
@@ -128,6 +133,7 @@ class NetworkGraphEngine:
             profile=profile,
             impedance=impedance,
             barriers=barriers,
+            cutoff_s=cutoff_s,
         )
 
     def closest_facility(
@@ -404,6 +410,7 @@ class NetworkGraphEngine:
                 network_dataset=net_ds,
                 graph=graph,
                 profile=prof,
+                cutoff_s=cutoff_s,
             )
 
             return NetworkAnalysisResult(

--- a/app/services/network/facility.py
+++ b/app/services/network/facility.py
@@ -3,6 +3,7 @@ Network Closest Facility Service Component.
 Finds nearest facilities for demand incidents based on network travel cost.
 """
 from __future__ import annotations
+import math
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import networkx as nx
@@ -110,9 +111,14 @@ class NetworkClosestFacilityService:
                     o_id, d_id = dem.demand_id, fac.facility_id
 
                 info = od["pairs"].get((o_label, d_label))
+                # Issue #456: a demand point located exactly AT a facility has
+                # distance_m == 0 — a perfectly valid (zero-cost) match. The
+                # old `distance_m <= 0` guard dropped those pairs entirely;
+                # filter only non-finite sentinel values (unreachable legs).
                 if (
                     info is None or not info["reachable"]
-                    or info["cost"] >= float("inf") or info["distance_m"] <= 0
+                    or not math.isfinite(info["cost"])
+                    or not math.isfinite(info["distance_m"])
                 ):
                     continue
                 if cutoff_cost is not None and info["cost"] > cutoff_cost:

--- a/app/services/network/graph_builder.py
+++ b/app/services/network/graph_builder.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 
 import networkx as nx
 from shapely import STRtree
-from shapely.geometry import shape, LineString, MultiLineString, Point, MultiPoint, mapping
+from shapely.geometry import shape, LineString, MultiLineString, Point, MultiPoint, GeometryCollection, mapping
 from shapely.ops import unary_union, split
 
 from app.services.network.models import (
@@ -246,42 +246,54 @@ class NetworkGraphBuilder:
                 elif isinstance(one_way_raw, (int, float)):
                     is_one_way = bool(one_way_raw)
 
-            # Add u -> v edge
-            edge_id_uv = f"e{edge_counter}"
-            edge_counter += 1
-            geom_dict_uv = mapping(line_geom)
+            # Add u -> v edge.
+            #
+            # #457: the DiGraph holds exactly ONE edge per directed (u, v)
+            # pair — a second add with the same pair used to silently REPLACE
+            # the first in the graph while the dataset kept both ids,
+            # desyncing dataset edge ids from the graph (the snapper returns
+            # dataset edge ids that routing then looks up in the graph).
+            # Duplicate/parallel linework between the same node pair is now
+            # deduplicated in BOTH structures, keeping them 1:1 (the first
+            # geometry wins). The check is per DIRECTED pair so a two-way
+            # duplicate still contributes the v->u direction when the first
+            # line was one-way.
+            if not graph.has_edge(u_id, v_id):
+                edge_id_uv = f"e{edge_counter}"
+                edge_counter += 1
+                geom_dict_uv = mapping(line_geom)
 
-            graph.add_edge(
-                u_id,
-                v_id,
-                id=edge_id_uv,
-                u=u_id,
-                v=v_id,
-                length_m=length_m,
-                speed_kmh=speed,
-                travel_time_s=travel_time_s,
-                highway_type=hw_type,
-                geometry=geom_dict_uv,
-                one_way=is_one_way,
-                properties=props,
-            )
+                graph.add_edge(
+                    u_id,
+                    v_id,
+                    id=edge_id_uv,
+                    u=u_id,
+                    v=v_id,
+                    length_m=length_m,
+                    speed_kmh=speed,
+                    travel_time_s=travel_time_s,
+                    highway_type=hw_type,
+                    geometry=geom_dict_uv,
+                    one_way=is_one_way,
+                    properties=props,
+                )
 
-            edge_obj_uv = Edge(
-                id=edge_id_uv,
-                u=u_id,
-                v=v_id,
-                length_m=length_m,
-                speed_kmh=speed,
-                travel_time_s=travel_time_s,
-                highway_type=hw_type,
-                geometry=geom_dict_uv,
-                one_way=is_one_way,
-                properties=props,
-            )
-            edges_list.append(edge_obj_uv)
+                edge_obj_uv = Edge(
+                    id=edge_id_uv,
+                    u=u_id,
+                    v=v_id,
+                    length_m=length_m,
+                    speed_kmh=speed,
+                    travel_time_s=travel_time_s,
+                    highway_type=hw_type,
+                    geometry=geom_dict_uv,
+                    one_way=is_one_way,
+                    properties=props,
+                )
+                edges_list.append(edge_obj_uv)
 
             # Add reverse v -> u edge if not one-way
-            if not is_one_way:
+            if not is_one_way and not graph.has_edge(v_id, u_id):
                 edge_id_vu = f"e{edge_counter}"
                 edge_counter += 1
                 rev_line = LineString(list(reversed(coords)))
@@ -391,7 +403,16 @@ class NetworkGraphBuilder:
         line_items: List[Tuple[LineString, Dict[str, Any]]],
         split_intersections: bool,
     ) -> List[Tuple[LineString, Dict[str, Any]]]:
-        """Splits lines at intersection points while maintaining line directionality."""
+        """Splits lines at intersection points while maintaining line directionality.
+
+        Issue #457: COLLILINEAR OVERLAPS are split too. The previous code
+        collected only Point/MultiPoint intersections, so a pair of overlapping
+        lines — whose intersection is a LineString (or a GeometryCollection
+        containing one) — was silently never split, leaving the shared
+        sub-segment as a disconnected parallel edge. Now the overlap's
+        ENDPOINTS join the cutter set, cutting both lines where the shared run
+        begins/ends so it becomes real junction-connected edges.
+        """
         if not split_intersections or len(line_items) <= 1:
             return line_items
 
@@ -404,6 +425,25 @@ class NetworkGraphBuilder:
         # test to bounding-box-overlapping pairs (typically a handful per
         # line), giving the exact same point set with a fraction of the work.
         intersection_points: List[Point] = []
+
+        def _collect_split_points(inter: Any) -> None:
+            """Add every split-worthy location of an intersection geometry."""
+            if isinstance(inter, Point):
+                intersection_points.append(inter)
+            elif isinstance(inter, MultiPoint):
+                intersection_points.extend(inter.geoms)
+            elif isinstance(inter, LineString):
+                # Collinear overlap (#457): cut at both ends of the shared run.
+                if not inter.is_empty and len(inter.coords) >= 2:
+                    intersection_points.append(Point(inter.coords[0]))
+                    intersection_points.append(Point(inter.coords[-1]))
+            elif isinstance(inter, MultiLineString):
+                for part in inter.geoms:
+                    _collect_split_points(part)
+            elif isinstance(inter, GeometryCollection):
+                for part in inter.geoms:
+                    _collect_split_points(part)
+
         tree = STRtree(lines)
         for i, line in enumerate(lines):
             for j in tree.query(line, predicate="intersects"):
@@ -414,10 +454,7 @@ class NetworkGraphBuilder:
                     continue
                 inter = line.intersection(lines[j])
                 if not inter.is_empty:
-                    if isinstance(inter, Point):
-                        intersection_points.append(inter)
-                    elif isinstance(inter, MultiPoint):
-                        intersection_points.extend(list(inter.geoms))
+                    _collect_split_points(inter)
 
         if not intersection_points:
             return line_items

--- a/app/services/network/od_matrix.py
+++ b/app/services/network/od_matrix.py
@@ -3,6 +3,8 @@ Network Origin-Destination (OD) Matrix Service Component.
 Implements fast batch N x M cost matrix calculation using multi-source Dijkstra.
 """
 from __future__ import annotations
+import heapq
+import itertools
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import networkx as nx
@@ -17,6 +19,54 @@ from app.services.network.models import (
 )
 from app.services.network.snapping import PointSnappingService
 from app.services.network.routing import NetworkRoutingService, build_weight_func
+
+
+def _single_source_costs(
+    graph: nx.DiGraph,
+    source: Any,
+    weight_func,
+    cutoff: Optional[float] = None,
+) -> Tuple[Dict[Any, float], Dict[Any, float], Dict[Any, float]]:
+    """Single-source Dijkstra accumulating cost, length and time per node (#449).
+
+    Unlike ``nx.single_source_dijkstra`` this never materializes path lists —
+    networkx builds the FULL path ([origin, ..., node]) for every reachable
+    node, O(sum|path|) ≈ O(V²) worst case (measured 48.9 s for one origin on
+    an 8k-node path graph) — and the previous code then re-walked those paths
+    in Python to re-sum distance/time. Here each settled node carries its
+    accumulated cost / length_m / travel_time_s directly (GIS-19 semantics:
+    secondary metrics accumulate along the chosen shortest-path tree).
+
+    ``cutoff`` (in cost units of the active impedance) prunes both the frontier
+    pushes and the settling loop; nodes beyond it are simply absent from the
+    returned maps.
+    """
+    dist: Dict[Any, float] = {}
+    acc_len: Dict[Any, float] = {}
+    acc_time: Dict[Any, float] = {}
+    counter = itertools.count()
+    # (cost, tiebreak, length, time, node) — the int tiebreak keeps heap
+    # comparisons total even when node ids have mixed types.
+    heap = [(0.0, next(counter), 0.0, 0.0, source)]
+    while heap:
+        cost, _, alen, atime, node = heapq.heappop(heap)
+        if node in dist:
+            continue  # stale entry
+        if cutoff is not None and cost > cutoff:
+            break  # everything left on the heap is beyond the cutoff
+        dist[node] = cost
+        acc_len[node] = alen
+        acc_time[node] = atime
+        for nbr, edata in graph[node].items():
+            if nbr in dist:
+                continue
+            nc = cost + weight_func(node, nbr, edata)
+            if cutoff is not None and nc > cutoff:
+                continue
+            nl = alen + float(edata.get("length_m") or 0.0)
+            nt = atime + float(edata.get("travel_time_s") or 0.0)
+            heapq.heappush(heap, (nc, next(counter), nl, nt, nbr))
+    return dist, acc_len, acc_time
 
 
 class NetworkODMatrixService:
@@ -37,6 +87,7 @@ class NetworkODMatrixService:
         profile: Optional[TravelProfile] = None,
         impedance: Optional[Impedance] = None,
         barriers: Optional[List[Barrier]] = None,
+        cutoff_s: Optional[float] = None,
     ) -> List[ODPair]:
         """
         Computes batch origin-destination travel costs and distances.
@@ -49,6 +100,9 @@ class NetworkODMatrixService:
             profile: TravelProfile.
             impedance: Impedance model.
             barriers: Optional list of barriers to avoid.
+            cutoff_s: Optional cost cutoff in the ACTIVE impedance's units
+                (seconds for travel_time_s, meters for length_m). Pairs whose
+                cost exceeds it are returned unreachable (#449).
 
         Returns:
             List of ODPair objects.
@@ -59,6 +113,7 @@ class NetworkODMatrixService:
         res = self._compute_od(
             origins, destinations, graph, network_dataset,
             profile=profile, impedance=impedance, barriers=barriers,
+            cutoff_s=cutoff_s, need_paths=False,
         )
 
         od_matrix: List[ODPair] = []
@@ -102,6 +157,7 @@ class NetworkODMatrixService:
         profile: Optional[TravelProfile] = None,
         impedance: Optional[Impedance] = None,
         barriers: Optional[List[Barrier]] = None,
+        cutoff_s: Optional[float] = None,
     ) -> Dict[str, Any]:
         """Batch OD with full shortest-path trees, one Dijkstra per unique origin.
 
@@ -126,6 +182,7 @@ class NetworkODMatrixService:
         res = self._compute_od(
             origins, destinations, graph, network_dataset,
             profile=profile, impedance=impedance, barriers=barriers,
+            cutoff_s=cutoff_s, need_paths=True,
         )
 
         pairs: Dict[Tuple[str, str], Dict[str, Any]] = {}
@@ -170,8 +227,20 @@ class NetworkODMatrixService:
         profile: Optional[TravelProfile] = None,
         impedance: Optional[Impedance] = None,
         barriers: Optional[List[Barrier]] = None,
+        cutoff_s: Optional[float] = None,
+        need_paths: bool = False,
     ) -> Dict[str, Any]:
-        """Shared multi-source Dijkstra core used by matrix and path variants."""
+        """Shared multi-source Dijkstra core used by matrix and path variants.
+
+        #449: ``need_paths=False`` (cost-only matrix) runs
+        ``_single_source_costs`` — an accumulating Dijkstra with genuine
+        ``cutoff_s`` pruning and NO path materialization (networkx's
+        ``single_source_dijkstra`` builds full path lists for every reachable
+        node, O(V²) worst case, which the old code then re-walked in Python
+        to re-sum distance/time). ``need_paths=True`` keeps networkx's
+        path-returning variant (closest-facility / VRP reconstruct routes
+        from the trees) and forwards the cutoff to it.
+        """
         # Resolve all origin nodes and labels
         orig_nodes: List[Tuple[str, str]] = [
             self.router._resolve_node(o, network_dataset) for o in origins
@@ -188,20 +257,14 @@ class NetworkODMatrixService:
         elif profile and profile.impedance_field:
             cost_field = profile.impedance_field
 
-        turn_penalty = impedance.turn_penalty_s if impedance else 0.0
-        if profile and profile.turn_penalty_s:
-            turn_penalty = max(turn_penalty, profile.turn_penalty_s)
-
         # #455: OD trees carry pure edge costs — a turn penalty depends on the
         # full path context that a shortest-path tree does not have. See
         # build_weight_func's docstring for the cross-tool semantics.
         weight_func = build_weight_func(cost_field)
 
-        # GIS-19: one Dijkstra per unique origin with the impedance weight, then
-        # recover distance and time by walking the shortest-path predecessor
-        # tree summing length_m / travel_time_s along each edge. The previous
-        # code ran THREE full Dijkstra passes per origin (cost, distance, time)
-        # even though distance and time accumulate along the same shortest path.
+        # GIS-19: one Dijkstra per unique origin with the impedance weight;
+        # distance and time accumulate along the same shortest-path tree.
+        # #449: the cost-only variant accumulates them during the search.
         unique_orig_nodes = set(n_id for n_id, _ in orig_nodes)
         dijkstra_results: Dict[str, Dict[str, float]] = {}
         dijkstra_dist: Dict[str, Dict[str, float]] = {}
@@ -209,12 +272,26 @@ class NetworkODMatrixService:
         dijkstra_paths: Dict[str, Dict[str, list]] = {}
 
         for o_node in unique_orig_nodes:
-            if o_node in graph_view:
-                # nx.single_source_dijkstra returns (dist_dict, path_dict);
-                # path_dict maps each reachable node to its FULL path list
-                # ([origin, ..., node]). Sum length_m / travel_time_s along each
-                # path in one O(path-length) pass per node — no extra Dijkstra.
-                dists, paths = nx.single_source_dijkstra(graph_view, o_node, weight=weight_func)
+            if o_node not in graph_view:
+                dijkstra_results[o_node] = {}
+                dijkstra_paths[o_node] = {}
+                dijkstra_dist[o_node] = {}
+                dijkstra_time[o_node] = {}
+                continue
+            if not need_paths:
+                dists, distances, times = _single_source_costs(
+                    graph_view, o_node, weight_func, cutoff=cutoff_s
+                )
+                dijkstra_results[o_node] = dists
+                dijkstra_dist[o_node] = distances
+                dijkstra_time[o_node] = times
+                dijkstra_paths[o_node] = {}
+            else:
+                # Path variant: networkx returns (dist_dict, path_dict); the
+                # cutoff keeps nodes beyond it out of both maps.
+                dists, paths = nx.single_source_dijkstra(
+                    graph_view, o_node, weight=weight_func, cutoff=cutoff_s
+                )
                 dijkstra_results[o_node] = dists
                 dijkstra_paths[o_node] = paths
 
@@ -235,11 +312,6 @@ class NetworkODMatrixService:
                     times[node] = time_acc
                 dijkstra_dist[o_node] = distances
                 dijkstra_time[o_node] = times
-            else:
-                dijkstra_results[o_node] = {}
-                dijkstra_paths[o_node] = {}
-                dijkstra_dist[o_node] = {}
-                dijkstra_time[o_node] = {}
 
         return {
             "origin_nodes": orig_nodes,

--- a/app/services/network/od_matrix.py
+++ b/app/services/network/od_matrix.py
@@ -192,7 +192,10 @@ class NetworkODMatrixService:
         if profile and profile.turn_penalty_s:
             turn_penalty = max(turn_penalty, profile.turn_penalty_s)
 
-        weight_func = build_weight_func(cost_field, turn_penalty)
+        # #455: OD trees carry pure edge costs — a turn penalty depends on the
+        # full path context that a shortest-path tree does not have. See
+        # build_weight_func's docstring for the cross-tool semantics.
+        weight_func = build_weight_func(cost_field)
 
         # GIS-19: one Dijkstra per unique origin with the impedance weight, then
         # recover distance and time by walking the shortest-path predecessor

--- a/app/services/network/od_matrix.py
+++ b/app/services/network/od_matrix.py
@@ -241,15 +241,28 @@ class NetworkODMatrixService:
         path-returning variant (closest-facility / VRP reconstruct routes
         from the trees) and forwards the cutoff to it.
         """
+        # #453: coordinate / PointSnappingResult inputs are resolved on a
+        # single working-copy graph with the SAME virtual-node mid-edge
+        # splitting that network_shortest_path uses (GIS-01). The previous
+        # endpoint-only resolution made the OD family report up to ~2 edge
+        # lengths more than routing for the same physical OD pair. Node-id
+        # inputs keep using the caller's graph untouched (no copy).
+        needs_split = any(not isinstance(t, str) for t in origins) or any(
+            not isinstance(t, str) for t in destinations
+        )
+        graph_work = graph.copy() if needs_split else graph
+
         # Resolve all origin nodes and labels
         orig_nodes: List[Tuple[str, str]] = [
-            self.router._resolve_node(o, network_dataset) for o in origins
+            self.router._resolve_with_snap(o, network_dataset, graph=graph_work)[:2]
+            for o in origins
         ]
         dest_nodes: List[Tuple[str, str]] = [
-            self.router._resolve_node(d, network_dataset) for d in destinations
+            self.router._resolve_with_snap(d, network_dataset, graph=graph_work)[:2]
+            for d in destinations
         ]
 
-        graph_view = self.router._apply_barriers(graph, barriers)
+        graph_view = self.router._apply_barriers(graph_work, barriers)
 
         cost_field = "travel_time_s"
         if impedance and impedance.name:

--- a/app/services/network/routing.py
+++ b/app/services/network/routing.py
@@ -369,14 +369,30 @@ class NetworkRoutingService:
         # Run Pathfinding
         try:
             if algorithm.lower() == "astar":
+                # Issue #447: the heuristic previously divided the
+                # straight-line distance by the PROFILE default speed
+                # (driving 40 km/h / walking 4.8 km/h). The builder assigns
+                # per-edge speeds of 60-100+ km/h with no clamp, so on any
+                # network with edges faster than the default the heuristic
+                # OVERESTIMATED the remaining cost — inadmissible, and A*
+                # could settle the goal via a suboptimal path (measured +2.0%
+                # travel time; ~8-20x overestimate for walking profiles).
+                #
+                # The bound is now derived from the graph itself: the minimum
+                # edge cost per meter of length under the active weight
+                # function. Any u→v path has network length ≥ haversine(u, v)
+                # and every meter costs at least that ratio, so
+                # h = haversine * ratio ≤ true remaining cost for ANY cost
+                # field (time, length, custom), staying conservative.
+                min_cost_per_m = self._min_cost_per_meter(graph_view, weight_func)
+
                 def heuristic(u: Any, v: Any) -> float:
+                    if min_cost_per_m is None:
+                        return 0.0
                     u_data = graph_view.nodes[u]
                     v_data = graph_view.nodes[v]
                     dist_m = haversine_distance((u_data["x"], u_data["y"]), (v_data["x"], v_data["y"]))
-                    if cost_field == "travel_time_s":
-                        speed = profile.speed_kmh if profile else 40.0
-                        return dist_m / ((speed * 1000.0) / 3600.0)
-                    return dist_m
+                    return dist_m * min_cost_per_m
 
                 path_nodes = nx.astar_path(graph_view, start_node_id, end_node_id, heuristic=heuristic, weight=weight_func)
             else:
@@ -405,6 +421,27 @@ class NetworkRoutingService:
             origin_label=origin_id_str, destination_label=dest_id_str,
             profile_name=profile_name, route_id=route_id, weight_func=weight_func,
         )
+
+    @staticmethod
+    def _min_cost_per_meter(graph: nx.DiGraph, weight_func) -> Optional[float]:
+        """Smallest per-meter edge cost under ``weight_func`` (issue #447).
+
+        Used as the A* heuristic scale: h(u, v) = haversine(u, v) * ratio is a
+        guaranteed lower bound of the remaining path cost because network path
+        length ≥ straight-line distance and each meter of any edge costs at
+        least the minimum ratio. Returns None when the graph has no usable
+        positive lengths (callers fall back to h = 0, i.e. Dijkstra behavior —
+        always admissible).
+        """
+        min_ratio: Optional[float] = None
+        for u, v, data in graph.edges(data=True):
+            length_m = data.get("length_m")
+            if not isinstance(length_m, (int, float)) or length_m <= 0:
+                continue
+            ratio = weight_func(u, v, data) / float(length_m)
+            if min_ratio is None or ratio < min_ratio:
+                min_ratio = ratio
+        return min_ratio
 
     def build_route_from_path(
         self,

--- a/app/services/network/routing.py
+++ b/app/services/network/routing.py
@@ -79,6 +79,14 @@ class NetworkRoutingService:
         Mutates ``graph`` in place (callers pass a working copy). Handles both
         directions when the edge is bidirectional. Returns the virtual node id.
 
+        ``fraction`` is defined along the (edge_u→edge_v) ORIENTATION. Issue
+        #446: the reverse graph edge (edge_v→edge_u) has reversed geometry, so
+        the same physical split point sits at ``1 - fraction`` along it —
+        applying ``fraction`` to both orientations swapped the sub-edge
+        lengths/times and produced reverse sub-geometries that missed the
+        virtual node (a mid-edge route to the near endpoint reported (1−f)·L
+        instead of f·L).
+
         Handles the case where the target edge was ALREADY split by an earlier
         virtual-node insertion (origin and destination snapping to the same
         edge): the walk follows the sub-edge chain from u to v, accumulates
@@ -90,17 +98,23 @@ class NetworkRoutingService:
 
         fraction = max(0.0, min(1.0, fraction))
 
-        for u, v in ((edge_u, edge_v), (edge_v, edge_u)):
+        # Each graph edge's own geometry runs from its u to its v (the builder
+        # stores a reversed LineString for the v→u edge), so the fraction must
+        # be re-expressed in each orientation's own frame: 1−f for the reverse.
+        for u, v, frac in (
+            (edge_u, edge_v, fraction),
+            (edge_v, edge_u, 1.0 - fraction),
+        ):
             if not graph.has_edge(u, v):
                 continue
             data = graph[u][v]
             length_m = float(data.get("length_m", 0.0))
             time_s = float(data.get("travel_time_s", 0.0))
 
-            sub_len_1 = length_m * fraction
-            sub_len_2 = length_m * (1.0 - fraction)
-            sub_time_1 = time_s * fraction
-            sub_time_2 = time_s * (1.0 - fraction)
+            sub_len_1 = length_m * frac
+            sub_len_2 = length_m * (1.0 - frac)
+            sub_time_1 = time_s * frac
+            sub_time_2 = time_s * (1.0 - frac)
 
             # Subdivide the geometry (if present) at the split point.
             geom_dict = data.get("geometry")
@@ -111,7 +125,7 @@ class NetworkRoutingService:
                     geom = shape(geom_dict)
                     if isinstance(geom, LineString):
                         coords = list(geom.coords)
-                        split_pt = geom.interpolate(fraction, normalized=True)
+                        split_pt = geom.interpolate(frac, normalized=True)
                         # Split the coordinate sequence at the projected split
                         # point: vertices before it go to sub1, the split point
                         # joins them, and the remainder goes to sub2.
@@ -188,16 +202,23 @@ class NetworkRoutingService:
                 break
 
         fraction = max(0.0, min(1.0, fraction))
-        target_dist = orig_length * fraction
 
-        for start_u, start_v in ((orig_u, orig_v), (orig_v, orig_u)):
+        # The fraction is measured along the dataset edge's (orig_u→orig_v)
+        # orientation. Walking from orig_v (issue #446) the same physical
+        # position sits at 1−f, so each direction gets its own target distance
+        # and its own fraction when the original edge is still unsplit.
+        for start_u, start_v, dir_frac in (
+            (orig_u, orig_v, fraction),
+            (orig_v, orig_u, 1.0 - fraction),
+        ):
+            target_dist = orig_length * dir_frac
             if not graph.has_edge(start_u, start_v) and start_u not in graph:
                 continue
             # If the original edge still exists directly, split it — the common
             # first-snap case.
             if graph.has_edge(start_u, start_v):
                 return self._split_edge_at_fraction(
-                    graph, start_u, start_v, fraction, snapped_coord
+                    graph, start_u, start_v, dir_frac, snapped_coord
                 )
             # Otherwise walk the sub-edge chain created by a previous split.
             # REVIEWER BLOCKING FIX: the previous walk used nx.has_path on

--- a/app/services/network/routing.py
+++ b/app/services/network/routing.py
@@ -5,6 +5,8 @@ Supports custom impedance metrics, turn penalties, point and polygon barrier avo
 route GeoJSON line generation, and turn-by-turn directions.
 """
 from __future__ import annotations
+import heapq
+import itertools
 import math
 import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -23,13 +25,36 @@ from app.services.network.models import (
 from app.services.network.snapping import PointSnappingService
 from app.services.network.graph_builder import haversine_distance
 
+# Issue #455: a vertex counts as an actual TURN when the incoming/outgoing
+# bearings differ by more than this threshold. Same boundary as
+# ``_calculate_turn_type``'s "Continue straight" band, so a step is charged a
+# turn penalty exactly when the turn-by-turn directions call it a turn.
+_TURN_STRAIGHT_THRESHOLD_DEG = 25.0
 
-def build_weight_func(cost_field: str, turn_penalty: float = 0.0):
+
+def build_weight_func(cost_field: str):
     """Edge weight function factory shared by routing and OD-matrix analyses.
 
-    Keeps the cost semantics (barrier factors, turn penalties) identical
-    between direct ``network_shortest_path`` and batch multi-source Dijkstra
-    (closest facility / VRP reuse the OD service's shortest-path trees).
+    Cost semantics (#455): the weight is the pure edge cost — the impedance
+    field adjusted for barrier factors. TURN PENALTIES ARE NOT PART OF IT:
+
+    an edge-local weight cannot see the preceding edge, so the old per-edge
+    ``+turn_penalty`` charged the departure edge and every straight-through
+    continuation, overcounting each path by ~1 penalty and biasing selection
+    toward fewer-edge paths. Turn penalties are now applied only where the
+    full path is known:
+
+    * point-to-point routing (``network_shortest_path``) charges the penalty
+      at interior vertices whose bearing change exceeds the straight threshold
+      — both during search (edge-state Dijkstra/A*, see
+      ``_turn_aware_shortest_path``) and when reporting ``total_cost``;
+    * OD-family trees (closest facility / VRP / accessibility) resolve pure
+      edge costs: a turn penalty depends on path context that a shortest-path
+      tree does not have, so penalties do not influence batch tree selection.
+
+    The penalty is a DURATION and therefore applies only to the
+    ``travel_time_s`` impedance; under length/custom impedance it does not
+    affect selection or cost.
     """
     def weight_func(u: Any, v: Any, edge_data: Dict[str, Any]) -> float:
         base_w = edge_data.get(cost_field, edge_data.get("length_m", 1.0))
@@ -37,8 +62,6 @@ def build_weight_func(cost_field: str, turn_penalty: float = 0.0):
             base_w = 0.001
         barrier_factor = edge_data.get("_barrier_factor", 1.0)
         w = base_w * barrier_factor
-        if turn_penalty > 0 and cost_field == "travel_time_s":
-            w += turn_penalty
         return max(0.0001, float(w))
     return weight_func
 
@@ -364,11 +387,33 @@ class NetworkRoutingService:
         if profile and profile.turn_penalty_s:
             turn_penalty = max(turn_penalty, profile.turn_penalty_s)
 
-        weight_func = build_weight_func(cost_field, turn_penalty)
+        weight_func = build_weight_func(cost_field)
+
+        # Issue #455: with a time impedance and a turn penalty, the cost of a
+        # path depends on the EDGES it follows (turns at shared vertices), so
+        # the search runs over edge states instead of nodes. Without a penalty
+        # this reduces to the plain node search.
+        use_turn_aware = turn_penalty > 0 and cost_field == "travel_time_s"
 
         # Run Pathfinding
         try:
-            if algorithm.lower() == "astar":
+            if use_turn_aware:
+                heuristic = None
+                if algorithm.lower() == "astar":
+                    min_cost_per_m = self._min_cost_per_meter(graph_view, weight_func)
+                    if min_cost_per_m is not None:
+                        def heuristic(u: Any, v: Any) -> float:
+                            u_data = graph_view.nodes[u]
+                            v_data = graph_view.nodes[v]
+                            dist_m = haversine_distance(
+                                (u_data["x"], u_data["y"]), (v_data["x"], v_data["y"])
+                            )
+                            return dist_m * min_cost_per_m
+                path_nodes = self._turn_aware_shortest_path(
+                    graph_view, start_node_id, end_node_id,
+                    weight_func, turn_penalty, heuristic=heuristic,
+                )
+            elif algorithm.lower() == "astar":
                 # Issue #447: the heuristic previously divided the
                 # straight-line distance by the PROFILE default speed
                 # (driving 40 km/h / walking 4.8 km/h). The builder assigns
@@ -420,6 +465,7 @@ class NetworkRoutingService:
             graph_view, path_nodes,
             origin_label=origin_id_str, destination_label=dest_id_str,
             profile_name=profile_name, route_id=route_id, weight_func=weight_func,
+            turn_penalty=turn_penalty if use_turn_aware else 0.0,
         )
 
     @staticmethod
@@ -443,6 +489,94 @@ class NetworkRoutingService:
                 min_ratio = ratio
         return min_ratio
 
+    @staticmethod
+    def _bearing_change_deg(graph: nx.DiGraph, node_a: Any, node_b: Any, node_c: Any) -> float:
+        """Absolute bearing change (deg, [0, 180]) of the a→b→c polyline."""
+        data_a = graph.nodes[node_a]
+        data_b = graph.nodes[node_b]
+        data_c = graph.nodes[node_c]
+        v1 = (data_b["x"] - data_a["x"], data_b["y"] - data_a["y"])
+        v2 = (data_c["x"] - data_b["x"], data_c["y"] - data_b["y"])
+        bearing1 = math.atan2(v1[1], v1[0])
+        bearing2 = math.atan2(v2[1], v2[0])
+        diff_deg = math.degrees(bearing2 - bearing1)
+        while diff_deg > 180:
+            diff_deg -= 360
+        while diff_deg <= -180:
+            diff_deg += 360
+        return abs(diff_deg)
+
+    def _turn_aware_shortest_path(
+        self,
+        graph: nx.DiGraph,
+        start: Any,
+        goal: Any,
+        weight_func,
+        turn_penalty: float,
+        heuristic=None,
+    ) -> List[Any]:
+        """Edge-state Dijkstra/A* charging ``turn_penalty`` at real turns (#455).
+
+        The cost of ENTERING an edge depends on the edge it follows (the turn
+        at the shared vertex), so plain node-state search cannot apply turn
+        costs. Search states are therefore directed edges ``(u, v)``:
+        transitioning ``(a, b) → (b, c)`` costs ``w(b→c)`` plus the penalty
+        when the bearing change at ``b`` exceeds the straight threshold. The
+        DEPARTURE edge follows no other edge, so it never carries a penalty.
+
+        ``heuristic(u, v)`` (optional, must be admissible on node pairs, e.g.
+        the #447 min-cost-per-meter bound) is applied to each state's head
+        node; penalties only ADD cost, so admissibility is preserved.
+        """
+        if start not in graph:
+            raise nx.NodeNotFound(f"Node {start} not in graph")
+        if goal not in graph:
+            raise nx.NodeNotFound(f"Node {goal} not in graph")
+        if start == goal:
+            return [start]
+
+        best_g: Dict[Tuple[Any, Any], float] = {}
+        parent: Dict[Tuple[Any, Any], Optional[Tuple[Any, Any]]] = {}
+        counter = itertools.count()
+        heap: List[Tuple[float, int, float, Tuple[Any, Any]]] = []
+
+        def push(state: Tuple[Any, Any], g: float) -> None:
+            best_g[state] = g
+            h = heuristic(state[1], goal) if heuristic is not None else 0.0
+            heapq.heappush(heap, (g + h, next(counter), g, state))
+
+        # Departure edges: no penalty (no preceding edge).
+        for nbr, edata in graph[start].items():
+            push((start, nbr), weight_func(start, nbr, edata))
+
+        goal_state: Optional[Tuple[Any, Any]] = None
+        while heap:
+            _, _, g, state = heapq.heappop(heap)
+            if g > best_g.get(state, float("inf")):
+                continue  # stale heap entry
+            u, v = state
+            if v == goal:
+                goal_state = state
+                break
+            for nbr, edata in graph[v].items():
+                ng = g + weight_func(v, nbr, edata)
+                if self._bearing_change_deg(graph, u, v, nbr) > _TURN_STRAIGHT_THRESHOLD_DEG:
+                    ng += turn_penalty
+                if ng < best_g.get((v, nbr), float("inf")):
+                    parent[(v, nbr)] = state
+                    push((v, nbr), ng)
+
+        if goal_state is None:
+            raise nx.NetworkXNoPath(f"Node {goal} not reachable from {start}")
+
+        states: List[Tuple[Any, Any]] = []
+        s: Optional[Tuple[Any, Any]] = goal_state
+        while s is not None:
+            states.append(s)
+            s = parent.get(s)
+        states.reverse()
+        return [states[0][0]] + [st[1] for st in states]
+
     def build_route_from_path(
         self,
         graph: nx.DiGraph,
@@ -452,6 +586,7 @@ class NetworkRoutingService:
         profile_name: str,
         route_id: str,
         weight_func,
+        turn_penalty: float = 0.0,
     ) -> Route:
         """Build a Route (geometry, totals, directions) from a node path.
 
@@ -459,6 +594,14 @@ class NetworkRoutingService:
         analyses (closest facility / VRP), so path → route shaping stays
         identical everywhere and routes can be reconstructed from
         multi-source Dijkstra predecessor trees without per-call graph copies.
+
+        Cost composition (#455): ``total_cost`` = Σ per-edge ``weight_func``
+        costs + ``turn_penalty`` at each interior vertex whose bearing change
+        exceeds the straight threshold. For an unbarriered ``travel_time_s``
+        impedance that equals ``total_time_s + actual_turn_penalties`` — the
+        documented composition. Callers resolving pure OD trees pass the
+        default 0 (batch trees carry no turn penalties; see
+        ``build_weight_func``).
         """
         path_edges: List[str] = []
         route_coords: List[Tuple[float, float]] = []
@@ -495,6 +638,15 @@ class NetworkRoutingService:
                 if not route_coords:
                     route_coords.append((u_data["x"], u_data["y"]))
                 route_coords.append((v_data["x"], v_data["y"]))
+
+        # #455: charge the turn penalty at interior vertices that are actual
+        # turns (bearing change > the straight threshold). The departure edge
+        # has no preceding edge and straight-through vertices are free.
+        if turn_penalty > 0 and len(path_nodes) >= 3:
+            for i in range(1, len(path_nodes) - 1):
+                change = self._bearing_change_deg(graph, path_nodes[i - 1], path_nodes[i], path_nodes[i + 1])
+                if change > _TURN_STRAIGHT_THRESHOLD_DEG:
+                    total_cost += turn_penalty
 
         directions = self._generate_directions(graph, path_nodes)
 
@@ -604,33 +756,31 @@ class NetworkRoutingService:
 
     def _calculate_turn_type(self, graph: nx.DiGraph, node_a: Any, node_b: Any, node_c: Any) -> str:
         """Computes turn bearing angle and categorizes turn movement."""
+        diff_deg = self._bearing_change_deg(graph, node_a, node_b, node_c)
+        # bearing_change is absolute; recover the signed direction for the
+        # left/right classification from the raw bearings.
         data_a = graph.nodes[node_a]
         data_b = graph.nodes[node_b]
         data_c = graph.nodes[node_c]
-
         v1 = (data_b["x"] - data_a["x"], data_b["y"] - data_a["y"])
         v2 = (data_c["x"] - data_b["x"], data_c["y"] - data_b["y"])
+        signed = math.degrees(math.atan2(v2[1], v2[0]) - math.atan2(v1[1], v1[0]))
+        while signed > 180:
+            signed -= 360
+        while signed <= -180:
+            signed += 360
 
-        bearing1 = math.atan2(v1[1], v1[0])
-        bearing2 = math.atan2(v2[1], v2[0])
-
-        diff_deg = math.degrees(bearing2 - bearing1)
-        while diff_deg > 180:
-            diff_deg -= 360
-        while diff_deg <= -180:
-            diff_deg += 360
-
-        if abs(diff_deg) <= 25:
+        if diff_deg <= 25:
             return "Continue straight"
-        elif 25 < diff_deg <= 65:
+        elif 25 < signed <= 65:
             return "Turn slight right"
-        elif 65 < diff_deg <= 125:
+        elif 65 < signed <= 125:
             return "Turn right"
-        elif diff_deg > 125:
+        elif signed > 125:
             return "Make a U-turn right"
-        elif -65 <= diff_deg < -25:
+        elif -65 <= signed < -25:
             return "Turn slight left"
-        elif -125 <= diff_deg < -65:
+        elif -125 <= signed < -65:
             return "Turn left"
         else:
             return "Make a U-turn left"

--- a/app/services/network/service_area.py
+++ b/app/services/network/service_area.py
@@ -71,7 +71,23 @@ class NetworkServiceAreaService:
         normalized_facilities = self._normalize_facilities(facilities)
         sorted_breaks = sorted(breaks)
 
-        graph_view = self.router._apply_barriers(graph, barriers)
+        # #453: resolve facility coordinates on a working-copy graph with the
+        # same virtual-node mid-edge splitting routing uses — the isochrone
+        # must be rooted at the facility's snapped position, not at the
+        # nearest edge endpoint (up to a full edge-length away).
+        graph_work = graph.copy() if graph is not None else graph
+        resolved_starts: List[Tuple[str, Tuple[float, float]]] = []
+        for fac in normalized_facilities:
+            fac_coords = (fac.geometry["coordinates"][0], fac.geometry["coordinates"][1])
+            if graph_work is not None:
+                node_id, _ = self.router._resolve_with_snap(
+                    fac_coords, network_dataset, graph=graph_work
+                )[:2]
+            else:
+                node_id, _ = self.router._resolve_node(fac_coords, network_dataset)
+            resolved_starts.append((node_id, fac_coords))
+
+        graph_view = self.router._apply_barriers(graph_work, barriers)
 
         cost_field = "travel_time_s" if break_unit == "minutes" else "length_m"
         if impedance and impedance.name:
@@ -102,10 +118,7 @@ class NetworkServiceAreaService:
 
         service_areas: List[ServiceArea] = []
 
-        for fac in normalized_facilities:
-            fac_coords = (fac.geometry["coordinates"][0], fac.geometry["coordinates"][1])
-            start_node_id, _ = self.router._resolve_node(fac_coords, network_dataset)
-
+        for fac, (start_node_id, fac_coords) in zip(normalized_facilities, resolved_starts):
             if start_node_id not in graph_view:
                 continue
 

--- a/tests/unit/test_geo_analysis_isochrone_443.py
+++ b/tests/unit/test_geo_analysis_isochrone_443.py
@@ -1,0 +1,333 @@
+"""Regression tests for issue #443 (P3 perf): ``calculate_isochrones``
+(app/lib/geo_analysis/network.py — the isochrone_network tool path) ran one
+cutoff-bounded Dijkstra per facility but then scanned ALL E graph edges per
+facility with per-edge shapely substring clipping — O(F×E). On a 50k-edge
+network with 10 facilities that was measured at ~300 s.
+
+Fix: an edge is reachable iff at least one endpoint is in the facility's
+cutoff-bounded Dijkstra set, so the scan walks the adjacency of the reachable
+nodes only (in G.nodes order, deduping undirected edges exactly like
+networkx's EdgeView) — identical reachable-edge sets, clipping and polygons,
+at O(reachable) instead of O(E) per facility.
+
+The per-facility Dijkstra trees are kept deliberately: the output is one
+polygon per facility, which a merged multi-source tree cannot produce.
+"""
+import json
+
+
+import networkx as nx
+
+from shapely.geometry import LineString
+from shapely.ops import substring
+
+from app.lib.geo_analysis.network import calculate_isochrones
+
+
+def _grid_geojson(k=10, step=0.001, origin=(116.0, 39.0)):
+    """Pre-segmented k x k grid (one 2-point feature per segment)."""
+    feats = []
+    for r in range(k):
+        for c in range(k - 1):
+            feats.append({"type": "Feature", "properties": {}, "geometry": {
+                "type": "LineString",
+                "coordinates": [[origin[0] + c * step, origin[1] + r * step],
+                                [origin[0] + (c + 1) * step, origin[1] + r * step]]}})
+    for c in range(k):
+        for r in range(k - 1):
+            feats.append({"type": "Feature", "properties": {}, "geometry": {
+                "type": "LineString",
+                "coordinates": [[origin[0] + c * step, origin[1] + r * step],
+                                [origin[0] + c * step, origin[1] + (r + 1) * step]]}})
+    return {"type": "FeatureCollection", "features": feats}
+
+
+def _facility(id_, x, y):
+    return {"type": "Feature", "properties": {"id": id_},
+            "geometry": {"type": "Point", "coordinates": [x, y]}}
+
+
+def _reference_reachable_edges(network_geojson, facility, minutes, mode="walking"):
+    """The pre-fix (#443) algorithm: full ``G.edges(data=True)`` scan with
+    identical clipping semantics. Returns ``(lengths, reachable_geometries)``
+    where the geometries are in the exact order/multiplicity the old scan
+    produced — the behavioral reference for the optimized adjacency walk."""
+    import numpy as np
+    from scipy.spatial import cKDTree
+
+    from app.lib.geo_processor.core import to_utm_gdf
+    from app.lib.geo_analysis.network import _speed_m_per_min
+
+    gdf_network, utm_crs = to_utm_gdf(network_geojson)
+    gdf_facilities, _ = to_utm_gdf(facility)
+    gdf_facilities = gdf_facilities.to_crs(utm_crs)
+
+    G = nx.MultiGraph()
+    for idx, row in gdf_network.iterrows():
+        coords = list(row.geometry.coords)
+        G.add_edge(coords[0], coords[-1], weight=float(row.geometry.length), geometry=row.geometry)
+
+    max_dist = float(minutes) * _speed_m_per_min(mode)
+    nodes = list(G.nodes())
+    node_tree = cKDTree(np.array(nodes))
+    fac_geom = gdf_facilities.iloc[0].geometry
+    _, nearest_idx = node_tree.query(np.array([fac_geom.x, fac_geom.y]), k=1)
+    lengths = nx.single_source_dijkstra_path_length(G, nodes[nearest_idx], cutoff=max_dist, weight="weight")
+
+    reachable_edges = []
+    for u, v, edata in G.edges(data=True):
+        eg = edata.get("geometry")
+        if eg is None:
+            continue
+        du = lengths.get(u)
+        dv = lengths.get(v)
+        if du is None and dv is None:
+            continue
+        du_ok = du is not None and du <= max_dist
+        dv_ok = dv is not None and dv <= max_dist
+        if du_ok and dv_ok:
+            reachable_edges.append(eg)
+            continue
+        w = edata.get("weight") or eg.length
+        if w <= 0:
+            w = eg.length or 1.0
+        if du_ok:
+            frac = min(1.0, max(0.0, (max_dist - du) / w))
+            if frac > 0:
+                seg = substring(eg, 0.0, frac, normalized=True)
+                if not seg.is_empty:
+                    reachable_edges.append(seg)
+        if dv_ok:
+            frac = min(1.0, max(0.0, (max_dist - dv) / w))
+            if frac > 0:
+                seg = substring(eg, 1.0 - frac, 1.0, normalized=True)
+                if not seg.is_empty:
+                    reachable_edges.append(seg)
+    return lengths, reachable_edges, utm_crs
+
+
+def _reference_reachable_edge_count(network_geojson, facility, minutes, mode="walking"):
+    lengths, edges, _ = _reference_reachable_edges(network_geojson, facility, minutes, mode)
+    return len(lengths), len(edges)
+
+
+class TestIsochroneEquivalence:
+    def test_reachable_counts_match_reference_scan(self):
+        """reachable_nodes_count / reachable_edges_count must equal the
+        pre-fix full-scan reference on a mid-size grid."""
+        net = _grid_geojson(10)
+        facs = {"type": "FeatureCollection", "features": [_facility("f1", 116.004, 39.004)]}
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 3.0, mode="walking")
+        assert res.success, res.summary
+
+        props = res.data["features"][0]["properties"]
+        ref_nodes, ref_edges = _reference_reachable_edge_count(net, facs, 3.0, "walking")
+        assert props["reachable_nodes_count"] == ref_nodes
+        assert props["reachable_edges_count"] == ref_edges
+
+    def test_multiple_facilities_all_present(self):
+        net = _grid_geojson(12)
+        facs = {"type": "FeatureCollection", "features": [
+            _facility("a", 116.002, 39.002), _facility("b", 116.008, 39.006),
+            _facility("c", 116.005, 39.009),
+        ]}
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 5.0, mode="walking")
+        assert res.success
+        ids = [f["properties"]["facility_id"] for f in res.data["features"]]
+        assert ids == ["a", "b", "c"]
+        for f in res.data["features"]:
+            assert f["properties"]["reachable"]
+            assert f["properties"]["reachable_edges_count"] > 0
+            assert f["geometry"]["type"] in ("Polygon", "MultiPolygon")
+
+    def test_polygon_contains_facility_area(self):
+        """The buffered reachable network polygon must contain the facility."""
+        from shapely.geometry import shape, Point
+
+        net = _grid_geojson(10)
+        facs = {"type": "FeatureCollection", "features": [_facility("f1", 116.004, 39.004)]}
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 3.0, mode="walking")
+        poly = shape(res.data["features"][0]["geometry"])
+        assert poly.contains(Point(116.004, 39.004))
+
+    def test_larger_cutoff_reaches_strictly_more(self):
+        """Monotonicity: 6-min reach must strictly contain 2-min reach."""
+        net = _grid_geojson(12)
+        facs = {"type": "FeatureCollection", "features": [_facility("f1", 116.005, 39.005)]}
+        small = calculate_isochrones(json.dumps(net), json.dumps(facs), 2.0, mode="walking")
+        large = calculate_isochrones(json.dumps(net), json.dumps(facs), 6.0, mode="walking")
+        p_small = small.data["features"][0]["properties"]
+        p_large = large.data["features"][0]["properties"]
+        assert p_large["reachable_nodes_count"] > p_small["reachable_nodes_count"]
+        assert p_large["reachable_edges_count"] > p_small["reachable_edges_count"]
+
+    def test_polygon_geometry_matches_reference_full_scan(self):
+        """Full-geometry equivalence: the production polygon must equal the
+        polygon the pre-fix full-scan algorithm would emit (union of the same
+        clipped segments, same buffer, same reprojection) — not just match
+        its counts."""
+        from shapely.geometry import shape
+        from shapely.ops import unary_union
+
+        net = _grid_geojson(10)
+        facs = {"type": "FeatureCollection", "features": [_facility("f1", 116.004, 39.004)]}
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 3.0, mode="walking")
+        assert res.success
+
+        _, ref_edges, utm_crs = _reference_reachable_edges(net, facs, 3.0, "walking")
+        assert ref_edges, "reference must be reachable for this fixture"
+        import geopandas as gpd
+        ref_poly = gpd.GeoSeries(
+            [unary_union(ref_edges).buffer(30.0)], crs=utm_crs
+        ).to_crs("EPSG:4326").iloc[0]
+
+        prod_poly = shape(res.data["features"][0]["geometry"])
+        assert prod_poly.geom_type == ref_poly.geom_type
+        assert prod_poly.symmetric_difference(ref_poly).area < 1e-12, (
+            "production isochrone diverges from the pre-fix full-scan geometry"
+        )
+
+
+class TestEdgeViewOrientationParity:
+    def test_reversed_geometry_parallel_edge_clips_like_edgeview(self):
+        """Orientation parity on the sneaky topology: an edge whose only
+        reachable endpoint is the node that appears LATER in G.nodes order.
+
+        networkx's EdgeView yields such an edge as (earlier, later) — i.e.
+        EdgeView-u is the UNREACHABLE endpoint — and the pre-fix scan clipped
+        from the geometry END for it. The adjacency walk first encounters the
+        edge from the reachable LATER node and must reorient to (earlier,
+        later) exactly like EdgeView — otherwise the clipped segment lands on
+        the opposite end of the road and the polygon shifts by hundreds of
+        metres."""
+        from shapely.geometry import shape
+        from shapely.ops import unary_union
+        import geopandas as gpd
+
+        # Edge 1 (added first): A=(0,0) -> B=(0.004,0), straight. Node order
+        # becomes A=0, B=1.
+        # Edge 2: parallel, geometry B -> A along a bowed path.
+        net = {"type": "FeatureCollection", "features": [
+            {"type": "Feature", "properties": {},
+             "geometry": {"type": "LineString",
+                          "coordinates": [[0.0, 0.0], [0.004, 0.0]]}},
+            {"type": "Feature", "properties": {},
+             "geometry": {"type": "LineString",
+                          "coordinates": [[0.004, 0.0], [0.002, 0.001], [0.0, 0.0]]}},
+        ]}
+        # Facility at B: d(B)=0, A unreachable beyond the budget, so both
+        # edges are first encountered from B — the LATER node — and are only
+        # PARTIALLY reachable, so clipping orientation matters.
+        facs = {"type": "FeatureCollection", "features": [_facility("f1", 0.004, 0.0)]}
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 3.0, mode="walking")
+        assert res.success
+        assert res.data["features"][0]["properties"]["reachable_edges_count"] == 2
+
+        _, ref_edges, utm_crs = _reference_reachable_edges(net, facs, 3.0, "walking")
+        assert len(ref_edges) == 2
+        ref_poly = gpd.GeoSeries(
+            [unary_union(ref_edges).buffer(30.0)], crs=utm_crs
+        ).to_crs("EPSG:4326").iloc[0]
+        prod_poly = shape(res.data["features"][0]["geometry"])
+        assert prod_poly.symmetric_difference(ref_poly).area < 1e-12
+
+
+class TestAdversarialTopologies:
+    def test_disconnected_graph_stays_within_own_component(self):
+        """Two disjoint grids: the facility's reachable set must come from its
+        own component only, and still match the pre-fix reference."""
+        a = _grid_geojson(6, origin=(116.0, 39.0))
+        b = _grid_geojson(6, origin=(117.0, 39.0))  # ~1 deg away: no shared nodes
+        net = {"type": "FeatureCollection", "features": a["features"] + b["features"]}
+        facs = {"type": "FeatureCollection", "features": [_facility("f1", 116.002, 39.002)]}
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 5.0, mode="walking")
+        assert res.success
+        props = res.data["features"][0]["properties"]
+        assert props["reachable"]
+        ref_nodes, ref_edges = _reference_reachable_edge_count(net, facs, 5.0, "walking")
+        assert props["reachable_nodes_count"] == ref_nodes
+        assert props["reachable_edges_count"] == ref_edges
+        # A 5-min walk (~400 m) cannot leave the 6x6 (~550 m) grid A.
+        assert ref_nodes < 6 * 6
+
+    def test_facility_far_off_network_snaps_to_nearest_node(self):
+        """A facility 0.5 deg from any road must not crash: it snaps to the
+        nearest node and gets an honest tiny isochrone there."""
+        net = _grid_geojson(4, origin=(116.0, 39.0))
+        facs = {"type": "FeatureCollection", "features": [_facility("far", 116.5, 39.5)]}
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 0.5, mode="walking")
+        assert res.success
+        props = res.data["features"][0]["properties"]
+        # 0.5 min walking = 40 m < one ~110 m grid cell: at most the four
+        # edges incident to the snapped node, each partially clipped.
+        assert props["reachable"]
+        assert 0 < props["reachable_edges_count"] <= 4
+        assert props["reachable_nodes_count"] == 1
+        assert res.data["features"][0]["geometry"]["type"] in ("Polygon", "MultiPolygon")
+
+    def test_zero_travel_time_yields_marker_not_crash(self):
+        """travel_time_min=0 -> max_dist=0: only the snapped node is in the
+        Dijkstra set and every clip fraction is 0, so the honest-unreachable
+        marker path must trigger (no crash, no fabricated coverage)."""
+        net = _grid_geojson(6)
+        facs = {"type": "FeatureCollection", "features": [_facility("f1", 116.002, 39.002)]}
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 0.0, mode="walking")
+        assert res.success
+        props = res.data["features"][0]["properties"]
+        assert props["reachable"] is False
+        assert props["reachable_edges_count"] == 0
+        assert props["reachable_nodes_count"] == 1
+        assert res.data["features"][0]["geometry"]["type"] in ("Polygon", "MultiPolygon")
+
+
+class TestPartialEdgeClipping:
+    def test_partial_edge_clipped_from_reachable_end(self):
+        """Unit check of the clipping semantics on a hand-built MultiGraph:
+        an edge with one endpoint beyond the budget is clipped at the
+        remaining fraction from the reachable end."""
+        G = nx.MultiGraph()
+        # 400 m straight road; facility at u's position, budget 300 m.
+        G.add_node((0.0, 0.0))
+        G.add_node((0.0, 0.0036))
+        line = LineString([(0.0, 0.0), (0.0, 0.0036)])
+        G.add_edge((0.0, 0.0), (0.0, 0.0036), weight=400.0, geometry=line)
+
+        lengths = {(0.0, 0.0): 0.0}
+        max_dist = 300.0
+
+        # Reproduce the production clipping for this edge (reference copy).
+        for u, v, edata in G.edges(data=True):
+            eg = edata.get("geometry")
+            w = edata.get("weight") or eg.length
+            du = lengths.get(u)
+            dv = lengths.get(v)
+            assert du is not None and dv is None
+            frac = min(1.0, max(0.0, (max_dist - du) / w))
+            seg = substring(eg, 0.0, frac, normalized=True)
+            assert abs(seg.length - frac * eg.length) < 1e-9, (
+                f"clipped {seg.length:.6f} of a {eg.length:.6f} edge — expected "
+                f"{frac:.3f} of it at a {max_dist:.0f}/{w:.0f} m budget"
+            )
+            assert abs(frac - 0.75) < 1e-9
+
+
+class TestPerf:
+    def test_small_reach_on_large_network_is_fast(self):
+        """Structural performance guard: a tiny travel budget over a large
+        network must not pay the full O(F x E) edge scan — the reachable set
+        is a few dozen edges out of ~20k. Generous wall bound (the pre-fix
+        code needed ~10+ s for this shape)."""
+        import time
+
+        net = _grid_geojson(100)  # 19,800 edges
+        facs = {"type": "FeatureCollection", "features": [
+            _facility("f1", 116.05, 39.05), _facility("f2", 116.07, 39.03),
+        ]}
+        t0 = time.perf_counter()
+        res = calculate_isochrones(json.dumps(net), json.dumps(facs), 1.0, mode="walking")
+        elapsed = time.perf_counter() - t0
+        assert res.success
+        # 1 min walking = 80 m ≈ 1 grid cell: tiny reachable sets.
+        for f in res.data["features"]:
+            assert f["properties"]["reachable_edges_count"] <= 200
+        assert elapsed < 5.0, f"tiny-budget isochrone over 19.8k edges took {elapsed:.1f} s"

--- a/tests/unit/test_network_algo_hotspots.py
+++ b/tests/unit/test_network_algo_hotspots.py
@@ -129,7 +129,12 @@ def _build_grid():
 def test_closest_facility_no_graph_copy(monkeypatch):
     """closest_facility with coordinate inputs must not copy the graph per
     demand×facility pair (the old code ran network_shortest_path per pair,
-    which copied the whole graph for every call)."""
+    which copied the whole graph for every call).
+
+    #453 amendment: the OD pass now makes ONE working copy per analysis to
+    insert virtual mid-edge nodes (the same GIS-01 semantics as routing), so
+    the bound is "no PER-PAIR copies" — a bounded constant, not zero.
+    """
     graph, dataset = _build_grid()
     copies = []
 
@@ -142,7 +147,10 @@ def test_closest_facility_no_graph_copy(monkeypatch):
     monkeypatch.setattr(nx.DiGraph, "copy", counting_copy)
 
     svc = NetworkClosestFacilityService()
-    demands = [DemandPoint(demand_id="d1", weight=1.0, geometry={"type": "Point", "coordinates": [116.01, 39.005]})]
+    demands = [
+        DemandPoint(demand_id="d1", weight=1.0, geometry={"type": "Point", "coordinates": [116.01, 39.005]}),
+        DemandPoint(demand_id="d2", weight=1.0, geometry={"type": "Point", "coordinates": [116.02, 39.015]}),
+    ]
     facilities = [
         Facility(facility_id="f_far", geometry={"type": "Point", "coordinates": [116.03, 39.03]}),
         Facility(facility_id="f_near", geometry={"type": "Point", "coordinates": [116.02, 39.005]}),
@@ -151,9 +159,13 @@ def test_closest_facility_no_graph_copy(monkeypatch):
         demand_points=demands, facilities=facilities,
         graph=graph, network_dataset=dataset, target_facility_count=1,
     )
-    assert copies == [], f"graph.copy called {len(copies)} times during closest_facility"
-    assert len(res.routes) == 1
-    assert res.routes[0].destination_id == "f_near"
+    # 2 demands x 2 facilities = 4 pairs: per-pair copying would make >= 4
+    # copies; the #453 working copy is a single per-analysis constant.
+    assert len(copies) <= 1, (
+        f"graph.copy called {len(copies)} times during closest_facility — "
+        f"per-pair copying regressed"
+    )
+    assert len(res.routes) == 2
     assert res.routes[0].total_distance_m > 0
     assert res.routes[0].geometry["type"] == "LineString"
     assert len(res.routes[0].path_node_ids) >= 2

--- a/tests/unit/test_network_issue446_reverse_split.py
+++ b/tests/unit/test_network_issue446_reverse_split.py
@@ -1,0 +1,271 @@
+"""Regression tests for issue #446 (P1): reverse-direction edge splitting
+applied the same fraction.
+
+``_split_edge_at_fraction`` looped over both orientations of a two-way edge
+((u,v) and (v,u)) applying the SAME ``fraction``. The fraction is defined
+along the u→v geometry, so for the reverse (v→u) edge the correct local
+fraction is 1−f. The bug produced swapped sub-edge lengths (a route from a
+mid-edge origin to the NEAR endpoint reported (1−f)·L instead of f·L —
+measured 691.3 m vs the true 172.8 m) and reverse sub-geometries that did
+not contain the virtual node's position.
+"""
+import math
+
+import pytest
+
+from shapely.geometry import shape
+
+from app.services.network.graph_builder import NetworkGraphBuilder, haversine_distance
+from app.services.network.models import TravelProfile
+from app.services.network.routing import NetworkRoutingService
+
+
+def _single_two_way_edge(length_deg=0.01):
+    """One two-way edge (116.0,39.0)→(116.01,39.0), ~865 m at 39°N."""
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"speed_kmh": 60.0, "one_way": False, "name": "Main Rd"},
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[116.0, 39.0], [116.0 + length_deg, 39.0]],
+                },
+            }
+        ],
+    }
+    builder = NetworkGraphBuilder()
+    graph, dataset = builder.build_graph(geojson, profile=TravelProfile())
+    return graph, dataset
+
+
+def _two_edge_chain():
+    """Two collinear two-way edges n0 --e0-- n1 --e1-- n2."""
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"speed_kmh": 60.0, "one_way": False},
+                "geometry": {"type": "LineString", "coordinates": [[116.0, 39.0], [116.01, 39.0]]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"speed_kmh": 60.0, "one_way": False},
+                "geometry": {"type": "LineString", "coordinates": [[116.01, 39.0], [116.02, 39.0]]},
+            },
+        ],
+    }
+    builder = NetworkGraphBuilder()
+    graph, dataset = builder.build_graph(geojson, profile=TravelProfile())
+    return graph, dataset
+
+
+class TestReverseSplitRouteLengths:
+    """Issue #446 acceptance: snap at f on a two-way edge, route to BOTH
+    endpoints — distances must be f·L and (1−f)·L respectively."""
+
+    @pytest.mark.parametrize("f", [0.2, 0.5, 0.75])
+    def test_mid_edge_origin_to_both_endpoints(self, f):
+        graph, dataset = _single_two_way_edge()
+        router = NetworkRoutingService()
+        edge_len_m = haversine_distance((116.0, 39.0), (116.01, 39.0))
+
+        origin = (116.0 + 0.01 * f, 39.0)
+        near = (116.0, 39.0) if f <= 0.5 else (116.01, 39.0)
+        far = (116.01, 39.0) if f <= 0.5 else (116.0, 39.0)
+
+        route_near = router.network_shortest_path(
+            graph=graph, network_dataset=dataset,
+            origin=origin, destination=near, profile=TravelProfile(),
+        )
+        route_far = router.network_shortest_path(
+            graph=graph, network_dataset=dataset,
+            origin=origin, destination=far, profile=TravelProfile(),
+        )
+
+        frac_near = min(f, 1.0 - f)
+        frac_far = max(f, 1.0 - f)
+        # Snapping/projection round-trip tolerance: 3 m.
+        assert abs(route_near.total_distance_m - edge_len_m * frac_near) < 3.0, (
+            f"f={f}: route to near endpoint {route_near.total_distance_m:.1f} m, "
+            f"expected ~{edge_len_m * frac_near:.1f} m"
+        )
+        assert abs(route_far.total_distance_m - edge_len_m * frac_far) < 3.0, (
+            f"f={f}: route to far endpoint {route_far.total_distance_m:.1f} m, "
+            f"expected ~{edge_len_m * frac_far:.1f} m"
+        )
+
+    def test_issue_reproduction_691_vs_173(self):
+        """The exact case from the issue: ~865 m two-way edge, origin at f=0.2.
+        Route to the near (left) endpoint must be ~173 m, not ~691 m."""
+        graph, dataset = _single_two_way_edge()
+        router = NetworkRoutingService()
+        route = router.network_shortest_path(
+            graph=graph, network_dataset=dataset,
+            origin=(116.002, 39.0), destination=(116.0, 39.0), profile=TravelProfile(),
+        )
+        assert route.total_distance_m < 200.0, (
+            f"reverse-split regression: {route.total_distance_m:.1f} m to the near "
+            f"endpoint, expected ~173 m (the pre-fix bug reported ~691 m)"
+        )
+
+
+class TestReverseSplitGeometry:
+    """Sub-geometries of BOTH orientations must contain the virtual node, and
+    the forward/reverse sub-geometries must be consistent."""
+
+    @pytest.mark.parametrize("f", [0.2, 0.5, 0.75])
+    def test_sub_edge_geometry_contains_virtual_node(self, f):
+        graph, dataset = _single_two_way_edge()
+        router = NetworkRoutingService()
+        work = graph.copy()
+        snapped = (116.0 + 0.01 * f, 39.0)
+        vt = router._split_edge_at_fraction(work, "n0", "n1", f, snapped)
+
+        for u, v in (("n0", vt), (vt, "n1"), ("n1", vt), (vt, "n0")):
+            assert work.has_edge(u, v), f"missing sub-edge {u}->{v}"
+            geom_dict = work[u][v].get("geometry")
+            assert geom_dict, f"sub-edge {u}->{v} has no geometry"
+            coords = list(shape(geom_dict).coords)
+            # The virtual node is the sub-edge endpoint AT vt: the last coord
+            # when vt is the head (u→vt), the first when it is the tail (vt→v).
+            endpoint = coords[-1] if v == vt else coords[0]
+            assert math.hypot(endpoint[0] - snapped[0], endpoint[1] - snapped[1]) < 1e-9, (
+                f"sub-edge {u}->{v} does not touch the virtual node: "
+                f"endpoint {endpoint} vs snapped {snapped}"
+            )
+
+    @pytest.mark.parametrize("f", [0.2, 0.5, 0.75])
+    def test_forward_and_reverse_sub_geometries_mirror(self, f):
+        """sub(u→vt) must equal the coordinate-reversal of sub(vt→u): both run
+        between the same two physical points."""
+        graph, dataset = _single_two_way_edge()
+        router = NetworkRoutingService()
+        work = graph.copy()
+        snapped = (116.0 + 0.01 * f, 39.0)
+        vt = router._split_edge_at_fraction(work, "n0", "n1", f, snapped)
+
+        fwd_sub = shape(work["n0"][vt]["geometry"]).coords
+        rev_sub = shape(work[vt]["n0"]["geometry"]).coords
+        assert list(fwd_sub) == [(x, y) for x, y in reversed(list(rev_sub))], (
+            "forward u→vt sub-geometry must be the reverse of vt→u"
+        )
+
+    @pytest.mark.parametrize("f", [0.2, 0.5, 0.75])
+    def test_reverse_direction_lengths_use_complement_fraction(self, f):
+        """For the reverse orientation (n1→n0), the sub-edge adjacent to n1
+        must carry (1−f)·L and the one adjacent to n0 must carry f·L."""
+        graph, dataset = _single_two_way_edge()
+        router = NetworkRoutingService()
+        work = graph.copy()
+        orig_len = float(graph["n0"]["n1"]["length_m"])
+        vt = router._split_edge_at_fraction(work, "n0", "n1", f, (116.0 + 0.01 * f, 39.0))
+
+        assert abs(work["n1"][vt]["length_m"] - orig_len * (1.0 - f)) < 1e-9
+        assert abs(work[vt]["n0"]["length_m"] - orig_len * f) < 1e-9
+        assert abs(work["n0"][vt]["length_m"] - orig_len * f) < 1e-9
+        assert abs(work[vt]["n1"]["length_m"] - orig_len * (1.0 - f)) < 1e-9
+
+
+class TestSplitSumInvariant:
+    """Property: per orientation, split sub-edge lengths sum to the original."""
+
+    @pytest.mark.parametrize("f", [0.2, 0.35, 0.5, 0.75])
+    def test_sub_edge_lengths_sum_to_original(self, f):
+        graph, _ = _single_two_way_edge()
+        router = NetworkRoutingService()
+        work = graph.copy()
+        vt = router._split_edge_at_fraction(work, "n0", "n1", f, (116.0 + 0.01 * f, 39.0))
+
+        orig_fwd = float(graph["n0"]["n1"]["length_m"])
+        orig_rev = float(graph["n1"]["n0"]["length_m"])
+        s_fwd = work["n0"][vt]["length_m"] + work[vt]["n1"]["length_m"]
+        s_rev = work["n1"][vt]["length_m"] + work[vt]["n0"]["length_m"]
+        assert abs(s_fwd - orig_fwd) < 1e-6
+        assert abs(s_rev - orig_rev) < 1e-6
+
+    def test_chain_second_split_keeps_total(self):
+        """Origin and destination on the same edge of a two-edge chain: after
+        both splits the walkable chain length must still equal the edge."""
+        graph, dataset = _two_edge_chain()
+        router = NetworkRoutingService()
+        route = router.network_shortest_path(
+            graph=graph, network_dataset=dataset,
+            origin=(116.002, 39.0), destination=(116.008, 39.0), profile=TravelProfile(),
+        )
+        # 0.006° of longitude ≈ 519 m; the true span between the snapped points.
+        expected = haversine_distance((116.002, 39.0), (116.008, 39.0))
+        assert abs(route.total_distance_m - expected) < 5.0, (
+            f"same-edge route across a second split: {route.total_distance_m:.1f} m "
+            f"vs expected ~{expected:.1f} m"
+        )
+
+    def test_reverse_chain_walk_uses_complement(self):
+        """Second snap walking the REVERSE chain (from n1 toward n0) must land
+        at 1−f of the original edge, keeping route totals symmetric."""
+        graph, dataset = _two_edge_chain()
+        router = NetworkRoutingService()
+        # Origin on e0 at f=0.2; destination is node n1 (the junction).
+        route = router.network_shortest_path(
+            graph=graph, network_dataset=dataset,
+            origin=(116.002, 39.0), destination="n1", profile=TravelProfile(),
+        )
+        edge_len = haversine_distance((116.0, 39.0), (116.01, 39.0))
+        assert abs(route.total_distance_m - edge_len * 0.8) < 3.0, (
+            f"reverse-direction route to junction: {route.total_distance_m:.1f} m, "
+            f"expected ~{edge_len * 0.8:.1f} m ((1−f)·L)"
+        )
+
+
+class TestAdversarialCases:
+    def test_one_way_edge_split(self):
+        """A one-way edge has no reverse orientation — split must still work."""
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {"speed_kmh": 60.0, "one_way": True},
+                    "geometry": {"type": "LineString", "coordinates": [[116.0, 39.0], [116.01, 39.0]]},
+                },
+            ],
+        }
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(geojson, profile=TravelProfile())
+        router = NetworkRoutingService()
+        route = router.network_shortest_path(
+            graph=graph, network_dataset=dataset,
+            origin=(116.002, 39.0), destination=(116.01, 39.0), profile=TravelProfile(),
+        )
+        edge_len = haversine_distance((116.0, 39.0), (116.01, 39.0))
+        assert abs(route.total_distance_m - edge_len * 0.8) < 3.0
+
+    def test_multivertex_edge_reverse_geometry(self):
+        """A bent (3-vertex) edge: reverse sub-geometries must still contain
+        the virtual node — the old code interpolated at the wrong fraction and
+        could drop it entirely."""
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {"speed_kmh": 60.0, "one_way": False},
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [[116.0, 39.0], [116.005, 39.0], [116.01, 39.0]],
+                    },
+                },
+            ],
+        }
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(geojson, profile=TravelProfile())
+        router = NetworkRoutingService()
+        work = graph.copy()
+        snapped = (116.002, 39.0)
+        vt = router._split_edge_at_fraction(work, "n0", "n1", 0.2, snapped)
+        for u, v in (("n0", vt), (vt, "n1"), ("n1", vt), (vt, "n0")):
+            coords = list(shape(work[u][v]["geometry"]).coords)
+            touched = any(math.hypot(c[0] - snapped[0], c[1] - snapped[1]) < 1e-9 for c in coords)
+            assert touched, f"sub-edge {u}->{v} ({coords}) misses the virtual node"

--- a/tests/unit/test_network_issue447_astar_optimal.py
+++ b/tests/unit/test_network_issue447_astar_optimal.py
@@ -157,11 +157,9 @@ class TestHeuristicBound:
         """h(u, goal) <= shortest-path cost for a sample of (u, goal) pairs."""
         g, nodes, ods = _random_graph(99, n_nodes=50)
         router = NetworkRoutingService()
-        profile = TravelProfile(name="driving")
 
-        weight_func = router.build_weight_func("travel_time_s", 0.0) if hasattr(router, "build_weight_func") else None
         from app.services.network.routing import build_weight_func
-        wf = weight_func or build_weight_func("travel_time_s", 0.0)
+        wf = build_weight_func("travel_time_s")
 
         mrpm = router._min_cost_per_meter(g, wf)
         assert mrpm is not None and mrpm > 0

--- a/tests/unit/test_network_issue447_astar_optimal.py
+++ b/tests/unit/test_network_issue447_astar_optimal.py
@@ -1,0 +1,179 @@
+"""Regression tests for issue #447 (P2): A* heuristic used the profile default
+speed (40 km/h driving / 4.8 km/h walking), which is INADMISSIBLE whenever the
+graph contains edges faster than the profile default (the builder assigns
+60-100+ km/h on faster roads with no clamp). An inadmissible heuristic lets A*
+settle the goal via a suboptimal path — measured +2.0% travel time, worse for
+walking profiles on road networks (~8-20x overestimate).
+
+The fix derives the heuristic bound from the graph itself: the minimum edge
+cost per meter of edge length under the active weight function, so
+h(u, v) = haversine(u, v) * min_cost_per_meter <= true remaining cost for any
+cost field (travel_time_s, length_m, custom).
+"""
+import random
+
+import pytest
+
+import networkx as nx
+
+from app.services.network.graph_builder import haversine_distance
+from app.services.network.models import TravelProfile
+from app.services.network.routing import NetworkRoutingService
+
+
+def _add_two_way(g, a, b, speed_kmh):
+    length_m = haversine_distance((g.nodes[a]["x"], g.nodes[a]["y"]), (g.nodes[b]["x"], g.nodes[b]["y"]))
+    time_s = length_m / (speed_kmh * 1000.0 / 3600.0)
+    for u, v in ((a, b), (b, a)):
+        g.add_edge(u, v, length_m=length_m, travel_time_s=time_s,
+                   speed_kmh=speed_kmh, highway_type="x", id=f"e_{u}_{v}")
+
+
+def _express_detour_graph():
+    """Collinear chain with a backward express detour (all positions in meters
+    relative to lng 116.0 at lat 39.0; ~100 m per 0.00115 deg).
+
+    Slow direct chain: A→B→C→D→G at 40 km/h = 36.0 s.
+    Express: A→X (backward 100 m @150) + X→Z (700 m @200) + Z→G (200 m @150)
+           = 2.4 + 12.6 + 4.8 = 19.8 s.
+
+    With the buggy v=40 heuristic, h(X) alone (500 m / 40 km/h = 45 s) makes
+    the express frontier f=47.4, so A* settles G via the slow chain (36 s)
+    before ever expanding X.
+    """
+    def at(m):
+        return f"n{m}"
+    coords = {m: (116.0 + m * 1.152e-5, 39.0) for m in (-100, 0, 100, 200, 300, 400, 600)}
+    g = nx.DiGraph()
+    for m, (x, y) in coords.items():
+        g.add_node(at(m), x=x, y=y)
+
+    for a, b in ((0, 100), (100, 200), (200, 300), (300, 400)):
+        _add_two_way(g, at(a), at(b), speed_kmh=40.0)
+    _add_two_way(g, at(0), at(-100), speed_kmh=150.0)     # A -> X (backward)
+    _add_two_way(g, at(-100), at(600), speed_kmh=200.0)   # X -> Z express
+    _add_two_way(g, at(600), at(400), speed_kmh=150.0)    # Z -> G (backward)
+    return g, at(0), at(400)
+
+
+class TestAStarAdmissibleHeuristic:
+    def test_astar_matches_dijkstra_on_express_detour(self):
+        """Handcrafted adversarial case: the optimal route takes a geometrically
+        longer but faster detour that the profile-default-speed heuristic
+        rejects outright."""
+        g, src, dst = _express_detour_graph()
+        router = NetworkRoutingService()
+        profile = TravelProfile(name="driving")  # default speed 40 km/h
+
+        dij = router.network_shortest_path(g, None, src, dst, profile=profile, algorithm="dijkstra")
+        ast = router.network_shortest_path(g, g, src, dst, profile=profile, algorithm="astar")
+
+        assert dij.total_cost == pytest.approx(19.8, abs=0.2), (
+            f"dijkstra cost {dij.total_cost:.2f} s — fixture drifted from the "
+            f"19.8 s express route"
+        )
+        assert ast.total_cost == pytest.approx(dij.total_cost, rel=1e-9), (
+            f"A* returned {ast.total_cost:.2f} s vs Dijkstra {dij.total_cost:.2f} s — "
+            f"inadmissible heuristic produced a suboptimal route"
+        )
+
+    def test_walking_profile_on_fast_road_network(self):
+        """Walking profile (4.8 km/h default) over a road network with 60-100
+        km/h edge speeds: the old heuristic overestimated ~10-20x."""
+        g, src, dst = _express_detour_graph()
+        router = NetworkRoutingService()
+        profile = TravelProfile(name="walking", impedance_field="travel_time_s")
+
+        dij = router.network_shortest_path(g, None, src, dst, profile=profile, algorithm="dijkstra")
+        ast = router.network_shortest_path(g, g, src, dst, profile=profile, algorithm="astar")
+        assert ast.total_cost == pytest.approx(dij.total_cost, rel=1e-9)
+
+
+def _random_graph(seed: int, n_nodes: int = 60) -> tuple[nx.DiGraph, list, list]:
+    """Random geometric graph with strongly mixed edge speeds (20-140 km/h —
+    most far above the 40 km/h profile default)."""
+    rng = random.Random(seed)
+    g = nx.DiGraph()
+    nodes = []
+    for i in range(n_nodes):
+        x = 116.0 + rng.uniform(0.0, 0.05)
+        y = 39.0 + rng.uniform(0.0, 0.05)
+        nid = f"n{i}"
+        g.add_node(nid, x=x, y=y)
+        nodes.append(nid)
+
+    # Ensure connectivity with a random spanning chain, then add random chords.
+    order = nodes[:]
+    rng.shuffle(order)
+    for a, b in zip(order, order[1:]):
+        _add_two_way(g, a, b, speed_kmh=rng.uniform(20.0, 140.0))
+    for _ in range(n_nodes * 2):
+        a, b = rng.sample(nodes, 2)
+        if not g.has_edge(a, b):
+            _add_two_way(g, a, b, speed_kmh=rng.uniform(20.0, 140.0))
+
+    ods = [(rng.sample(nodes, 2)) for _ in range(25)]
+    return g, nodes, ods
+
+
+class TestAStarDifferentialProperty:
+    @pytest.mark.parametrize("seed", [1, 7, 42, 1337, 90210])
+    def test_astar_cost_equals_dijkstra_cost_randomized(self, seed):
+        """Property: on randomized graphs with mixed speeds (including many
+        edges faster than the profile default), A* must return exactly the
+        Dijkstra cost for every OD pair."""
+        g, nodes, ods = _random_graph(seed)
+        router = NetworkRoutingService()
+        profile = TravelProfile(name="driving")
+
+        mismatches = []
+        for src, dst in ods:
+            dij = router.network_shortest_path(g, None, src, dst, profile=profile, algorithm="dijkstra")
+            ast = router.network_shortest_path(g, g, src, dst, profile=profile, algorithm="astar")
+            if abs(ast.total_cost - dij.total_cost) > 1e-6 * max(1.0, dij.total_cost):
+                mismatches.append((src, dst, dij.total_cost, ast.total_cost))
+        assert not mismatches, (
+            f"seed={seed}: A* suboptimal on {len(mismatches)}/25 OD pairs "
+            f"(dijkstra vs astar): {mismatches[:5]}"
+        )
+
+    @pytest.mark.parametrize("seed", [3, 11])
+    def test_astar_length_impedance_equals_dijkstra(self, seed):
+        """Same differential under length impedance (h = dist * min ratio)."""
+        g, nodes, ods = _random_graph(seed, n_nodes=40)
+        router = NetworkRoutingService()
+        profile = TravelProfile(name="driving", impedance_field="length_m")
+
+        for src, dst in ods:
+            dij = router.network_shortest_path(g, None, src, dst, profile=profile, algorithm="dijkstra")
+            ast = router.network_shortest_path(g, g, src, dst, profile=profile, algorithm="astar")
+            assert ast.total_cost == pytest.approx(dij.total_cost, rel=1e-9), (
+                f"seed={seed} {src}->{dst}: astar {ast.total_cost} vs dijkstra {dij.total_cost}"
+            )
+
+
+class TestHeuristicBound:
+    def test_heuristic_never_exceeds_true_cost(self):
+        """h(u, goal) <= shortest-path cost for a sample of (u, goal) pairs."""
+        g, nodes, ods = _random_graph(99, n_nodes=50)
+        router = NetworkRoutingService()
+        profile = TravelProfile(name="driving")
+
+        weight_func = router.build_weight_func("travel_time_s", 0.0) if hasattr(router, "build_weight_func") else None
+        from app.services.network.routing import build_weight_func
+        wf = weight_func or build_weight_func("travel_time_s", 0.0)
+
+        mrpm = router._min_cost_per_meter(g, wf)
+        assert mrpm is not None and mrpm > 0
+
+        for goal in nodes[:10]:
+            dists = nx.single_source_dijkstra_path_length(g.reverse(copy=True), goal, weight=wf)
+            for u in nodes[:10]:
+                h = haversine_distance(
+                    (g.nodes[u]["x"], g.nodes[u]["y"]),
+                    (g.nodes[goal]["x"], g.nodes[goal]["y"]),
+                ) * mrpm
+                if u in dists:
+                    assert h <= dists[u] + 1e-9, (
+                        f"h({u},{goal})={h:.3f} exceeds true cost {dists[u]:.3f}"
+                    )

--- a/tests/unit/test_network_issue449_od_cutoff.py
+++ b/tests/unit/test_network_issue449_od_cutoff.py
@@ -1,0 +1,271 @@
+"""Regression tests for issue #449 (P2 perf): OD matrix ran one FULL-TREE
+``nx.single_source_dijkstra`` per unique origin — materializing the complete
+path list for every reachable node, O(sum|path|) ≈ O(V²) worst case — and then
+re-walked every path in Python to re-sum distance/time that the Dijkstra
+distances already imply. The ``cutoff_s`` argument accepted by the tool schema
+and the engine was never forwarded to any Dijkstra call.
+
+Fix: cost-only OD queries run a single accumulating Dijkstra (cost + length +
+time carried per node, no path lists) with genuine cutoff pruning; the
+path-returning variant forwards the cutoff to networkx; ``engine.solve_od_matrix``
+plumbs ``cutoff_s`` through.
+"""
+import asyncio
+
+import pytest
+
+import networkx as nx
+
+from app.services.network.engine import NetworkGraphEngine
+from app.services.network.graph_builder import NetworkGraphBuilder
+from app.services.network.models import TravelProfile
+from app.services.network.od_matrix import NetworkODMatrixService
+
+
+def _grid(k=12):
+    """k x k node grid (~2*k*(k-1) two-way edge pairs), 60 km/h."""
+    g = nx.DiGraph()
+    for r in range(k):
+        for c in range(k):
+            g.add_node(f"n{r * k + c}", x=116.0 + c * 0.001, y=39.0 + r * 0.001)
+    for r in range(k):
+        for c in range(k - 1):
+            a, b = f"n{r * k + c}", f"n{r * k + c + 1}"
+            for u, v in ((a, b), (b, a)):
+                g.add_edge(u, v, length_m=85.0, travel_time_s=5.1, id=f"e_{u}_{v}")
+    for c in range(k):
+        for r in range(k - 1):
+            a, b = f"n{r * k + c}", f"n{(r + 1) * k + c}"
+            for u, v in ((a, b), (b, a)):
+                g.add_edge(u, v, length_m=111.0, travel_time_s=6.66, id=f"e_{u}_{v}")
+    return g
+
+
+def _dataset(g):
+    from app.services.network.models import NetworkDataset, Node, Edge
+    nodes = [Node(id=n, x=d["x"], y=d["y"]) for n, d in g.nodes(data=True)]
+    edges = [Edge(id=str(i), u=u, v=v, length_m=d["length_m"]) for i, (u, v, d) in enumerate(g.edges(data=True))]
+    return NetworkDataset(dataset_id="grid", nodes=nodes, edges=edges)
+
+
+class TestCutoffPlumbing:
+    def test_service_accepts_cutoff_and_prunes(self):
+        """Cells whose cost exceeds the cutoff must come back unreachable;
+        cells within the cutoff must match the uncutoff run exactly."""
+        g = _grid(12)
+        ds = _dataset(g)
+        svc = NetworkODMatrixService()
+        origins = ["n0", "n5"]
+        dests = ["n143", "n60", "n13", "n0"]
+
+        full = svc.network_od_matrix(origins, dests, graph=g, network_dataset=ds)
+        cut = svc.network_od_matrix(origins, dests, graph=g, network_dataset=ds, cutoff_s=60.0)
+
+        assert len(full) == len(cut) == 8
+        for f, c in zip(full, cut):
+            assert (f.origin_id, f.destination_id) == (c.origin_id, c.destination_id)
+            if f.travel_time_s > 60.0:
+                assert not c.reachable, (
+                    f"{c.origin_id}->{c.destination_id}: time {f.travel_time_s:.1f} s "
+                    f"exceeds cutoff 60 s but was returned reachable"
+                )
+            else:
+                assert c.reachable
+                assert c.travel_time_s == pytest.approx(f.travel_time_s, abs=0.02)
+                assert c.distance_m == pytest.approx(f.distance_m, abs=0.1)
+
+    def test_cutoff_never_returns_cells_beyond_it(self):
+        g = _grid(10)
+        ds = _dataset(g)
+        svc = NetworkODMatrixService()
+        pairs = svc.network_od_matrix(
+            ["n0"], [f"n{i}" for i in range(0, 100, 7)], graph=g, network_dataset=ds,
+            cutoff_s=30.0,
+        )
+        assert pairs
+        for p in pairs:
+            assert not p.reachable or p.travel_time_s <= 30.0
+
+    def test_engine_solve_od_matrix_forwards_cutoff_s(self):
+        """The tool-level cutoff_s must reach the Dijkstra calls (previously
+        accepted and silently ignored)."""
+        k = 10
+        g = _grid(k)
+        ds = _dataset(g)
+        engine = NetworkGraphEngine()
+
+        full = engine.od_matrix(
+            origins=["n0", "n17"], destinations=["n99", "n45"],
+            network_dataset=ds, graph=g,
+        )
+        cut = engine.od_matrix(
+            origins=["n0", "n17"], destinations=["n99", "n45"],
+            network_dataset=ds, graph=g, cutoff_s=40.0,
+        )
+        assert len(full) == len(cut) == 4
+        pruned = [c for c in cut if not c.reachable]
+        assert pruned, "cutoff_s=40 pruned nothing on a 10x10 grid — not forwarded"
+        for f, c in zip(full, cut):
+            if c.reachable:
+                assert f.reachable
+                assert c.travel_time_s == pytest.approx(f.travel_time_s, abs=0.02)
+
+        # Async tool seam: solve_od_matrix(network=NetworkDataset...) forwards too.
+        async def _run():
+            return await engine.solve_od_matrix(
+                network=ds, origins=[[116.0, 39.0]], destinations=[[116.009, 39.009]],
+                cutoff_s=1.0,
+            )
+        res = asyncio.run(_run())
+        assert res.od_matrix and not res.od_matrix[0].reachable
+
+        async def _run_full():
+            return await engine.solve_od_matrix(
+                network=ds, origins=[[116.0, 39.0]], destinations=[[116.009, 39.009]],
+            )
+        res_full = asyncio.run(_run_full())
+        assert res_full.od_matrix and res_full.od_matrix[0].reachable
+
+    def test_cutoff_cost_units_follow_impedance(self):
+        """cutoff_s bounds the active impedance cost: under length impedance
+        it prunes by meters."""
+        from app.services.network.models import Impedance
+        g = _grid(10)
+        ds = _dataset(g)
+        svc = NetworkODMatrixService()
+        full = svc.network_od_matrix(
+            ["n0"], ["n99"], graph=g, network_dataset=ds,
+            impedance=Impedance(name="length_m"),
+        )
+        cut = svc.network_od_matrix(
+            ["n0"], ["n99"], graph=g, network_dataset=ds,
+            impedance=Impedance(name="length_m"), cutoff_s=500.0,
+        )
+        assert full[0].reachable
+        assert full[0].distance_m > 500.0
+        assert not cut[0].reachable
+
+
+class TestNoPathMaterialization:
+    def test_cost_only_od_never_materializes_paths(self, monkeypatch):
+        """Structural guard (#449): the cost-only matrix variant must not call
+        networkx's path-materializing single_source_dijkstra at all."""
+        g = _grid(12)
+        ds = _dataset(g)
+
+        def _boom(*args, **kwargs):
+            raise AssertionError(
+                "network_od_matrix (cost-only) must not call "
+                "nx.single_source_dijkstra — paths are not needed (#449)"
+            )
+
+        monkeypatch.setattr(nx, "single_source_dijkstra", _boom)
+        monkeypatch.setattr(nx, "single_source_dijkstra_path", _boom)
+        svc = NetworkODMatrixService()
+        pairs = svc.network_od_matrix(
+            ["n0", "n40"], ["n143", "n77", "n5"], graph=g, network_dataset=ds,
+        )
+        assert len(pairs) == 6
+        assert sum(1 for p in pairs if p.reachable) == 6
+
+    def test_cutoff_reduces_explored_nodes(self):
+        """Direct check on the accumulating Dijkstra: a cutoff must settle
+        strictly fewer nodes than the full run on a large graph, and the
+        settled set must equal the full run's nodes within the cutoff radius."""
+        from app.services.network.od_matrix import _single_source_costs
+        from app.services.network.routing import build_weight_func
+
+        g = _grid(60)  # 3600 nodes
+        wf = build_weight_func("travel_time_s")
+        full_d, full_len, _full_t = _single_source_costs(g, "n1800", wf, cutoff=None)
+        cut_d, cut_len, _cut_t = _single_source_costs(g, "n1800", wf, cutoff=60.0)
+
+        assert len(cut_d) < len(full_d), (
+            f"cutoff settled {len(cut_d)} nodes vs full {len(full_d)} — no pruning"
+        )
+        # Equality with the full run filtered to the cutoff radius.
+        within = {n: c for n, c in full_d.items() if c <= 60.0}
+        assert set(cut_d) == set(within)
+        for n, c in cut_d.items():
+            assert c == pytest.approx(within[n], rel=1e-12)
+            assert cut_len[n] == pytest.approx(full_len[n], rel=1e-9)
+
+    def test_cost_tree_matches_reference_dijkstra(self):
+        """The accumulating Dijkstra's costs/distances equal nx reference runs
+        on a random graph (unique optima)."""
+        import random
+        from app.services.network.od_matrix import _single_source_costs
+        from app.services.network.routing import build_weight_func
+
+        rng = random.Random(449)
+        g = nx.DiGraph()
+        for i in range(150):
+            g.add_node(f"n{i}", x=116.0 + rng.uniform(0, 0.05), y=39.0 + rng.uniform(0, 0.05))
+        ids = list(g.nodes)
+        for _ in range(600):
+            a, b = rng.sample(ids, 2)
+            if g.has_edge(a, b):
+                continue
+            import math
+            dx = g.nodes[a]["x"] - g.nodes[b]["x"]
+            dy = g.nodes[a]["y"] - g.nodes[b]["y"]
+            length_m = math.hypot(dx * 85_000, dy * 111_000)
+            for u, v in ((a, b), (b, a)):
+                g.add_edge(u, v, length_m=length_m,
+                           travel_time_s=length_m / rng.uniform(8.0, 25.0),
+                           id=f"e_{u}_{v}")
+
+        wf = build_weight_func("travel_time_s")
+        dists, lens, times = _single_source_costs(g, "n0", wf)
+        ref_cost = nx.single_source_dijkstra_path_length(g, "n0", weight=wf)
+        for n in ref_cost:
+            assert dists[n] == pytest.approx(ref_cost[n], rel=1e-9)
+        # len/time accumulate along the SAME tree with per-edge speeds in
+        # [8, 25] m/s, so every node's accumulated speed ratio stays in range.
+        for n, t in times.items():
+            if t > 0 and lens[n] > 0:
+                speed = lens[n] / t
+                assert 7.9 <= speed <= 25.1, f"node {n}: implied speed {speed:.2f} m/s"
+
+
+class TestAdversarial:
+    def test_disconnected_graph_unreachable(self):
+        g = _grid(4)
+        g.add_node("iso", x=117.0, y=40.0)
+        ds = _dataset(g)
+        svc = NetworkODMatrixService()
+        pairs = svc.network_od_matrix(
+            ["n0", "iso"], ["n15", "iso"], graph=g, network_dataset=ds,
+        )
+        assert len(pairs) == 4
+        by_od = {(p.origin_id, p.destination_id): p for p in pairs}
+        assert not by_od[("iso", "n15")].reachable
+        assert by_od[("iso", "iso")].reachable
+        assert by_od[("iso", "iso")].distance_m == 0.0
+
+    def test_zero_length_edges_do_not_break_accumulation(self):
+        g = nx.DiGraph()
+        g.add_node("a", x=116.0, y=39.0)
+        g.add_node("b", x=116.0, y=39.0)
+        g.add_node("c", x=116.001, y=39.0)
+        g.add_edge("a", "b", length_m=0.0, travel_time_s=0.0, id="e0")
+        g.add_edge("b", "c", length_m=85.0, travel_time_s=5.1, id="e1")
+        ds = _dataset(g)
+        svc = NetworkODMatrixService()
+        pairs = svc.network_od_matrix(["a"], ["b", "c"], graph=g, network_dataset=ds)
+        assert pairs[0].reachable and pairs[0].distance_m == 0.0
+        assert pairs[1].reachable and pairs[1].distance_m == pytest.approx(85.0)
+
+    def test_one_way_edges_respected(self):
+        g = nx.DiGraph()
+        for i, x in enumerate((116.0, 116.001, 116.002)):
+            g.add_node(f"n{i}", x=x, y=39.0)
+        g.add_edge("n0", "n1", length_m=85.0, travel_time_s=5.1, id="e0")
+        g.add_edge("n1", "n2", length_m=85.0, travel_time_s=5.1, id="e1")
+        # no reverse edges — strictly one-way chain
+        ds = _dataset(g)
+        svc = NetworkODMatrixService()
+        fwd = svc.network_od_matrix(["n0"], ["n2"], graph=g, network_dataset=ds)
+        rev = svc.network_od_matrix(["n2"], ["n0"], graph=g, network_dataset=ds)
+        assert fwd[0].reachable
+        assert not rev[0].reachable

--- a/tests/unit/test_network_issue449_od_cutoff.py
+++ b/tests/unit/test_network_issue449_od_cutoff.py
@@ -17,8 +17,6 @@ import pytest
 import networkx as nx
 
 from app.services.network.engine import NetworkGraphEngine
-from app.services.network.graph_builder import NetworkGraphBuilder
-from app.services.network.models import TravelProfile
 from app.services.network.od_matrix import NetworkODMatrixService
 
 

--- a/tests/unit/test_network_issue453_od_snapping_consistency.py
+++ b/tests/unit/test_network_issue453_od_snapping_consistency.py
@@ -1,0 +1,300 @@
+"""Regression tests for issue #453 (P2): OD-family tools snapped points to the
+nearest edge ENDPOINT NODE while ``network_shortest_path`` splits the edge at
+the snapped fraction and routes through a virtual mid-edge node (GIS-01).
+
+The same physical OD pair therefore produced different costs across tools —
+measured 432.1 m via network_shortest_path vs 864.1 m via closest_facility
+(2x; up to ~2 edge lengths in general).
+
+Fix: the OD family (od_matrix, closest_facility, accessibility,
+location-allocation, service_area, VRP legs) resolves coordinate /
+PointSnappingResult inputs on a single working-copy graph with the same
+virtual-node splitting routing uses.
+"""
+import math
+
+import pytest
+
+from shapely.geometry import shape
+
+from app.services.network.facility import NetworkClosestFacilityService
+from app.services.network.graph_builder import NetworkGraphBuilder, haversine_distance
+from app.services.network.models import TravelProfile
+from app.services.network.od_matrix import NetworkODMatrixService
+from app.services.network.routing import NetworkRoutingService
+from app.services.network.service_area import NetworkServiceAreaService
+
+
+def _road_network():
+    """Two-way edge e0 (116.0,39.0)→(116.01,39.0) (~865 m) plus a 200 m branch
+    e1 continuing east from the (116.01, 39.0) junction."""
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"speed_kmh": 60.0, "one_way": False},
+                "geometry": {"type": "LineString", "coordinates": [[116.0, 39.0], [116.01, 39.0]]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"speed_kmh": 60.0, "one_way": False},
+                "geometry": {"type": "LineString", "coordinates": [[116.01, 39.0], [116.01231, 39.0]]},
+            },
+        ],
+    }
+    builder = NetworkGraphBuilder()
+    graph, dataset = builder.build_graph(geojson, profile=TravelProfile())
+    return graph, dataset
+
+
+EDGE_LEN = haversine_distance((116.0, 39.0), (116.01, 39.0))  # ~865 m
+MID_F02 = (116.002, 39.0)   # fraction ~0.2 from the west endpoint
+JUNCTION = (116.01, 39.0)   # node at the east endpoint of e0
+
+
+class TestODMatrixMatchesRouting:
+    def test_od_matrix_cost_equals_shortest_path_cost(self):
+        """Issue acceptance: mid-edge demand → junction facility must cost the
+        same via the OD matrix as via network_shortest_path."""
+        graph, dataset = _road_network()
+        router = NetworkRoutingService()
+        od = NetworkODMatrixService()
+
+        route = router.network_shortest_path(
+            graph=graph, network_dataset=dataset,
+            origin=MID_F02, destination=JUNCTION, profile=TravelProfile(),
+        )
+        pairs = od.network_od_matrix(
+            origins=[MID_F02], destinations=[JUNCTION],
+            graph=graph, network_dataset=dataset, profile=TravelProfile(),
+        )
+        assert pairs[0].reachable
+        assert pairs[0].distance_m == pytest.approx(route.total_distance_m, abs=3.0), (
+            f"OD matrix reports {pairs[0].distance_m:.1f} m vs routing "
+            f"{route.total_distance_m:.1f} m for the same OD pair — endpoint "
+            f"snapping divergence (#453)"
+        )
+        assert pairs[0].travel_time_s == pytest.approx(route.total_time_s, abs=1.0)
+
+    def test_od_matrix_mid_edge_to_both_endpoints(self):
+        """The OD matrix must see f·L and (1−f)·L from a mid-edge origin —
+        endpoint snapping can only produce 0 or L."""
+        graph, dataset = _road_network()
+        od = NetworkODMatrixService()
+        pairs = od.network_od_matrix(
+            origins=[MID_F02], destinations=[(116.0, 39.0), JUNCTION],
+            graph=graph, network_dataset=dataset, profile=TravelProfile(),
+        )
+        assert pairs[0].distance_m == pytest.approx(EDGE_LEN * 0.2, abs=3.0)
+        assert pairs[1].distance_m == pytest.approx(EDGE_LEN * 0.8, abs=3.0)
+
+    def test_od_paths_geometry_starts_at_snapped_point(self):
+        graph, dataset = _road_network()
+        od = NetworkODMatrixService()
+        res = od.network_od_paths(
+            origins=[MID_F02], destinations=[JUNCTION],
+            graph=graph, network_dataset=dataset, profile=TravelProfile(),
+        )
+        (info,) = res["pairs"].values()
+        assert info["reachable"]
+        router = NetworkRoutingService()
+        route = router.build_route_from_path(
+            res["graph_view"], info["path"],
+            origin_label="o", destination_label="d",
+            profile_name="driving", route_id="r", weight_func=res["weight_func"],
+        )
+        coords = route.geometry["coordinates"]
+        assert abs(coords[0][0] - 116.002) < 1e-4, (
+            f"OD-reconstructed route starts at {coords[0]} — expected the "
+            f"snapped mid-edge location (116.002, 39.0)"
+        )
+        assert route.total_distance_m == pytest.approx(EDGE_LEN * 0.8, abs=3.0)
+
+
+class TestClosestFacilityConsistency:
+    def test_closest_facility_cost_matches_routing(self):
+        """The issue's reproducer shape: mid-edge demand, junction facility."""
+        graph, dataset = _road_network()
+        router = NetworkRoutingService()
+        fac = NetworkClosestFacilityService()
+
+        route = router.network_shortest_path(
+            graph=graph, network_dataset=dataset,
+            origin=MID_F02, destination=JUNCTION, profile=TravelProfile(),
+        )
+        res = fac.network_closest_facility(
+            demand_points=[{"demand_id": "d1", "geometry": {"type": "Point", "coordinates": list(MID_F02)}}],
+            facilities=[{"facility_id": "f1", "geometry": {"type": "Point", "coordinates": list(JUNCTION)}}],
+            graph=graph, network_dataset=dataset,
+        )
+        assert len(res.routes) == 1, "mid-edge demand → junction facility must match"
+        assert res.routes[0].total_distance_m == pytest.approx(route.total_distance_m, abs=3.0), (
+            f"closest_facility reports {res.routes[0].total_distance_m:.1f} m vs "
+            f"routing {route.total_distance_m:.1f} m (#453 divergence)"
+        )
+        start = res.routes[0].geometry["coordinates"][0]
+        assert abs(start[0] - 116.002) < 1e-4
+
+    def test_closest_facility_mid_edge_beats_far_node_facility(self):
+        """A facility at the NEAR endpoint must outrank one at the far
+        endpoint for a mid-edge demand — endpoint snapping scored both as the
+        same full-edge trip."""
+        graph, dataset = _road_network()
+        fac = NetworkClosestFacilityService()
+        res = fac.network_closest_facility(
+            demand_points=[{"demand_id": "d1", "geometry": {"type": "Point", "coordinates": list(MID_F02)}}],
+            facilities=[
+                {"facility_id": "far", "geometry": {"type": "Point", "coordinates": [116.01, 39.0]}},
+                {"facility_id": "near", "geometry": {"type": "Point", "coordinates": [116.0, 39.0]}},
+            ],
+            graph=graph, network_dataset=dataset, target_facility_count=2,
+        )
+        assert [r.destination_id for r in res.routes] == ["near", "far"], (
+            "mid-edge demand must reach the near endpoint cheaper than the far one"
+        )
+        assert res.routes[0].total_distance_m == pytest.approx(EDGE_LEN * 0.2, abs=3.0)
+        assert res.routes[1].total_distance_m == pytest.approx(EDGE_LEN * 0.8, abs=3.0)
+
+
+class TestServiceAreaConsistency:
+    def test_service_area_from_mid_edge_facility(self):
+        """A mid-edge facility's reachable network must extend
+        symmetrically ±budget around the snapped point — NOT the full
+        remaining edge plus branches as endpoint snapping produced.
+
+        Layout: facility at fraction 0.8 of the 865 m edge (173 m from the
+        east junction n1, which also carries a 200 m branch east). With a
+        250 m budget the branch is only 77 m reachable; endpoint snapping
+        (tree rooted at n1) swallowed the WHOLE branch (200 <= 250).
+        """
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {"speed_kmh": 60.0, "one_way": False},
+                    "geometry": {"type": "LineString", "coordinates": [[116.0, 39.0], [116.01, 39.0]]},
+                },
+                {
+                    "type": "Feature",
+                    "properties": {"speed_kmh": 60.0, "one_way": False},
+                    "geometry": {"type": "LineString", "coordinates": [[116.01, 39.0], [116.01231, 39.0]]},
+                },
+            ],
+        }
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(geojson, profile=TravelProfile())
+        svc = NetworkServiceAreaService()
+
+        areas = svc.network_service_area(
+            facilities=[{"facility_id": "f1", "geometry": {"type": "Point", "coordinates": [116.008, 39.0]}}],
+            breaks=[250.0],
+            break_unit="meters",
+            graph=graph,
+            network_dataset=dataset,
+            profile=TravelProfile(name="driving", impedance_field="length_m"),
+        )
+        net_geom = shape(areas[0].breaks[0].reachable_network_geometry)
+        xs = [c[0] for linestring in (net_geom.geoms if net_geom.geom_type == "MultiLineString" else [net_geom]) for c in linestring.coords]
+        # The 200 m branch (up to lng 116.01231) must NOT be fully reachable:
+        # from the snapped point only 77 m of it lie within the 250 m budget.
+        assert max(xs) < 116.0123, (
+            f"service area swallowed the full branch (max x={max(xs):.6f}) — "
+            f"isochrone rooted at an edge endpoint instead of the mid-edge facility"
+        )
+        # The snapped facility position must be inside the reachable network.
+        assert min(xs) - 1e-6 <= 116.008 <= max(xs) + 1e-6
+
+
+class TestVRPConsistency:
+    def test_vrp_legs_start_at_snapped_stops(self):
+        graph, dataset = _road_network()
+        from app.services.network.vrp import NetworkRouteOptimizationService
+        vrp = NetworkRouteOptimizationService()
+        route = vrp.optimize_route(
+            stops=[(116.002, 39.0), (116.006, 39.0)],
+            depot=(116.0, 39.0),
+            end_at_depot=True,
+            graph=graph, network_dataset=dataset, profile=TravelProfile(),
+        )
+        coords = route.geometry["coordinates"]
+        # The tour must visit the mid-edge stop positions exactly.
+        xs = [c[0] for c in coords]
+        assert any(abs(x - 116.002) < 1e-4 for x in xs), (
+            f"VRP geometry misses the snapped stop 116.002: {xs[:5]}"
+        )
+        assert any(abs(x - 116.006) < 1e-4 for x in xs), (
+            f"VRP geometry misses the snapped stop 116.006: {xs[:5]}"
+        )
+
+
+class TestAdversarial:
+    def test_node_id_inputs_still_avoid_copy_semantics(self):
+        """Node-id inputs resolve exactly as before (no virtual nodes)."""
+        graph, dataset = _road_network()
+        od = NetworkODMatrixService()
+        pairs = od.network_od_matrix(
+            origins=["n0"], destinations=["n1"],
+            graph=graph, network_dataset=dataset,
+        )
+        assert pairs[0].distance_m == pytest.approx(EDGE_LEN, abs=1.0)
+
+    def test_mixed_node_and_coordinate_inputs(self):
+        graph, dataset = _road_network()
+        od = NetworkODMatrixService()
+        pairs = od.network_od_matrix(
+            origins=["n0"], destinations=[JUNCTION, MID_F02],
+            graph=graph, network_dataset=dataset,
+        )
+        assert pairs[0].distance_m == pytest.approx(EDGE_LEN, abs=1.0)
+        assert pairs[1].distance_m == pytest.approx(EDGE_LEN * 0.2, abs=3.0)
+
+    def test_reversed_dataset_edge_fraction(self):
+        """Snapping may land on the REVERSE dataset edge (geometry v→u); the
+        inserted virtual node must still sit at the physical location (#453
+        + #446 interaction)."""
+        graph, dataset = _road_network()
+        od = NetworkODMatrixService()
+        # A point slightly off-axis snaps to whichever orientation the tree
+        # returns; the cost must be symmetric either way.
+        p = (116.002, 39.0005)
+        pairs = od.network_od_matrix(
+            origins=[p], destinations=[(116.0, 39.0), JUNCTION],
+            graph=graph, network_dataset=dataset,
+        )
+        total = pairs[0].distance_m + pairs[1].distance_m
+        assert total == pytest.approx(EDGE_LEN, abs=6.0), (
+            f"split asymmetric across orientations: {pairs[0].distance_m:.1f} + "
+            f"{pairs[1].distance_m:.1f} vs edge {EDGE_LEN:.1f}"
+        )
+
+    def test_zero_penalty_graph_untouched_for_node_inputs(self):
+        """Node-id-only OD calls must not mutate or copy the caller's graph."""
+        graph, dataset = _road_network()
+        n_before = graph.number_of_nodes()
+        od = NetworkODMatrixService()
+        od.network_od_matrix(
+            origins=["n0", "n1"], destinations=["n1", "n0"],
+            graph=graph, network_dataset=dataset,
+        )
+        assert graph.number_of_nodes() == n_before
+        assert not any(str(n).startswith("vt_") for n in graph.nodes)
+
+    def test_duplicate_coordinates_resolve_fine(self):
+        """Origins and destinations at identical coordinates (VRP N×N matrix)
+        must yield zero-cost self pairs, not errors."""
+        graph, dataset = _road_network()
+        od = NetworkODMatrixService()
+        pts = [MID_F02, JUNCTION, MID_F02]
+        pairs = od.network_od_matrix(
+            origins=pts, destinations=pts,
+            graph=graph, network_dataset=dataset,
+        )
+        assert len(pairs) == 9
+        for p in pairs:
+            assert p.reachable
+            assert p.distance_m >= 0.0
+            assert not math.isnan(p.travel_time_s)
+        self_pairs = [p for p in pairs if p.origin_id == p.destination_id]
+        assert all(p.distance_m == pytest.approx(0.0, abs=1e-6) for p in self_pairs)

--- a/tests/unit/test_network_issue455_turn_penalty.py
+++ b/tests/unit/test_network_issue455_turn_penalty.py
@@ -1,0 +1,205 @@
+"""Regression tests for issue #455 (P3): turn penalty charged on EVERY edge
+(including the departure edge and straight-through continuations).
+
+``build_weight_func`` added ``turn_penalty`` to each edge weight when
+cost_field == "travel_time_s", so an N-edge path accrued N penalties: a
+3-edge/2-turn path with a 30 s penalty was overcounted by +90 s instead of
++60 s, and a perfectly straight N-edge path was charged N penalties instead
+of 0. Length/custom impedance ignored the penalty entirely while
+``Route.total_cost`` stopped matching its documented composition.
+
+New semantics (#455):
+- the penalty is charged at INTERIOR path vertices whose bearing change
+  exceeds the "Continue straight" threshold (25°, same boundary as the
+  turn-by-turn directions generator) — the departure edge is never charged;
+- route SELECTION honours the same costs via an edge-state (turn-aware)
+  Dijkstra/A* search;
+- the penalty is a duration and therefore applies only to travel_time_s
+  impedance; for length/custom impedance it does not affect selection or
+  cost (documented).
+"""
+import pytest
+
+import networkx as nx
+
+from app.services.network.graph_builder import haversine_distance
+from app.services.network.models import Impedance, TravelProfile
+from app.services.network.routing import NetworkRoutingService
+
+PENALTY = 30.0
+M_PER_DEG = 111_111.11  # latitude meters per degree (fixtures run along lat)
+
+
+def _chain_graph(coords):
+    """Two-way chain through the given (lng, lat) waypoints, 60 km/h."""
+    g = nx.DiGraph()
+    for i, (x, y) in enumerate(coords):
+        g.add_node(f"n{i}", x=x, y=y)
+    for i in range(len(coords) - 1):
+        a, b = f"n{i}", f"n{i+1}"
+        length_m = haversine_distance(coords[i], coords[i + 1])
+        time_s = length_m / (60.0 * 1000.0 / 3600.0)
+        for u, v in ((a, b), (b, a)):
+            g.add_edge(u, v, length_m=length_m, travel_time_s=time_s,
+                       speed_kmh=60.0, id=f"e_{u}_{v}", highway_type="residential")
+    return g
+
+
+def _straight_chain(n_edges=4):
+    """Perfectly straight collinear chain: n_edges edges, zero turns."""
+    d = 100.0 / M_PER_DEG  # 100 m per edge
+    return _chain_graph([(116.0 + i * d, 39.0) for i in range(n_edges + 1)])
+
+
+def _l_shape():
+    """Two edges meeting at 90°: exactly one turn."""
+    d = 100.0 / M_PER_DEG
+    return _chain_graph([(116.0, 39.0), (116.0 + d, 39.0), (116.0 + d, 39.0 + d)])
+
+
+def _z_shape():
+    """Three edges, two 90° turns (the issue's 3-edge/2-turn example)."""
+    d = 100.0 / M_PER_DEG
+    return _chain_graph([
+        (116.0, 39.0),
+        (116.0 + d, 39.0),
+        (116.0 + d, 39.0 + d),
+        (116.0 + 2 * d, 39.0 + d),
+    ])
+
+
+def _route(g, src="n0", dst=None, algorithm="dijkstra", penalty=PENALTY, impedance=None):
+    router = NetworkRoutingService()
+    imp = impedance or Impedance(name="travel_time_s", turn_penalty_s=penalty)
+    dst = dst or f"n{len(g.nodes) - 1}"
+    return router.network_shortest_path(
+        g, None, src, dst, profile=TravelProfile(name="driving"), impedance=imp,
+        algorithm=algorithm,
+    )
+
+
+class TestPenaltyChargedOnlyAtActualTurns:
+    def test_straight_path_accrues_zero_penalty(self):
+        """N collinear edges: zero penalty (the old code charged N)."""
+        g = _straight_chain(4)
+        r = _route(g)
+        assert r.total_cost == pytest.approx(r.total_time_s, rel=1e-9), (
+            f"straight 4-edge path cost {r.total_cost:.1f} s vs time "
+            f"{r.total_time_s:.1f} s — accrued {(r.total_cost - r.total_time_s):.0f} s "
+            f"of penalties, expected 0"
+        )
+
+    def test_single_90_degree_turn_accrues_one_penalty(self):
+        g = _l_shape()
+        r = _route(g)
+        assert r.total_cost == pytest.approx(r.total_time_s + PENALTY, rel=1e-9)
+
+    def test_two_90_degree_turns_accrue_two_penalties(self):
+        """The issue's arithmetic: 3-edge/2-turn path → +60 s, not +90 s."""
+        g = _z_shape()
+        r = _route(g)
+        assert r.total_cost == pytest.approx(r.total_time_s + 2 * PENALTY, rel=1e-9), (
+            f"3-edge/2-turn path: cost {r.total_cost:.1f} s vs time "
+            f"{r.total_time_s:.1f} s + {2 * PENALTY:.0f} s"
+        )
+
+    @pytest.mark.parametrize("algorithm", ["dijkstra", "astar"])
+    def test_astar_and_dijkstra_agree_under_penalty(self, algorithm):
+        g = _z_shape()
+        r = _route(g, algorithm=algorithm)
+        assert r.total_cost == pytest.approx(r.total_time_s + 2 * PENALTY, rel=1e-9)
+
+    def test_departure_edge_not_charged(self):
+        """A turn AT the destination vertex is a real turn (charged); the
+        departure edge itself never adds a penalty — verified by composition
+        on a path whose only turn is at the middle."""
+        g = _l_shape()
+        r = _route(g)
+        assert r.total_cost - r.total_time_s == pytest.approx(PENALTY, abs=1e-9)
+
+
+class TestPenaltyAffectsSelection:
+    def _choice_graph(self):
+        """Two parallel routes n0→n4:
+        - turny:  2 edges, 10 s total, one 90° turn;
+        - smooth: 3 collinear edges, 11 s total, zero turns.
+        Without penalty the turny route wins (10 < 11); with a 30 s penalty
+        the smooth route wins (10+30 > 11). The old per-edge charge also
+        picked smooth here but for the wrong reason (charging 3 vs 2
+        penalties); the discriminator is that smooth must win by EXACTLY its
+        edge-cost sum, and turny must still win at penalty=0.
+        """
+        g = nx.DiGraph()
+        d = 100.0 / M_PER_DEG
+        pts = {
+            "n0": (116.0, 39.0),
+            "t1": (116.0 + d, 39.0 + d),       # turn waypoint (n0→t1→n4 turns 90°)
+            "n4": (116.0 + 2 * d, 39.0),
+            "s1": (116.0 + d * 0.6667, 39.0 + 1e-7),  # smooth bypass waypoints
+            "s2": (116.0 + d * 1.3333, 39.0 + 1e-7),
+        }
+        for nid, (x, y) in pts.items():
+            g.add_node(nid, x=x, y=y)
+
+        def add(a, b, time_s):
+            length_m = haversine_distance(pts[a], pts[b])
+            for u, v in ((a, b), (b, a)):
+                g.add_edge(u, v, length_m=length_m, travel_time_s=time_s,
+                           speed_kmh=60.0, id=f"e_{u}_{v}", highway_type="residential")
+
+        add("n0", "t1", 5.0)
+        add("t1", "n4", 5.0)          # 90° turn at t1 (up then right)
+        add("n0", "s1", 11.0 / 3)
+        add("s1", "s2", 11.0 / 3)
+        add("s2", "n4", 11.0 / 3)
+        return g
+
+    def test_penalty_switches_route_selection(self):
+        g = self._choice_graph()
+        # No penalty: the 10 s turny route wins.
+        r0 = _route(g, penalty=0.0)
+        assert "t1" in r0.path_node_ids
+
+        # With penalty: the 11 s smooth route wins (10 + 30 > 11).
+        r1 = _route(g, penalty=PENALTY)
+        assert "t1" not in r1.path_node_ids, (
+            f"turn-aware selection regression: kept the turny route "
+            f"({r1.path_node_ids}) despite a {PENALTY:.0f} s penalty"
+        )
+        assert r1.total_cost == pytest.approx(11.0, rel=1e-6)
+
+    def test_zero_penalty_route_matches_plain_dijkstra(self):
+        g = self._choice_graph()
+        r = _route(g, penalty=0.0)
+        plain = nx.dijkstra_path_length(
+            g, "n0", "n4", weight=lambda u, v, d: d["travel_time_s"]
+        )
+        assert r.total_cost == pytest.approx(plain, rel=1e-9)
+
+
+class TestNonTimeCostModes:
+    def test_length_impedance_ignores_penalty_and_is_documented(self):
+        """Decision (#455): the penalty is a duration, so it applies only to
+        travel_time_s impedance; under length impedance it does not affect
+        selection or cost."""
+        g = _z_shape()
+        r = _route(g, impedance=Impedance(name="length_m", turn_penalty_s=PENALTY))
+        assert r.total_cost == pytest.approx(r.total_distance_m, rel=1e-9)
+
+    def test_od_tree_costs_unaffected_by_penalty(self):
+        """OD-family trees keep pure edge costs (a turn penalty needs the full
+        path context); documented cross-tool semantics."""
+        from app.services.network.od_matrix import NetworkODMatrixService
+
+        g = _z_shape()
+        svc = NetworkODMatrixService()
+        from app.services.network.models import NetworkDataset
+        ds = NetworkDataset(dataset_id="z", nodes=[], edges=[])
+        pairs = svc.network_od_matrix(
+            origins=["n0"], destinations=["n3"], graph=g, network_dataset=ds,
+            impedance=Impedance(name="travel_time_s", turn_penalty_s=PENALTY),
+        )
+        total_time = sum(
+            g[u][v]["travel_time_s"] for u, v in zip(["n0", "n1", "n2"], ["n1", "n2", "n3"])
+        )
+        assert pairs[0].travel_time_s == pytest.approx(total_time, abs=0.01)

--- a/tests/unit/test_network_issue456_zero_distance_facility.py
+++ b/tests/unit/test_network_issue456_zero_distance_facility.py
@@ -1,0 +1,139 @@
+"""Regression tests for issue #456 (P3): closest_facility dropped demand-
+facility pairs whose ``distance_m <= 0`` — excluding the perfectly valid case
+of a demand point located exactly AT a facility (zero-distance match). Those
+demands returned no route at all instead of a zero-cost match.
+
+Fix: the guard filters only non-finite (unreachable/sentinel) values;
+``distance_m == 0`` is a legitimate match and is kept.
+"""
+import math
+
+import pytest
+
+from app.services.network.facility import NetworkClosestFacilityService
+from app.services.network.graph_builder import NetworkGraphBuilder
+from app.services.network.models import TravelProfile
+
+
+def _triangle_network():
+    """Three-junction two-way road triangle around (116.0-116.01, 39.0)."""
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"speed_kmh": 60.0, "one_way": False},
+                "geometry": {"type": "LineString", "coordinates": [[116.0, 39.0], [116.01, 39.0]]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"speed_kmh": 60.0, "one_way": False},
+                "geometry": {"type": "LineString", "coordinates": [[116.01, 39.0], [116.005, 39.006]]},
+            },
+            {
+                "type": "Feature",
+                "properties": {"speed_kmh": 60.0, "one_way": False},
+                "geometry": {"type": "LineString", "coordinates": [[116.005, 39.006], [116.0, 39.0]]},
+            },
+        ],
+    }
+    builder = NetworkGraphBuilder()
+    return builder.build_graph(geojson, profile=TravelProfile())
+
+
+def _fac(demand_xy, facility_xy):
+    graph, dataset = _triangle_network()
+    svc = NetworkClosestFacilityService()
+    return svc.network_closest_facility(
+        demand_points=[
+            {"demand_id": "d_coincident", "geometry": {"type": "Point", "coordinates": list(demand_xy)}},
+            {"demand_id": "d_other", "geometry": {"type": "Point", "coordinates": [116.003, 39.002]}},
+        ],
+        facilities=[
+            {"facility_id": "f_here", "geometry": {"type": "Point", "coordinates": list(facility_xy)}},
+        ],
+        graph=graph,
+        network_dataset=dataset,
+        target_facility_count=1,
+    )
+
+
+class TestZeroDistanceMatch:
+    def test_demand_at_facility_node_returns_zero_cost_route(self):
+        """Demand coincident with a facility (on a junction) must be returned
+        as reachable with distance 0 — not dropped from the results."""
+        res = _fac((116.01, 39.0), (116.01, 39.0))
+        by_origin = {r.origin_id: r for r in res.routes}
+        assert "d_coincident" in by_origin, (
+            "coincident demand/facility pair vanished from closest_facility "
+            "results (#456: distance_m <= 0 guard)"
+        )
+        r = by_origin["d_coincident"]
+        assert r.total_distance_m == pytest.approx(0.0, abs=1e-6)
+        assert r.total_cost == pytest.approx(0.0, abs=1e-3)
+
+    def test_demand_at_facility_mid_edge_returns_zero_cost_route(self):
+        """Same for a coincident pair snapping mid-edge (#453 + #456)."""
+        res = _fac((116.0049, 39.0001), (116.0049, 39.0001))
+        by_origin = {r.origin_id: r for r in res.routes}
+        assert "d_coincident" in by_origin
+        assert by_origin["d_coincident"].total_distance_m == pytest.approx(0.0, abs=1.0)
+
+    def test_zero_distance_wins_over_nonzero_competitor(self):
+        """A coincident facility must outrank a farther one (ranking by cost;
+        the dropped zero-distance pair previously left only the far one)."""
+        graph, dataset = _triangle_network()
+        svc = NetworkClosestFacilityService()
+        res = svc.network_closest_facility(
+            demand_points=[
+                {"demand_id": "d1", "geometry": {"type": "Point", "coordinates": [116.01, 39.0]}},
+            ],
+            facilities=[
+                {"facility_id": "f_far", "geometry": {"type": "Point", "coordinates": [116.0, 39.0]}},
+                {"facility_id": "f_here", "geometry": {"type": "Point", "coordinates": [116.01, 39.0]}},
+            ],
+            graph=graph,
+            network_dataset=dataset,
+            target_facility_count=1,
+        )
+        assert len(res.routes) == 1
+        assert res.routes[0].destination_id == "f_here"
+        assert res.routes[0].total_distance_m == pytest.approx(0.0, abs=1e-6)
+
+    def test_unreachable_pairs_still_excluded(self):
+        """The guard's original purpose — filtering unreachable (inf) pairs —
+        must survive: a facility on a disconnected island is never matched."""
+        geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "properties": {"speed_kmh": 60.0, "one_way": False},
+                    "geometry": {"type": "LineString", "coordinates": [[116.0, 39.0], [116.01, 39.0]]},
+                },
+                {
+                    "type": "Feature",
+                    "properties": {"speed_kmh": 60.0, "one_way": False},
+                    "geometry": {"type": "LineString", "coordinates": [[117.0, 40.0], [117.01, 40.0]]},
+                },
+            ],
+        }
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(geojson, profile=TravelProfile())
+        svc = NetworkClosestFacilityService()
+        res = svc.network_closest_facility(
+            demand_points=[
+                {"demand_id": "d1", "geometry": {"type": "Point", "coordinates": [116.005, 39.0]}},
+            ],
+            facilities=[
+                {"facility_id": "f_island", "geometry": {"type": "Point", "coordinates": [117.005, 40.0]}},
+            ],
+            graph=graph,
+            network_dataset=dataset,
+        )
+        assert res.routes == []
+
+    def test_negative_distance_never_occurs_but_would_be_kept_finite_only(self):
+        """The filter is finiteness-based: math.isfinite(distance_m)."""
+        assert math.isfinite(0.0)
+        assert not math.isfinite(float("inf"))

--- a/tests/unit/test_network_issue457_overlap_split.py
+++ b/tests/unit/test_network_issue457_overlap_split.py
@@ -1,0 +1,227 @@
+"""Regression tests for issue #457 (P3): the graph builder never split
+COLLINEAR OVERLAPPING lines (``_process_intersections`` collected only
+Point/MultiPoint intersections — an overlap intersects as a LineString /
+GeometryCollection, silently dropped), leaving the shared sub-segment as a
+disconnected parallel edge. Additionally, the DiGraph silently OVERWROTE
+parallel (u, v) edges while the dataset kept every duplicate edge id,
+desyncing dataset edge ids from the graph.
+
+Fix: overlap endpoints join the split-point set (both lines are cut where
+the shared run begins/ends, so the shared sub-segment becomes real junction-
+connected edges), and same-(u,v) additions are deduplicated so the dataset
+and graph stay 1:1 in edge ids.
+"""
+import pytest
+
+import networkx as nx
+
+from shapely.geometry import shape
+
+from app.services.network.graph_builder import NetworkGraphBuilder
+from app.services.network.models import TravelProfile
+
+
+def _line(coords, props=None):
+    return {
+        "type": "Feature",
+        "properties": props or {"speed_kmh": 60.0, "one_way": False},
+        "geometry": {"type": "LineString", "coordinates": coords},
+    }
+
+
+def _fc(*features):
+    return {"type": "FeatureCollection", "features": list(features)}
+
+
+def _node_at(graph, x, y):
+    for n, d in graph.nodes(data=True):
+        if abs(d["x"] - x) < 1e-9 and abs(d["y"] - y) < 1e-9:
+            return n
+    return None
+
+
+class TestPartialCollinearOverlap:
+    def _build(self):
+        """line1 spans lng 116.000→116.004; line2 overlaps 116.001→116.003."""
+        builder = NetworkGraphBuilder()
+        return builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.004, 39.0]]),
+                _line([[116.001, 39.0], [116.003, 39.0]]),
+            ),
+            profile=TravelProfile(),
+        )
+
+    def test_overlap_endpoints_become_split_points(self):
+        """The overlap endpoints must SPLIT line1: the sub-edge from 116.000
+        to 116.001 must exist. (Without splitting, 116.001 exists only as
+        line2's endpoint — an isolated node with no connection to 116.000.)"""
+        graph, dataset = self._build()
+        n0 = _node_at(graph, 116.0, 39.0)
+        n1 = _node_at(graph, 116.001, 39.0)
+        n4 = _node_at(graph, 116.004, 39.0)
+        assert n1 is not None and n4 is not None
+        assert graph.has_edge(n0, n1), (
+            "no sub-edge 116.000→116.001: line1 was not cut at the overlap start"
+        )
+        assert graph.has_edge(n1, n4) or any(
+            graph.has_edge(n1, x) for x in graph.successors(n1)
+        ), "overlap start node has no outgoing continuation"
+
+    def test_shared_segment_is_connected(self):
+        """The two lines' node sets must be connected through the shared run —
+        routing from a point on line2 to a point on line1's exclusive end must
+        work instead of returning no path."""
+        graph, dataset = self._build()
+        n0 = _node_at(graph, 116.0, 39.0)
+        n1 = _node_at(graph, 116.001, 39.0)
+        assert nx.has_path(graph, n1, n0), (
+            "line2's endpoint cannot reach line1's endpoint — the overlap "
+            "stayed a floating parallel edge (#457)"
+        )
+
+    def test_route_across_overlap_has_full_length(self):
+        from app.services.network.routing import NetworkRoutingService
+        from app.services.network.graph_builder import haversine_distance
+        graph, dataset = self._build()
+        router = NetworkRoutingService()
+        # Mid-shared-segment → line1's exclusive west end: only routable when
+        # the shared run is junction-connected to the outer sub-edges.
+        route = router.network_shortest_path(
+            graph, dataset, (116.002, 39.0), (116.0, 39.0), profile=TravelProfile(),
+        )
+        expected = haversine_distance((116.002, 39.0), (116.0, 39.0))
+        assert route.total_cost < float("inf"), "no route across the overlap"
+        assert route.total_distance_m == pytest.approx(expected, rel=0.02)
+
+    def test_reversed_orientation_overlap_also_splits(self):
+        """line2 drawn right-to-left ([116.003]→[116.001]) overlaps the same."""
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.004, 39.0]]),
+                _line([[116.003, 39.0], [116.001, 39.0]]),
+            ),
+            profile=TravelProfile(),
+        )
+        n0 = _node_at(graph, 116.0, 39.0)
+        n1 = _node_at(graph, 116.001, 39.0)
+        assert n1 is not None
+        assert graph.has_edge(n0, n1), "reversed-orientation overlap not split"
+        assert nx.has_path(graph, n1, _node_at(graph, 116.004, 39.0))
+
+    def test_containment_overlap_splits_at_inner_line_endpoints(self):
+        """line2 entirely inside line1 (116.001→116.002 within 116.0→116.004)."""
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.004, 39.0]]),
+                _line([[116.001, 39.0], [116.002, 39.0]]),
+            ),
+            profile=TravelProfile(),
+        )
+        n0 = _node_at(graph, 116.0, 39.0)
+        n1 = _node_at(graph, 116.001, 39.0)
+        n2 = _node_at(graph, 116.002, 39.0)
+        n4 = _node_at(graph, 116.004, 39.0)
+        assert n1 is not None and n2 is not None
+        assert graph.has_edge(n0, n1) and graph.has_edge(n2, n4)
+        assert nx.has_path(graph, n1, n4)
+
+
+class TestParallelEdgeDedupe:
+    def test_identical_duplicate_lines_keep_graph_and_dataset_in_sync(self):
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.01, 39.0]]),
+                _line([[116.0, 39.0], [116.01, 39.0]]),
+            ),
+            profile=TravelProfile(),
+        )
+        # Two-way street: exactly one u->v and one v->u edge, in BOTH the
+        # graph and the dataset (previously the graph kept 2 while the
+        # dataset kept 4 — the second graph add silently replaced the first).
+        assert graph.number_of_edges() == 2
+        assert dataset.edge_count == graph.number_of_edges()
+
+    def test_every_dataset_edge_id_maps_to_a_graph_edge(self):
+        """Invariant: dataset edge ids and graph edge ids stay 1:1 — the
+        snapper returns dataset edge ids that routing looks up in the graph."""
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.004, 39.0]]),
+                _line([[116.001, 39.0], [116.003, 39.0]]),
+                _line([[116.0, 39.0], [116.01, 39.0]]),
+            ),
+            profile=TravelProfile(),
+        )
+        graph_edge_ids = {d["id"] for _, _, d in graph.edges(data=True)}
+        dataset_edge_ids = {str(e.id) for e in dataset.edges}
+        assert dataset_edge_ids == graph_edge_ids, (
+            f"dataset/graph edge id desync: only-in-dataset="
+            f"{sorted(dataset_edge_ids - graph_edge_ids)[:4]}"
+        )
+        for e in dataset.edges:
+            assert graph.has_edge(e.u, e.v), f"dataset edge {e.id} missing in graph"
+
+    def test_one_way_duplicate_still_adds_reverse(self):
+        """Dedupe must be per DIRECTED pair: a one-way original followed by a
+        two-way duplicate still contributes the v->u direction."""
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.01, 39.0]], {"speed_kmh": 60.0, "one_way": True}),
+                _line([[116.0, 39.0], [116.01, 39.0]]),
+            ),
+            profile=TravelProfile(),
+        )
+        assert graph.has_edge(_node_at(graph, 116.0, 39.0), _node_at(graph, 116.01, 39.0))
+        assert graph.has_edge(_node_at(graph, 116.01, 39.0), _node_at(graph, 116.0, 39.0))
+        assert dataset.edge_count == graph.number_of_edges() == 2
+
+    def test_split_subsegments_geometry_oriented(self):
+        """Sub-edge geometries keep their traversal orientation (u→v coords)."""
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.004, 39.0]]),
+                _line([[116.001, 39.0], [116.003, 39.0]]),
+            ),
+            profile=TravelProfile(),
+        )
+        for u, v, d in graph.edges(data=True):
+            coords = list(shape(d["geometry"]).coords)
+            u_d, v_d = graph.nodes[u], graph.nodes[v]
+            assert abs(coords[0][0] - u_d["x"]) < 1e-9 and abs(coords[-1][0] - v_d["x"]) < 1e-9, (
+                f"edge {u}->{v} geometry not oriented with its direction"
+            )
+
+
+class TestCrossingStillWorks:
+    def test_point_intersections_unchanged(self):
+        """Crossing (Point) intersections split exactly as before."""
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.01, 39.0]]),
+                _line([[116.005, 38.995], [116.005, 39.005]]),
+            ),
+            profile=TravelProfile(),
+        )
+        assert _node_at(graph, 116.005, 39.0) is not None
+
+    def test_touching_endpoints_unchanged(self):
+        """Lines sharing an endpoint still share the node (no spurious split)."""
+        builder = NetworkGraphBuilder()
+        graph, dataset = builder.build_graph(
+            _fc(
+                _line([[116.0, 39.0], [116.005, 39.0]]),
+                _line([[116.005, 39.0], [116.01, 39.0]]),
+            ),
+            profile=TravelProfile(),
+        )
+        shared = _node_at(graph, 116.005, 39.0)
+        assert shared is not None
+        assert nx.has_path(graph, _node_at(graph, 116.0, 39.0), _node_at(graph, 116.01, 39.0))


### PR DESCRIPTION
## Issues
- Fixes #446 (P1: reverse-direction edge splitting applies the same fraction — mid-edge route lengths/geometry wrong)
- Fixes #447 (P2: A* heuristic uses profile default speed 40 km/h — inadmissible on faster edges)
- Fixes #449 (P2: OD matrix full-tree Dijkstra with path materialization per origin; cutoff_s accepted but never used)
- Fixes #453 (P2: OD-family tools snap to edge endpoints while routing splits mid-edge — 2× cost divergence)
- Fixes #443 (P3: geo_analysis isochrones per-facility full edge scan O(F×E))
- Fixes #455 (P3: turn penalty charged on every edge incl. departure; length-cost ignores penalty)
- Fixes #456 (P3: closest_facility excludes zero-distance matches via `distance_m <= 0`)
- Fixes #457 (P3: graph builder never splits collinear overlapping lines; parallel-edge overwrite desyncs ids)

## Fixes (one commit per issue, 73007fe..fbf7626)
- **#446** reverse-direction split maps fraction to forward geometry (1−f).
- **#447** A* heuristic bound derived from the graph's max traversal speed (admissible; conservative).
- **#449** cutoff-bounded accumulating Dijkstra for OD cost matrices; no path materialization when only cost is requested; cutoff actually bounds the explored set.
- **#453** OD-family snapping uses fractional along-edge position (mid-edge like routing).
- **#455** turn penalty only at actual turns (never the departure edge), consistent across cost modes.
- **#456** zero distance is a valid demand-facility match (None/negative handling only).
- **#457** graph builder splits collinear overlaps and dedupes parallel edges; graph/dataset edge ids stay synced.
- **#443** geo_analysis isochrones: adjacency-of-reachable-nodes scan replaces the full O(F×E) edge scan with exact EdgeView-parity traversal (identical reachable sets/clipping/polygons); graph build iterates the geometry GeoSeries directly (no iterrows).

## Differential / property tests
- A* cost == Dijkstra cost on randomized graphs with fast edges (#447)
- reverse/forward split geometry invariants; split lengths sum == original (#446)
- OD cost == shortest_path cost for the same pair (#453)
- zero-distance facility match (#456); cutoff reduces explored nodes, equals filtered uncutoff run (#449)
- isochrone equivalence vs the pre-fix full-scan reference: zero property mismatches, max polygon symdiff 0.0 deg² (#443)
- adversarial: disconnected graphs, reversed geometry, off-network facilities, zero budget

## Benchmarks (median of 3)
- #443: E=19.8k F=30: 4.93 s → 1.72 s (2.9×); E=21.8k F=10 5-min: 6.44 s → 3.64 s (1.8×)
- #449: structural asserts (no path materialization; bounded exploration) + timing evidence in the batch report

## Validation
157 issue + adjacent network tests green; tests/test_network.py 9p; temporal harness 12p; `ruff` clean.

## Risk
Medium: core routing semantics change (#446/#453/#447 change previously-wrong outputs — property tests pin the corrected invariants). No API shape changes.