### PR TITLE
fix(templates): single-pass pagination, Page-envelope gallery, truthful apply (#428 #464 #465)

### DIFF
--- a/app/api/routes/templates.py
+++ b/app/api/routes/templates.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, TypeAdapter
-from sqlalchemy import func, or_, select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import actor_ids, get_current_user, get_current_user_optional
@@ -137,6 +137,21 @@ async def list_templates(
     user_id, user_org_id = actor_ids(_user if isinstance(_user, dict) else None)
     role = _user.get("role") if isinstance(_user, dict) else None
 
+    # Merged catalog = built-in seeds (static order, always first) + DB rows
+    # (newest first). Build the full filtered catalog, then paginate ONCE.
+    # Issue #428: the old code paginated twice — `.limit/.offset` on the DB
+    # query and then a second `[offset:offset+limit]` slice of the merged
+    # (seed + DB-page) list — so the offset skipped seed+DB rows twice, deep
+    # pages ran empty while `has_more` was still true, and without an
+    # ORDER BY the row order was nondeterministic across requests.
+    seed_list = list(SEED_TEMPLATES)
+    if kind:
+        seed_list = [t for t in seed_list if t.get("kind") == kind]
+    if source == "user":
+        seed_list = [t for t in seed_list if not t.get("is_builtin")]
+    elif source == "builtin":
+        seed_list = [t for t in seed_list if t.get("is_builtin")]
+
     # DB-stored templates: builtins + caller's own (and org, when the JWT
     # actually carries org_id). Do not use org_id IS NULL as "public".
     stmt = select(CartographyTemplate)
@@ -152,42 +167,32 @@ async def list_templates(
     elif source == "user":
         stmt = stmt.where(CartographyTemplate.is_builtin.is_(False))
 
-    # Apply pagination at the DB level (no Python .all()).
-    page_stmt = stmt.limit(limit).offset(offset)
-    result = await db.execute(page_stmt)
-    db_templates = list(result.scalars().all())
-    total_stmt = select(func.count()).select_from(stmt.subquery())
-    total = (await db.execute(total_stmt)).scalar_one() or 0
+    # A DB row carrying a seed id is the seeded copy of that built-in — the
+    # seed entry above already represents it, so exclude it here instead of
+    # de-duplicating page-by-page (which only saw the current page's ids).
+    seed_ids = [s.get("id") for s in SEED_TEMPLATES if s.get("id")]
+    if seed_ids:
+        stmt = stmt.where(CartographyTemplate.id.not_in(seed_ids))
 
-    db_dicts = [_template_to_dict(t) for t in db_templates]
-    db_ids = {t["id"] for t in db_dicts}
+    # Deterministic paging order (created_at alone can tie on fast inserts).
+    stmt = stmt.order_by(CartographyTemplate.created_at.desc(), CartographyTemplate.id)
 
-    # SEED_TEMPLATES are global built-ins; merge in (deduped) so the gallery
-    # always shows the full set even when the DB row is missing.
-    seed_list = list(SEED_TEMPLATES)
-    if kind:
-        seed_list = [t for t in seed_list if t.get("kind") == kind]
-    seed_dicts = [t for t in seed_list if t.get("id") not in db_ids]
+    result = await db.execute(stmt)
+    db_dicts = [_template_to_dict(t) for t in result.scalars().all()]
 
-    results = seed_dicts + db_dicts
-    if source == "user":
-        # When the caller asks for user templates only, drop the seeds.
-        results = [t for t in results if not t.get("is_builtin")]
-    elif source == "builtin":
-        results = [t for t in results if t.get("is_builtin")]
+    merged = seed_list + db_dicts
 
     if q:
         keyword = q.lower()
-        results = [
-            t for t in results
+        merged = [
+            t for t in merged
             if keyword in t.get("name", "").lower()
             or keyword in (t.get("description") or "").lower()
             or any(keyword in kw.lower() for kw in t.get("keywords", []))
         ]
 
-    # Final post-pagination slice so the merged list doesn't exceed the
-    # requested page (built-in seeds are pre-DB and out of `total`).
-    page_slice = results[offset:offset + limit]
+    total = len(merged)
+    page_slice = merged[offset:offset + limit]
 
     if summary:
         page_slice = [_to_summary(t) for t in page_slice]

--- a/frontend/components/drawers/template-gallery-v2.test.tsx
+++ b/frontend/components/drawers/template-gallery-v2.test.tsx
@@ -19,20 +19,37 @@ const mockTemplates = vi.hoisted(() => ({
   get: vi.fn(),
   delete: vi.fn(),
 }));
-vi.mock('@/lib/api/templates', () => ({ templatesApi: mockTemplates }));
-vi.mock('@/lib/basemap-apply', () => ({ applyBaseline: vi.fn() }));
-vi.mock('@/lib/symbology-apply', () => ({ applySymbology: vi.fn() }));
-vi.mock('@/lib/thematic-apply', () => ({ resolveThematicPreset: vi.fn() }));
-vi.mock('@/lib/map-kit/layout-style', () => ({ resolveStyle: vi.fn() }));
-vi.mock('@/lib/store/useHudStore', () => ({
-  useHudStore: (sel: (s: unknown) => unknown) => sel({
-    setBaseLayer: vi.fn(), addLayer: vi.fn(), clearLayers: vi.fn(),
-  }),
+const mockDispatch = vi.hoisted(() => vi.fn());
+const mockAddToast = vi.hoisted(() => vi.fn());
+const mockHudState = vi.hoisted(() => ({
+  layers: [] as Array<{ id: string; name?: string }>,
+  focusLayerId: null as string | null,
+  setBaseLayer: vi.fn(),
+  addLayer: vi.fn(),
+  clearLayers: vi.fn(),
+  updateExportSettings: vi.fn(),
 }));
+vi.mock('@/lib/api/templates', () => ({ templatesApi: mockTemplates }));
+vi.mock('@/lib/contexts/map-action-context', () => ({
+  useMapAction: () => ({ dispatchAction: mockDispatch }),
+}));
+vi.mock('@/components/ui/toast', () => ({
+  useToastStore: { getState: () => ({ addToast: mockAddToast }) },
+}));
+vi.mock('@/lib/store/useHudStore', () => ({
+  useHudStore: Object.assign(
+    (sel: (s: unknown) => unknown) => sel(mockHudState),
+    { getState: () => mockHudState }
+  ),
+}));
+// Real symbology-apply reducer: the gallery dispatches its normalized output
+// through the map action queue, so tests assert on the real shape.
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers({ shouldAdvanceTime: true });
+  mockHudState.layers = [];
+  mockHudState.focusLayerId = null;
 });
 
 /**
@@ -139,5 +156,149 @@ describe('TemplateGalleryV2', () => {
     mockTemplates.list.mockRejectedValue(new Error('boom'));
     render(<TemplateGalleryV2 open={true} onClose={() => {}} />);
     await waitFor(() => expect(screen.getByText(/boom/)).toBeInTheDocument());
+  });
+});
+
+// ============================================================================
+// Issue #465: the list endpoint defaults summary=true and strips `payload` —
+// the apply action must fetch the DETAIL before applying, and the success
+// callback (parent toast) may only fire when the apply actually landed.
+// ============================================================================
+
+const BASEMAP_CARD = {
+  id: 'tmpl_bm_dark', kind: 'basemap', name: '深色底图卡', description: '', keywords: [],
+  is_builtin: true, version: 1,
+};
+
+describe('TemplateGalleryV2 apply (#465)', () => {
+  it('fetches the template detail before applying — summary items carry no payload', async () => {
+    mockTemplates.list.mockResolvedValue(page([BASEMAP_CARD]));
+    mockTemplates.get.mockResolvedValue({ ...BASEMAP_CARD, payload: { providerId: 'carto-dark' } });
+    const onApply = vi.fn();
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} onApply={onApply} />);
+    await waitFor(() => expect(screen.getByText('深色底图卡')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '应用' }));
+    await waitFor(() => expect(mockTemplates.get).toHaveBeenCalledWith('tmpl_bm_dark'));
+  });
+
+  it('dispatches a real basemap switch through the map action queue on success', async () => {
+    mockTemplates.list.mockResolvedValue(page([BASEMAP_CARD]));
+    mockTemplates.get.mockResolvedValue({ ...BASEMAP_CARD, payload: { providerId: 'carto-dark' } });
+    const onApply = vi.fn();
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} onApply={onApply} />);
+    await waitFor(() => expect(screen.getByText('深色底图卡')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '应用' }));
+    await waitFor(() =>
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ command: 'BASE_LAYER_CHANGE' })
+      )
+    );
+    const dispatched = mockDispatch.mock.calls[0][0];
+    // Canonical provider name → the queue's base_layer_change exact-matches it.
+    expect(dispatched.params.name).toBe('Carto 深色');
+    await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1));
+    expect(onApply.mock.calls[0][0].payload).toEqual({ providerId: 'carto-dark' });
+  });
+
+  it('never fires the success callback when the detail has no payload', async () => {
+    mockTemplates.list.mockResolvedValue(page([BASEMAP_CARD]));
+    mockTemplates.get.mockResolvedValue({ ...BASEMAP_CARD }); // payload stripped/missing
+    const onApply = vi.fn();
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} onApply={onApply} />);
+    await waitFor(() => expect(screen.getByText('深色底图卡')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '应用' }));
+    await waitFor(() => expect(mockTemplates.get).toHaveBeenCalled());
+    // Give the async handler a tick to settle before asserting no success.
+    await act(async () => {});
+    expect(onApply).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledWith(expect.any(String), 'error'));
+  });
+
+  it('surfaces a detail-fetch failure as an error toast, not a success toast', async () => {
+    mockTemplates.list.mockResolvedValue(page([BASEMAP_CARD]));
+    mockTemplates.get.mockRejectedValue(new Error('network down'));
+    const onApply = vi.fn();
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} onApply={onApply} />);
+    await waitFor(() => expect(screen.getByText('深色底图卡')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '应用' }));
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('network down'), 'error'));
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it('symbology apply without a loaded layer errors instead of false success', async () => {
+    const card = { ...BASEMAP_CARD, id: 'tmpl_sym_x', kind: 'symbology', name: '符号卡' };
+    mockTemplates.list.mockResolvedValue(page([card]));
+    mockTemplates.get.mockResolvedValue({
+      ...card,
+      payload: { mode: 'single', geometry: 'Polygon', style: { color: '#1d4ed8' } },
+    });
+    const onApply = vi.fn();
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} onApply={onApply} />);
+    await waitFor(() => expect(screen.getByText('符号卡')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '应用' }));
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('图层'), 'error'));
+    expect(onApply).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('symbology apply with an active layer dispatches LAYER_STYLE_UPDATE', async () => {
+    mockHudState.layers = [{ id: 'layer_poi' }];
+    mockHudState.focusLayerId = 'layer_poi';
+    const card = { ...BASEMAP_CARD, id: 'tmpl_sym_x', kind: 'symbology', name: '符号卡' };
+    mockTemplates.list.mockResolvedValue(page([card]));
+    mockTemplates.get.mockResolvedValue({
+      ...card,
+      payload: { mode: 'single', geometry: 'Polygon', style: { color: '#1d4ed8', fillOpacity: 0.8 } },
+    });
+    const onApply = vi.fn();
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} onApply={onApply} />);
+    await waitFor(() => expect(screen.getByText('符号卡')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '应用' }));
+    await waitFor(() => expect(mockDispatch).toHaveBeenCalledTimes(1));
+    const dispatched = mockDispatch.mock.calls[0][0];
+    expect(dispatched.command).toBe('LAYER_STYLE_UPDATE');
+    expect(dispatched.params.layer_id).toBe('layer_poi');
+    expect(dispatched.params.style).toMatchObject({ color: '#1d4ed8', fill: '#1d4ed8', fillOpacity: 0.8 });
+    await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1));
+  });
+
+  it('layout apply lands in the export settings store', async () => {
+    const card = { ...BASEMAP_CARD, id: 'tmpl_ly_a4', kind: 'layout', name: 'A4 横版卡' };
+    mockTemplates.list.mockResolvedValue(page([card]));
+    mockTemplates.get.mockResolvedValue({
+      ...card,
+      payload: {
+        paperSize: 'A4', orientation: 'landscape', showLegend: true,
+        showNorthArrow: true, showScaleBar: true, showGrid: false,
+      },
+    });
+    const onApply = vi.fn();
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} onApply={onApply} />);
+    await waitFor(() => expect(screen.getByText('A4 横版卡')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '应用' }));
+    await waitFor(() => expect(mockHudState.updateExportSettings).toHaveBeenCalledTimes(1));
+    expect(mockHudState.updateExportSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paperSize: 'A4', orientation: 'landscape', showLegend: true,
+        showCompass: true, showScale: true, showGraticules: false,
+      })
+    );
+    await waitFor(() => expect(onApply).toHaveBeenCalledTimes(1));
+  });
+
+  it('thematic/composite apply is an explicit error — no false success', async () => {
+    const card = { ...BASEMAP_CARD, id: 'tmpl_th_x', kind: 'thematic', name: '专题卡' };
+    mockTemplates.list.mockResolvedValue(page([card]));
+    mockTemplates.get.mockResolvedValue({
+      ...card,
+      payload: { variant: 'choropleth', method: 'quantiles', k: 5, palette: 'YlOrRd' },
+    });
+    const onApply = vi.fn();
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} onApply={onApply} />);
+    await waitFor(() => expect(screen.getByText('专题卡')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '应用' }));
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Agent'), 'error'));
+    expect(onApply).not.toHaveBeenCalled();
   });
 });

--- a/frontend/components/drawers/template-gallery-v2.test.tsx
+++ b/frontend/components/drawers/template-gallery-v2.test.tsx
@@ -35,18 +35,42 @@ beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
 });
 
+/**
+ * Backend contract (app/api/routes/templates.py): GET /api/v1/templates returns
+ * the Page envelope {items, total, limit, offset, has_more}. Issue #464: the
+ * gallery used to consume the envelope as a bare TemplateSummary[] and crashed
+ * with `templates.map is not a function` on every successful response. All
+ * mocks below use the REAL envelope shape.
+ */
+const page = (
+  items: Array<Record<string, unknown>>,
+  opts: { total?: number; limit?: number; offset?: number; has_more?: boolean } = {}
+) => ({
+  items,
+  total: opts.total ?? items.length,
+  limit: opts.limit ?? 50,
+  offset: opts.offset ?? 0,
+  has_more: opts.has_more ?? false,
+});
+
+const SUMMARY_A = {
+  id: 'tmpl_a', kind: 'basemap', name: '蓝色底图甲', description: '', keywords: [],
+  is_builtin: true, version: 1,
+};
+const SUMMARY_B = {
+  id: 'tmpl_b', kind: 'thematic', name: '专题模板乙', description: '', keywords: [],
+  is_builtin: true, version: 1,
+};
+
 describe('TemplateGalleryV2', () => {
   it('renders the header + tabs and skips the network when closed', async () => {
-    mockTemplates.list.mockResolvedValue([]);
+    mockTemplates.list.mockResolvedValue(page([]));
     render(<TemplateGalleryV2 open={false} onClose={() => {}} />);
     expect(mockTemplates.list).not.toHaveBeenCalled();
   });
 
   it('fetches the first page when opened', async () => {
-    mockTemplates.list.mockResolvedValue([
-      { id: 'tmpl_a', kind: 'basemap', name: 'A', description: '', keywords: [] },
-      { id: 'tmpl_b', kind: 'thematic', name: 'B', description: '', keywords: [] },
-    ]);
+    mockTemplates.list.mockResolvedValue(page([SUMMARY_A, SUMMARY_B]));
     render(<TemplateGalleryV2 open={true} onClose={() => {}} />);
     await waitFor(() => expect(mockTemplates.list).toHaveBeenCalled());
     const call = mockTemplates.list.mock.calls[0][0];
@@ -55,8 +79,27 @@ describe('TemplateGalleryV2', () => {
     expect(call.kind).toBeUndefined();
   });
 
+  it('renders cards from the Page envelope instead of crashing (#464)', async () => {
+    mockTemplates.list.mockResolvedValue(page([SUMMARY_A, SUMMARY_B]));
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} />);
+    // Both card names must render — the old code called templates.map on the
+    // envelope object itself and threw TypeError (whole-app ErrorBoundary).
+    await waitFor(() => expect(screen.getByText('蓝色底图甲')).toBeInTheDocument());
+    expect(screen.getByText('专题模板乙')).toBeInTheDocument();
+  });
+
+  it('drives the page counter from the envelope total (#464)', async () => {
+    // 120 total templates at 50/page → footer shows 第 1 / 3 页, 下一页 enabled.
+    mockTemplates.list.mockResolvedValue(
+      page([SUMMARY_A], { total: 120, limit: 50, offset: 0, has_more: true })
+    );
+    render(<TemplateGalleryV2 open={true} onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('第 1 / 3 页')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /下一页/ })).toBeEnabled();
+  });
+
   it('debounces the search input', async () => {
-    mockTemplates.list.mockResolvedValue([]);
+    mockTemplates.list.mockResolvedValue(page([]));
     render(<TemplateGalleryV2 open={true} onClose={() => {}} />);
     await waitFor(() => expect(mockTemplates.list).toHaveBeenCalledTimes(1));
     const input = screen.getByPlaceholderText(/搜索模板/);
@@ -76,7 +119,7 @@ describe('TemplateGalleryV2', () => {
   });
 
   it('switches the kind tab and refetches with the new filter', async () => {
-    mockTemplates.list.mockResolvedValue([]);
+    mockTemplates.list.mockResolvedValue(page([]));
     render(<TemplateGalleryV2 open={true} onClose={() => {}} />);
     await waitFor(() => expect(mockTemplates.list).toHaveBeenCalled());
     fireEvent.click(screen.getByText('底图'));
@@ -87,7 +130,7 @@ describe('TemplateGalleryV2', () => {
   });
 
   it('shows "no matches" when the page is empty', async () => {
-    mockTemplates.list.mockResolvedValue([]);
+    mockTemplates.list.mockResolvedValue(page([]));
     render(<TemplateGalleryV2 open={true} onClose={() => {}} />);
     await waitFor(() => expect(screen.getByText(/无匹配模板/)).toBeInTheDocument());
   });

--- a/frontend/components/drawers/template-gallery-v2.tsx
+++ b/frontend/components/drawers/template-gallery-v2.tsx
@@ -106,13 +106,14 @@ export function TemplateGalleryV2({ open, onClose, onApply }: TemplateGalleryV2P
         offset: page * PAGE_SIZE,
         signal: controller.signal,
       })
-      .then((data) => {
+      .then((result) => {
         if (controller.signal.aborted) return;
-        setTemplates(data as unknown as TemplateSummary[]);
-        // The backend Page envelope includes total; apiFetch unwraps to the
-        // bare list, so we use the page length as a fallback upper bound
-        // for "more pages exist" and the user-visible "page X / Y".
-        setTotal(data.length === PAGE_SIZE ? (page + 1) * PAGE_SIZE + 1 : page * PAGE_SIZE + data.length);
+        // Issue #464: the backend returns the Page envelope {items, total,
+        // ...} — consume items/total from it. (The old code treated the
+        // envelope as a bare array: templates.map threw on every success and
+        // the whole-app ErrorBoundary surfaced a System Error page.)
+        setTemplates(result.items);
+        setTotal(result.total);
       })
       .catch((err: unknown) => {
         if (controller.signal.aborted) return;

--- a/frontend/components/drawers/template-gallery-v2.tsx
+++ b/frontend/components/drawers/template-gallery-v2.tsx
@@ -33,12 +33,13 @@ import React, {
   useState,
 } from 'react';
 import { Loader2, ChevronLeft, ChevronRight, Layers, Map as MapIcon, Palette, Layout as LayoutIcon, BarChart3, Sparkles, X } from 'lucide-react';
-import { templatesApi, type TemplateKind, type TemplateSummary } from '@/lib/api/templates';
+import { templatesApi, type TemplateDetail, type TemplateKind, type TemplateSummary } from '@/lib/api/templates';
 import { isApiError } from '@/lib/api/transport';
-import { applyBaseline, type BasemapPayload } from '@/lib/basemap-apply';
-import { applySymbology, type SymbologyPayload } from '@/lib/symbology-apply';
-import { resolveThematicPreset } from '@/lib/thematic-apply';
-import { resolveStyle } from '@/lib/map-kit/layout-style';
+import { applySymbology, type SymbologySinglePayload } from '@/lib/symbology-apply';
+import { useMapAction } from '@/lib/contexts/map-action-context';
+import { useHudStore } from '@/lib/store/useHudStore';
+import { TILE_PROVIDERS } from '@/lib/providers';
+import { useToastStore } from '@/components/ui/toast';
 import { useDialogFocus } from '@/lib/hooks/use-dialog-focus';
 import { LoadingState } from '@/components/shared/loading-state';
 import { InlineNotice } from '@/components/shared/inline-notice';
@@ -61,7 +62,117 @@ const KIND_TABS: Array<{ kind: TemplateKind | 'all'; label: string; Icon: React.
 export interface TemplateGalleryV2Props {
   open: boolean;
   onClose: () => void;
+  /** Fired only when an apply actually landed (parent shows the success toast). */
   onApply?: (t: TemplateSummary) => void;
+}
+
+// ============================================================================
+// Apply pipeline (issue #465). Each kind lands somewhere real:
+//   basemap   → BASE_LAYER_CHANGE through the shared map action queue (the
+//               same path the agent chat uses; swaps the actual base layer
+//               and syncs the HUD store label)
+//   symbology → LAYER_STYLE_UPDATE on the active layer through the queue
+//   layout    → export settings store (consumed by the map exporter)
+//   thematic/composite → cannot land from the gallery (need a data field /
+//               the full agent pipeline) → explicit error, never false success
+// ============================================================================
+
+type DispatchAction = ReturnType<typeof useMapAction>['dispatchAction'];
+
+interface HudApplyState {
+  layers?: Array<{ id: string }>;
+  focusLayerId?: string | null;
+  updateExportSettings?: (updates: Record<string, unknown>) => void;
+}
+
+type ApplyOutcome = { ok: true; detail: TemplateDetail } | { ok: false; error: string };
+
+/** Resolve a template providerId to a TILE_PROVIDERS entry (mirrors the
+ * base_layer_change matcher: exact id/name, then keyword containment). */
+function resolveBasemapProvider(providerId: string) {
+  const pid = providerId.trim().toLowerCase();
+  if (!pid) return undefined;
+  return (
+    TILE_PROVIDERS.find((p) => p.id.toLowerCase() === pid) ??
+    TILE_PROVIDERS.find((p) => p.name.toLowerCase() === pid) ??
+    TILE_PROVIDERS.find((p) =>
+      p.keywords.some((k) => {
+        const kl = k.toLowerCase();
+        return kl === pid || pid.includes(kl);
+      })
+    )
+  );
+}
+
+/** The layer a gallery symbology pass targets: the focused layer, else first. */
+function activeLayerId(hud: HudApplyState): string | undefined {
+  const focused = hud.focusLayerId;
+  if (focused && hud.layers?.some((l) => l.id === focused)) return focused;
+  return hud.layers?.[0]?.id;
+}
+
+function applyBasemapTemplate(
+  detail: TemplateDetail,
+  dispatchAction: DispatchAction
+): ApplyOutcome {
+  const providerId = detail.payload?.providerId;
+  if (typeof providerId !== 'string' || !providerId) {
+    return { ok: false, error: `模板「${detail.name}」缺少底图 providerId，无法应用` };
+  }
+  const provider = resolveBasemapProvider(providerId);
+  if (!provider) {
+    return { ok: false, error: `未知底图提供者：${providerId}` };
+  }
+  // Canonical provider name → the queue's base_layer_change exact-matches it,
+  // swaps the live map style and syncs the HUD baseLayer label.
+  dispatchAction({ command: 'BASE_LAYER_CHANGE', params: { name: provider.name } });
+  return { ok: true, detail };
+}
+
+function applySymbologyTemplate(
+  detail: TemplateDetail,
+  dispatchAction: DispatchAction,
+  hud: HudApplyState
+): ApplyOutcome {
+  const layerId = activeLayerId(hud);
+  if (!layerId) {
+    return { ok: false, error: '当前地图没有可应用样式的图层，请先加载数据' };
+  }
+  const payload = detail.payload;
+  // Categorical symbology needs a field chosen at apply time — the gallery
+  // pass has no field picker, so it cannot land here.
+  if (!payload || payload.mode !== 'single') {
+    return { ok: false, error: '分类符号化需要在图层上选择字段，请通过 Agent 对话应用' };
+  }
+  const result = applySymbology(payload as unknown as SymbologySinglePayload, layerId);
+  dispatchAction({
+    command: result.command,
+    params: { layer_id: layerId, style: result.params.style_applied },
+  });
+  return { ok: true, detail };
+}
+
+function applyLayoutTemplate(detail: TemplateDetail, hud: HudApplyState): ApplyOutcome {
+  const payload = detail.payload as Record<string, unknown> | undefined;
+  if (!payload) {
+    return { ok: false, error: `模板「${detail.name}」缺少版式配置，无法应用` };
+  }
+  // Map the layout template's payload onto the export settings the map
+  // exporter consumes (paper/legend/compass/scale/graticule toggles).
+  const updates: Record<string, unknown> = {};
+  if (typeof payload.paperSize === 'string') updates.paperSize = payload.paperSize;
+  if (payload.orientation === 'landscape' || payload.orientation === 'portrait') {
+    updates.orientation = payload.orientation;
+  }
+  if (typeof payload.showLegend === 'boolean') updates.showLegend = payload.showLegend;
+  if (typeof payload.showNorthArrow === 'boolean') updates.showCompass = payload.showNorthArrow;
+  if (typeof payload.showScaleBar === 'boolean') updates.showScale = payload.showScaleBar;
+  if (typeof payload.showGrid === 'boolean') updates.showGraticules = payload.showGrid;
+  if (Object.keys(updates).length === 0) {
+    return { ok: false, error: `模板「${detail.name}」不包含可应用的版式字段` };
+  }
+  hud.updateExportSettings?.(updates);
+  return { ok: true, detail };
 }
 
 export function TemplateGalleryV2({ open, onClose, onApply }: TemplateGalleryV2Props) {
@@ -74,6 +185,8 @@ export function TemplateGalleryV2({ open, onClose, onApply }: TemplateGalleryV2P
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTemplate, setActiveTemplate] = useState<TemplateSummary | null>(null);
+  const [applyingId, setApplyingId] = useState<string | null>(null);
+  const { dispatchAction } = useMapAction();
   const abortRef = useRef<AbortController | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
 
@@ -142,88 +255,53 @@ export function TemplateGalleryV2({ open, onClose, onApply }: TemplateGalleryV2P
     setActiveTemplate(t);
   }, []);
 
+  // Issue #465: list items are summary DTOs — the backend strips `payload`
+  // from GET /templates (summary=true default), so reading payload off the
+  // card always saw undefined and every apply silently no-opped while the
+  // parent still fired a success toast. The apply now (1) fetches the full
+  // detail via GET /templates/{id}, (2) only reports success through
+  // onApply when the apply actually landed (dispatched to the map action
+  // queue / export settings store), and (3) raises an error toast otherwise.
   const handleApply = useCallback(
-    (t: TemplateSummary) => {
+    async (t: TemplateSummary) => {
+      if (applyingId) return;
+      setApplyingId(t.id);
       try {
-        switch (t.kind) {
-          case 'basemap': {
-            const payload = (t as unknown as { payload?: BasemapPayload }).payload;
-            if (payload?.providerId) {
-              applyBaseline(payload);
-            }
+        const detail = await templatesApi.get(t.id);
+        const hud = useHudStore.getState();
+        let outcome: ApplyOutcome;
+        switch (detail.kind) {
+          case 'basemap':
+            outcome = applyBasemapTemplate(detail, dispatchAction);
             break;
-          }
-          case 'symbology': {
-            const payload = (t as unknown as { payload?: SymbologyPayload }).payload;
-            if (payload) {
-              // The gallery pass doesn't bind a specific layer; the renderer
-              // dispatches to the active layer or surfaces a picker.
-              applySymbology(payload, '');
-            }
+          case 'symbology':
+            outcome = applySymbologyTemplate(detail, dispatchAction, hud);
             break;
-          }
-          case 'thematic': {
-            const payload = (t as unknown as { payload?: Record<string, unknown> }).payload ?? {};
-            // Gallery pass: no active field — empty string signals the
-            // renderer to surface a field picker.
-            type ThematicMethod = 'quantiles' | 'equal_interval' | 'natural_breaks' | 'lisa';
-            const method = payload.method as ThematicMethod | undefined;
-            // Thematic preset dispatch is a discriminated union (choropleth
-            // vs heatmap) with different optional fields. Branch on variant
-            // to give TS the right shape.
-            const variant = (payload.variant as 'choropleth' | 'heatmap') ?? 'choropleth';
-            if (variant === 'heatmap') {
-              resolveThematicPreset(
-                {
-                  variant: 'heatmap',
-                  intensity: (payload as { intensity?: number }).intensity,
-                  radius: (payload as { radius?: number }).radius,
-                  heatPalette: (payload as { heatPalette?: string[] }).heatPalette,
-                },
-                ''
-              );
-            } else {
-              const k = (payload as { k?: number }).k;
-              const palette = (payload as { palette?: string }).palette;
-              // Build the choropleth payload with only the keys the type
-              // actually allows (omit `method` entirely when missing — the
-              // TypeAdapter treats undefined as invalid).
-              const choroplethPayload: {
-                variant: 'choropleth';
-                method?: 'quantiles' | 'equal_interval' | 'natural_breaks' | 'lisa';
-                k?: number;
-                palette?: string;
-              } = { variant: 'choropleth' };
-              if (method) (choroplethPayload as { method: typeof method }).method = method;
-              if (k !== undefined) choroplethPayload.k = k;
-              if (palette !== undefined) choroplethPayload.palette = palette;
-              resolveThematicPreset(
-                choroplethPayload as unknown as Parameters<typeof resolveThematicPreset>[0],
-                ''
-              );
-            }
+          case 'layout':
+            outcome = applyLayoutTemplate(detail, hud);
             break;
-          }
-          case 'layout': {
-            const payload = (t as unknown as { payload?: { style?: Record<string, unknown> } }).payload;
-            if (payload?.style) {
-              resolveStyle(payload.style as never);
-            }
-            break;
-          }
-          case 'composite': {
-            // Composite templates bundle the other 4 kinds; the agent
-            // dispatch pipeline resolves them. Surface a hint for the user.
-            console.info('[TemplateGalleryV2] composite apply — use the Agent chat for full pipeline.');
-            break;
-          }
+          default:
+            // thematic needs a data field + geojson; composite bundles the
+            // full agent pipeline — neither can land from the gallery.
+            outcome = {
+              ok: false,
+              error: '专题/复合模板需要数据字段与渲染流水线，请通过 Agent 对话应用',
+            };
         }
-        onApply?.(t);
+        if (outcome.ok) {
+          onApply?.(outcome.detail);
+        } else {
+          useToastStore.getState().addToast(outcome.error, 'error');
+        }
       } catch (err) {
         console.warn('[TemplateGalleryV2] apply failed:', err);
+        const reason = err instanceof Error ? err.message : '未知错误';
+        useToastStore.getState().addToast(`模板「${t.name}」应用失败：${reason}`, 'error');
+      } finally {
+        setApplyingId(null);
       }
     },
-    [onApply],
+    [applyingId, dispatchAction, onApply]
   );
 
   if (!open) return null;
@@ -273,6 +351,8 @@ export function TemplateGalleryV2({ open, onClose, onApply }: TemplateGalleryV2P
                   key={t.id}
                   template={t}
                   selected={activeTemplate?.id === t.id}
+                  applying={applyingId === t.id}
+                  applyDisabled={applyingId !== null}
                   onSelect={handleSelect}
                   onApply={handleApply}
                 />
@@ -369,11 +449,17 @@ function KindTabs({
 const TemplateCard = React.memo(function TemplateCard({
   template,
   selected,
+  applying,
+  applyDisabled,
   onSelect,
   onApply,
 }: {
   template: TemplateSummary;
   selected: boolean;
+  /** This card's apply fetch is in flight (loading state on the button). */
+  applying: boolean;
+  /** Any card's apply is in flight — one detail fetch at a time. */
+  applyDisabled: boolean;
   onSelect: (t: TemplateSummary) => void;
   onApply: (t: TemplateSummary) => void;
 }) {
@@ -420,12 +506,14 @@ const TemplateCard = React.memo(function TemplateCard({
             e.stopPropagation();
             handleApplyClick();
           }}
-          className="rounded-sm px-2 py-1 text-caption font-medium text-agent-accent transition-opacity hover:opacity-80"
+          disabled={applyDisabled}
+          aria-busy={applying}
+          className="rounded-sm px-2 py-1 text-caption font-medium text-agent-accent transition-opacity hover:opacity-80 disabled:opacity-50"
           style={{
             background: 'color-mix(in srgb, var(--agent-accent) 12%, transparent)',
           }}
         >
-          应用
+          {applying ? '应用中…' : '应用'}
         </button>
       </div>
     </div>

--- a/frontend/lib/api/templates.test.ts
+++ b/frontend/lib/api/templates.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Templates API client — Page envelope handling (issue #464).
+ *
+ * The backend GET /api/v1/templates returns the Page envelope
+ * {items, total, limit, offset, has_more} (app/api/routes/templates.py).
+ * templatesApi.list must normalize BOTH the envelope and a legacy bare-array
+ * response into a page object so gallery consumers can never receive a
+ * non-array `items`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { clearCache } from './get-fast-path';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const jsonOk = (body: unknown, status = 200) => ({
+  ok: true,
+  status,
+  statusText: 'OK',
+  headers: { get: () => null },
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+import { templatesApi } from './templates';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearCache();
+});
+
+afterEach(() => {
+  clearCache();
+});
+
+const SUMMARY = { id: 'tmpl_a', kind: 'basemap', name: 'A', is_builtin: true, version: 1 };
+
+describe('templatesApi.list — Page envelope (issue #464)', () => {
+  it('normalizes the backend Page envelope into a page object', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonOk({ items: [SUMMARY], total: 120, limit: 50, offset: 0, has_more: true })
+    );
+    const res = await templatesApi.list();
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0]?.id).toBe('tmpl_a');
+    expect(res.total).toBe(120);
+    expect(res.limit).toBe(50);
+    expect(res.offset).toBe(0);
+    expect(res.has_more).toBe(true);
+  });
+
+  it('tolerates a legacy bare-array response (defensive both-shapes handling)', async () => {
+    mockFetch.mockResolvedValueOnce(jsonOk([SUMMARY, { ...SUMMARY, id: 'tmpl_b' }]));
+    const res = await templatesApi.list();
+    expect(Array.isArray(res.items)).toBe(true);
+    expect(res.items).toHaveLength(2);
+    expect(res.total).toBe(2);
+    expect(res.has_more).toBe(false);
+  });
+
+  it('guards a malformed envelope (items not an array) to empty items', async () => {
+    mockFetch.mockResolvedValueOnce(jsonOk({ items: 'nope', total: 5, has_more: true }));
+    const res = await templatesApi.list();
+    expect(res.items).toEqual([]);
+    expect(res.total).toBe(5);
+  });
+
+  it('passes pagination params through to the query string', async () => {
+    mockFetch.mockResolvedValueOnce(jsonOk({ items: [], total: 0, limit: 50, offset: 50, has_more: false }));
+    await templatesApi.list({ kind: 'basemap', q: 'dark', limit: 50, offset: 50 });
+    const url = String(mockFetch.mock.calls[mockFetch.mock.calls.length - 1]?.[0]);
+    expect(url).toContain('/api/v1/templates');
+    expect(url).toContain('kind=basemap');
+    expect(url).toContain('q=dark');
+    expect(url).toContain('limit=50');
+    expect(url).toContain('offset=50');
+  });
+});

--- a/frontend/lib/api/templates.ts
+++ b/frontend/lib/api/templates.ts
@@ -6,9 +6,12 @@
  * fires `getTemplates` from multiple components on mount, and we don't want
  * 4-5 parallel GETs. The create path invalidates the list cache.
  *
- * The response shape is the same as the backend: a flat array of
- * `TemplateResponse` objects (no `{items, total}` envelope to keep
- * backward compatibility with the existing gallery consumer).
+ * Issue #464: GET /api/v1/templates returns the backend Page envelope
+ * {items, total, limit, offset, has_more} (parseBody is a plain JSON.parse —
+ * nothing unwraps it). `list` therefore normalizes the envelope (and a legacy
+ * bare array, defensively) into a TemplatePage so consumers always see an
+ * array-valued `items` plus the real `total` / `has_more` — the same
+ * both-shapes handling as project.ts `asPage`.
  */
 
 import { apiFetch } from './transport';
@@ -19,6 +22,10 @@ const TPL_LABEL = 'Template API error';
 export type TemplateKind = 'basemap' | 'symbology' | 'layout' | 'thematic' | 'composite';
 export type TemplateSource = 'builtin' | 'user';
 
+/**
+ * List DTO (summary=true, the default): the backend strips the heavy
+ * `payload` JSON — only the detail endpoint (templatesApi.get) returns it.
+ */
 export interface TemplateSummary {
   id: string;
   org_id?: number | null;
@@ -28,11 +35,40 @@ export interface TemplateSummary {
   category?: string | null;
   keywords?: string[];
   description?: string | null;
-  payload: Record<string, unknown>;
+  payload?: Record<string, unknown>;
   is_builtin: boolean;
   version: number;
   created_at?: string;
   updated_at?: string;
+}
+
+/** Detail DTO (GET /templates/{id}): the full template including payload. */
+export type TemplateDetail = TemplateSummary & { payload: Record<string, unknown> };
+
+/** Page envelope contract (app/schemas/pagination.py Page[T]). */
+export interface TemplatePage {
+  items: TemplateSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+/** Normalize the Page envelope or a legacy bare array into a TemplatePage. */
+function asTemplatePage(data: TemplatePage | TemplateSummary[] | undefined | null): TemplatePage {
+  if (Array.isArray(data)) {
+    return { items: data, total: data.length, limit: data.length || 50, offset: 0, has_more: false };
+  }
+  if (!data || typeof data !== 'object') {
+    return { items: [], total: 0, limit: 50, offset: 0, has_more: false };
+  }
+  return {
+    items: Array.isArray(data.items) ? data.items : [],
+    total: data.total ?? 0,
+    limit: data.limit ?? 50,
+    offset: data.offset ?? 0,
+    has_more: Boolean(data.has_more),
+  };
 }
 
 export interface ListTemplatesParams {
@@ -46,14 +82,14 @@ export interface ListTemplatesParams {
 }
 
 export const templatesApi = {
-  async list(params?: ListTemplatesParams): Promise<TemplateSummary[]> {
+  async list(params?: ListTemplatesParams): Promise<TemplatePage> {
     const queryParams: Record<string, string | number> = {};
     if (params?.kind) queryParams.kind = params.kind;
     if (params?.q) queryParams.q = params.q;
     if (params?.source) queryParams.source = params.source;
     if (params?.limit !== undefined) queryParams.limit = params.limit;
     if (params?.offset !== undefined) queryParams.offset = params.offset;
-    const result = await fastGet<TemplateSummary[]>('/api/v1/templates', {
+    const result = await fastGet<TemplatePage | TemplateSummary[]>('/api/v1/templates', {
       params: queryParams,
       forceRefresh: params?.forceRefresh,
       signal: params?.signal,
@@ -61,11 +97,14 @@ export const templatesApi = {
       // Template list is light; cache briefly so multi-component mounts dedupe.
       ttlMs: 5_000,
     });
-    return result.data;
+    return asTemplatePage(result.data);
   },
 
-  async get(id: string, opts?: { signal?: AbortSignal; forceRefresh?: boolean }): Promise<TemplateSummary> {
-    const result = await fastGet<TemplateSummary>(`/api/v1/templates/${encodeURIComponent(id)}`, {
+  async get(
+    id: string,
+    opts?: { signal?: AbortSignal; forceRefresh?: boolean }
+  ): Promise<TemplateDetail> {
+    const result = await fastGet<TemplateDetail>(`/api/v1/templates/${encodeURIComponent(id)}`, {
       signal: opts?.signal,
       forceRefresh: opts?.forceRefresh,
       label: TPL_LABEL,

--- a/tests/unit/test_templates_api.py
+++ b/tests/unit/test_templates_api.py
@@ -269,6 +269,266 @@ async def test_setup_purge_deletes_non_builtin_templates():
         assert probe is None
 
 
+# ============================================================================
+# Issue #428: GET /templates double-applied the pagination offset (DB-level
+# .offset + a second Python slice of the merged seed+DB list), had no ORDER BY,
+# and counted only DB rows in `total`. These tests pin the corrected contract:
+# sequential pages form a contiguous, gap-free, duplicate-free union of the
+# merged catalog and has_more flips exactly at the end.
+# ============================================================================
+
+from datetime import datetime, timedelta, timezone
+
+from app.schemas.template_schema import SEED_TEMPLATES
+
+_SYM_PAYLOAD = {
+    "mode": "single",
+    "geometry": "Polygon",
+    "style": {"fill_color": "#1d4ed8", "opacity": 0.85},
+}
+
+
+async def _insert_user_templates(
+    count: int, kind: str = "symbology", creator: str = "user_123", prefix: str = "tmpl_user_pg"
+):
+    """Insert `count` user templates with strictly staggered created_at values.
+
+    ids are {prefix}_000..N-1 with created_at ascending in i, so the
+    deterministic (created_at DESC, id) order is i = N-1 .. 0.
+    """
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with _TestSession() as s:
+        for i in range(count):
+            s.add(
+                CartographyTemplate(
+                    id=f"{prefix}_{i:03d}",
+                    creator_id=creator,
+                    org_id=None,
+                    kind=kind,
+                    name=f"分页模板 {i:03d}",
+                    category=kind,
+                    keywords=[],
+                    description=f"pagination probe {i:03d}",
+                    payload=dict(_SYM_PAYLOAD),
+                    is_builtin=False,
+                    version=1,
+                    created_at=base + timedelta(minutes=i),
+                    updated_at=base + timedelta(minutes=i),
+                )
+            )
+        await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_contiguous_user_source(client):
+    """Sequential offsets must yield every user template exactly once (#428).
+
+    150 user rows, source=user (seeds dropped), limit=100: page 1 → 100 rows,
+    page 2 → the remaining 50, page 3 → empty. Old code applied the offset at
+    both the SQL layer and the merged-list re-slice, so offset=100 returned an
+    empty page while 50 rows existed.
+    """
+    await _insert_user_templates(150)
+
+    seen: list[str] = []
+    page_specs = [(0, 100, True), (100, 50, False), (200, 0, False)]
+    for offset, expect_len, expect_more in page_specs:
+        res = await client.get(
+            f"/api/v1/templates?source=user&summary=false&limit=100&offset={offset}",
+            headers=user_headers,
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 150, f"total at offset={offset}"
+        assert body["limit"] == 100
+        assert body["offset"] == offset
+        assert body["has_more"] is expect_more, f"has_more at offset={offset}"
+        items = body["items"]
+        assert len(items) == expect_len, f"page size at offset={offset}"
+        seen.extend(t["id"] for t in items)
+
+    expected = [f"tmpl_user_pg_{i:03d}" for i in range(149, -1, -1)]
+    assert seen == expected
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_merged_catalog_seeds_first(client):
+    """Default source: seeds lead the merged catalog, DB rows follow (#428).
+
+    The test DB starts empty, so the merged catalog = all SEED_TEMPLATES plus
+    the 10 inserted user rows (newest first). Paging at an awkward page size
+    (13) must cover the union exactly once, contiguously across page bounds.
+    """
+    await _insert_user_templates(10)
+
+    seed_count = len(SEED_TEMPLATES)
+    total = seed_count + 10
+    limit = 13
+
+    seen: list[str] = []
+    offset = 0
+    pages = 0
+    while True:
+        res = await client.get(
+            f"/api/v1/templates?summary=false&limit={limit}&offset={offset}",
+            headers=user_headers,
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == total
+        items = body["items"]
+        seen.extend(t["id"] for t in items)
+        pages += 1
+        if not body["has_more"]:
+            break
+        offset += limit
+        assert pages < 20, "pagination did not terminate"
+
+    assert pages == 6  # 72 items / 13 per page
+    expected = [s["id"] for s in SEED_TEMPLATES] + [
+        f"tmpl_user_pg_{i:03d}" for i in range(9, -1, -1)
+    ]
+    assert seen == expected
+    # Duplicate-free: a DB row carrying a seed id must not appear twice.
+    assert len(seen) == len(set(seen)) == total
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_beyond_range(client):
+    """An offset past the end returns an empty page with has_more=False."""
+    await _insert_user_templates(3)
+    res = await client.get(
+        "/api/v1/templates?summary=false&limit=50&offset=10000",
+        headers=user_headers,
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["items"] == []
+    assert body["has_more"] is False
+    assert body["total"] == len(SEED_TEMPLATES) + 3
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_single_page(client):
+    """One page spanning the whole catalog: has_more flips off exactly."""
+    await _insert_user_templates(5)
+    res = await client.get(
+        "/api/v1/templates?summary=false&limit=200&offset=0",
+        headers=user_headers,
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == len(SEED_TEMPLATES) + 5
+    assert len(body["items"]) == body["total"]
+    assert body["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_seed_db_dedupe(client):
+    """A DB row shadowing a seed id appears exactly once (seed version wins)."""
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with _TestSession() as s:
+        s.add(
+            CartographyTemplate(
+                id=SEED_TEMPLATES[0]["id"],
+                creator_id="user_123",
+                org_id=None,
+                kind=SEED_TEMPLATES[0]["kind"],
+                name="DB copy of a seed",
+                category=SEED_TEMPLATES[0]["kind"],
+                keywords=[],
+                description=None,
+                payload=dict(_SYM_PAYLOAD),
+                is_builtin=True,
+                version=1,
+                created_at=base,
+                updated_at=base,
+            )
+        )
+        await s.commit()
+
+    res = await client.get(
+        "/api/v1/templates?summary=false&limit=200", headers=user_headers
+    )
+    assert res.status_code == 200
+    body = res.json()
+    ids = [t["id"] for t in body["items"]]
+    assert ids.count(SEED_TEMPLATES[0]["id"]) == 1
+    # The seed representation is canonical (not the stale DB copy).
+    first = next(t for t in body["items"] if t["id"] == SEED_TEMPLATES[0]["id"])
+    assert first["name"] == SEED_TEMPLATES[0]["name"]
+    assert body["total"] == len(SEED_TEMPLATES)
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_deterministic_order(client):
+    """No ORDER BY made paging nondeterministic across requests (#428)."""
+    await _insert_user_templates(40)
+    orders = []
+    for _ in range(2):
+        res = await client.get(
+            "/api/v1/templates?source=user&summary=false&limit=20&offset=0",
+            headers=user_headers,
+        )
+        assert res.status_code == 200
+        orders.append([t["id"] for t in res.json()["items"]])
+    assert orders[0] == orders[1]
+    # Newest-first ordering among DB rows.
+    assert orders[0][0] == "tmpl_user_pg_039"
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_with_search(client):
+    """q-filtered pages stay contiguous; total reflects the filtered catalog."""
+    await _insert_user_templates(150)
+    res = await client.get(
+        "/api/v1/templates?source=user&summary=false&limit=100&offset=0&q=probe 14",
+        headers=user_headers,
+    )
+    assert res.status_code == 200
+    body = res.json()
+    # ids 140-149 match "probe 14"; keyword search also matches names
+    # ("分页模板 14x") via the shared description/name filter.
+    assert body["total"] == 10
+    assert len(body["items"]) == 10
+    assert body["has_more"] is False
+    ids = {t["id"] for t in body["items"]}
+    assert ids == {f"tmpl_user_pg_{i:03d}" for i in range(140, 150)}
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_anonymous(client):
+    """Anonymous listing is seeds+builtin DB rows only, still contiguous."""
+    await _insert_user_templates(5, creator="user_123")
+    res = await client.get("/api/v1/templates?summary=false&limit=200")
+    assert res.status_code == 200
+    body = res.json()
+    ids = [t["id"] for t in body["items"]]
+    # Anonymous scope: builtins only — user rows invisible, seeds present.
+    assert body["total"] == len(SEED_TEMPLATES)
+    assert not any(i.startswith("tmpl_user_pg_") for i in ids)
+    assert len(ids) == len(set(ids))
+
+
+@pytest.mark.asyncio
+async def test_templates_list_pagination_kind_filter(client):
+    """kind-scoped paging: total matches the filtered catalog, pages contiguous."""
+    await _insert_user_templates(30, kind="symbology", prefix="tmpl_user_sym")
+    await _insert_user_templates(20, kind="basemap", prefix="tmpl_user_bm")
+    sym_seeds = [s for s in SEED_TEMPLATES if s.get("kind") == "symbology"]
+    res = await client.get(
+        "/api/v1/templates?kind=symbology&summary=false&limit=40",
+        headers=user_headers,
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == len(sym_seeds) + 30
+    assert len(body["items"]) == 40
+    assert body["has_more"] is True
+    # All items are symbology (seeds first, then user rows newest-first).
+    assert all(t["kind"] == "symbology" for t in body["items"])
+
+
 _LAYOUT_PAYLOAD = {
     "paperSize": "A4",
     "orientation": "landscape",


### PR DESCRIPTION
## Issues
- Fixes #428 (P2: GET /templates double-applies the pagination offset — wrong/empty pages once tenant templates exceed seed count)
- Fixes #464 (P1 UI: Template Gallery crashes the whole app — Page envelope consumed as a bare list, templates.map TypeError)
- Fixes #465 (P3 UI: Template 应用 reads payload off summary list items — silent no-op with success toast)

## Root causes
1. **#428** `list_templates` paginated twice (SQL `.offset` + a second Python re-slice of the merged seed+DB list), no ORDER BY, and `total` excluded seeds.
2. **#464** `templatesApi.list` returned the raw Page envelope typed as a bare array.
3. **#465** apply read `payload` from summary items (backend strips it) and discarded reducer results; parent fired success toast unconditionally.

## Implementation
- Backend: build the full filtered merged catalog first (seeds first; DB rows `ORDER BY created_at DESC, id`; seed ids shadow DB ids), apply `q` before slicing, paginate exactly once, `total = len(merged)`.
- Frontend: envelope normalizer in `frontend/lib/api/templates.ts` (envelope + legacy bare array + malformed guard); gallery consumes `result.items`/`result.total`.
- Apply: `handleApply` awaits `templatesApi.get(id)` (per-card loading); each kind must actually land (BASE_LAYER_CHANGE / LAYER_STYLE_UPDATE via real reducers / export-settings store) before `onApply`; thematic/composite direct to Agent chat with explicit toast; failures raise error toasts, never success.

## Regression tests
Backend 9 new (contiguity over 150 rows, beyond-range, dedupe, determinism, q+pagination, anonymous, kind-filter); gallery crash reproduced in RED then fixed; api-normalizer suite; 8 apply-semantics tests. Backend 82 template-scoped tests green; frontend 1368 passed (only pre-existing `chat-tab.render-scope` baseline failure); `tsc --noEmit` clean; `ruff` clean.

## Risk
Low-medium: list now materializes the merged catalog per request (contract pinned by tests; scale acceptable); seed providerIds without a TILE_PROVIDERS entry (e.g. `carto-voyager`) now honestly error instead of falsely succeeding.