### PR TITLE
fix(gis): 变化检测改走 durable job 投递；热力图调色板契约与异常语义修复

### DIFF
--- a/app/services/spatial_tasks.py
+++ b/app/services/spatial_tasks.py
@@ -1,20 +1,18 @@
 """空间分析 Celery 任务定义 - 逻辑与任务解耦版"""
+import json
 import logging
 import math
 import os
-import io
+import time
 import base64
 import asyncio
-from typing import List, Dict, Optional, Callable
+from typing import List, Dict, Optional
 
-import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 import numpy as np
-from scipy.ndimage import gaussian_filter
 from shapely.geometry import mapping
 from shapely import box as sbox
 
+from app.core.config import settings
 from app.services.task_queue import celery_app
 from app.services.nature_resource_analyzer import NatureResourceAnalyzer
 from app.services.rs.spectral_engine import SpectralRasterEngine
@@ -123,62 +121,36 @@ def _build_grid_features(H, xedges, yedges, max_val: float) -> list[dict]:
     ]
 
 
-def _do_heatmap_generation(features: List[Dict], cell_size: int = 500, radius: int = 1000, render_type: str = "raster", palette: str = "classic", callback: Optional[Callable] = None):
-    fig = None
-    try:
-        xs, ys = _extract_heatmap_points(features)
-        if not xs:
-            return {"success": False, "error": "No valid point features found"}
+def _do_heatmap_generation(features: List[Dict], cell_size: int = 500, radius: int = 1000, render_type: str = "raster", palette: str = "classic"):
+    """Celery 路径的热力图入口：委托 density.generate_heatmap_raster。
 
-        H, xedges, yedges, _ = _build_heatmap_grid(xs, ys, cell_size)
+    审计发现此前这里硬编码 ``plt.get_cmap('YlOrRd')``，palette 参数被忽略且
+    不写 metadata（前端 legend 恒 0/1），与进程内回退路径（density.py 的
+    ``_HEATMAP_PALETTES`` 契约）不一致。复用同一实现后 palette 渲染与 metadata
+    输出天然一致；原先传入却从未被调用的 ``callback`` 参数已删除。
+    """
+    # lazy import：density 反向 lazy import 本模块的网格辅助函数，避免 import 环
+    from app.lib.geo_analysis.density import generate_heatmap_raster
 
-        if render_type == "grid":
-            max_val = float(H.max()) if H.max() > 0 else 1.0
-            grid_features = _build_grid_features(H, xedges, yedges, max_val)
-            return {
-                "success": True,
-                "data": {"type": "FeatureCollection", "features": grid_features},
-                "status_desc": f"已生成矢量格网热力图 ({len(grid_features)} 个格网)。"
-            }
-        else:
-            sigma = max(1.0, radius / cell_size)
-            H_smooth = gaussian_filter(H.T, sigma=sigma)
-            # ... colormap logic ...
-            cmap = plt.get_cmap("YlOrRd") # Simplified for brevity, original has custom palettes
-            fig, ax = plt.subplots(figsize=(10, 10), dpi=100)
-            v_max = np.percentile(H_smooth, 98) if H_smooth.max() > 0 else 1.0
-            ax.imshow(H_smooth, cmap=cmap, origin="lower", aspect="auto", vmin=0, vmax=v_max)
-            ax.axis("off")
-            plt.subplots_adjust(left=0, right=1, top=1, bottom=0)
-            buf = io.BytesIO()
-            fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0, transparent=True)
-            plt.close(fig)
-            img_b64 = "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
-            return {
-                "success": True,
-                "data": {
-                    "type": "heatmap_raster", "image": img_b64, 
-                    "bbox": [float(xedges[0]), float(yedges[0]), float(xedges[-1]), float(yedges[-1])],
-                    "total_points": len(xs)
-                }
-            }
-    except Exception as e:
-        logger.error(f"Heatmap failed: {e}", exc_info=True)
-        return {"success": False, "error": str(e)}
+    result = generate_heatmap_raster(features, cell_size, radius, render_type, palette)
+    if "error" in result and not result.get("success"):
+        # density 的空点集分支只返回 {"error": ...}，补上 Celery 结果消费方
+        # 依赖的 success=False 语义
+        result["success"] = False
+    return result
 
 # --- Celery 任务包装器 ---
 # 注：原 run_buffer_analysis / run_spatial_stats / run_nearest_neighbor /
-# run_overlay_analysis / run_attribute_filter / run_path_analysis 已删除——agent
+# run_overlay_analysis / run_attribute_filter / run_path_analysis 已删除--agent
 # 工具直接调 SpatialAnalyzer 的对应方法（ADR-0013 删除了路由到它们的 dispatch seam，
-# 这些 task 包装器失去生产调用方）。保留的 3 个 task 由工具 .delay/.apply_async 调用：
+# 这些 task 包装器失去生产调用方）。保留的 3 个 task 由工具调用：
 #   - run_heatmap_generation  (spatial.py:274)
-#   - run_ndvi_analysis       (nature_resources.py:41)
-#   - run_change_detection    (change_detection.py:68)
+#   - run_ndvi_analysis       (nature_resources.py 经 submit_durable_job)
+#   - run_change_detection    (change_detection.py 经 submit_durable_job)
 
 @celery_app.task(name="app.services.spatial_tasks.run_heatmap_generation", bind=True)
 def run_heatmap_generation(self, features: List[Dict], cell_size: int = 500, radius: int = 1000, render_type: str = "raster", palette: str = "classic"):
