### PR TITLE
fix(explorer): whole-chain status/SSE/abort, tz-safe publish_time, deadline-bounded geocode (#481 #482 #483)

### DIFF
--- a/app/adapters/gov/gov_data_adapter.py
+++ b/app/adapters/gov/gov_data_adapter.py
@@ -4,7 +4,7 @@ import logging
 import aiohttp
 import csv
 import io
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from app.adapters.base import BaseDataAdapter, DataSource
 from app.services.explorer.models import (
@@ -262,12 +262,21 @@ class GovDataAdapter(BaseDataAdapter):
 
     @staticmethod
     def _parse_date(date_str: str) -> Optional[datetime]:
-        """解析日期字符串"""
+        """解析日期字符串
+
+        Gov platform publish_time strings carry no UTC offset, so the parsed
+        value is normalized to timezone-aware UTC (issue #482): a naive
+        datetime later reaches ``datetime.now(timezone.utc) - published_at``
+        in QualityEngine.calc_temporal_score and raises TypeError, killing
+        the discover task (and the whole chain) after its retries. House
+        convention for offset-less inputs (services/temporal/*, services/
+        jobs/*): assume UTC.
+        """
         if not date_str:
             return None
         for fmt in ("%Y-%m-%d", "%Y-%m", "%Y/%m/%d", "%Y%m%d"):
             try:
-                return datetime.strptime(date_str, fmt)
+                return datetime.strptime(date_str, fmt).replace(tzinfo=timezone.utc)
             except ValueError:
                 continue
         return None

--- a/app/services/explorer/geocode_stage.py
+++ b/app/services/explorer/geocode_stage.py
@@ -27,6 +27,7 @@ Design contract (the seam this module exposes):
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable
 
@@ -39,6 +40,15 @@ from app.services.geocode_strategy import (
     GeocodeProviderStrategy,
 )
 
+# Issue #483: dispatch deadline for the geocode stage when running under the
+# Celery task's soft_time_limit=290 / time_limit=300. The stage stops
+# DISPATCHING new ≤BATCH_SIZE partitions once this budget is spent, leaving
+# ~60 s headroom for an in-flight partition (with per-address provider
+# fallback) to finish before the soft limit — instead of the worker being
+# hard-killed mid-run at 300 s with sibling tasks as collateral. Rows not
+# dispatched are honestly marked "skipped" in the summary/handoff.
+GEOCODE_STAGE_TIME_BUDGET = 230.0
+
 
 @dataclass
 class GeocodeSummary:
@@ -48,8 +58,10 @@ class GeocodeSummary:
     success: int = 0
     failed: int = 0
     predefined: int = 0
+    skipped: int = 0
     success_rate: float = 0.0
     multi_provider: bool = False
+    deadline_exceeded: bool = False
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -57,8 +69,10 @@ class GeocodeSummary:
             "success": self.success,
             "failed": self.failed,
             "predefined": self.predefined,
+            "skipped": self.skipped,
             "success_rate": self.success_rate,
             "multi_provider": self.multi_provider,
+            "deadline_exceeded": self.deadline_exceeded,
         }
 
 
@@ -92,13 +106,15 @@ async def geocode_stage(
     store_ref: StoreRef | None = None,
     on_progress: OnProgress | None = None,
     providers: list[str] | None = None,
+    time_budget: float | None = None,
+    clock: Callable[[], float] | None = None,
 ) -> GeocodeStageResult:
     """Geocode every row across ``parsed_sources`` via a provider fallback chain.
 
     For each parsed source: rows already carrying lat/lon are marked
-    ``predefined`` and skipped; the rest are geocoded in batches of
-    :data:`BATCH_SIZE`, rotating to the next provider when a batch's failure
-    rate exceeds :data:`PROVIDER_FAILURE_THRESHOLD`.
+    ``predefined`` and skipped; the rest are geocoded in partitions of
+    :data:`BATCH_SIZE`, rotating to the next provider when a partition's
+    failure rate exceeds :data:`PROVIDER_FAILURE_THRESHOLD`.
 
     Args:
         parsed_sources: list of ``{ref_id, row_count, mapping}`` dicts (the
@@ -115,13 +131,28 @@ async def geocode_stage(
             to ``self.update_state``).
         providers: override the fallback order; defaults to
             :data:`DEFAULT_PROVIDERS`.
+        time_budget: optional seconds after which NO new partition is
+            dispatched (issue #483) — bounds the stage under the Celery task's
+            hard ``time_limit`` instead of being hard-killed mid-run. Rows
+            left un-dispatched are marked ``_geocode_status="skipped"`` and
+            tallied in ``summary.skipped`` with
+            ``summary.deadline_exceeded=True``. ``None`` keeps the historical
+            unbounded behavior (in-process mode).
+        clock: monotonic time source injected for tests; defaults to
+            :func:`time.monotonic`.
 
     Returns:
         rows annotated with ``_lat``/``_lon``/``_geocode_status``/
-        ``_geocode_provider``/``_geocode_error`` plus an aggregate summary.
+        ``_geocode_provider``/``_geocode_error`` plus an aggregate summary
+        carrying the partial-completion metadata when the budget ran out.
     """
     providers = providers if providers is not None else DEFAULT_PROVIDERS
     total_rows = sum(s.get("row_count", 0) for s in parsed_sources)
+    monotonic = clock if clock is not None else time.monotonic
+    start_time = monotonic()
+
+    def _out_of_budget() -> bool:
+        return time_budget is not None and (monotonic() - start_time) >= time_budget
 
     if total_rows == 0:
         result = GeocodeStageResult()
@@ -135,6 +166,7 @@ async def geocode_stage(
     # One flag across all chunks, mirroring the original single-boolean
     # semantics: set whenever any batch rotated past the first provider.
     multi_provider = _MultiProviderFlag()
+    deadline_exceeded = False
 
     def _report_progress() -> None:
         if on_progress is not None:
@@ -181,19 +213,22 @@ async def geocode_stage(
                     row["_geocode_error"] = "missing address"
             all_geocoded.append(row)
 
-        await _geocode_chunk(
+        skipped = await _geocode_chunk(
             rows,
             chunk,
             batch_geocode=batch_geocode,
             providers=providers,
             flag=multi_provider,
+            out_of_budget=_out_of_budget,
         )
+        deadline_exceeded = deadline_exceeded or skipped > 0
 
         processed += len(rows)
         _report_progress()
 
     summary = _summarize(all_geocoded)
     summary.multi_provider = multi_provider.hit
+    summary.deadline_exceeded = deadline_exceeded
 
     if store_ref is not None:
         store_ref({"rows": all_geocoded, "summary": summary.as_dict()})
@@ -215,62 +250,95 @@ async def _geocode_chunk(
     batch_geocode: BatchGeocode,
     providers: list[str],
     flag: _MultiProviderFlag,
-) -> None:
-    """Geocode one source's ``chunk`` of (row_idx, address) pairs in batches.
+    out_of_budget: Callable[[], bool] | None = None,
+) -> int:
+    """Geocode one source's ``chunk`` of (row_idx, address) pairs in partitions.
 
     Mutates ``rows`` in place, writing the ``_lat``/``_lon``/``_geocode_*``
-    status keys. Implements the per-batch provider fallback: if a batch's
-    failure rate exceeds the threshold and another provider remains, the
-    failed addresses are retried against the next provider, and ``flag`` is
-    set to signal that a rotation occurred.
+    status keys. Implements the per-partition provider fallback: if a
+    partition's failure rate exceeds the threshold and another provider
+    remains, the failed addresses are retried against the next provider, and
+    ``flag`` is set to signal that a rotation occurred.
 
     Deduplicates addresses before geocoding: each unique address is geocoded
     once, then the result is fanned out to every row that shares it. This
     avoids re-billing quota-limited/paid provider calls for duplicate
     addresses (common in real datasets - e.g. multiple rows in the same
     district).
+
+    Issue #483 bounding: unique addresses are dispatched in partitions of
+    :data:`BATCH_SIZE`; when ``out_of_budget`` fires, no further partition is
+    dispatched and its rows are marked ``skipped``. Returns the number of
+    rows skipped due to the budget (0 when unbounded).
     """
     addresses = [address for _, address in chunk]
     # Dedup preserving first-occurrence order so the strategy sees each unique
     # address exactly once. dict.fromkeys is insertion-ordered (3.7+).
     unique_addrs: list[str] = list(dict.fromkeys(addresses))
-    strategy = GeocodeProviderStrategy()
-    results, hit = await strategy.geocode_addresses(
-        unique_addrs,
-        batch_geocode=batch_geocode,
-        providers=providers,
-        failure_threshold=PROVIDER_FAILURE_THRESHOLD,
-        batch_size=BATCH_SIZE
-    )
-    if hit:
-        flag.hit = True
 
-    # Fan out unique-address results to every row_idx that shares the address.
-    addr_to_result = dict(zip(unique_addrs, results))
+    addr_to_result: dict[str, Any] = {}
+    skipped_addresses: set[str] = set()
+
+    for part_start in range(0, len(unique_addrs), BATCH_SIZE):
+        partition = unique_addrs[part_start:part_start + BATCH_SIZE]
+        if out_of_budget is not None and out_of_budget():
+            skipped_addresses.update(partition)
+            continue
+        strategy = GeocodeProviderStrategy()
+        results, hit = await strategy.geocode_addresses(
+            partition,
+            batch_geocode=batch_geocode,
+            providers=providers,
+            failure_threshold=PROVIDER_FAILURE_THRESHOLD,
+            batch_size=BATCH_SIZE
+        )
+        if hit:
+            flag.hit = True
+        addr_to_result.update(zip(partition, results))
+
+    # Fan out unique-address results to every row_idx that shares the address;
+    # budget-skipped addresses get an honest "skipped" annotation.
     for row_idx, addr in chunk:
-        res = addr_to_result[addr]
+        res = addr_to_result.get(addr)
         row = rows[row_idx]
-        row["_lat"] = res.lat
-        row["_lon"] = res.lon
-        row["_geocode_status"] = res.status
-        row["_geocode_provider"] = res.provider
-        row["_geocode_error"] = res.error
+        if res is not None:
+            row["_lat"] = res.lat
+            row["_lon"] = res.lon
+            row["_geocode_status"] = res.status
+            row["_geocode_provider"] = res.provider
+            row["_geocode_error"] = res.error
+        else:
+            row["_lat"] = None
+            row["_lon"] = None
+            row["_geocode_status"] = "skipped"
+            row["_geocode_provider"] = None
+            row["_geocode_error"] = "skipped: geocode time budget exceeded"
+
+    return sum(1 for _, addr in chunk if addr in skipped_addresses)
 
 
 def _summarize(all_geocoded: list[dict]) -> GeocodeSummary:
-    """Tally row statuses into a :class:`GeocodeSummary`."""
+    """Tally row statuses into a :class:`GeocodeSummary`.
+
+    ``success_rate`` covers the rows actually dispatched to providers
+    (total minus predefined minus budget-skipped) so a deadline truncation
+    does not masquerade as provider failure; the skip count itself is
+    reported separately for honest partial-completion metadata.
+    """
     total = len(all_geocoded)
     success = sum(1 for r in all_geocoded if r.get("_geocode_status") == "ok")
     failed = sum(1 for r in all_geocoded if r.get("_geocode_status") == "failed")
     predefined = sum(
         1 for r in all_geocoded if r.get("_geocode_status") == "predefined"
     )
-    to_geocode = total - predefined
-    success_rate = round(success / to_geocode, 4) if to_geocode > 0 else 0.0
+    skipped = sum(1 for r in all_geocoded if r.get("_geocode_status") == "skipped")
+    attempted = total - predefined - skipped
+    success_rate = round(success / attempted, 4) if attempted > 0 else 0.0
     return GeocodeSummary(
         total=total,
         success=success,
         failed=failed,
         predefined=predefined,
+        skipped=skipped,
         success_rate=success_rate,
     )

--- a/app/services/explorer/orchestrator.py
+++ b/app/services/explorer/orchestrator.py
@@ -1,6 +1,8 @@
 """探索任务编排器"""
 import logging
 import asyncio
+from collections import OrderedDict
+from dataclasses import dataclass
 from typing import AsyncGenerator, Optional, Any
 from celery import chain
 from app.services.explorer.models import SearchContext, ExplorerPerceptionEvent
@@ -9,6 +11,80 @@ from app.services.task_queue import TaskQueueService
 from app.utils.sse import sse_event
 
 logger = logging.getLogger(__name__)
+
+# ─── Issue #481: whole-chain run tracking ──────────────────────────────────
+#
+# Celery chain semantics (verified against Celery 5.6.3):
+# ``chain(a, b, c).apply_async()`` returns the LAST task's result — the
+# durable whole-chain handle (SUCCESS only when the whole chain finished) —
+# and ``result.parent`` walks backward toward the FIRST task. The previous
+# code inverted this: it walked to the root (the discover stage, done in
+# seconds) and polled/revoked that id, so the SSE stream faked "completed"
+# while stages 2-5 ran dark, late-stage failures never surfaced (downstream
+# ids stay PENDING forever when an upstream stage fails), and abort was a
+# no-op once discover succeeded.
+#
+# The orchestrator therefore registers, per exploration, every stage task id
+# ordered [first..last] under the final id it hands to the client. Status is
+# aggregated across all stage ids (any stage failure ⇒ run failed; all
+# SUCCESS ⇒ run completed; otherwise PROGRESS on the first not-yet-SUCCESS
+# stage), and abort revokes every stage id.
+
+EXPLORER_STAGES = ("discover", "fetch", "parse", "geocode", "validate")
+
+# Bound the registry with the same LRU discipline as TaskQueueService's
+# owner map (F29): entries are only useful while a run is live/queried.
+_CHAIN_RUNS_MAX_ENTRIES = 20_000
+
+
+@dataclass
+class ExplorerChainRun:
+    """All Celery stage task ids of one exploration, ordered first→last.
+
+    ``stage_ids[-1]`` is the whole-chain handle returned to the client; the
+    ids before it are the predecessors walked via ``AsyncResult.parent``.
+    """
+
+    stage_ids: list[str]
+
+
+_chain_runs: "OrderedDict[str, ExplorerChainRun]" = OrderedDict()
+
+
+def register_chain_run(final_task_id: str, stage_ids: list[str]) -> ExplorerChainRun:
+    """Record the stage task ids of a submitted exploration under its final
+    (whole-chain) id, so status/abort/stream can act on the whole chain."""
+    run = ExplorerChainRun(stage_ids=list(stage_ids))
+    _chain_runs[final_task_id] = run
+    _chain_runs.move_to_end(final_task_id)
+    while len(_chain_runs) > _CHAIN_RUNS_MAX_ENTRIES:
+        _chain_runs.popitem(last=False)
+    return run
+
+
+def get_chain_run(final_task_id: str) -> Optional[ExplorerChainRun]:
+    """Look up the chain-run record for a whole-chain (final) task id."""
+    run = _chain_runs.get(final_task_id)
+    if run is not None:
+        # Refresh recency so a live run is never LRU-evicted mid-flight.
+        _chain_runs.move_to_end(final_task_id)
+    return run
+
+
+def collect_stage_ids(result: Any) -> list[str]:
+    """Collect every stage task id of a chain result, ordered first→last.
+
+    ``result`` is what ``chain(...).apply_async()`` returned: the LAST task's
+    AsyncResult/EagerResult, whose ``.parent`` chain walks back to the first
+    task. Verified against Celery 5.6.3 (both real and eager application).
+    """
+    ids: list[str] = []
+    node: Any = result
+    while node is not None:
+        ids.append(node.id)
+        node = getattr(node, "parent", None)
+    ids.reverse()
+    return ids
 
 
 class ExplorerOrchestrator:
@@ -65,18 +141,20 @@ class ExplorerOrchestrator:
 
         # 提交任务 — 计算隔离不变式 1：apply_async 是 broker socket I/O，
         # offload 到 worker 线程（#386），避免阻塞事件循环上的 SSE 流。
-        def _submit_chain() -> str:
+        def _submit_chain() -> list[str]:
             result = task_chain.apply_async()
-            # F-06 fix: traverse parent chain to find the root (first) task ID
-            # so stream_progress can poll from the beginning of the pipeline
-            root_result = result
-            while getattr(root_result, "parent", None) is not None:
-                root_result = root_result.parent
-            return root_result.id
+            # Issue #481: apply_async returns the LAST task's result — the
+            # durable whole-chain handle. Walk .parent backward to collect
+            # every stage's task id (first→last) for status aggregation and
+            # abort. The FIRST task's id (the old return value) goes SUCCESS
+            # seconds in and must never be used as the run's handle.
+            return collect_stage_ids(result)
 
-        celery_task_id = await asyncio.to_thread(_submit_chain)
+        stage_ids = await asyncio.to_thread(_submit_chain)
+        celery_task_id = stage_ids[-1]
+        register_chain_run(celery_task_id, stage_ids)
 
-        # 审计 S42：记录任务所有权
+        # 审计 S42：记录任务所有权 — on the whole-chain id the client polls.
         if user_id:
             TaskQueueService.register_owner(celery_task_id, user_id)
 
@@ -84,65 +162,165 @@ class ExplorerOrchestrator:
 
         return celery_task_id
 
+    def _aggregate_chain_status(self, run: ExplorerChainRun) -> dict:
+        """Fold the per-stage Celery states into one honest run status.
+
+        Rules (see the issue-#481 note at module top):
+        - any stage FAILURE/REVOKED ⇒ run failed, naming the failed stage
+          (downstream ids stay PENDING forever after an upstream failure, so
+          the final id alone can never report this);
+        - all stages SUCCESS ⇒ run completed;
+        - otherwise ⇒ PROGRESS on the first not-yet-SUCCESS stage (a later
+          stage is PENDING while its predecessors run — that is chain order,
+          not completion).
+        """
+        final_id = run.stage_ids[-1]
+        per_stage = [
+            self.task_queue.get_task_status(task_id)
+            for task_id in run.stage_ids
+        ]
+        statuses = [d.get("status") for d in per_stage]
+
+        if statuses and all(s == "UNKNOWN" for s in statuses):
+            # Result backend unavailable: degrade honestly (ADR-0052), never
+            # report a fake completion.
+            return {"task_id": final_id, "status": "UNKNOWN", "result": None, "progress": 0}
+
+        for name, stage in zip(EXPLORER_STAGES, per_stage):
+            if stage.get("status") in ("FAILURE", "REVOKED"):
+                return {
+                    "task_id": final_id,
+                    "status": stage["status"],
+                    "stage": name,
+                    "progress": stage.get("progress", 0),
+                    "result": None,
+                }
+
+        if statuses and all(s == "SUCCESS" for s in statuses):
+            last = per_stage[-1]
+            return {
+                "task_id": final_id,
+                "status": "SUCCESS",
+                "stage": EXPLORER_STAGES[-1],
+                "progress": 100,
+                "result": last.get("result"),
+            }
+
+        for name, stage in zip(EXPLORER_STAGES, per_stage):
+            if stage.get("status") != "SUCCESS":
+                return {
+                    "task_id": final_id,
+                    "status": "PROGRESS",
+                    "stage": name,
+                    "progress": stage.get("progress", 0),
+                    "result": None,
+                }
+
+        # Unreachable (a non-terminal aggregate must hit the loop above), but
+        # keep a safe default rather than returning None.
+        return {"task_id": final_id, "status": "UNKNOWN", "result": None, "progress": 0}
+
     async def get_task_status(self, task_id: str) -> dict:
         """查询任务状态 — AsyncResult 读 result backend 是 socket I/O，
-        SSE stream_progress 每秒轮询，必须 offload（#386）。"""
+        SSE stream_progress 每秒轮询，必须 offload（#386）。
+
+        For a registered chain run this aggregates ALL stage ids (issue #481):
+        polling the final id alone cannot see mid-chain failures (they leave
+        it PENDING forever), and polling the first id fakes SUCCESS early.
+        """
+        run = get_chain_run(task_id)
+        if run is not None:
+            return await asyncio.to_thread(self._aggregate_chain_status, run)
         return await asyncio.to_thread(self.task_queue.get_task_status, task_id)
 
     async def abort_task(self, task_id: str) -> bool:
-        """中止任务 — control.revoke 是 broker socket I/O，offload（#386）。"""
-        return await asyncio.to_thread(self.task_queue.revoke_task, task_id)
+        """中止任务 — control.revoke 是 broker socket I/O，offload（#386）。
+
+        For a chain run every stage id is revoked (issue #481): revoking only
+        the first id is a no-op once discover succeeded, and revoking only the
+        final id is a no-op while earlier stages run.
+        """
+        run = get_chain_run(task_id)
+        if run is None:
+            return await asyncio.to_thread(self.task_queue.revoke_task, task_id)
+
+        def _revoke_all() -> bool:
+            outcomes = []
+            for stage_task_id in run.stage_ids:
+                outcomes.append(self.task_queue.revoke_task(stage_task_id))
+            failed = [
+                tid for tid, ok in zip(run.stage_ids, outcomes) if not ok
+            ]
+            if failed:
+                logger.warning(
+                    f"[Explorer] Partial abort for {task_id}: revoke failed for {failed}"
+                )
+            return all(outcomes)
+
+        return await asyncio.to_thread(_revoke_all)
 
     async def stream_progress(
         self,
         task_id: str,
     ) -> AsyncGenerator[str, None]:
-        """SSE 进度流生成器"""
+        """SSE 进度流生成器
+
+        Issue #481: ``task_id`` is the whole-chain handle; status comes from
+        the per-stage aggregate, so the stream stays open through validate,
+        reports real stage events (including late-stage failures), and only
+        terminates on whole-chain completion/failure/revocation.
+        """
         import time
 
         last_state = None
+        last_stage = None
         heartbeat_interval = 15  # seconds
         last_heartbeat = time.time()
 
         while True:
             status = await self.get_task_status(task_id)
             current_state = status.get("status")
-
-            # 发送进度事件
-            if current_state != last_state or current_state == "PROGRESS":
-                info = status.get("result") or {}
-                meta = info.get("meta", {}) if isinstance(info, dict) else {}
-
-                event = ExplorerPerceptionEvent(
-                    stage=meta.get("stage", "pending"),
-                    task_id=task_id,
-                    status="progress" if current_state == "PROGRESS" else (
-                        "completed" if current_state == "SUCCESS" else (
-                            "failed" if current_state == "FAILURE" else "started"
-                        )
-                    ),
-                    context={"progress": meta.get("progress", 0)},
-                )
-
-                yield sse_event("explorer_progress", event)
-                last_state = current_state
-
-            # 心跳
-            now = time.time()
-            if now - last_heartbeat >= heartbeat_interval:
-                yield sse_event("heartbeat", {"ts": now})
-                last_heartbeat = now
+            current_stage = status.get("stage") or "pending"
 
             # 结束条件
             if current_state in ("SUCCESS", "FAILURE", "REVOKED"):
-                # 发送最终事件
+                # 发送最终事件 — 成功即整链完成（validate）；失败时点名失败
+                # 的阶段，而不是硬编码 validate。终态只发这一条事件（上方
+                # 的常规发射跳过终态，避免重复的 completed/failed）。
                 final_event = ExplorerPerceptionEvent(
-                    stage="validate",
+                    stage="validate" if current_state == "SUCCESS" else current_stage,
                     task_id=task_id,
                     status="completed" if current_state == "SUCCESS" else "failed",
                     context={"final_status": current_state},
                 )
                 yield sse_event("explorer_progress", final_event)
                 break
+
+            # 发送进度事件（阶段切换或 PROGRESS 更新时；终态走上方最终事件）
+            if (
+                current_state != last_state
+                or current_stage != last_stage
+                or current_state == "PROGRESS"
+            ):
+                info = status.get("result")
+                meta = info.get("meta", {}) if isinstance(info, dict) else {}
+                progress = status.get("progress") or meta.get("progress") or 0
+
+                event = ExplorerPerceptionEvent(
+                    stage=current_stage,
+                    task_id=task_id,
+                    status="progress" if current_state == "PROGRESS" else "started",
+                    context={"progress": progress},
+                )
+
+                yield sse_event("explorer_progress", event)
+                last_state = current_state
+                last_stage = current_stage
+
+            # 心跳
+            now = time.time()
+            if now - last_heartbeat >= heartbeat_interval:
+                yield sse_event("heartbeat", {"ts": now})
+                last_heartbeat = now
 
             await asyncio.sleep(1)

--- a/app/services/explorer/quality_engine.py
+++ b/app/services/explorer/quality_engine.py
@@ -29,9 +29,21 @@ class QualityEngine:
     }
 
     def calc_temporal_score(self, data_type: str, published_at: datetime) -> float:
-        """计算时效性分数"""
+        """计算时效性分数
+
+        Issue #482: ``published_at`` may arrive naive (offset-less gov
+        ``publish_time`` strings, or any adapter that skipped UTC
+        normalization) — subtracting it from an aware ``now`` raises
+        TypeError and kills the discover stage. Normalize naive values to
+        UTC per house convention (services/temporal/*, services/jobs/*).
+        A future timestamp (clock skew / bad data) clamps to age 0 so the
+        score stays within [0, 1] instead of exceeding 1 via exp(+x).
+        """
         lambda_val = self.TEMPORAL_LAMBDA.get(data_type, self.TEMPORAL_LAMBDA["default"])
-        delta_months = (datetime.now(timezone.utc) - published_at).days / 30.0
+        if published_at.tzinfo is None:
+            published_at = published_at.replace(tzinfo=timezone.utc)
+        age_days = (datetime.now(timezone.utc) - published_at).days
+        delta_months = max(age_days, 0) / 30.0
         score = math.exp(-lambda_val * delta_months)
         return round(score, 4)
 

--- a/app/tasks/explorer/task_chain.py
+++ b/app/tasks/explorer/task_chain.py
@@ -130,9 +130,20 @@ def explorer_parse_task(self, prev_result: dict):
 # idempotency guard.
 @celery_app.task(bind=True, soft_time_limit=290, time_limit=300)
 def explorer_geocode_task(self, prev_result: dict):
-    """地理编码阶段 - thin Celery adapter over the pure :func:`geocode_stage`."""
+    """地理编码阶段 - thin Celery adapter over the pure :func:`geocode_stage`.
+
+    Issue #483: the stage is bounded by :data:`GEOCODE_STAGE_TIME_BUDGET`
+    (230 s vs the 290 s soft / 300 s hard limits): it stops dispatching new
+    address partitions once the budget is spent and finishes gracefully with
+    honest partial-completion metadata (``skipped_rows`` /
+    ``deadline_exceeded``) instead of being hard-killed mid-run, which would
+    take sibling tasks on the worker down with it.
+    """
     from app.tools.chinese_maps import batch_geocode_cn
-    from app.services.explorer.geocode_stage import geocode_stage
+    from app.services.explorer.geocode_stage import (
+        geocode_stage,
+        GEOCODE_STAGE_TIME_BUDGET,
+    )
 
     task_id = prev_result["task_id"]
     logger.info(f"[Explorer:{task_id}] Starting geocode stage")
@@ -145,11 +156,14 @@ def explorer_geocode_task(self, prev_result: dict):
         load_ref=lambda ref_id: _load_ref(ref_id, task_id=task_id),
         batch_geocode=batch_geocode_cn,
         on_progress=_on_progress,
+        time_budget=GEOCODE_STAGE_TIME_BUDGET,
     ))
 
     # Fail-fast: if there were rows to geocode but none survived (every parsed
     # ref unresolved), the handoff is broken — fail loudly rather than handing
-    # an empty geocoded_ref_id to validate and reporting success.
+    # an empty geocoded_ref_id to validate and reporting success. Deadline
+    # truncation does NOT trip this: budget-skipped rows are still carried in
+    # result.rows with an honest "skipped" status.
     expected_rows = sum(s.get("row_count", 0) for s in prev_result["parsed_results"])
     if expected_rows > 0 and not result.rows:
         raise RuntimeError(
@@ -172,6 +186,8 @@ def explorer_geocode_task(self, prev_result: dict):
         "geocoded_ref_id": geocoded_ref_id,
         "total_rows": result.summary.total,
         "success_rate": result.summary.success_rate,
+        "skipped_rows": result.summary.skipped,
+        "deadline_exceeded": result.summary.deadline_exceeded,
     }
 
 

--- a/tests/test_explorer_quality.py
+++ b/tests/test_explorer_quality.py
@@ -63,3 +63,33 @@ def test_field_score_partial():
         actual_fields=["name", "address"],
     )
     assert score == 0.5
+
+
+def test_temporal_score_naive_datetime_does_not_crash():
+    """Issue #482: a naive published_at (e.g. from a source that skipped the
+    adapter's UTC normalization) must not raise TypeError in the scoring
+    path — it is treated as UTC per house convention."""
+    engine = QualityEngine()
+    published = datetime(2024, 3, 15)  # naive
+    score = engine.calc_temporal_score("education", published)
+    assert 0.0 <= score <= 1.0
+
+
+def test_temporal_score_naive_equals_aware_utc():
+    """A naive datetime and its UTC-aware equivalent must score identically
+    (naive is interpreted as UTC, not local time)."""
+    engine = QualityEngine()
+    naive = datetime(2024, 3, 15)
+    aware = naive.replace(tzinfo=timezone.utc)
+    assert engine.calc_temporal_score("education", naive) == engine.calc_temporal_score(
+        "education", aware
+    )
+
+
+def test_temporal_score_future_timestamp_is_clamped_sane():
+    """Adversarial: a publish time in the future (clock skew / bad data) must
+    produce a bounded score, not an error or an explosion."""
+    engine = QualityEngine()
+    future = datetime.now(timezone.utc) + timedelta(days=365)
+    score = engine.calc_temporal_score("education", future)
+    assert 0.0 <= score <= 1.0

--- a/tests/test_explorer_task_chain.py
+++ b/tests/test_explorer_task_chain.py
@@ -1,4 +1,5 @@
 """Explorer task chain integration tests"""
+import json
 import pytest
 from unittest.mock import patch, MagicMock
 from app.services.explorer.orchestrator import ExplorerOrchestrator
@@ -16,13 +17,19 @@ async def test_orchestrator_start_and_status():
     orchestrator = ExplorerOrchestrator()
 
     with patch("app.services.explorer.orchestrator.chain") as mock_chain:
+        # Shape the mock like a REAL 5-stage chain result: the leaf result
+        # carries a 4-deep .parent chain back to the first task (issue #481;
+        # shape pinned by test_chain_apply_async_returns_final_stage_result).
+        # A bare MagicMock would auto-create truthy .parent forever.
         mock_result = MagicMock()
-        mock_result.id = "test_task_123"
-        # F-06 fix: start_exploration traverses result.parent to find the root
-        # task. A MagicMock auto-creates a truthy .parent on every access, which
-        # makes that traversal loop forever. Pin .parent to None so the loop
-        # terminates (the result IS the root in this single-link mock).
-        mock_result.parent = None
+        mock_result.id = "final_task_id"
+        node = mock_result
+        for _ in range(4):
+            parent = MagicMock()
+            parent.parent = None
+            node.parent = parent
+            node = parent
+        node.id = "first_task_id"
         mock_chain.return_value.apply_async.return_value = mock_result
 
         task_id = await orchestrator.start_exploration(
@@ -30,7 +37,14 @@ async def test_orchestrator_start_and_status():
             context=SearchContext(query="海淀区学校"),
         )
 
-        assert task_id == "test_task_123"
+        # The whole-chain handle handed to the client is the FINAL stage's
+        # id, not the first task's.
+        assert task_id == "final_task_id"
+        run = orchestrator_mod.get_chain_run(task_id)
+        assert run is not None
+        assert run.stage_ids[0] == "first_task_id"
+        assert run.stage_ids[-1] == "final_task_id"
+        assert len(run.stage_ids) == 5
 
 
 @pytest.mark.asyncio
@@ -116,3 +130,403 @@ def test_store_ref_uses_seam_not_module_singleton(monkeypatch):
         assert seen_stores == [fake], "_store_ref did not route through get_session_store()"
     finally:
         set_active_session_store(None)
+
+
+# ─── Issue #481: whole-chain handle semantics ──────────────────────────────
+#
+# The SSE stream / status / abort endpoints must track the WHOLE 5-stage
+# chain, not its first task. Celery semantics this pins (verified against the
+# installed Celery 5.6.3): ``chain(a..e).apply_async()`` returns the LAST
+# task's AsyncResult (SUCCESS only when the whole chain finished) and
+# ``.parent`` walks backward toward the first task. Polling the FIRST task's
+# id reports SUCCESS seconds in while stages 2-5 still run; a mid-chain
+# failure leaves downstream ids PENDING forever (never FAILURE), so honest
+# status requires aggregating every stage id.
+
+from app.services.explorer import orchestrator as orchestrator_mod
+from app.services.task_queue import TaskQueueService, celery_app
+from celery import chain as celery_chain
+
+_STAGE_ATTRS = (
+    "explorer_discover_task",
+    "explorer_fetch_task",
+    "explorer_parse_task",
+    "explorer_geocode_task",
+    "explorer_validate_task",
+)
+
+_stub_seq = {"n": 0}
+
+
+def _make_stub_chain_tasks():
+    """Build 5 real Celery tasks shaped like the explorer stage tasks.
+
+    Real ``celery_app.task`` objects (real signatures, real chain semantics,
+    real backend marks) whose bodies just return the next stage's handoff
+    dict — so tests exercise the canvas machinery without the real stages'
+    network/store touchpoints.
+    """
+    _stub_seq["n"] += 1
+    n = _stub_seq["n"]
+
+    @celery_app.task(bind=True, name=f"stub.explorer.{n}.discover")
+    def stub_discover(self, task_id, query, context):
+        return {"task_id": task_id, "selected_sources": []}
+
+    @celery_app.task(bind=True, name=f"stub.explorer.{n}.fetch")
+    def stub_fetch(self, prev):
+        return {"task_id": prev["task_id"], "fetch_results": []}
+
+    @celery_app.task(bind=True, name=f"stub.explorer.{n}.parse")
+    def stub_parse(self, prev):
+        return {"task_id": prev["task_id"], "parsed_results": []}
+
+    @celery_app.task(bind=True, name=f"stub.explorer.{n}.geocode")
+    def stub_geocode(self, prev):
+        return {
+            "task_id": prev["task_id"],
+            "geocoded_ref_id": None,
+            "total_rows": 0,
+            "success_rate": 0.0,
+        }
+
+    @celery_app.task(bind=True, name=f"stub.explorer.{n}.validate")
+    def stub_validate(self, prev):
+        return {"task_id": prev["task_id"], "status": "completed"}
+
+    return (stub_discover, stub_fetch, stub_parse, stub_geocode, stub_validate)
+
+
+def _build_real_stub_chain():
+    stubs = _make_stub_chain_tasks()
+    return celery_chain(
+        stubs[0].s("t-stub", "q", {}),
+        stubs[1].s(),
+        stubs[2].s(),
+        stubs[3].s(),
+        stubs[4].s(),
+    )
+
+
+def _parse_sse(event_str: str) -> dict:
+    for line in event_str.split("\n"):
+        if line.startswith("data: "):
+            return json.loads(line[len("data: "):])
+    raise AssertionError(f"no data line in {event_str!r}")
+
+
+@pytest.mark.asyncio
+async def test_start_exploration_returns_whole_chain_handle(monkeypatch):
+    """start_exploration must return the FINAL stage's task id (the durable
+    whole-chain handle), and record every stage id for status/abort."""
+    stubs = _make_stub_chain_tasks()
+    for attr, stub in zip(_STAGE_ATTRS, stubs):
+        monkeypatch.setattr(task_chain, attr, stub)
+
+    orch = ExplorerOrchestrator()
+    returned = await orch.start_exploration(
+        query="海淀区学校",
+        context=SearchContext(query="海淀区学校"),
+        session_id="s-481",
+        user_id="user-481",
+    )
+
+    run = orchestrator_mod.get_chain_run(returned)
+    assert run is not None, "no chain-run record registered under the returned id"
+    assert len(run.stage_ids) == 5, "run record must know all 5 stage task ids"
+    assert len(set(run.stage_ids)) == 5
+    # The handle handed to the client is the LAST stage (validate), not the
+    # first (discover): Celery's returned result is the chain-completion
+    # signal; the root id goes SUCCESS seconds in and fakes completion.
+    assert returned == run.stage_ids[-1]
+    # Ownership is registered on the same id the client will poll/abort.
+    assert TaskQueueService.verify_owner(returned, "user-481")
+
+
+def test_chain_apply_async_returns_final_stage_result():
+    """Pin real Celery canvas semantics: apply_async() returns the LAST task's
+    result and .parent walks back to the FIRST task."""
+    result = _build_real_stub_chain().apply_async()
+
+    node, root, depth = result, result, 0
+    while getattr(node, "parent", None) is not None:
+        node = node.parent
+        root = node
+        depth += 1
+
+    assert depth == 4, "leaf result must have 4 ancestors (5-stage chain)"
+    # The returned handle is the final stage; the ROOT (what the buggy code
+    # returned) is a different task that reports SUCCESS after stage 1 only.
+    assert result.id != root.id
+
+
+@pytest.mark.asyncio
+async def test_status_reports_mid_chain_failure(monkeypatch):
+    """A stage-3 FAILURE must surface as the run's status.
+
+    Celery leaves downstream task ids PENDING forever when an upstream stage
+    fails, so polling the final id alone shows PENDING; polling the FIRST id
+    (the old behavior) shows SUCCESS. Only the aggregate over all stage ids
+    is honest.
+    """
+    stubs = _make_stub_chain_tasks()
+    for attr, stub in zip(_STAGE_ATTRS, stubs):
+        monkeypatch.setattr(task_chain, attr, stub)
+
+    # Non-eager so nothing executes at submit time; tasks sit on the in-memory
+    # broker queue. We then drive the backend marks by hand.
+    monkeypatch.setattr(celery_app.conf, "task_always_eager", False)
+
+    orch = ExplorerOrchestrator()
+    final_id = await orch.start_exploration(
+        query="海淀区学校", context=SearchContext(query="海淀区学校"),
+    )
+    run = orchestrator_mod.get_chain_run(final_id)
+    discover_id, fetch_id, parse_id, geocode_id, validate_id = run.stage_ids
+
+    # Discover + fetch done, parse died (e.g. unresolvable refs), successors
+    # never started (PENDING — exactly how a real worker leaves a broken chain).
+    for tid in (discover_id, fetch_id):
+        celery_app.backend.store_result(tid, {"task_id": "x"}, state="SUCCESS")
+    celery_app.backend.store_result(
+        parse_id, RuntimeError("parse boom"), state="FAILURE"
+    )
+
+    status = await orch.get_task_status(final_id)
+    assert status["status"] == "FAILURE", (
+        f"mid-chain parse failure must read as FAILURE, got {status!r}"
+    )
+    assert status.get("stage") == "parse"
+    # The old bug: the polled id was discover's, which reads SUCCESS here —
+    # a fake 'completed' while the chain is actually dead.
+    assert TaskQueueService.get_task_status(discover_id)["status"] == "SUCCESS"
+
+
+@pytest.mark.asyncio
+async def test_status_pending_while_later_stages_run(monkeypatch):
+    """While stage 1 succeeded but stages 2-5 are still PENDING/alive, the
+    run status must stay PROGRESS — never SUCCESS (the fake-completion bug)."""
+    stubs = _make_stub_chain_tasks()
+    for attr, stub in zip(_STAGE_ATTRS, stubs):
+        monkeypatch.setattr(task_chain, attr, stub)
+    monkeypatch.setattr(celery_app.conf, "task_always_eager", False)
+
+    orch = ExplorerOrchestrator()
+    final_id = await orch.start_exploration(
+        query="海淀区学校", context=SearchContext(query="海淀区学校"),
+    )
+    run = orchestrator_mod.get_chain_run(final_id)
+
+    # Stage 1-3 finished; stages 4-5 not started.
+    for tid in run.stage_ids[:3]:
+        celery_app.backend.store_result(tid, {"task_id": "x"}, state="SUCCESS")
+    # geocode mid-flight with a PROGRESS mark, validate still PENDING.
+    celery_app.backend.store_result(
+        run.stage_ids[3], {"stage": "geocode", "progress": 40}, state="PROGRESS"
+    )
+
+    status = await orch.get_task_status(final_id)
+    assert status["status"] == "PROGRESS"
+    assert status.get("stage") == "geocode"
+
+
+@pytest.mark.asyncio
+async def test_abort_revokes_every_stage(monkeypatch):
+    """Abort must revoke ALL stage task ids, not just the polled one.
+
+    Revoking only the first id is a no-op once discover succeeded; revoking
+    only the final id is a no-op while earlier stages run (the final task
+    hasn't been dispatched yet).
+    """
+    revoked: list[str] = []
+
+    def fake_revoke(task_id):
+        revoked.append(task_id)
+        return True
+
+    monkeypatch.setattr(TaskQueueService, "revoke_task", staticmethod(fake_revoke))
+
+    final_id = "fin-481"
+    stage_ids = ["id-disc", "id-fetch", "id-parse", "id-geo", final_id]
+    orchestrator_mod.register_chain_run(final_id, stage_ids)
+
+    orch = ExplorerOrchestrator()
+    ok = await orch.abort_task(final_id)
+
+    assert ok is True
+    assert set(revoked) == set(stage_ids), (
+        f"abort must revoke all 5 stage ids, revoked={revoked}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_covers_all_stages_until_validate(monkeypatch):
+    """The SSE stream must stay open and report real per-stage progress while
+    geocode (stage 4) runs, and only emit 'completed' when validate finishes.
+
+    Regression shape of the bug: the stream polled the FIRST task's id, whose
+    SUCCESS fired seconds in and ended the stream with a hardcoded final
+    'completed' event while fetch/parse/geocode/validate ran dark.
+    """
+    final_id = "fin-stream-481"
+    stage_ids = ["sid-1", "sid-2", "sid-3", "sid-4", final_id]
+    orchestrator_mod.register_chain_run(final_id, stage_ids)
+
+    # Per-task backend view, evolving over aggregate polls:
+    #   polls 1-2: discover/fetch/parse SUCCESS, geocode PROGRESS 40, validate PENDING
+    #   poll 3+:   all SUCCESS (validate result ready)
+    base = {
+        "sid-1": {"status": "SUCCESS", "progress": 100, "result": {}},
+        "sid-2": {"status": "SUCCESS", "progress": 100, "result": {}},
+        "sid-3": {"status": "SUCCESS", "progress": 100, "result": {}},
+        "sid-4": {"status": "PROGRESS", "progress": 40, "result": None},
+        final_id: {"status": "PENDING", "progress": 0, "result": None},
+    }
+    polls = {"n": 0}
+
+    def counting_get(task_id):
+        if task_id == final_id:
+            polls["n"] += 1
+            if polls["n"] >= 3:
+                return {"status": "SUCCESS", "progress": 100,
+                        "result": {"task_id": "x", "status": "completed"}}
+        if polls["n"] >= 3:
+            return {"status": "SUCCESS", "progress": 100, "result": {}}
+        return dict(base[task_id])
+
+    monkeypatch.setattr(TaskQueueService, "get_task_status", staticmethod(counting_get))
+    # Skip the 1s poll interval; heartbeat window (15s) never trips.
+    async def _no_sleep(_s):
+        return None
+    monkeypatch.setattr("app.services.explorer.orchestrator.asyncio.sleep", _no_sleep)
+
+    orch = ExplorerOrchestrator()
+    events = [e async for e in orch.stream_progress(final_id)]
+
+    progress_payloads = [_parse_sse(e) for e in events if e.startswith("event: explorer_progress")]
+    stages_seen = [p["stage"] for p in progress_payloads]
+
+    # Geocode progress was reported while the chain was still alive...
+    assert "geocode" in stages_seen, f"stream went dark during stages 2-5: {stages_seen}"
+    assert any(p["status"] == "progress" and p["stage"] == "geocode" for p in progress_payloads)
+    # ...and 'completed' appears exactly once, as the FINAL event.
+    completed = [p for p in progress_payloads if p["status"] == "completed"]
+    assert len(completed) == 1
+    assert progress_payloads[-1]["status"] == "completed"
+    assert progress_payloads[-1]["stage"] == "validate"
+    # The generator terminated (loop ended) — no hang.
+    assert events, "stream produced no events"
+
+
+@pytest.mark.asyncio
+async def test_stream_reports_late_stage_failure(monkeypatch):
+    """A geocode-stage FAILURE must end the stream with a failed event naming
+    the failed stage — not a fake 'completed'."""
+    final_id = "fin-fail-481"
+    stage_ids = ["fid-1", "fid-2", "fid-3", "fid-4", final_id]
+    orchestrator_mod.register_chain_run(final_id, stage_ids)
+
+    by_id = {
+        "fid-1": {"status": "SUCCESS", "progress": 100, "result": {}},
+        "fid-2": {"status": "SUCCESS", "progress": 100, "result": {}},
+        "fid-3": {"status": "SUCCESS", "progress": 100, "result": {}},
+        "fid-4": {"status": "FAILURE", "progress": 90, "result": None},
+        final_id: {"status": "PENDING", "progress": 0, "result": None},
+    }
+    monkeypatch.setattr(
+        TaskQueueService, "get_task_status",
+        staticmethod(lambda tid: dict(by_id.get(tid, {"status": "PENDING", "progress": 0, "result": None}))),
+    )
+
+    async def _no_sleep(_s):
+        return None
+    monkeypatch.setattr("app.services.explorer.orchestrator.asyncio.sleep", _no_sleep)
+
+    orch = ExplorerOrchestrator()
+    events = [e async for e in orch.stream_progress(final_id)]
+    payloads = [_parse_sse(e) for e in events if e.startswith("event: explorer_progress")]
+
+    assert payloads[-1]["status"] == "failed"
+    assert payloads[-1]["stage"] == "geocode"
+    assert payloads[-1]["context"].get("final_status") == "FAILURE"
+    assert all(p["status"] != "completed" for p in payloads), (
+        "stream must not report completed when a late stage failed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_explores_keep_independent_runs(monkeypatch):
+    """Two concurrent explores register independent runs; status of one never
+    reflects the other's stages."""
+    stubs = _make_stub_chain_tasks()
+    for attr, stub in zip(_STAGE_ATTRS, stubs):
+        monkeypatch.setattr(task_chain, attr, stub)
+    monkeypatch.setattr(celery_app.conf, "task_always_eager", False)
+
+    orch = ExplorerOrchestrator()
+    id_a = await orch.start_exploration(query="a", context=SearchContext(query="a"))
+    id_b = await orch.start_exploration(query="b", context=SearchContext(query="b"))
+
+    run_a = orchestrator_mod.get_chain_run(id_a)
+    run_b = orchestrator_mod.get_chain_run(id_b)
+    assert id_a != id_b
+    assert set(run_a.stage_ids).isdisjoint(run_b.stage_ids)
+
+    # Run A fully done, run B untouched: A reports SUCCESS, B stays pending.
+    for tid in run_a.stage_ids:
+        celery_app.backend.store_result(tid, {"task_id": "a"}, state="SUCCESS")
+    status_a = await orch.get_task_status(id_a)
+    status_b = await orch.get_task_status(id_b)
+    assert status_a["status"] == "SUCCESS"
+    assert status_b["status"] == "PROGRESS"
+
+
+@pytest.mark.asyncio
+async def test_status_revoked_stage_is_terminal_failure(monkeypatch):
+    """A REVOKED stage (post-abort) reads as a terminal run status — the
+    stream/status must not hang on it forever."""
+    final_id = "fin-revoke-481"
+    stage_ids = ["rid-1", "rid-2", "rid-3", "rid-4", final_id]
+    orchestrator_mod.register_chain_run(final_id, stage_ids)
+
+    by_id = {
+        "rid-1": {"status": "SUCCESS", "progress": 100, "result": {}},
+        "rid-2": {"status": "REVOKED", "progress": 0, "result": None},
+        "rid-3": {"status": "PENDING", "progress": 0, "result": None},
+        "rid-4": {"status": "PENDING", "progress": 0, "result": None},
+        final_id: {"status": "PENDING", "progress": 0, "result": None},
+    }
+    monkeypatch.setattr(
+        TaskQueueService, "get_task_status",
+        staticmethod(lambda tid: dict(by_id.get(tid, {"status": "PENDING", "progress": 0, "result": None}))),
+    )
+
+    async def _no_sleep(_s):
+        return None
+    monkeypatch.setattr("app.services.explorer.orchestrator.asyncio.sleep", _no_sleep)
+
+    orch = ExplorerOrchestrator()
+    status = await orch.get_task_status(final_id)
+    assert status["status"] == "REVOKED"
+    assert status["stage"] == "fetch"
+
+    events = [e async for e in orch.stream_progress(final_id)]
+    payloads = [_parse_sse(e) for e in events if e.startswith("event: explorer_progress")]
+    assert payloads[-1]["status"] == "failed"
+    assert payloads[-1]["context"].get("final_status") == "REVOKED"
+
+
+@pytest.mark.asyncio
+async def test_status_backend_unavailable_degrades_to_unknown(monkeypatch):
+    """When the result backend is unreachable every stage read degrades to
+    UNKNOWN — the aggregate must report UNKNOWN, never a fake completion."""
+    final_id = "fin-unknown-481"
+    orchestrator_mod.register_chain_run(final_id, ["uid-1", "uid-2", "uid-3", "uid-4", final_id])
+    monkeypatch.setattr(
+        TaskQueueService, "get_task_status",
+        staticmethod(lambda tid: {"task_id": tid, "status": "UNKNOWN", "result": None, "progress": 0}),
+    )
+
+    orch = ExplorerOrchestrator()
+    status = await orch.get_task_status(final_id)
+    assert status["status"] == "UNKNOWN"

--- a/tests/test_geocode_stage.py
+++ b/tests/test_geocode_stage.py
@@ -432,3 +432,267 @@ def test_geocode_stage_dedup_preserves_result_mapping():
     assert result.rows[0]["_lon"] == 116.4
     assert result.rows[1]["_lat"] == 39.9
     assert result.rows[1]["_lon"] == 116.4
+
+
+# ─── Issue #483: bounded geocode work vs the hard Celery time limit ─────────
+#
+# explorer_geocode_task runs under soft_time_limit=290 / time_limit=300; the
+# stage used to iterate every row of every source with no bound, so large
+# datasets hard-killed the worker mid-run. The stage now takes a time budget:
+# unique addresses are dispatched in ≤BATCH_SIZE partitions, the deadline is
+# checked before each partition, un-dispatched rows are marked "skipped", and
+# the summary carries honest partial-completion metadata — the task finishes
+# gracefully before the soft limit instead of being killed.
+
+from app.services.explorer.geocode_stage import GeocodeSummary
+
+
+class _FakeClock:
+    """Deterministic clock advanced manually by the fake geocoder."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def monotonic(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def _ok_batch_response(addresses, provider="amap"):
+    return {
+        "total": len(addresses),
+        "success_count": len(addresses),
+        "error_count": 0,
+        "results": [
+            {"index": i, "status": "ok", "address": a,
+             "results": [{"location": [116.0 + i * 0.001, 39.9]}]}
+            for i, a in enumerate(addresses)
+        ],
+        "errors": [],
+        "provider": provider,
+    }
+
+
+def test_geocode_stage_zero_budget_skips_all_rows():
+    """time_budget=0: no provider calls at all, every row honestly skipped,
+    rows still carried (partial checkpoint for validate), metadata set."""
+    rows = [{"name": f"r{i}", "addr": f"地址{i}"} for i in range(5)]
+    parsed_sources = [{"ref_id": "ref_z", "row_count": len(rows),
+                       "mapping": {"address": "addr"}}]
+
+    async def batch_geocode(addresses, provider="amap", max_concurrency=3):
+        pytest.fail("batch_geocode must not run with an exhausted budget")
+
+    result = _run(geocode_stage(
+        parsed_sources,
+        load_ref=lambda ref_id: {"rows": rows, "mapping": {"address": "addr"}},
+        batch_geocode=batch_geocode,
+        time_budget=0,
+        clock=lambda: 0.0,
+    ))
+
+    assert result.summary.deadline_exceeded is True
+    assert result.summary.skipped == 5
+    assert result.summary.total == 5
+    assert result.summary.success == 0
+    assert all(r["_geocode_status"] == "skipped" for r in result.rows)
+    assert all(r["_lat"] is None for r in result.rows)
+    assert "budget" in result.rows[0]["_geocode_error"]
+
+
+def test_geocode_stage_stops_dispatching_at_deadline():
+    """250 unique addresses, 100 per partition, 50s per partition, budget 75s:
+    partition 1 dispatches (elapsed 0 < 75), partition 2 dispatches
+    (elapsed 50 < 75), partition 3 is skipped (elapsed 100 >= 75) — 200
+    geocoded, 50 honestly reported as skipped."""
+    from app.services.geocode_strategy import BATCH_SIZE
+    rows = [{"name": f"r{i}", "addr": f"地址{i}"} for i in range(250)]
+    parsed_sources = [{"ref_id": "ref_d", "row_count": len(rows),
+                       "mapping": {"address": "addr"}}]
+
+    clock = _FakeClock()
+    dispatched: list[int] = []
+
+    async def batch_geocode(addresses, provider="amap", max_concurrency=3):
+        assert len(addresses) <= BATCH_SIZE
+        dispatched.append(len(addresses))
+        clock.advance(50.0)
+        return _ok_batch_response(addresses)
+
+    result = _run(geocode_stage(
+        parsed_sources,
+        load_ref=lambda ref_id: {"rows": rows, "mapping": {"address": "addr"}},
+        batch_geocode=batch_geocode,
+        time_budget=75.0,
+        clock=clock.monotonic,
+    ))
+
+    assert dispatched == [100, 100], f"unexpected dispatch pattern: {dispatched}"
+    assert result.summary.success == 200
+    assert result.summary.skipped == 50
+    assert result.summary.deadline_exceeded is True
+    statuses = [r["_geocode_status"] for r in result.rows]
+    assert statuses.count("ok") == 200
+    assert statuses.count("skipped") == 50
+    # success_rate covers the rows actually attempted, not budget skips.
+    assert result.summary.success_rate == 1.0
+
+
+def test_geocode_stage_no_budget_processes_everything():
+    """time_budget=None keeps the historical unbounded behavior (no skips) —
+    the in-process pipeline path stays unchanged."""
+    rows = [{"name": f"r{i}", "addr": f"地址{i}"} for i in range(3)]
+    parsed_sources = [{"ref_id": "ref_n", "row_count": 3,
+                       "mapping": {"address": "addr"}}]
+
+    async def batch_geocode(addresses, provider="amap", max_concurrency=3):
+        return _ok_batch_response(addresses)
+
+    result = _run(geocode_stage(
+        parsed_sources,
+        load_ref=lambda ref_id: {"rows": rows, "mapping": {"address": "addr"}},
+        batch_geocode=batch_geocode,
+        time_budget=None,
+        clock=lambda: 0.0,
+    ))
+
+    assert result.summary.skipped == 0
+    assert result.summary.deadline_exceeded is False
+    assert result.summary.success == 3
+
+
+def test_geocode_stage_deadline_mid_second_source():
+    """Budget exhausted while source 2 is queued: source 2 rows load and are
+    marked skipped; source 1 results survive; summary reports both."""
+    rows_1 = [{"name": "a1", "addr": "地址一"}, {"name": "a2", "addr": "地址二"}]
+    rows_2 = [{"name": "b1", "addr": "地址三"}, {"name": "b2", "addr": "地址四"}]
+    parsed_sources = [
+        {"ref_id": "ref_s1", "row_count": 2, "mapping": {"address": "addr"}},
+        {"ref_id": "ref_s2", "row_count": 2, "mapping": {"address": "addr"}},
+    ]
+    store = {}
+    refs = {"ref_s1": {"rows": rows_1, "mapping": {"address": "addr"}},
+            "ref_s2": {"rows": rows_2, "mapping": {"address": "addr"}}}
+
+    clock = _FakeClock()
+    progress: list[int] = []
+
+    async def batch_geocode(addresses, provider="amap", max_concurrency=3):
+        clock.advance(200.0)
+        return _ok_batch_response(addresses)
+
+    result = _run(geocode_stage(
+        parsed_sources,
+        load_ref=lambda ref_id: refs[ref_id],
+        batch_geocode=batch_geocode,
+        store_ref=lambda payload: store.update(payload) or "ref_out",
+        on_progress=progress.append,
+        time_budget=150.0,
+        clock=clock.monotonic,
+    ))
+
+    assert result.summary.success == 2
+    assert result.summary.skipped == 2
+    assert result.summary.deadline_exceeded is True
+    # Partial checkpoint: store received the annotated rows + honest summary.
+    assert len(store["rows"]) == 4
+    assert store["summary"]["skipped"] == 2
+    assert store["summary"]["deadline_exceeded"] is True
+    # Progress was still reported while work happened.
+    assert progress
+
+
+def test_geocode_stage_summary_dict_carries_partial_metadata():
+    """GeocodeSummary.as_dict exposes skipped + deadline_exceeded so the task
+    handoff can surface honest partial-completion metadata."""
+    s = GeocodeSummary(total=10, success=6, failed=1, predefined=1, skipped=2,
+                       success_rate=6 / 7, deadline_exceeded=True)
+    d = s.as_dict()
+    assert d["skipped"] == 2
+    assert d["deadline_exceeded"] is True
+
+
+def test_geocode_stage_predefined_rows_not_counted_skipped():
+    """Adversarial: rows with coordinates are predefined regardless of budget;
+    only un-dispatched geocode rows count as skipped."""
+    rows = [
+        {"name": "p", "addr": "x", "lat": 39.9, "lon": 116.4},
+        {"name": "q", "addr": "y"},
+    ]
+    parsed_sources = [{"ref_id": "ref_p", "row_count": 2,
+                       "mapping": {"address": "addr", "lat": "lat", "lon": "lon"}}]
+
+    async def batch_geocode(addresses, provider="amap", max_concurrency=3):
+        pytest.fail("must not dispatch with zero budget")
+
+    result = _run(geocode_stage(
+        parsed_sources,
+        load_ref=lambda ref_id: {"rows": rows,
+                                 "mapping": {"address": "addr", "lat": "lat", "lon": "lon"}},
+        batch_geocode=batch_geocode,
+        time_budget=0,
+        clock=lambda: 0.0,
+    ))
+
+    assert result.summary.predefined == 1
+    assert result.summary.skipped == 1
+    assert result.rows[0]["_geocode_status"] == "predefined"
+    assert result.rows[1]["_geocode_status"] == "skipped"
+    assert result.summary.success_rate == 0.0
+
+
+def test_geocode_task_bounded_by_time_budget_and_reports_partial_completion(monkeypatch):
+    """The Celery adapter passes GEOCODE_STAGE_TIME_BUDGET into the stage and
+    surfaces skipped_rows/deadline_exceeded in the validate-stage handoff."""
+    from app.services.explorer import geocode_stage as gs_mod
+    from app.services.session_data_protocol import set_active_session_store
+    from app.services.session_data import MemorySessionStore
+    from app.tasks.explorer import task_chain
+    import asyncio as _asyncio
+
+    captured: dict = {}
+
+    class _FakeResult:
+        rows = [{"name": "A", "_geocode_status": "ok"},
+                {"name": "B", "_geocode_status": "skipped"}]
+        summary = gs_mod.GeocodeSummary(
+            total=2, success=1, skipped=1, success_rate=1.0,
+            deadline_exceeded=True,
+        )
+
+    async def fake_stage(parsed_sources, *, load_ref, batch_geocode,
+                         on_progress=None, **kwargs):
+        captured.update(kwargs)
+        return _FakeResult()
+
+    monkeypatch.setattr(gs_mod, "geocode_stage", fake_stage)
+
+    def fake_run_async(coro):
+        loop = _asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    monkeypatch.setattr(task_chain, "_run_async", fake_run_async)
+
+    store = MemorySessionStore()
+    set_active_session_store(store)
+    try:
+        out = task_chain.explorer_geocode_task.apply(
+            args=[{
+                "task_id": "t-483",
+                "parsed_results": [{"ref_id": "r1", "row_count": 2, "mapping": {}}],
+            }]
+        )
+    finally:
+        set_active_session_store(None)
+
+    assert captured.get("time_budget") == gs_mod.GEOCODE_STAGE_TIME_BUDGET
+    assert out.successful()
+    assert out.result["skipped_rows"] == 1
+    assert out.result["deadline_exceeded"] is True
+    assert out.result["total_rows"] == 2
+    assert out.result["geocoded_ref_id"]

--- a/tests/test_gov_adapter.py
+++ b/tests/test_gov_adapter.py
@@ -26,9 +26,11 @@ def test_detect_encoding_gbk():
 
 def test_parse_date():
     adapter = GovDataAdapter()
-    from datetime import datetime
-    assert adapter._parse_date("2024-03-15") == datetime(2024, 3, 15)
-    assert adapter._parse_date("2024-03") == datetime(2024, 3, 1)
+    from datetime import datetime, timezone
+    # Issue #482: _parse_date returns UTC-aware datetimes (offset-less gov
+    # publish_time strings are interpreted as UTC).
+    assert adapter._parse_date("2024-03-15") == datetime(2024, 3, 15, tzinfo=timezone.utc)
+    assert adapter._parse_date("2024-03") == datetime(2024, 3, 1, tzinfo=timezone.utc)
     assert adapter._parse_date("") is None
     assert adapter._parse_date("invalid") is None
 
@@ -56,3 +58,142 @@ async def test_parse_csv_with_nulls():
     assert len(structured.rows) == 2
     assert structured.fields[0].nullable_ratio == 0.0
     assert structured.fields[1].nullable_ratio == 0.5
+
+
+# ─── Issue #482: naive vs aware publish_time must not crash discover ───────
+
+def test_parse_date_returns_utc_aware():
+    """_parse_date must produce timezone-AWARE datetimes (UTC).
+
+    Gov platform publish_time strings carry no offset; a naive strptime
+    result later hits ``datetime.now(timezone.utc) - published_at`` in
+    QualityEngine.calc_temporal_score and raises TypeError, killing the
+    whole 5-stage chain after retries. House convention for naive inputs
+    (services/temporal/*, services/jobs/*): assume UTC.
+    """
+    from datetime import timezone
+    adapter = GovDataAdapter()
+    dt = adapter._parse_date("2024-03-15")
+    assert dt is not None
+    assert dt.tzinfo is not None, "_parse_date returned a naive datetime"
+    assert dt.utcoffset() == timezone.utc.utcoffset(None)
+    # %Y-%m still parses to the first of month, now aware.
+    dt2 = adapter._parse_date("2024-03")
+    assert dt2 is not None and dt2.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_quick_assess_with_naive_publish_time_does_not_crash():
+    """quick_assess over a naive published_at must yield a temporal score,
+    not TypeError: can't subtract offset-naive and offset-aware datetimes."""
+    from datetime import datetime
+    from app.adapters.base import DataSource
+
+    adapter = GovDataAdapter()
+    source = DataSource(
+        id="gov_test_1",
+        name="海淀区学校名录",
+        description="学校",
+        url="http://example.com/schools.csv",
+        format="csv",
+        published_at=datetime(2024, 3, 15),  # naive — pre-fix shape
+    )
+    score = await adapter.quick_assess("海淀区学校", source)
+    assert 0.0 <= score.temporal_score <= 1.0
+    assert 0.0 <= score.overall <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_quick_assess_aware_publish_time_still_works():
+    """Aware published_at (post-fix adapter shape) keeps scoring correctly."""
+    from datetime import datetime, timedelta, timezone
+    from app.adapters.base import DataSource
+
+    adapter = GovDataAdapter()
+    source = DataSource(
+        id="gov_test_2",
+        name="海淀区学校名录",
+        url="http://example.com/schools.csv",
+        format="csv",
+        published_at=datetime.now(timezone.utc) - timedelta(days=30),
+    )
+    score = await adapter.quick_assess("海淀区学校", source)
+    assert 0.0 < score.temporal_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_quick_assess_missing_publish_time_uses_default():
+    """No publish_time at all: temporal falls back to the 0.5 default, no crash."""
+    from app.adapters.base import DataSource
+
+    adapter = GovDataAdapter()
+    source = DataSource(
+        id="gov_test_3",
+        name="海淀区学校名录",
+        url="http://example.com/schools.csv",
+        format="csv",
+        published_at=None,
+    )
+    score = await adapter.quick_assess("海淀区学校", source)
+    assert score.temporal_score == 0.5
+
+
+@pytest.mark.asyncio
+async def test_run_discover_stage_with_publish_time_source_completes():
+    """End-to-end through the discover stage: a gov source carrying a parseable
+    naive publish_time must not kill the chain (issue #482's exact repro —
+    explorer_discover_task retried 2x then FAILURE)."""
+    from datetime import datetime
+    from app.adapters.base import DataSource
+    from app.services.explorer.discover_stage import run_discover_stage
+    from app.services.explorer.models import SearchContext
+
+    real_gov = GovDataAdapter()
+
+    class PublishTimeAdapter:
+        async def discover(self, query, context):
+            return [
+                DataSource(
+                    id="gov_bj_1",
+                    name="海淀区学校名录",
+                    description="海淀区学校",
+                    url="http://example.com/schools.csv",
+                    format="csv",
+                    published_at=datetime(2024, 3, 15),  # naive strptime shape
+                )
+            ]
+
+        async def quick_assess(self, query, source):
+            # Route through the REAL gov adapter's scoring path — that is
+            # where the naive/aware subtraction crashed.
+            return await real_gov.quick_assess(query, source)
+
+    res = await run_discover_stage(
+        "task_482", "海淀区学校", SearchContext(query="海淀区学校").model_dump(),
+        adapter=PublishTimeAdapter(),
+    )
+    assert res.success is True
+    assert res.stage == "discover"
+    assert len(res.data["selected_sources"]) == 1
+    assert 0.0 <= res.data["selected_sources"][0]["score"]["temporal_score"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_run_discover_stage_empty_gov_results():
+    """Empty gov platform response: discover succeeds with no candidates."""
+    from app.services.explorer.discover_stage import run_discover_stage
+    from app.services.explorer.models import SearchContext
+
+    class EmptyAdapter:
+        async def discover(self, query, context):
+            return []
+
+        async def quick_assess(self, query, source):  # pragma: no cover
+            raise AssertionError("quick_assess must not run on empty results")
+
+    res = await run_discover_stage(
+        "task_482b", "anything", SearchContext(query="anything").model_dump(),
+        adapter=EmptyAdapter(),
+    )
+    assert res.success is True
+    assert res.data["selected_sources"] == []


### PR DESCRIPTION
## Issues
- Fixes #481 (P1: Explorer SSE/status poll the chain's FIRST task — stream fakes "completed" while stages 2-5 run dark; abort revokes the wrong id)
- Fixes #482 (P1: discover crashes on naive vs aware datetime when a gov source carries publish_time — chain dies after retries)
- Fixes #483 (P2: geocode stage unbounded against hard time_limit=300 — large datasets hard-kill the worker)

## Root causes (verified empirically against real Celery 5.6.3 semantics — no mocked assumptions)
1. **#481** `apply_async` on a chain returns the LAST task's id; `.parent` walks to the first; a mid-chain failure leaves downstream ids PENDING forever — no single-id poll can be honest. The routes polled the FIRST task id.
2. **#482** `GovDataAdapter._parse_date` produced naive datetimes; `calc_temporal_score` compared against `datetime.now(timezone.utc)` → TypeError.
3. **#483** geocode dispatched every unique address with no deadline accounting under the worker's hard 300 s limit.

## Implementation
- **#481** orchestrator returns the final task id as the client handle; all 5 stage ids recorded in a bounded LRU chain-run registry; status aggregates across stages (FAILURE/REVOKED naming the failed stage; SUCCESS only when all stages done; PROGRESS on current stage); abort revokes EVERY stage id; SSE streams real per-stage events with exactly one terminal event. Routes unchanged.
- **#482** `_parse_date` attaches UTC (house convention); `calc_temporal_score` normalizes naive datetimes defensively; future timestamps clamp to age 0 (adversarial finding: scores could exceed 1.0).
- **#483** geocode takes a time_budget (+injectable clock): ≤100-address partitions, deadline check before each, un-dispatched rows marked `skipped` and checkpointed; summary carries skipped/deadline_exceeded; Celery task passes 230 s (60 s headroom under soft_time_limit=290) — graceful partial completion instead of hard kill.

## Validation
Sanctioned suite 60 passed; wider regression (pipeline/stages, critical-backend, sse, #386 offload, runtime followups, session-store contract) green; `ruff` clean.

## Risk
Medium-low: status payloads now report the whole chain (previously lying "completed"); abort semantics change to revoke-all (intended).