### PR TITLE
fix(api): 修复模板列表分页 offset 双重应用导致第 2 页起丢行

### DIFF
--- a/app/api/routes/templates.py
+++ b/app/api/routes/templates.py
@@ -152,9 +152,12 @@ async def list_templates(
     elif source == "user":
         stmt = stmt.where(CartographyTemplate.is_builtin.is_(False))
 
-    # Apply pagination at the DB level (no Python .all()).
-    page_stmt = stmt.limit(limit).offset(offset)
-    result = await db.execute(page_stmt)
+    # The template table is small (seed builtins + user saves), so fetch all
+    # rows matching the scope/kind/source filters and paginate ONCE in Python
+    # after merging seeds and applying q. Paginating here as well (limit/
+    # offset at the DB) applied the offset twice and dropped rows from page 2
+    # onward; filtering q after DB pagination shrank pages the same way.
+    result = await db.execute(stmt)
     db_templates = list(result.scalars().all())
     total_stmt = select(func.count()).select_from(stmt.subquery())
     total = (await db.execute(total_stmt)).scalar_one() or 0
@@ -185,8 +188,8 @@ async def list_templates(
             or any(keyword in kw.lower() for kw in t.get("keywords", []))
         ]
 
-    # Final post-pagination slice so the merged list doesn't exceed the
-    # requested page (built-in seeds are pre-DB and out of `total`).
+    # Single pagination slice over the fully filtered merged list (seeds are
+    # pre-DB and intentionally out of `total`).
     page_slice = results[offset:offset + limit]
 
     if summary:

--- a/tests/unit/test_templates_api.py
+++ b/tests/unit/test_templates_api.py
@@ -307,3 +307,74 @@ async def test_unauthenticated_list_hides_user_templates(client):
     allowed = await client.get(f"/api/v1/templates/{tmpl_id}", headers=user_headers)
     assert allowed.status_code == 200
     assert allowed.json()["name"] == "他人模板"
+
+
+async def _create_layout_templates(client, names):
+    """Save layout templates as user_123 and return their ids."""
+    ids = []
+    for name in names:
+        res = await client.post(
+            "/api/v1/templates",
+            json={"name": name, "kind": "layout", "payload": _LAYOUT_PAYLOAD},
+            headers=user_headers,
+        )
+        assert res.status_code == 201, res.text
+        ids.append(res.json()["id"])
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_list_templates_page2_continuity(client):
+    """Regression: offset must be applied exactly once.
+
+    The old path paginated at the DB (limit/offset) and then sliced the
+    seed-merged list by the same offset again, so page 2 came back empty
+    and rows were silently dropped.
+    """
+    created_ids = await _create_layout_templates(
+        client, [f"分页模板{i}" for i in range(1, 8)]
+    )
+
+    pages = []
+    for offset in (0, 3, 6):
+        res = await client.get(
+            f"/api/v1/templates?source=user&kind=layout&limit=3&offset={offset}",
+            headers=user_headers,
+        )
+        assert res.status_code == 200
+        pages.append([t["id"] for t in res.json()["items"]])
+
+    assert [len(p) for p in pages] == [3, 3, 1]
+    flat = [tid for p in pages for tid in p]
+    assert len(flat) == len(set(flat)) == len(created_ids)
+    assert set(flat) == set(created_ids)
+
+
+@pytest.mark.asyncio
+async def test_list_templates_q_filter_before_pagination(client):
+    """Regression: q must filter the full set before the page slice.
+
+    Previously q ran on the DB page after limit/offset, so a page could
+    shrink below `limit` and later matches never appeared on any page.
+    """
+    match_ids = await _create_layout_templates(
+        client, [f"检索模板{i}" for i in range(1, 7)]
+    )
+    await _create_layout_templates(client, ["无关模板甲", "无关模板乙"])
+
+    page1 = await client.get(
+        "/api/v1/templates?source=user&kind=layout&q=检索&limit=4&offset=0",
+        headers=user_headers,
+    )
+    page2 = await client.get(
+        "/api/v1/templates?source=user&kind=layout&q=检索&limit=4&offset=4",
+        headers=user_headers,
+    )
+    assert page1.status_code == 200 and page2.status_code == 200
+
+    ids1 = [t["id"] for t in page1.json()["items"]]
+    ids2 = [t["id"] for t in page2.json()["items"]]
+    assert len(ids1) == 4
+    assert len(ids2) == 2
+    assert set(ids1) | set(ids2) == set(match_ids)
+    assert not set(ids1) & set(ids2)


### PR DESCRIPTION
## 问题（P1）

`app/api/routes/templates.py` 列表端点分页被应用两次：DB 层 `stmt.limit(limit).offset(offset)`（:156）分页后，合并 seed 模板并做 `q` 关键词过滤（:179，发生在 DB 分页之后），最后又 `results[offset:offset+limit]`（:190）二次切片。第 2 页起 offset 双重应用导致窗口错位丢行；`q` 过滤在分页后执行导致页内缩水。

## 修复

- 去掉 DB 层 limit/offset，保留 scope/kind/source 过滤拉全量（模板表规模小）
- 合并 seeds、source/q 过滤全部前置，单次切片分页
- `total` 语义保持原约定（seeds 不计入）

## 验证

- 新增 2 个回归测试：第 2 页连续性（7 模板翻 3 页 `[3,3,1]` 无重复）、q 过滤前置分页（`[4,2]` 两页并集恰为匹配集）；已在修复前代码验证会失败
- `pytest tests/unit/test_templates_api.py tests/unit/test_cartography_templates_db.py -q`：17 → **19 passed**
- `ruff check` 通过

来源：全库深度审查（8 个独立修复 PR 之一）。