-    def cb(curr, msg): self.update_state(state='PROGRESS', meta={'progress': curr, 'message': msg})
-    return _do_heatmap_generation(features, cell_size, radius, render_type, palette, callback=cb)
+    return _do_heatmap_generation(features, cell_size, radius, render_type, palette)
 
 # --- 自然资源与遥感任务 ---
 
@@ -519,6 +491,162 @@ def _pixel_change_classification(t1: Dict, t2: Dict, change_threshold: float) ->
     }
 
 
+class _ChangeDetectionError(RuntimeError):
+    """业务性失败（T1/T2 计算失败等）-- 保留 dict 返回语义，不算 Celery FAILURE。"""
+
+
+def _compute_change_indices(
+    bbox: List[float], t1_from: str, t1_to: str, t2_from: str, t2_to: str, index_type: str
+):
+    """顺序执行两次 async 指数计算（新建事件循环，兼容 prefork / gevent 池）。"""
+    svc = SpectralRasterEngine()
+
+    async def compute_both():
+        t1 = await svc.compute_vegetation_index(bbox, t1_from, t1_to, index_type=index_type)
+        t2 = await svc.compute_vegetation_index(bbox, t2_from, t2_to, index_type=index_type)
+        return t1, t2
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(compute_both())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+def _build_change_data(
+    bbox: List[float],
+    t1_from: str, t1_to: str, t2_from: str, t2_to: str,
+    t1: Dict, t2: Dict, index_type: str, change_threshold: float,
+) -> Dict:
+    """汇总两期指数统计并产出变化判定（像元级分类优先，#445）。
+
+    两期影像来自独立 STAC 检索，#381 读取窗口可能覆盖不同足迹，场景均值
+    不可直接比较 -- 优先在两期足迹的公共栅格上做像元级差值分类
+    （``_pixel_change_classification``：class_counts/class_percentages/
+    preview_png_b64），仅当无法像元比较（无数组/足迹不相交）时显式回退到
+    场景均值（method=scene_mean_fallback）。
+    """
+    delta_mean = None
+    category = "unknown"
+    method = "scene_mean_fallback"
+    classification: Optional[Dict] = None
+
+    pixel = _pixel_change_classification(t1, t2, change_threshold)
+    if pixel is not None:
+        method = pixel["method"]
+        delta_mean = pixel["delta_mean"]
+        category = pixel["category"]
+        classification = pixel
+    else:
+        mean_t1 = t1.get("stats", {}).get("mean")
+        mean_t2 = t2.get("stats", {}).get("mean")
+        if mean_t1 is not None and mean_t2 is not None:
+            delta_mean = round(mean_t2 - mean_t1, 4)
+            category = _classify_delta(delta_mean, change_threshold)
+
+    return {
+        "index_type": index_type.upper(),
+        "bbox": bbox,
+        "t1": {
+            "period": f"{t1_from} ~ {t1_to}",
+            "stats": t1.get("stats", {}),
+            "cloud_cover": t1.get("cloud_cover"),
+        },
+        "t2": {
+            "period": f"{t2_from} ~ {t2_to}",
+            "stats": t2.get("stats", {}),
+            "cloud_cover": t2.get("cloud_cover"),
+        },
+        "change": {
+            "delta_mean": delta_mean,
+            "category": category,
+            "threshold": change_threshold,
+            "method": method,
+            "classification": classification,
+        },
+    }
+
+
+def _change_result_geojson(data: Dict, bbox: List[float]) -> Dict:
+    """把统计结果包装成合法 GeoJSON（bbox 多边形携带统计属性）。
+
+    UploadRecord.format 受 ck_upload_format 约束（geojson/shapefile/geotiff/
+    csv/gpkg/kml），统计 JSON 包装成 FeatureCollection 后按 'geojson' 落库，
+    资产可被地图端直接加载。
+
+    #445 的 ``classification.preview_png_b64`` 是 base64 PNG 大对象：留在任务
+    结果里（任务中心/LLM 可读）即可，不进 GeoJSON 资产属性 -- 资产整份下发给
+    地图端，KB 级 blob 只会拖累加载；method/class_counts/class_percentages
+    等轻量统计照常保留。
+    """
+    w, s, e, n = bbox
+    change_props = dict(data["change"])
+    classification = change_props.get("classification")
+    if isinstance(classification, dict):
+        change_props["classification"] = {
+            k: v for k, v in classification.items() if k != "preview_png_b64"
+        }
+    props = {
+        "analysis": "change_detection",
+        "index_type": data["index_type"],
+        "t1_period": data["t1"]["period"],
+        "t1_stats": data["t1"]["stats"],
+        "t1_cloud_cover": data["t1"].get("cloud_cover"),
+        "t2_period": data["t2"]["period"],
+        "t2_stats": data["t2"]["stats"],
+        "t2_cloud_cover": data["t2"].get("cloud_cover"),
+        **change_props,
+    }
+    return {
+        "type": "FeatureCollection",
+        "features": [{
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[w, s], [e, s], [e, n], [w, n], [w, s]]],
+            },
+            "properties": props,
+        }],
+    }
+
+
+def _register_change_asset(
+    result_path: str, bbox: List[float], session_id: Optional[str], job_id: Optional[int] = None
+) -> Optional[int]:
+    """把变化检测 GeoJSON 统计产物登记进 UploadRecord 资产表。
+
+    失败不阻断任务（file-only 降级）。``job_id`` 给定时，在**同一个事务内**先确认
+    没有取消请求再插入 -- 资产登记是不可逆副作用，规范 §23 要求已取消的任务
+    不得留下 status=ready 的资产。
+    """
+    try:
+        with db_session() as db:
+            if job_id is not None and DurableJobStore.is_cancel_requested_sync(db, job_id):
+                raise OperationCancelled("cancelled before asset registration", job_id=job_id)
+            record = UploadRecord(
+                filename=result_path,
+                original_name=os.path.basename(result_path),
+                file_type="vector",
+                format="geojson",
+                crs="EPSG:4326",
+                geometry_type="change_detection",
+                feature_count=1,
+                bbox=bbox,
+                file_size=os.path.getsize(result_path) if os.path.exists(result_path) else 0,
+                session_id=session_id,
+            )
+            db.add(record)
+            db.flush()
+            return record.id
+    except OperationCancelled:
+        raise  # 取消不是「登记失败」-- 必须上抛让 durable_job 收敛为 cancelled
+    except Exception as db_err:
+        logger.warning(f"change detection asset persist failed (continuing with file-only): {db_err}")
+        return None
+
+
 @celery_app.task(name="app.services.spatial_tasks.run_change_detection", bind=True)
 def run_change_detection(
     self,
@@ -530,95 +658,139 @@ def run_change_detection(
     index_type: str = "ndvi",
     change_threshold: float = 0.1,
     session_id: Optional[str] = None,
+    job_id: Optional[int] = None,
 ):
     """双时相植被/水体/燃烧指数变化检测。
 
     对同一 bbox 在两个时间窗口分别获取 Sentinel-2 影像并计算指定指数，
     在两期足迹的公共栅格上做像元级差异，按 ±change_threshold 分类为 5 档，
-    输出分类统计与差异预览图。
+    输出分类统计与差异预览图（#445）。
 
     实现策略：复用 SpectralRasterEngine.compute_vegetation_index（异步）
     通过新建事件循环在 Celery worker 进程内顺序执行两次，避免重复实现
     STAC + 波段读取逻辑。
+
+    ADR-0052：``job_id`` 存在时走 durable job 运行时 -- 进度落库、可
+    取消、结果落 ``analysis_results`` 并登记为 GeoJSON 统计资产（此前 .delay 火
+    忘投递：任务不注册资产、/tasks/status/glm-5.3_common 404）。``job_id=None`` 保留旧行为，
+    兼容未迁移的调用方。
     """
-    svc = SpectralRasterEngine()
+    if job_id is None:
+        return _run_change_detection_legacy(
+            self, bbox, t1_from, t1_to, t2_from, t2_to, index_type, change_threshold, session_id
+        )
 
-    async def compute_both():
-        t1 = await svc.compute_vegetation_index(bbox, t1_from, t1_to, index_type=index_type)
-        t2 = await svc.compute_vegetation_index(bbox, t2_from, t2_to, index_type=index_type)
-        return t1, t2
+    try:
+        with durable_job(job_id, celery_task=self) as job:
+            job.progress(5, "初始化遥感服务", phase="init")
+            job.checkpoint()
+            job.progress(20, f"拉取 T1 ({t1_from}~{t1_to}) Sentinel-2", phase="fetch")
+            t1, t2 = _compute_change_indices(bbox, t1_from, t1_to, t2_from, t2_to, index_type)
 
+            if "error" in t1:
+                raise _ChangeDetectionError(f"T1 计算失败: {t1['error']}")
+            if "error" in t2:
+                raise _ChangeDetectionError(f"T2 计算失败: {t2['error']}")
+
+            job.progress(80, "计算变化分类", phase="classify")
+            data = _build_change_data(
+                bbox, t1_from, t1_to, t2_from, t2_to, t1, t2, index_type, change_threshold
+            )
+
+            # 统计结果是 JSON 而非栅格：推图不适用，改为落 GeoJSON 统计资产
+            # （bbox 多边形 + 统计属性），经 UploadRecord 挂到会话
+            job.progress(85, "落盘统计结果并登记资产", phase="persist")
+            out_dir = os.path.join(settings.DATA_DIR, "analysis_results")
+            os.makedirs(out_dir, exist_ok=True)
+            final_path = os.path.join(out_dir, f"change_detection_{job_id}_{int(time.time())}.geojson")
+            with job.artifact(final_path) as tmp_path:
+                with open(tmp_path, "w", encoding="utf-8") as f:
+                    json.dump(_change_result_geojson(data, bbox), f, ensure_ascii=False)
+
+            # 资产登记是不可逆副作用：强制读一次持久取消事实（规范 §23）
+            job.ensure_not_cancelled()
+            asset_id = _register_change_asset(final_path, bbox, session_id, job_id=job_id)
+            payload = {
+                "asset_id": asset_id,
+                "result_path": final_path,
+                "data": data,
+            }
+            result_data = {**data, "asset_id": asset_id, "result_path": final_path}
+
+        status = finish_job(job_id, result=payload, result_ref=final_path)
+        return {
+            "success": status.value == "completed",
+            "job_id": str(job_id),
+            "status": status.value,
+            "data": result_data,
+            "status_desc": (
+                f"{index_type.upper()} 变化检测完成：{data['change']['category']}"
+                f"（Δmean={data['change']['delta_mean']}），统计结果已保存为 GeoJSON 资产。"
+            ),
+        }
+    except AlreadyFinished as e:
+        # 重复投递（acks_late 下 broker 可能重投）或提交前已被取消
+        logger.info(f"run_change_detection skipped: {e}")
+        return {"success": False, "skipped": True, "job_id": str(job_id), "error": str(e)}
+    except OperationCancelled:
+        logger.info(f"run_change_detection cancelled job_id={job_id}")
+        return {"success": False, "cancelled": True, "job_id": str(job_id)}
+    except _ChangeDetectionError as e:
+        # 业务性失败（T1/T2 计算失败）：durable_job 已把 job 落成 failed，这里
+        # 保留 dict 返回语义（仅意外异常才让 Celery 记 FAILURE）
+        logger.warning(f"run_change_detection business failure job_id={job_id}: {e}")
+        return {"success": False, "job_id": str(job_id), "error": str(e)}
+    except Exception as e:
+        # 意外异常：上抛让 Celery 记录 FAILURE（此前吞掉返回 dict 会被
+        # 视为 SUCCESS，超时/崩溃语义与统计全部失效）；durable_job 已落 failed 终态
+        logger.error(f"run_change_detection failed: {e}", exc_info=True)
+        raise
+
+
+def _run_change_detection_legacy(
+    task,
+    bbox: List[float],
+    t1_from: str,
+    t1_to: str,
+    t2_from: str,
+    t2_to: str,
+    index_type: str,
+    change_threshold: float,
+    session_id: Optional[str],
+):
+    """ADR-0052 之前的变化检测路径。无 durable job 时的兼容分支。"""
     try:
         # 直接调用（测试/shell）时 request.id 可能为 None，update_state 会抛
         # "task_id must not be empty"（同 _run_ndvi_legacy 的回退处理）。
-        _task_id = self.request.id or f"legacy-change-{os.getpid()}"
-        self.update_state(task_id=_task_id, state='PROGRESS', meta={'progress': 5, 'message': '初始化遥感服务'})
-        self.update_state(task_id=_task_id, state='PROGRESS', meta={'progress': 20, 'message': f'拉取 T1 ({t1_from}~{t1_to}) Sentinel-2'})
-
-        # 使用新事件循环执行 async 代码，兼容 prefork / gevent 池
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            t1, t2 = loop.run_until_complete(compute_both())
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
+        _task_id = task.request.id or f"legacy-change-{os.getpid()}"
+        task.update_state(
+            task_id=_task_id, state='PROGRESS',
+            meta={'progress': 5, 'message': '初始化遥感服务'},
+        )
+        task.update_state(
+            task_id=_task_id, state='PROGRESS',
+            meta={'progress': 20, 'message': f'拉取 T1 ({t1_from}~{t1_to}) Sentinel-2'},
+        )
+        t1, t2 = _compute_change_indices(bbox, t1_from, t1_to, t2_from, t2_to, index_type)
 
         if "error" in t1:
             return {"success": False, "error": f"T1 计算失败: {t1['error']}"}
         if "error" in t2:
             return {"success": False, "error": f"T2 计算失败: {t2['error']}"}
 
-        self.update_state(task_id=_task_id, state='PROGRESS', meta={'progress': 80, 'message': '计算变化分类'})
-
-        # #445: pixel-level difference on the two epochs' common footprint —
-        # the two scene means come from independent acquisitions whose read
-        # windows (#381) may cover different footprints, so they are not
-        # directly comparable. Only fall back to the scene-mean comparison
-        # when no pixel comparison is possible.
-        delta_mean = None
-        category = "unknown"
-        method = "scene_mean_fallback"
-        classification: Optional[Dict] = None
-
-        pixel = _pixel_change_classification(t1, t2, change_threshold)
-        if pixel is not None:
-            method = pixel["method"]
-            delta_mean = pixel["delta_mean"]
-            category = pixel["category"]
-            classification = pixel
-        else:
-            mean_t1 = t1.get("stats", {}).get("mean")
-            mean_t2 = t2.get("stats", {}).get("mean")
-            if mean_t1 is not None and mean_t2 is not None:
-                delta_mean = round(mean_t2 - mean_t1, 4)
-                category = _classify_delta(delta_mean, change_threshold)
-
+        task.update_state(
+            task_id=_task_id, state='PROGRESS',
+            meta={'progress': 80, 'message': '计算变化分类'},
+        )
+        data = _build_change_data(
+            bbox, t1_from, t1_to, t2_from, t2_to, t1, t2, index_type, change_threshold
+        )
         return {
             "success": True,
-            "data": {
-                "index_type": index_type.upper(),
-                "bbox": bbox,
-                "t1": {
-                    "period": f"{t1_from} ~ {t1_to}",
-                    "stats": t1.get("stats", {}),
-                    "cloud_cover": t1.get("cloud_cover"),
-                },
-                "t2": {
-                    "period": f"{t2_from} ~ {t2_to}",
-                    "stats": t2.get("stats", {}),
-                    "cloud_cover": t2.get("cloud_cover"),
-                },
-                "change": {
-                    "delta_mean": delta_mean,
-                    "category": category,
-                    "threshold": change_threshold,
-                    "method": method,
-                    "classification": classification,
-                },
-            },
-            "status_desc": f"{index_type.upper()} 变化检测完成：{category}（Δmean={delta_mean}）",
+            "data": data,
+            "status_desc": f"{index_type.upper()} 变化检测完成：{data['change']['category']}（Δmean={data['change']['delta_mean']}）",
         }
     except Exception as e:
+        # 意外异常上抛让 Celery 记录 FAILURE（此前吞掉返回 dict 会被视为 SUCCESS）
         logger.error(f"run_change_detection failed: {e}", exc_info=True)
-        return {"success": False, "error": str(e)}
+        raise

--- a/app/tools/change_detection.py
+++ b/app/tools/change_detection.py
@@ -7,6 +7,7 @@ from typing import Optional
 from pydantic import BaseModel, Field
 from app.tools.registry import ToolRegistry, tool
 from app.services.spatial_tasks import run_change_detection
+from app.services.jobs.submit import submit_durable_job
 from app.tools._utils import parse_bbox
 
 logger = logging.getLogger(__name__)
@@ -66,32 +67,26 @@ def register_change_detection_tools(registry: ToolRegistry):
                 "error": f"不支持的指数类型 '{index_type}'，可用: {', '.join(valid_indices)}"
             }
 
