### PR TITLE
fix(deploy): celery uploads volume, CI image + nginx/TLS shipping, dual-process healthcheck, k8s SSE ingress (#471 #472 #474 #475)

### DIFF
--- a/deploy/ci-generate-env-priv.sh
+++ b/deploy/ci-generate-env-priv.sh
@@ -9,8 +9,23 @@
 #
 # Prefer this over sed-replacing .env.Priv.example: secret values may contain
 # | / & etc., which would corrupt a sed replacement.
+#
+# #472: 在 GitHub Actions 上追加 WEBGIS_IMAGE（ghcr.io/<repo>:<sha>）。compose
+# 通过 `--env-file .env.Priv` 插值 api/celery 的
+# `image: ${WEBGIS_IMAGE:-webgis-ai-agent:local}`，使其解析为 `docker load`
+# 出的 CI 镜像 —— 主机上没有构建上下文，缺了这一行 compose 只会构建失败或
+# 静默复用过期本地镜像。GITHUB_REPOSITORY / GITHUB_SHA / REGISTRY 是 Actions
+# 的默认注入（workflow 级 env.REGISTRY=ghcr.io），无需 workflow 额外传参；
+# 已导出的 WEBGIS_IMAGE 环境变量优先（供 rollback 等流程指定别的 tag）。
 set -eu
 
 printf 'DB_PWD=%s\nREDIS_PASSWORD=%s\nJWT_SECRET_KEY=%s\nLLM_API_KEY=%s\nCORS_ORIGINS=%s\n' \
   "$DB_PWD" "$REDIS_PASSWORD" "$JWT_SECRET_KEY" "$LLM_API_KEY" \
   "${CORS_ORIGINS:-[\"https://your-domain.com\"]}" > .env.Priv
+
+if [ -n "${WEBGIS_IMAGE:-}" ]; then
+  printf 'WEBGIS_IMAGE=%s\n' "$WEBGIS_IMAGE" >> .env.Priv
+elif [ -n "${GITHUB_SHA:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  repo_lc=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+  printf 'WEBGIS_IMAGE=%s/%s:%s\n' "${REGISTRY:-ghcr.io}" "$repo_lc" "$GITHUB_SHA" >> .env.Priv
+fi

--- a/deploy/k8s/04-ingress.yaml
+++ b/deploy/k8s/04-ingress.yaml
@@ -7,8 +7,20 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    # #475: SSE 传输契约与 compose nginx 对齐（deploy/nginx/nginx.conf 的两个
+    # 流式 location：/api/v1/chat/stream 与 /api/v1/explorer/stream/）。
+    # ingress-nginx 默认开启 proxy buffering —— SSE chunk 被攒在缓冲区里批量
+    # 下发（用户看到"卡顿 + 一次性涌出"）；nginx.conf 侧对两个流式 location
+    # 显式 proxy_buffering off。注解作用于整个 ingress（无法按 path 差异化，
+    # 除非拆分多个 Ingress 对象），对非流式路径关闭 buffering 只是轻微的代理
+    # 效率损失，可接受。
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    # #475: 300s 会把工具链跑数分钟的 chat 轮次硬切断 —— 前端被迫走
+    # Last-Event-ID 重连，额外压测 #377 的进程本地 resume 注册表（多副本下
+    # 本就是弱依赖）。与 nginx.conf 流式 location 的 proxy_read/send_timeout
+    # 3600s 对齐。
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/use-regex: "true"
     # #377: sticky routing for SSE resume — the turn-resume buffers are
     # process-local (event_resume.py), so a reconnect must reach the SAME pod

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -58,7 +58,7 @@ http {
     gzip_proxied any;
     gzip_comp_level 6;
     gzip_min_length 1024;
-    gzip_types text/plain text/css text/xml application/json application/javascript 
+    gzip_types text/plain text/css text/xml application/json application/javascript
                application/rss+xml application/atom+xml image/svg+xml;
 
     # 上游服务
@@ -87,7 +87,7 @@ http {
         # SSL 证书配置（使用自签名证书示例）
         ssl_certificate /etc/nginx/ssl/server.crt;
         ssl_certificate_key /etc/nginx/ssl/server.key;
-        
+
         # SSL 安全配置
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
@@ -241,7 +241,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            
+
             # 大文件上传配置
             client_max_body_size 100M;
             proxy_connect_timeout 300s;

--- a/docker-compose.prod.secure.yml
+++ b/docker-compose.prod.secure.yml
@@ -115,8 +115,12 @@ services:
       - uploads:/app/uploads
     # 审计 P0：api healthcheck 使用 wget，但 Dockerfile.prod runner 不装 wget。
     # 改用 python3 urllib（已修复 Dockerfile.prod HEALTHCHECK，此处同步）。
+    # #474：compose 的 service healthcheck 会完全覆盖镜像 HEALTHCHECK —— 之前
+    # 这里只探 uvicorn:8000，与 #400 的双进程镜像 HEALTHCHECK 相比是退化：
+    # node frontend/.next/standalone/server.js 挂掉时容器仍"healthy"，nginx
+    # 对 / 502 而编排层（depends_on/CI 探针）毫无感知。与镜像保持一致的双探测。
     healthcheck:
-      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health/live', timeout=5)\" || exit 1"]
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request as u; u.urlopen('http://localhost:8000/api/v1/health/live', timeout=5); u.urlopen('http://localhost:3000/', timeout=5)\" || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.prod.secure.yml
+++ b/docker-compose.prod.secure.yml
@@ -148,6 +148,11 @@ services:
     env_file:
       - .env.Priv
     command: celery -A app.services.task_queue worker --loglevel=info --concurrency=2
+    volumes:
+      # #471（#394 的 compose 兄弟项）：worker 必须看到 api 写入的上传文件
+      # （celery 任务按本地路径打开 raster/shapefile）。与 api 挂同一个
+      # uploads 卷，否则上传成功的分析任务在 worker 侧"No such file"。
+      - uploads:/app/uploads
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.prod.secure.yml
+++ b/docker-compose.prod.secure.yml
@@ -9,6 +9,18 @@
 # 使用: docker-compose -f docker-compose.prod.secure.yml up -d
 #
 # ⚠️ 部署前必须创建 .env.Priv 文件（见 .env.Priv.example 模板）。
+#
+# #472 部署契约（deploy-prod 只 scp 本文件 + deploy/redis*.conf + 镜像 tar +
+# .env.Priv 到主机，主机上没有源码/构建上下文）：
+# - api / celery-worker 的镜像经 ${WEBGIS_IMAGE:-webgis-ai-agent:local} 引用：
+#   CI 侧 deploy/ci-generate-env-priv.sh 把 WEBGIS_IMAGE=ghcr.io/<repo>:<sha>
+#   写入 .env.Priv（与 docker load 出的 tar 同名），compose --env-file 解析；
+#   本地检出则保留 build: 回退（打为 webgis-ai-agent:local）。
+# - nginx 的配置/证书用内联 configs 分发（见文件尾 configs:），不依赖任何
+#   未随部署分发的 bind-mount 路径。真实证书：复制本文件为 override，把
+#   webgis_ssl_scaffold_cert / webgis_ssl_scaffold_key 两个 config 换成
+#   `file: ./deploy/nginx/ssl/server.crt` 形式的源，并
+#   `docker compose -f docker-compose.prod.secure.yml -f <override> up -d`。
 # ============================================================
 
 services:
@@ -85,6 +97,12 @@ services:
           cpus: "0.25"
 
   api:
+    # #472: 镜像优先、build 兜底。deploy-prod 主机上没有构建上下文 —— 仅
+    # build: 会让 `up` 构建失败（或静默复用过期本地镜像，CI 加载的 tar 从未被
+    # 引用）。WEBGIS_IMAGE 由 deploy/ci-generate-env-priv.sh 在 CI 写入
+    # .env.Priv，与 docker load 出的 ghcr.io/<repo>:<sha> 完全一致；本地检出
+    # 未设 WEBGIS_IMAGE 时走 build:（镜像打为 webgis-ai-agent:local）。
+    image: ${WEBGIS_IMAGE:-webgis-ai-agent:local}
     build:
       context: .
       dockerfile: Dockerfile.prod
@@ -104,8 +122,12 @@ services:
       DATA_DIR: /app
     env_file:
       - .env.Priv
-    expose:
-      - "8000"
+    # #472: 健康检查必须在主机上可达。之前只有 expose（仅容器网络内可见），
+    # deploy-prod 在主机上 curl http://localhost:8000/... 必然 connection
+    # refused（或被无关的 :8000 占用者误判为绿）。改为发布到主机 loopback ——
+    # 公网入口仍然只有 nginx 的 80/443，与 db/redis 不暴露端口的姿态一致。
+    ports:
+      - "127.0.0.1:${API_PORT:-8000}:8000"
     depends_on:
       db:
         condition: service_healthy
@@ -137,6 +159,8 @@ services:
           cpus: "0.5"
 
   celery-worker:
+    # #472: 与 api 相同的镜像引用契约（见 api 服务的注释）。
+    image: ${WEBGIS_IMAGE:-webgis-ai-agent:local}
     build:
       context: .
       dockerfile: Dockerfile.prod
@@ -188,9 +212,21 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./deploy/nginx/ssl:/etc/nginx/ssl:ro
-      - ./deploy/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - nginx_logs_secure:/var/log/nginx
+    # #472: nginx 配置与证书随本文件内联分发（见文件尾 configs:）。之前
+    # bind-mount ./deploy/nginx/nginx.conf 与 ./deploy/nginx/ssl —— 两者都不在
+    # deploy-prod 的 scp 清单里（ssl 甚至未被 git 追踪），Docker 会把缺失的
+    # 挂载源创建为空目录，nginx 启动即死（"nginx.conf failed: Is a directory"）。
+    # 内容与 deploy/nginx/nginx.conf 逐字节一致，由
+    # tests/test_nginx_security.py 的 parity 测试强制防漂移。真实证书的替换
+    # 方式见文件头注释。
+    configs:
+      - source: webgis_nginx_conf
+        target: /etc/nginx/nginx.conf
+      - source: webgis_ssl_scaffold_cert
+        target: /etc/nginx/ssl/server.crt
+      - source: webgis_ssl_scaffold_key
+        target: /etc/nginx/ssl/server.key
     depends_on:
       - api
     networks:
@@ -239,3 +275,355 @@ volumes:
 networks:
   webgis-internal:
     driver: bridge
+
+# ============================================================================
+# #472: 内联分发的 nginx 传输配置与 TLS scaffold（部署工件自包含）。
+# deploy-prod 只把 compose 文件 + deploy/redis*.conf + 镜像 tar + .env.Priv
+# scp 到主机 —— nginx 的配置/证书不能再依赖未随部署分发的 bind-mount 路径。
+# 真实证书替换方式见文件头注释。
+# 注意：content 内的 nginx 变量（$remote_addr 等）必须双写为 $$ —— compose
+# 渲染时会把单 $ 视作插值变量并置空；parity 测试按 $$→$ 还原后比对。
+# ============================================================================
+configs:
+  webgis_nginx_conf:
+    # 与 deploy/nginx/nginx.conf 逐字节一致（$$ 按 compose 转义规则双写）；
+    # parity 由 tests/test_nginx_security.py 强制（deploy-config CI 门的
+    # nginx -t 只校验仓库文件，此内联副本靠 parity 测试锁定同一份语法/语义）。
+    content: |
+      # ============================================================
+      # WebGIS AI Agent 生产环境 Nginx 配置
+      # 支持 HTTPS、静态资源缓存、API 路由转发、CORS 处理
+      # ============================================================
+
+      # 运行用户
+      user nginx;
+      worker_processes auto;
+      error_log /var/log/nginx/error.log warn;
+      pid /var/run/nginx.pid;
+
+      events {
+          worker_connections 1024;
+          use epoll;
+          multi_accept on;
+      }
+
+      http {
+          # CORS allow-list: only echo approved origins
+          map $$http_origin $$allowed_origin {
+              default "";
+              "~^https://your-domain\.com$$" $$http_origin;
+              "~^https://www\.your-domain\.com$$" $$http_origin;
+              "~^http://localhost:" $$http_origin;
+          }
+
+          # Connection upgrade map (transport goal E-F-7/E-F-8): canonical nginx
+          # pattern so non-upgrade requests keep upstream connections reusable.
+          # Without this, every proxied request opened a fresh TCP connection to
+          # uvicorn/node (the `keepalive 32/16` directives were a no-op because no
+          # location ever cleared the Connection header, and `location /` hard-coded
+          # `Connection 'upgrade'` for all frontend traffic).
+          map $$http_upgrade $$connection_upgrade {
+              default upgrade;
+              ''      close;
+          }
+
+          include /etc/nginx/mime.types;
+          default_type application/octet-stream;
+
+          # 日志格式
+          log_format main '$$remote_addr - $$remote_user [$$time_local] "$$request" '
+                          '$$status $$body_bytes_sent "$$http_referer" '
+                          '"$$http_user_agent" "$$http_x_forwarded_for"';
+
+          access_log /var/log/nginx/access.log main;
+
+          # 性能优化
+          sendfile on;
+          tcp_nopush on;
+          tcp_nodelay on;
+          keepalive_timeout 65;
+          types_hash_max_size 2048;
+
+          # Gzip 压缩
+          gzip on;
+          gzip_vary on;
+          gzip_proxied any;
+          gzip_comp_level 6;
+          gzip_min_length 1024;
+          gzip_types text/plain text/css text/xml application/json application/javascript
+                     application/rss+xml application/atom+xml image/svg+xml;
+
+          # 上游服务
+          upstream api_backend {
+              server api:8000;
+              keepalive 32;
+          }
+
+          upstream frontend_backend {
+              server api:3000;
+              keepalive 16;
+          }
+
+          # ======== HTTP 服务器 ========
+          server {
+              listen 80;
+              server_name _;
+              return 301 https://$$host$$request_uri;
+          }
+
+          # ======== HTTPS 服务器 ========
+          server {
+              listen 443 ssl http2;
+              server_name _;
+
+              # SSL 证书配置（使用自签名证书示例）
+              ssl_certificate /etc/nginx/ssl/server.crt;
+              ssl_certificate_key /etc/nginx/ssl/server.key;
+
+              # SSL 安全配置
+              ssl_protocols TLSv1.2 TLSv1.3;
+              ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+              ssl_prefer_server_ciphers off;
+              ssl_session_cache shared:SSL:10m;
+              ssl_session_timeout 1d;
+
+              # 安全头
+              server_tokens off;
+              add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+              add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws: wss:" always;
+              add_header X-Frame-Options "SAMEORIGIN" always;
+              add_header X-Content-Type-Options "nosniff" always;
+              add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+              # ======== 静态资源缓存（顶层 regex 匹配，必须在 location / 之前）========
+              # 审计 P0：之前嵌套在 location / 内的 location ~* 被 nginx 忽略（嵌套
+              # regex location 无效），导致静态资源永不过期缓存未生效。提取到 server 顶层。
+
+              # JS / CSS — 1 年强缓存
+              location ~* \.(js|css)$$ {
+                  proxy_pass http://frontend_backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Host $$host;
+                  proxy_set_header X-Real-IP $$remote_addr;
+                  proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $$scheme;
+                  expires 1y;
+                  add_header Cache-Control "public, max-age=31536000, immutable" always;
+                  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                  add_header X-Content-Type-Options "nosniff" always;
+              }
+
+              # 图片 / 字体 / SVG — 1 年强缓存
+              location ~* \.(png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$$ {
+                  proxy_pass http://frontend_backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Host $$host;
+                  proxy_set_header X-Real-IP $$remote_addr;
+                  proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $$scheme;
+                  expires 1y;
+                  add_header Cache-Control "public, max-age=31536000, immutable" always;
+                  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                  add_header X-Content-Type-Options "nosniff" always;
+              }
+
+              # ======== 前端（SPA + Next.js standalone server）========
+              # 不匹配上述 regex 的请求全部转发给 Node.js standalone server。
+              location / {
+                  proxy_pass http://frontend_backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $$http_upgrade;
+                  proxy_set_header Connection $$connection_upgrade;
+                  proxy_set_header Host $$host;
+                  proxy_set_header X-Real-IP $$remote_addr;
+                  proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $$scheme;
+                  proxy_cache_bypass $$http_upgrade;
+              }
+
+              # ======== API 路由 ========
+              location /api/ {
+                  proxy_pass http://api_backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Connection "";
+                  proxy_set_header Host $$host;
+                  proxy_set_header X-Real-IP $$remote_addr;
+                  proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $$scheme;
+
+                  # 超时配置（transport goal E-F-5）：普通 API 调用也可能较重
+                  # （报告生成、重型工具 dispatch、非流式 /chat），60s 会把合法长
+                  # 调用 504。提升到 300s（与 upload 一致）。SSE 流有独立 location
+                  # 用 3600s。
+                  proxy_connect_timeout 60s;
+                  proxy_send_timeout 300s;
+                  proxy_read_timeout 300s;
+
+                  # CORS 头
+                  add_header Access-Control-Allow-Origin $$allowed_origin always;
+                  add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
+                  add_header Access-Control-Allow-Headers "Authorization, Content-Type, X-Requested-With" always;
+                  add_header Access-Control-Allow-Credentials "true" always;
+                  # 安全头（nginx add_header 会覆盖父级，必须重复）
+                  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                  add_header X-Frame-Options "SAMEORIGIN" always;
+                  add_header X-Content-Type-Options "nosniff" always;
+                  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+                  # 处理预检请求
+                  if ($$request_method = 'OPTIONS') {
+                      return 204;
+                  }
+              }
+
+              # ======== SSE 流式端点（必须在 /api/ 之前匹配） ========
+              # proxy_buffering 默认开启会把 SSE chunk 攒在 nginx 缓冲区里再批量下发，
+              # 用户感受到的是"卡顿 + 一次性涌出"。关闭后才能逐 chunk 转发。
+              location = /api/v1/chat/stream {
+                  proxy_pass http://api_backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Connection "";
+                  proxy_set_header Host $$host;
+                  proxy_set_header X-Real-IP $$remote_addr;
+                  proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $$scheme;
+
+                  # 关键：SSE 必须关闭缓冲
+                  proxy_buffering off;
+                  proxy_cache off;
+                  chunked_transfer_encoding on;
+                  add_header X-Accel-Buffering no;
+
+                  # 长连接：工具链可能跑数分钟
+                  proxy_connect_timeout 10s;
+                  proxy_send_timeout 3600s;
+                  proxy_read_timeout 3600s;
+              }
+
+              # ======== Explorer SSE 流（transport goal E-F-1，P0 修复） ========
+              # 之前的 regex `^/api/v1/stream/` 匹配不到任何真实路由（实际路由是
+              # /api/v1/explorer/stream/{task_id}，explorer.py:15,90），导致 explorer
+              # 的进度流落到 `location /api/`：proxy_buffering 默认 ON（chunk 攒到
+              # ~32KB 才下发）+ proxy_read_timeout 60s（空闲>60s 直接 504）。修正为
+              # 匹配真实路径，并同样关闭缓冲 / 拉长超时。
+              location ~ ^/api/v1/explorer/stream/ {
+                  proxy_pass http://api_backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Connection "";
+                  proxy_set_header Host $$host;
+                  proxy_set_header X-Real-IP $$remote_addr;
+                  proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $$scheme;
+
+                  proxy_buffering off;
+                  proxy_cache off;
+                  chunked_transfer_encoding on;
+                  add_header X-Accel-Buffering no;
+
+                  proxy_connect_timeout 10s;
+                  proxy_send_timeout 3600s;
+                  proxy_read_timeout 3600s;
+              }
+
+              # ======== 上传文件 ========
+              location /api/v1/upload {
+                  proxy_pass http://api_backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Connection "";
+                  proxy_set_header Host $$host;
+                  proxy_set_header X-Real-IP $$remote_addr;
+                  proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+
+                  # 大文件上传配置
+                  client_max_body_size 100M;
+                  proxy_connect_timeout 300s;
+                  proxy_send_timeout 300s;
+                  proxy_read_timeout 300s;
+              }
+
+              # ======== WebSocket 支持 ========
+              location /ws/ {
+                  proxy_pass http://api_backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Upgrade $$http_upgrade;
+                  proxy_set_header Connection "upgrade";
+                  proxy_set_header Host $$host;
+                  proxy_set_header X-Real-IP $$remote_addr;
+                  proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                  proxy_read_timeout 86400s;
+              }
+
+              # ======== 健康检查端点 ========
+              location /health {
+                  access_log off;
+                  return 200 "healthy\n";
+                  add_header Content-Type text/plain;
+                  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+                  add_header X-Frame-Options "SAMEORIGIN" always;
+                  add_header X-Content-Type-Options "nosniff" always;
+              }
+
+              # ======== 错误页面 ========
+              error_page 500 502 503 504 /50x.html;
+              location = /50x.html {
+                  root /usr/share/nginx/html;
+              }
+          }
+      }
+  webgis_ssl_scaffold_cert:
+    # 自签名 scaffold（CN=webgis-deploy-scaffold，仅保证 nginx 能以 TLS 启动，
+    # 浏览器会告警不受信）。部署真实证书：override 文件把本 config 换成
+    # `file: ./deploy/nginx/ssl/server.crt` 形式的源。
+    content: |
+      -----BEGIN CERTIFICATE-----
+      MIIDcTCCAlmgAwIBAgIURO8NpbclSV5UlCmv0VXqHEPIvWMwDQYJKoZIhvcNAQEL
+      BQAwSDFGMEQGA1UEAww9d2ViZ2lzLWRlcGxveS1zY2FmZm9sZCAoc2VsZi1zaWdu
+      ZWQ7IHJlcGxhY2Ugd2l0aCByZWFsIGNlcnRzKTAeFw0yNjA4MTYwMjIxNTlaFw0z
+      NjA4MTMwMjIxNTlaMEgxRjBEBgNVBAMMPXdlYmdpcy1kZXBsb3ktc2NhZmZvbGQg
+      KHNlbGYtc2lnbmVkOyByZXBsYWNlIHdpdGggcmVhbCBjZXJ0cykwggEiMA0GCSqG
+      SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCyIUX+w1GQOWoiHd4IC4SHPw9q4NnhE9+l
+      KBOqDXXDj748yvXPg6tTKou7zdjNklQCUbOsCJlLIjqcGi0VvO115FDchsc0fQ36
+      K+KGW6vMGPxvCt81/XqFymaJSgqttw6QaqD3WOqnt24xhtQri53TpBIiLhR9kqoZ
+      brzlkRm0fzpzKZlwDNBUAK9YnsWl0wrYhrIYqV48eW+Xs0MXqtiCzRfxsfr60/yV
+      NpjCla3UPaKXVGnYSkWT6ww6vl+Wr86TxAXgTZ+3l8EcJ6/szz0kNk9e21he7LA3
+      TWgYHIkOnsxZCHlCyT5XnmQz23d8tQV1h0J7buPZ8sIVLB8RX/rVAgMBAAGjUzBR
+      MB0GA1UdDgQWBBRrJl+GZE81KGYYV4W1xuR6YL8majAfBgNVHSMEGDAWgBRrJl+G
+      ZE81KGYYV4W1xuR6YL8majAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUA
+      A4IBAQAcY/ordhga0sI2VbiaHf1sYLYxntR15O5r5EDB9ICZ77uUPnnV8XmZAX+q
+      NSXV5IvB4FNMWdByJuWPN1gpHWr06RYQg+vrKf/ETcjlMma35Pej1OqqUzf2yziV
+      pnpKkNzgvQxzcpsYleIoXn/lW/eJYdiZtYY3e7STIggL5u62Xntdzg/xTAFrL51W
+      wmFE8ke52ZBA0VbG6hqL+G9/wOllGolU3mcOyLYt/mgm1tNGOjZOdFCy+ouB0DNK
+      XKbn2c4EXDCAWyDOmdVJi26XsE2rlCWhZwzSVtcT79DC2oqE9DD3Vsk/bb4D2SpA
+      6jLpV2z2jp2zzA0iz1jAwAVaD3wq
+      -----END CERTIFICATE-----
+  webgis_ssl_scaffold_key:
+    # 对应 scaffold 私钥（占位用途，非生产凭据 —— 与证书一并被 override 替换）。
+    content: |
+      -----BEGIN PRIVATE KEY-----
+      MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCyIUX+w1GQOWoi
+      Hd4IC4SHPw9q4NnhE9+lKBOqDXXDj748yvXPg6tTKou7zdjNklQCUbOsCJlLIjqc
+      Gi0VvO115FDchsc0fQ36K+KGW6vMGPxvCt81/XqFymaJSgqttw6QaqD3WOqnt24x
+      htQri53TpBIiLhR9kqoZbrzlkRm0fzpzKZlwDNBUAK9YnsWl0wrYhrIYqV48eW+X
+      s0MXqtiCzRfxsfr60/yVNpjCla3UPaKXVGnYSkWT6ww6vl+Wr86TxAXgTZ+3l8Ec
+      J6/szz0kNk9e21he7LA3TWgYHIkOnsxZCHlCyT5XnmQz23d8tQV1h0J7buPZ8sIV
+      LB8RX/rVAgMBAAECggEAAL3INYr5Di1a/nja2XQ40TpHNWXpqjjjs6OCz3CeZpm0
+      zDp5AuvUnPQ+oCG3bwWWoWrXIVZo0un5zfgC64X9hAHW/0/1SMfjdMDVgMMlaCRL
+      eqfULXyYU7G3swcSm834+stiz5y4X0nRZNXfkK3UUpLqe2dvMOWZHSF7mkX8Eib6
+      nl7RhLg6t6XcPvk1XyxYDDEqGr3k4vyEYBmDP/URVTAxSlUePC+GRQjqxmgp5J5E
+      vKgleaixAcT7b1080w1Ps1xaV44+RVjC0etbKQBijFDNXSF9FFrvrXTudIP0fzyx
+      EooVdGlW8PwLkTWAbxg36LrE4UwjduRfWVm3S5302QKBgQDlNxc9XryNBnp5dfiT
+      Z/VMFcjzDO7Lk0r4shL87LJ8VQPsh22vlX2m00v8/eGuQGND2uwxZa8HllwH9VJ/
+      jkBq0e3B0hVvSQbMTSjMSA1l1t9IRoleqhPVziEB127984w5763yOKazFfm16YMV
+      gD5WTOu0Ir5pQPVFR+l8T2/ZuQKBgQDG8ft39HQ5F/On2F4R+K1vaoypT8cfj7H/
+      HgviPIFbPBNWkRHILXtzgIJedL762sypbIB/9o5qYB7l6UcX14BIJFapgkovaKuM
+      sMupWaC1jy6AAEpE8KrU4TXeNQei3AKPYP6NJRPmOtnlqcgs3ZTzQVAhpHaCjADH
+      6g+Umc/H/QKBgGT+XRMBRvqsPBKAVEI+r+oSPzQ4Io84GvRxIcSnVg1KOCxjj4Sp
+      zW9P8k9KXcG1RQeE0kUBlJk3Ot2Wzf694swuKyAXPLKH7qLd7Hf111Fj14W07pnz
+      PkIaTJjPH2xtfv+YB4COTYTizd/FP6idlNnZkpEQLe2aXXdlNA89wP6hAoGAffKg
+      MvbtxV9mf/I4y8PVeN3Joz7AXzjHhS1udJG9ixbjX0CEM2in6R2Ia2gZqBJw0ym/
+      yEM9MhccOI2Q1oU1z3ZB7xpvAMiRIoaiyNnXJlo5JAwK+M4sOI1DXyPPa8lBTago
+      Pw8kI/NKE12DPvQg4keNBV9rL4aWz/lcV8Vwh7kCgYAQL7pOGVEfCkB8uHGgPXMP
+      hdVu4lA2uzpt6bV8Wsf9ho6+x7HGNp7BCRkQi1QIsZUW16095eyIfvbx2RYD6jA5
+      U+uWihYqmPW0vnHyY3L+mdgz1jwrBOjaRwdt6IzwYR0CD7ZEnnU1eJjsTEcTY9Xp
+      1PTPIcu6RoWfbptRXuIv4A==
+      -----END PRIVATE KEY-----

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -100,8 +100,12 @@ services:
         condition: service_healthy
     volumes:
       - uploads:/app/uploads
+    # #474：compose 的 service healthcheck 会完全覆盖镜像 HEALTHCHECK —— 之前
+    # 这里只探 uvicorn:8000，与 #400 的双进程镜像 HEALTHCHECK（Dockerfile.prod，
+    # 同时探测 :8000 与 node :3000）相比是退化：node 前端进程挂掉时容器仍
+    # "healthy"，nginx 对 / 502 而编排层毫无感知。与镜像保持一致的双探测。
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health/live', timeout=5)"]
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request as u; u.urlopen('http://localhost:8000/api/v1/health/live', timeout=5); u.urlopen('http://localhost:3000/', timeout=5)\" || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -143,6 +143,11 @@ services:
       redis:
         condition: service_healthy
     command: celery -A app.services.task_queue worker --loglevel=info --concurrency=2
+    volumes:
+      # #471（#394 的 compose 兄弟项）：worker 必须看到 api 写入的上传文件
+      # （celery 任务按本地路径打开 raster/shapefile）。与 api 挂同一个
+      # uploads 卷，否则上传成功的分析任务在 worker 侧"No such file"。
+      - uploads:/app/uploads
     networks:
       - webgis-net
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,9 +114,16 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    # #471（#394 的 compose 兄弟项）：celery 任务按本地路径打开 api 写入的
+    # 上传文件（run_ndvi_analysis → rasterio.open(raster_path)）。worker 在
+    # 独立容器/独立文件系统层里，不挂同一个卷就只能看到空的容器层目录 ——
+    # 上传成功的 raster 分析在 worker 侧"No such file"。与 api 挂同一个
+    # uploads 卷；dev 栈 DATA_DIR 默认 ./data → 上传落在 /app/data/uploads。
+    # （与 api 服务结构一致：WEBGIS_DEV_MOUNT 展开后紧跟固定挂载项。）
     volumes:
       # 审计 INF-003：bind-mount 改为显式 opt-in，与 api 服务一致。
       ${WEBGIS_DEV_MOUNT:+- ${WEBGIS_DEV_MOUNT}:/app/app}
+      - uploads:/app/data
     env_file:
       - .env
     command: celery -A app.services.task_queue worker -l info

--- a/tests/test_docker_security.py
+++ b/tests/test_docker_security.py
@@ -1,9 +1,12 @@
 """Security: docker-compose files must follow secure defaults."""
+import os
+import subprocess
 import yaml
 
 
 DOCKER_COMPOSE = "docker-compose.yml"
 DOCKER_COMPOSE_PROD = "docker-compose.prod.yml"
+DOCKER_COMPOSE_PROD_SECURE = "docker-compose.prod.secure.yml"
 
 
 def _load_compose(path):
@@ -182,3 +185,109 @@ class TestComposeDualProcessHealthcheck:
                     f"{path}: compose healthcheck 缺少 {probe} 探测（与镜像 "
                     "HEALTHCHECK 契约不一致）"
                 )
+
+
+class TestProdDeployTransport:
+    """#472: deploy-prod 的工件集（compose + redis 配置 + 镜像 tar + .env.Priv）
+    必须能在一个干净主机上产出可用部署。
+
+    - 镜像：api/celery 引用 ${WEBGIS_IMAGE:-...}（CI 写入 .env.Priv 解析为
+      `docker load` 出的 ghcr.io/<repo>:<sha>），本地检出保留 build: 兜底。
+    - 健康检查：api 端口发布到主机 loopback —— deploy-prod 在主机上
+      curl http://localhost:8000，仅 expose 的端口对主机不可达。
+    - nginx：配置/证书内联为 configs（见 test_nginx_security.py 的 parity）。
+    """
+
+    def test_secure_compose_references_ci_image(self):
+        compose = _load_compose(DOCKER_COMPOSE_PROD_SECURE)
+        for svc in ("api", "celery-worker"):
+            image = compose["services"][svc].get("image", "")
+            assert image.startswith("${WEBGIS_IMAGE:") and ":-" in image, (
+                f"{DOCKER_COMPOSE_PROD_SECURE} {svc}: image={image!r} 未参数化 —— "
+                "deploy-prod 主机上没有构建上下文，仅 build: 会让 compose 构建失败"
+                "或静默复用过期本地镜像（CI 加载的 tar 从未被引用）"
+            )
+
+    def test_secure_compose_keeps_local_build_fallback(self):
+        compose = _load_compose(DOCKER_COMPOSE_PROD_SECURE)
+        for svc in ("api", "celery-worker"):
+            assert "build" in compose["services"][svc], (
+                f"{DOCKER_COMPOSE_PROD_SECURE} {svc}: 丢失 build: —— 本地检出"
+                "（未设 WEBGIS_IMAGE）将无法构建镜像"
+            )
+
+    def test_secure_api_port_published_on_loopback(self):
+        compose = _load_compose(DOCKER_COMPOSE_PROD_SECURE)
+        api = compose["services"]["api"]
+        assert "expose" not in api, (
+            "api 仍用 expose（仅容器网络可见）—— 主机侧健康检查不可达"
+        )
+        ports = api.get("ports", [])
+        assert any(
+            str(p).startswith("127.0.0.1:") and str(p).endswith(":8000")
+            for p in ports
+        ), (
+            f"api 必须把 8000 发布到主机 loopback（deploy-prod 在主机上探测），"
+            f"且不得暴露到非 loopback 地址：ports={ports}"
+        )
+        for p in ports:
+            assert str(p).startswith("127.0.0.1:"), f"端口暴露到网络: {p}"
+
+
+class TestCiEnvPrivScript:
+    """#472: deploy/ci-generate-env-priv.sh 必须把 CI 镜像 tag 写进 .env.Priv。"""
+
+    SCRIPT = os.path.join(
+        os.path.dirname(__file__), os.pardir, "deploy", "ci-generate-env-priv.sh"
+    )
+
+    def _run(self, tmp_path, extra_env):
+        env = {
+            "DB_PWD": "db",
+            "REDIS_PASSWORD": "redis",
+            "JWT_SECRET_KEY": "jwt",
+            "LLM_API_KEY": "llm",
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        }
+        env.update(extra_env)
+        proc = subprocess.run(
+            ["sh", self.SCRIPT],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, f"script failed: {proc.stderr}"
+        return (tmp_path / ".env.Priv").read_text()
+
+    def test_emits_webgis_image_from_github_env(self, tmp_path):
+        content = self._run(
+            tmp_path,
+            {
+                "GITHUB_REPOSITORY": "WindWang2/webgis-ai-agent",
+                "GITHUB_SHA": "abc123def",
+            },
+        )
+        # docker tag 要求全小写 —— 与 build job 的 Lowercase IMAGE_NAME 步骤一致
+        assert "WEBGIS_IMAGE=ghcr.io/windwang2/webgis-ai-agent:abc123def" in content, (
+            f".env.Priv 缺少与 docker load 出的 tar 同名的 WEBGIS_IMAGE: {content!r}"
+        )
+
+    def test_env_webgis_image_override_wins(self, tmp_path):
+        content = self._run(
+            tmp_path,
+            {
+                "GITHUB_REPOSITORY": "WindWang2/webgis-ai-agent",
+                "GITHUB_SHA": "abc123def",
+                "WEBGIS_IMAGE": "ghcr.io/windwang2/webgis-ai-agent:rollback",
+            },
+        )
+        assert "WEBGIS_IMAGE=ghcr.io/windwang2/webgis-ai-agent:rollback" in content
+
+    def test_no_webgis_image_outside_ci(self, tmp_path):
+        content = self._run(tmp_path, {})
+        assert "WEBGIS_IMAGE" not in content, (
+            "非 CI 环境（无 GITHUB_SHA）不应写入 WEBGIS_IMAGE —— 本地走 "
+            "${WEBGIS_IMAGE:-webgis-ai-agent:local} 的 build: 兜底"
+        )

--- a/tests/test_docker_security.py
+++ b/tests/test_docker_security.py
@@ -60,3 +60,74 @@ class TestProdComposeSecurity:
             assert str(p).startswith("127.0.0.1:"), (
                 f"Prometheus port exposed to network: {p}"
             )
+
+
+def _uploads_mounts(service):
+    """The `uploads:` named-volume mounts (target paths) of a compose service."""
+    return [
+        v
+        for v in service.get("volumes", [])
+        if isinstance(v, str) and v.startswith("uploads:")
+    ]
+
+
+class TestComposeUploadsVolumeParity:
+    """#471（#394 的 compose 兄弟项）：每个 compose 栈里 celery-worker 都必须
+    与 api 挂同一个 uploads 卷。
+
+    celery 任务按本地路径打开 api 写入的上传文件（spatial_tasks.py 的
+    run_ndvi_analysis → rasterio.open(raster_path)）。worker 在独立容器文件
+    系统层里 —— 不挂同一个卷，上传成功的 raster/shapefile 分析任务在 worker
+    侧必然 "No such file"。#394 已为 k8s 修复（celery deployment 挂同一 PVC），
+    这里守住 compose 路径。
+    """
+
+    CASES = [
+        # docker-compose.yml 的 volumes 是 `${WEBGIS_DEV_MOUNT:+...}` 可选展开
+        # 块（审计 INF-003），yaml.safe_load 折叠成 plain scalar —— 由独立的
+        # 文本断言用例覆盖，见 test_dev_celery_uploads_mount_present_textually。
+        ("docker-compose.prod.yml", "/app/uploads"),
+        ("docker-compose.prod.secure.yml", "/app/uploads"),
+    ]
+
+    def test_celery_mounts_same_uploads_volume_as_api(self):
+        for path, target in self.CASES:
+            compose = _load_compose(path)
+            services = compose["services"]
+            assert "celery-worker" in services, f"{path}: no celery-worker service"
+
+            api_mounts = _uploads_mounts(services["api"])
+            celery_mounts = _uploads_mounts(services["celery-worker"])
+            assert api_mounts, f"{path}: api mounts no uploads volume"
+            assert celery_mounts, (
+                f"{path}: celery-worker mounts no uploads volume — celery tasks "
+                "open uploaded files by local path in a separate container "
+                "filesystem; uploaded-raster analysis fails with 'No such file'"
+            )
+            assert celery_mounts == api_mounts, (
+                f"{path}: celery-worker uploads mount {celery_mounts} != api "
+                f"{api_mounts} — the worker would not see the api's uploads"
+            )
+            assert celery_mounts == [f"uploads:{target}"], (
+                f"{path}: expected uploads volume at {target} "
+                f"(the stack's DATA_DIR uploads path), got {celery_mounts}"
+            )
+
+    def test_uploads_volume_declared(self):
+        for path, _ in self.CASES:
+            compose = _load_compose(path)
+            assert "uploads" in compose.get("volumes", {}), (
+                f"{path}: top-level `uploads` volume not declared"
+            )
+
+    def test_dev_celery_uploads_mount_present_textually(self):
+        """docker-compose.yml 的 volumes 块含 `${WEBGIS_DEV_MOUNT:+...}` 可选
+        展开行（审计 INF-003），yaml.safe_load 把整块折叠成 plain scalar 而非
+        数组 —— 该文件按折叠后的文本断言（与 api 服务相同的既有结构）。"""
+        compose = _load_compose("docker-compose.yml")
+        for svc in ("api", "celery-worker"):
+            volumes = compose["services"][svc]["volumes"]
+            assert isinstance(volumes, str) and "- uploads:/app/data" in volumes, (
+                f"docker-compose.yml {svc}: volumes={volumes!r} 缺少 "
+                "`- uploads:/app/data` —— celery 必须与 api 共享 uploads 卷"
+            )

--- a/tests/test_docker_security.py
+++ b/tests/test_docker_security.py
@@ -131,3 +131,54 @@ class TestComposeUploadsVolumeParity:
                 f"docker-compose.yml {svc}: volumes={volumes!r} 缺少 "
                 "`- uploads:/app/data` —— celery 必须与 api 共享 uploads 卷"
             )
+
+
+class TestComposeDualProcessHealthcheck:
+    """#474（#400 的 compose-override 兄弟项）：api 的 compose healthcheck
+    不得退化成 api-only 探测。
+
+    compose service healthcheck 会完全覆盖镜像 HEALTHCHECK。Dockerfile.prod
+    （#400）的双进程 HEALTHCHECK 同时探测 uvicorn:8000 与 node:3000 —— 若
+    compose 覆盖成只探 :8000，node 前端进程死亡时容器仍 "healthy"，nginx 对
+    / 502 而编排层与 CI 探针毫无感知。
+    """
+
+    PROD_FILES = ["docker-compose.prod.yml", "docker-compose.prod.secure.yml"]
+
+    def test_api_healthcheck_probes_both_processes(self):
+        for path in self.PROD_FILES:
+            compose = _load_compose(path)
+            hc = compose["services"]["api"].get("healthcheck", {})
+            test = hc.get("test", [])
+            cmd = " ".join(test) if isinstance(test, list) else str(test)
+            assert ":8000/api/v1/health/live" in cmd, (
+                f"{path}: api healthcheck 未探测 uvicorn:8000 健康端点: {cmd}"
+            )
+            assert "localhost:3000" in cmd, (
+                f"{path}: api healthcheck 只探测 uvicorn:8000 —— node 前端进程"
+                "死亡时容器仍 healthy（覆盖了 #400 的镜像双进程 HEALTHCHECK）"
+            )
+
+    def test_compose_healthcheck_matches_image_healthcheck_contract(self):
+        """compose 探测必须与 Dockerfile.prod 的镜像 HEALTHCHECK 同步（双端口）。"""
+        with open("Dockerfile.prod") as f:
+            lines = f.read().splitlines()
+        idx = next(
+            (i for i, ln in enumerate(lines) if ln.startswith("HEALTHCHECK")), None
+        )
+        assert idx is not None, "Dockerfile.prod has no HEALTHCHECK directive"
+        # HEALTHCHECK 指令跨行（续行是 CMD python3 -c "..."）
+        image_hc = "\n".join(lines[idx : idx + 2])
+        assert ":8000" in image_hc and ":3000" in image_hc, (
+            "Dockerfile.prod 镜像 HEALTHCHECK 不再是双进程探测？本测试的契约"
+            "前提变了，需同步更新"
+        )
+        for path in self.PROD_FILES:
+            compose = _load_compose(path)
+            test = compose["services"]["api"]["healthcheck"]["test"]
+            cmd = " ".join(test) if isinstance(test, list) else str(test)
+            for probe in ("localhost:8000", "localhost:3000"):
+                assert probe in cmd, (
+                    f"{path}: compose healthcheck 缺少 {probe} 探测（与镜像 "
+                    "HEALTHCHECK 契约不一致）"
+                )

--- a/tests/test_k8s_security.py
+++ b/tests/test_k8s_security.py
@@ -141,3 +141,60 @@ class TestK8sResumeStickyRouting:
             assert "nginx.ingress.kubernetes.io/session-cookie-name" in ann, (
                 "webgis-ingress must name its session affinity cookie"
             )
+
+
+class TestK8sIngressSSETransport:
+    """#475: k8s ingress 的 SSE 传输行为必须与 compose nginx 契约一致。
+
+    deploy/nginx/nginx.conf（deploy-config CI 门用 nginx -t 校验的传输层）对
+    两个流式 location（/api/v1/chat/stream、/api/v1/explorer/stream/）设置
+    proxy_buffering off + proxy_read/send_timeout 3600s。ingress 缺少等价配置
+    时，k8s 部署得到的是被缓冲的 SSE（延迟尖峰 + chunk 突发）和 300s 硬切断
+    —— 前端被迫走 Last-Event-ID 重连，压测 #377 的进程本地 resume 注册表。
+    """
+
+    def _ingress_annotations(self):
+        ingresses = [
+            doc for doc in _load_k8s("deploy/k8s/04-ingress.yaml")
+            if doc and doc.get("kind") == "Ingress"
+        ]
+        assert ingresses, "no Ingress found in 04-ingress.yaml"
+        ann = ingresses[0]["metadata"].get("annotations", {})
+        assert "nginx.ingress.kubernetes.io" in " ".join(ann) or ann, (
+            "webgis-ingress has no annotations"
+        )
+        return ann
+
+    def test_ingress_disables_proxy_buffering(self):
+        ann = self._ingress_annotations()
+        assert ann.get("nginx.ingress.kubernetes.io/proxy-buffering") == "off", (
+            "webgis-ingress 必须 proxy-buffering: off —— ingress-nginx 默认缓冲"
+            "会把 SSE chunk 攒批下发（compose nginx 契约是 proxy_buffering off）"
+        )
+
+    def test_ingress_read_timeout_not_cutting_sse_turns(self):
+        ann = self._ingress_annotations()
+        for key in ("proxy-read-timeout", "proxy-send-timeout"):
+            value = ann.get(f"nginx.ingress.kubernetes.io/{key}", "0")
+            assert int(value) >= 3600, (
+                f"webgis-ingress {key}={value} 会在多分钟工具链轮次中途切断 "
+                "SSE（compose nginx 流式 location 契约是 3600s）"
+            )
+
+    def test_compose_nginx_sse_contract_still_holds(self):
+        """契约源头：compose nginx.conf 的流式 location 必须保持不缓冲 +
+        3600s —— ingress 注解与之对齐（防止一边漂移后另一边失去参照）。"""
+        with open("deploy/nginx/nginx.conf") as f:
+            conf = f.read()
+        assert "proxy_buffering off;" in conf, (
+            "deploy/nginx/nginx.conf 丢失 SSE 不缓冲契约（proxy_buffering off）"
+        )
+        for stream_loc in ("location = /api/v1/chat/stream", "~ ^/api/v1/explorer/stream/"):
+            assert stream_loc in conf, (
+                f"deploy/nginx/nginx.conf 缺少 SSE location: {stream_loc}"
+            )
+            # 每个 SSE location 块内都有 3600s 读超时
+            block = conf.split(stream_loc, 1)[1].split("location", 1)[0]
+            assert "proxy_read_timeout 3600s;" in block, (
+                f"{stream_loc}: 丢失 proxy_read_timeout 3600s 契约"
+            )

--- a/tests/test_nginx_security.py
+++ b/tests/test_nginx_security.py
@@ -11,3 +11,70 @@ def test_nginx_cors_not_wildcard_echo():
         "nginx.conf echoes $http_origin directly — any website can make "
         "credentialed cross-origin requests. Use a map with explicit allow-list."
     )
+
+
+class TestSecureComposeInlineNginxParity:
+    """#472: docker-compose.prod.secure.yml 内联分发的 nginx 配置/TLS scaffold
+    必须与仓库文件逐字节一致，且 nginx 服务不得再 bind-mount 未随 deploy-prod
+    分发的路径。
+
+    deploy-prod 只 scp compose 文件 + deploy/redis*.conf + 镜像 tar +
+    .env.Priv —— `./deploy/nginx/nginx.conf` 与 `./deploy/nginx/ssl` 都到不了
+    主机，Docker 把缺失的挂载源创建为空目录后 nginx 启动即死。内联 configs
+    让部署工件自包含；parity 测试保证内联副本不会与 deploy-config CI 门
+    （nginx -t）校验的仓库文件漂移。
+    """
+
+    def test_embedded_nginx_conf_matches_repo_conf(self):
+        import yaml
+
+        with open("docker-compose.prod.secure.yml") as f:
+            compose = yaml.safe_load(f)
+        embedded = compose["configs"]["webgis_nginx_conf"]["content"]
+        with open("deploy/nginx/nginx.conf") as f:
+            repo = f.read()
+        # content 内 nginx 变量按 compose 转义规则双写为 $$（渲染时还原为 $）；
+        # 未双写的话，docker compose 渲染时会把 $remote_addr 等当作未定义的
+        # 插值变量置空 —— nginx 得到一份被抽掉变量的配置。
+        assert "$$" not in repo, "repo nginx.conf 自身含 $$，还原比对将歧义"
+        assert embedded.replace("$$", "$") == repo, (
+            "docker-compose.prod.secure.yml 内联的 webgis_nginx_conf 与 "
+            "deploy/nginx/nginx.conf 不一致 —— 修改 nginx.conf 后必须同步更新"
+            "内联 configs（deploy-config 的 nginx -t 只校验仓库文件）"
+        )
+
+    def test_embedded_ssl_scaffold_is_valid_pem_pair(self):
+        import yaml
+
+        with open("docker-compose.prod.secure.yml") as f:
+            compose = yaml.safe_load(f)
+        crt = compose["configs"]["webgis_ssl_scaffold_cert"]["content"]
+        key = compose["configs"]["webgis_ssl_scaffold_key"]["content"]
+        # 自签名 scaffold：只需是结构合法的 PEM，让 nginx 能以 TLS 启动
+        assert crt.startswith("-----BEGIN CERTIFICATE-----"), "cert 非 PEM"
+        assert crt.rstrip().endswith("-----END CERTIFICATE-----"), "cert 未闭合"
+        assert key.startswith("-----BEGIN PRIVATE KEY-----"), "key 非 PEM"
+        assert key.rstrip().endswith("-----END PRIVATE KEY-----"), "key 未闭合"
+
+    def test_nginx_service_consumes_inline_configs(self):
+        import yaml
+
+        with open("docker-compose.prod.secure.yml") as f:
+            compose = yaml.safe_load(f)
+        nginx = compose["services"]["nginx"]
+        sources = {c["source"] for c in nginx.get("configs", [])}
+        assert {
+            "webgis_nginx_conf",
+            "webgis_ssl_scaffold_cert",
+            "webgis_ssl_scaffold_key",
+        } <= sources, f"nginx 服务未挂载内联 configs: {sources}"
+        # 挂载到 nginx.conf 引用的路径（/etc/nginx/nginx.conf 与 /etc/nginx/ssl/）
+        targets = {c["target"] for c in nginx["configs"]}
+        assert "/etc/nginx/nginx.conf" in targets
+        assert "/etc/nginx/ssl/server.crt" in targets
+        assert "/etc/nginx/ssl/server.key" in targets
+        # 不得再依赖未随 deploy-prod 分发的 bind-mount 源
+        for v in nginx.get("volumes", []):
+            assert "deploy/" not in str(v), (
+                f"nginx 仍 bind-mount 未随部署分发的路径: {v}"
+            )


### PR DESCRIPTION
## Issues
- Fixes #471 (P1: celery-worker has no uploads volume in any compose stack — uploaded-raster analysis fails; compose sibling of #394)
- Fixes #472 (P1: deploy-prod cannot produce a working deployment: CI image never referenced, nginx conf/ssl not shipped, health check probes an unpublished port)
- Fixes #474 (P2: compose healthcheck overrides the #400 dual-process image HEALTHCHECK with an api-only probe)
- Fixes #475 (P2: k8s ingress lacks the SSE config compose nginx has — buffered streams + 300 s cut)

## Implementation
- **#471** celery-worker mounts the same uploads volume as the api in all three compose stacks (`/app/data` dev matching DATA_DIR, `/app/uploads` both prod stacks), mirroring the k8s #394 fix.
- **#472** api/celery get `image: ${WEBGIS_IMAGE:-webgis-ai-agent:local}` alongside `build:`; `deploy/ci-generate-env-priv.sh` (already run by deploy-prod) writes `WEBGIS_IMAGE=ghcr.io/<repo>:<sha>` so compose resolves to the exact docker-load'ed tag; nginx conf + self-signed TLS scaffold ship inline as compose `configs` (verified byte-identical to `deploy/nginx/nginx.conf` by mounting in a real container; nginx `$$` escaping checked against a clean-host simulation); api publishes `127.0.0.1:8000` so the existing host health check works. Zero workflow edits.
- **#474** both prod composes' api healthcheck probes both processes (`:8000/api/v1/health/live` + `:3000/`), mirroring the #400 image HEALTHCHECK.
- **#475** ingress gains `proxy-buffering: "off"` and read/send timeouts 300→3600, matching the compose nginx SSE contract; both sides pinned by test so they cannot drift.

## Validation
30/30 tests pass (17 new: uploads parity, dual-process healthcheck, k8s SSE transport); `docker compose config` resolves both prod files incl. a simulated clean host; all k8s manifests parse; `ruff` clean. No app code or workflow files touched; no real deployment performed.

## Notes
Out-of-scope gaps documented in the batch report (rollback tag pinning, prometheus bind mounts, preview node-path probe).