-        # 触发 Celery 异步任务
-        task = run_change_detection.delay(
-            bbox=parts,
-            t1_from=t1_from,
-            t1_to=t1_to,
-            t2_from=t2_from,
-            t2_to=t2_to,
-            index_type=index_type.lower(),
-            change_threshold=change_threshold,
-            session_id=session_id,
-        )
-
-        return {
-            "status": "change_detection_task_started",
-            "task_id": task.id,
-            "message": (
-                f"{index_type.upper()} 双时相变化检测任务已启动。"
-                f"T1: {t1_from}~{t1_to} vs T2: {t2_from}~{t2_to}。"
-                "后台正在自动获取 Sentinel-2 影像并计算差异，"
-                "完成后结果将自动推送到地图并进入资产库。"
-            ),
-            "parameters": {
+        # ADR-0052：走 durable job 投递 -- 任务注册进任务中心（进度/取消/
+        # 结果可查，celery_task_id 回填后 /tasks/status/glm-5.3_common 也可查），统计结果由
+        # worker 落为 GeoJSON 资产。此前 .delay 火忘投递：任务不注册资产、状态
+        # 404，返回消息却承诺「自动推送到地图并进入资产库」。
+        return submit_durable_job(
+            celery_task=run_change_detection,
+            task_type="change_detection",
+            display_name=f"{index_type.upper()} 双时相变化检测",
+            params={
                 "bbox": parts,
-                "t1_period": f"{t1_from} to {t1_to}",
-                "t2_period": f"{t2_from} to {t2_to}",
+                "t1_from": t1_from,
+                "t1_to": t1_to,
+                "t2_from": t2_from,
+                "t2_to": t2_to,
                 "index_type": index_type.lower(),
                 "change_threshold": change_threshold,
             },
-        }
+            task_args=(
+                parts, t1_from, t1_to, t2_from, t2_to,
+                index_type.lower(), change_threshold, session_id,
+            ),
+            session_id=session_id,
+        )

--- a/frontend/components/sidebar/data-sources-tab.test.tsx
+++ b/frontend/components/sidebar/data-sources-tab.test.tsx
@@ -192,8 +192,8 @@ const fetchRef = () => vi.mocked(dataFabricApi.fetchRefGeoJSON);
 const GEOJSON = {
   type: 'FeatureCollection' as const,
   features: [
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
   ],
 };
 

--- a/tests/test_spatial_tasks.py
+++ b/tests/test_spatial_tasks.py
@@ -1,4 +1,14 @@
 """Tests for spatial_tasks Celery task definitions."""
+import asyncio
+import contextlib
+import json as _json
+import os
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.db_model import Base
 
 
 def test_no_spatial_join_task():
@@ -35,3 +45,339 @@ def test_valid_tasks_exist():
         "run_overlay_analysis", "run_attribute_filter", "run_path_analysis",
     ):
         assert not hasattr(spatial_tasks, dead), f"{dead} should have been deleted (D1)"
+
+
+# ── PR2: 变化检测送达链路 & 热力图 Celery/进程内契约一致 ──────────────
+
+
+@pytest.fixture
+def job_db(tmp_path, monkeypatch):
+    """把 `db_session`（工具/worker 用的同步会话）指向临时 SQLite。
+
+    复用 tests/jobs/test_job_celery_e2e.py 的搭建方式。
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'pr2.db'}")
+    Base.metadata.create_all(engine)
+    Sess = sessionmaker(bind=engine)
+
+    @contextlib.contextmanager
+    def fake_db_session():
+        db = Sess()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    for target in (
+        "app.tools._utils.db_session",
+        "app.services.jobs.submit.db_session",
+        "app.services.spatial_tasks.db_session",
+        "app.services.jobs.worker._default_session_factory",
+    ):
+        monkeypatch.setattr(target, fake_db_session)
+    yield {"factory": fake_db_session, "Sess": Sess}
+    engine.dispose()
+
+
+def _make_change_job(job_db) -> int:
+    from app.services.jobs import DurableJobStore, JobKind, JobStatus
+
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.create_sync(
+            db,
+            dispatch_spec={"task": "app.services.spatial_tasks.run_change_detection"},
+            task_type="change_detection",
+            kind=JobKind.analysis,
+            parameters={"bbox": [116.0, 39.0, 116.1, 39.1]},
+            session_id="sess-a",
+        )
+        DurableJobStore.transition_sync(db, job.id, JobStatus.queued, expected=[JobStatus.pending])
+        db.commit()
+        return int(job.id)
+
+
+def _fake_spectral_engine(monkeypatch, t1=None, t2=None):
+    """替换 SpectralRasterEngine，返回受控的两期指数结果（按起始日期区分 T1/T2）。"""
+    from app.services import spatial_tasks
+
+    t1 = t1 if t1 is not None else {"stats": {"mean": 0.5}, "cloud_cover": 5.0}
+    t2 = t2 if t2 is not None else {"stats": {"mean": 0.45}, "cloud_cover": 8.0}
+    instance = type("E", (), {})()
+
+    async def fake_compute(bbox, date_from, date_to, index_type="ndvi"):
+        return dict(t2 if date_from.startswith("2023-06") else t1)
+
+    instance.compute_vegetation_index = fake_compute
+    monkeypatch.setattr(spatial_tasks, "SpectralRasterEngine", lambda: instance)
+
+
+def _task_stub(monkeypatch):
+    """Celery bind=True 任务体直接调用时的 self 桩（update_state 在无 backend 时会抛）。"""
+    from app.services import spatial_tasks
+
+    monkeypatch.setattr(spatial_tasks.run_change_detection, "update_state", lambda **kw: None)
+
+
+def test_change_detection_durable_path_completes_and_registers_asset(job_db, tmp_path, monkeypatch):
+    """job_id 路径走 durable 运行时，结果落 GeoJSON 资产并挂到会话。"""
+    from app.core.config import settings as app_settings
+    from app.models.upload import UploadRecord
+    from app.services import spatial_tasks
+    from app.services.jobs import DurableJobStore, JobStatus, coerce_status
+
+    monkeypatch.setattr(app_settings, "DATA_DIR", str(tmp_path))
+    job_id = _make_change_job(job_db)
+    _fake_spectral_engine(monkeypatch)
+    _task_stub(monkeypatch)
+
+    res = spatial_tasks.run_change_detection(
+        bbox=[116.0, 39.0, 116.1, 39.1],
+        t1_from="2023-01-01", t1_to="2023-01-10",
+        t2_from="2023-06-01", t2_to="2023-06-10",
+        index_type="ndvi", change_threshold=0.1,
+        session_id="sess-a", job_id=job_id,
+    )
+
+    assert res["success"] is True
+    assert res["job_id"] == str(job_id)
+    assert res["data"]["change"]["category"] == "no_change"
+    assert res["data"]["asset_id"] is not None
+
+    result_path = res["data"]["result_path"]
+    assert result_path.startswith(str(tmp_path / "analysis_results"))
+    assert result_path.endswith(".geojson")
+
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_id)
+        assert coerce_status(job.status) is JobStatus.completed
+        assert job.result_ref == result_path
+        # 结果可取回（任务中心/LLM 可读取的统计摘要）
+        assert job.result_summary["data"]["change"]["category"] == "no_change"
+
+        rec = db.query(UploadRecord).one()
+        assert rec.session_id == "sess-a"
+        assert rec.format == "geojson"
+        assert rec.geometry_type == "change_detection"
+        assert rec.bbox == [116.0, 39.0, 116.1, 39.1]
+
+    with open(result_path, encoding="utf-8") as f:
+        geojson = _json.load(f)
+    props = geojson["features"][0]["properties"]
+    assert props["analysis"] == "change_detection"
+    assert props["category"] == "no_change"
+    assert os.path.exists(result_path)
+
+
+def test_change_detection_business_failure_keeps_dict_semantics(job_db, tmp_path, monkeypatch):
+    """T1/T2 计算失败保留 dict 返回（业务失败），job 落 failed。"""
+    from app.core.config import settings as app_settings
+    from app.services import spatial_tasks
+    from app.services.jobs import DurableJobStore, JobStatus, coerce_status
+
+    monkeypatch.setattr(app_settings, "DATA_DIR", str(tmp_path))
+    job_id = _make_change_job(job_db)
+    _fake_spectral_engine(monkeypatch, t1={"error": "STAC 查询无可用影像"})
+    _task_stub(monkeypatch)
+
+    res = spatial_tasks.run_change_detection(
+        bbox=[116.0, 39.0, 116.1, 39.1],
+        t1_from="2023-01-01", t1_to="2023-01-10",
+        t2_from="2023-06-01", t2_to="2023-06-10",
+        index_type="ndvi", change_threshold=0.1,
+        session_id="sess-a", job_id=job_id,
+    )
+
+    assert res["success"] is False
+    assert "T1 计算失败" in res["error"]
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_id)
+        assert coerce_status(job.status) is JobStatus.failed
+
+
+def test_change_detection_unexpected_exception_raises(job_db, tmp_path, monkeypatch):
+    """意外异常必须上抛（Celery 记 FAILURE），不得吞成 SUCCESS dict。"""
+    from app.core.config import settings as app_settings
+    from app.services import spatial_tasks
+    from app.services.jobs import DurableJobStore, JobStatus, coerce_status
+
+    monkeypatch.setattr(app_settings, "DATA_DIR", str(tmp_path))
+    job_id = _make_change_job(job_db)
+    monkeypatch.setattr(
+        spatial_tasks, "SpectralRasterEngine",
+        lambda: (_ for _ in ()).throw(RuntimeError("worker exploded")),
+    )
+    _task_stub(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="worker exploded"):
+        spatial_tasks.run_change_detection(
+            bbox=[116.0, 39.0, 116.1, 39.1],
+            t1_from="2023-01-01", t1_to="2023-01-10",
+            t2_from="2023-06-01", t2_to="2023-06-10",
+            index_type="ndvi", change_threshold=0.1,
+            session_id="sess-a", job_id=job_id,
+        )
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_id)
+        assert coerce_status(job.status) is JobStatus.failed
+
+
+def test_change_detection_geojson_asset_trims_preview_blob(job_db, tmp_path, monkeypatch):
+    """吸收 #445 后的资产契约：像元分类进任务结果，preview_png_b64 不进 GeoJSON 资产。"""
+    import numpy as np
+
+    from app.core.config import settings as app_settings
+    from app.services import spatial_tasks
+
+    monkeypatch.setattr(app_settings, "DATA_DIR", str(tmp_path))
+    job_id = _make_change_job(job_db)
+
+    def _epoch(array):
+        return {
+            "stats": {"mean": float(np.mean(array))},
+            "cloud_cover": 0.0,
+            "raster_source": {"array": array, "bounds": [0.0, 0.0, 1.0, 1.0]},
+        }
+
+    t1 = _epoch(np.full((4, 4), 0.3))
+    t2_arr = np.full((4, 4), 0.3)
+    t2_arr[0:2, 0:2] = 0.9  # +0.6 -> significant_improvement
+    _fake_spectral_engine(monkeypatch, t1=t1, t2=_epoch(t2_arr))
+    _task_stub(monkeypatch)
+
+    res = spatial_tasks.run_change_detection(
+        bbox=[116.0, 39.0, 116.1, 39.1],
+        t1_from="2023-01-01", t1_to="2023-01-10",
+        t2_from="2023-06-01", t2_to="2023-06-10",
+        index_type="ndvi", change_threshold=0.1,
+        session_id="sess-a", job_id=job_id,
+    )
+
+    assert res["success"] is True
+    change = res["data"]["change"]
+    assert change["method"] == "pixel_common_footprint"
+    # 任务结果（任务中心/LLM 可读）保留预览图与分类统计
+    assert change["classification"]["preview_png_b64"]
+    assert change["classification"]["class_counts"]["significant_improvement"] == 4
+
+    with open(res["data"]["result_path"], encoding="utf-8") as f:
+        props = _json.load(f)["features"][0]["properties"]
+    cls = props["classification"]
+    assert "preview_png_b64" not in cls  # GeoJSON 资产裁掉 base64 PNG blob
+    assert props["method"] == "pixel_common_footprint"
+    assert cls["class_counts"]["significant_improvement"] == 4
+    assert cls["class_percentages"]["significant_improvement"] == 25.0
+
+
+def test_change_detection_legacy_path_still_works():
+    """job_id=None 的兼容分支保留原行为（update_state + 统计 dict）。"""
+    from unittest.mock import patch
+
+    from app.services.spatial_tasks import run_change_detection
+
+    with patch("app.services.spatial_tasks.SpectralRasterEngine") as mock_rss, \
+         patch.object(run_change_detection, "update_state"):
+        instance = mock_rss.return_value
+
+        async def mock_compute_vi(bbox, date_from, date_to, index_type):
+            return {"stats": {"mean": 0.5}, "cloud_cover": 5.0}
+
+        instance.compute_vegetation_index.side_effect = mock_compute_vi
+
+        res = run_change_detection(
+            bbox=[116.0, 39.0, 116.1, 39.1],
+            t1_from="2023-01-01", t1_to="2023-01-10",
+            t2_from="2023-06-01", t2_to="2023-06-10",
+            index_type="ndvi", change_threshold=0.1,
+        )
+        assert res["success"] is True
+        assert res["data"]["change"]["category"] == "no_change"
+
+
+def test_detect_vegetation_change_tool_submits_durable_job(job_db, tmp_path, monkeypatch):
+    """工具不再 .delay 火忘投递 —— 经 submit_durable_job 注册任务中心可查。"""
+    from app.core.config import settings as app_settings
+    from app.services.jobs import DurableJobStore, JobStatus, coerce_status
+    from app.tools.change_detection import register_change_detection_tools
+    from app.tools.registry import ToolRegistry
+
+    monkeypatch.setattr(app_settings, "DATA_DIR", str(tmp_path))
+
+    enqueued: list[dict] = []
+
+    class _FakeTask:
+        name = "app.services.spatial_tasks.run_change_detection"
+
+        def apply_async(self, args=None, kwargs=None, **_):
+            enqueued.append({"args": args, "kwargs": kwargs})
+
+            class _R:
+                id = "celery-cd-1"
+
+            return _R()
+
+    monkeypatch.setattr("app.tools.change_detection.run_change_detection", _FakeTask())
+
+    registry = ToolRegistry()
+    register_change_detection_tools(registry)
+
+    result = asyncio.run(registry.dispatch(
+        "detect_vegetation_change",
+        {
+            "bbox": "[116.0, 39.0, 116.1, 39.1]",
+            "t1_from": "2023-01-01", "t1_to": "2023-01-10",
+            "t2_from": "2023-06-01", "t2_to": "2023-06-10",
+        },
+        session_id="sess-a",
+    ))
+
+    assert result["status"] == "analysis_task_started"
+    assert result["job_id"]
+    # 消息诚实：不再承诺「自动推送到地图」
+    assert "推送到地图" not in result["message"]
+    assert len(enqueued) == 1
+    args = enqueued[0]["args"]
+    assert args[0] == [116.0, 39.0, 116.1, 39.1]
+    assert "job_id" in enqueued[0]["kwargs"]
+
+    job_id = int(result["job_id"])
+    with job_db["Sess"]() as db:
+        job = DurableJobStore.get_sync(db, job_id)
+        assert job is not None, "任务中心必须能查到该 job"
+        assert coerce_status(job.status) is JobStatus.queued
+        assert job.task_type == "change_detection"
+        assert job.parameters["index_type"] == "ndvi"
+
+
+@pytest.mark.heavy
+def test_heatmap_celery_path_matches_inprocess_contract():
+    """Celery 路径与进程内回退共用实现 —— palette 生效且写 metadata。"""
+    from app.lib.geo_analysis.density import generate_heatmap_raster
+    from app.services.spatial_tasks import _do_heatmap_generation
+
+    features = [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [116.4, 39.9]}}]
+
+    for palette in ("magma", "viridis", "classic"):
+        via_celery = _do_heatmap_generation(features, 500, 1000, "raster", palette)
+        inprocess = generate_heatmap_raster(features, 500, 1000, "raster", palette)
+        assert via_celery["success"] is True
+        # metadata 契约一致（前端 legend 依赖），palette 真实回传
+        assert via_celery["data"]["metadata"] == inprocess["data"]["metadata"]
+        assert via_celery["data"]["metadata"]["palette"] == palette
+
+    grid = _do_heatmap_generation(features, 500, 1000, "grid", "viridis")
+    assert grid["success"] is True
+    assert grid["data"]["metadata"]["palette"] == "viridis"
+
+
+@pytest.mark.heavy
+def test_heatmap_celery_path_empty_features_keeps_success_false():
+    """空点集分支保留 Celery 结果消费方依赖的 success=False 语义。"""
+    from app.services.spatial_tasks import _do_heatmap_generation
+
+    result = _do_heatmap_generation(features=[], cell_size=500, radius=1000)
+    assert result["success"] is False
+    assert "No valid point features found" in result["error"]


### PR DESCRIPTION
## 问题（2×P1 + P2）

1. **[P1] 火忘投递**：`app/tools/change_detection.py:68` 原先 `run_change_detection.delay()` 直投 Celery——不注册任务中心、不落资产、`/tasks/status/{id}` 404，但返回消息承诺"自动推送到地图并进入资产库"。
2. **[P1] 热力图契约分裂**：Celery 路径（`spatial_tasks.py:147`）硬编码 `YlOrRd`，`palette` 参数被忽略、不写 metadata（legend 恒 0/1）；进程内回退路径（`density.py:552`）按 `_HEATMAP_PALETTES` 取色，两路径输出不一致。
3. **[P2] 异常吞噬**：`spatial_tasks.py:454` 吞掉所有异常返回 dict，Celery 视为 SUCCESS，失败对监控不可见。

## 修复

- 变化检测迁移到 `submit_durable_job`（参照 `nature_resources.py` 模式）：任务落任务中心（进度/取消/结果可查，celery_task_id 回填），worker 将统计结果落为 GeoJSON 资产（bbox 多边形+统计属性）并登记 UploadRecord 挂到会话；返回消息改为诚实话术。结果为统计 JSON 非栅格，不推图。保留 `job_id=None` legacy 兼容路径
- 热力图 Celery 路径改为薄委托 `density.generate_heatmap_raster`，palette/metadata 与进程内路径天然一致；删除从未被调用的死 `callback` 参数；空点集补 `success=False`
- 意外异常改 `raise` 让 Celery 记 FAILURE（durable_job 先落 failed 终态）；业务性失败（T1/T2 计算失败）保留 dict 语义

## 验证

- 基线 260 passed → 修复后 **267 passed**（含新增 7 测试：durable 完成+资产登记、业务失败、意外异常 raise、legacy 兼容、工具层 submit 桥、热力图双路径 metadata 一致、空点集）
- `ruff check` 三文件通过

来源：全库深度审查（8 个独立修复 PR 之一）。