### PR TITLE
fix(fe): 模板库「应用」真正派发地图动作；explorer 深度搜索进度可见

### DIFF
--- a/frontend/components/sidebar/tasks-tab.tsx
+++ b/frontend/components/sidebar/tasks-tab.tsx
@@ -22,6 +22,7 @@ import { useHudStore } from '@/lib/store/useHudStore';
 import { EmptyState } from '@/components/shared/empty-state';
 import { IconButton } from '@/components/shared/icon-button';
 import { InlineNotice } from '@/components/shared/inline-notice';
+import { ExplorerProgressPanel } from '@/components/explorer/explorer-progress-panel';
 import { LoadingState } from '@/components/shared/loading-state';
 import { StatusBadge } from '@/components/shared/status-badge';
 
@@ -224,6 +225,9 @@ export function TasksTab({ sessionId, ownerToken }: TasksTabProps) {
       )}
 
       <div className="flex-1 space-y-2 overflow-y-auto px-panel py-2">
+        {/* 深度探索（explorer_progress SSE 驱动，任务条目由 use-sse-stream 首见
+            插入 store）；无任务时组件自渲染 null，不影响空态展示。 */}
+        <ExplorerProgressPanel />
         {jobs.length === 0 && loading ? (
           <LoadingState label="加载任务…" />
         ) : jobs.length === 0 ? (

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -691,5 +691,82 @@ describe('useSSEStream — plan approval rollback (#468)', () => {
       await new Promise((r) => setTimeout(r, 20));
     });
     expect(planMsg().status).toBe('pending');
+describe('useSSEStream explorer_progress（回归：任务条目首见插入，进度可见）', () => {
+  beforeEach(() => {
+    bridgeMock.onEventCallback = null;
+    useHudStore.setState({ explorerTasks: [] });
+  });
+
+  function emitExplorer(data: Record<string, unknown>) {
+    act(() => {
+      bridgeMock.onEventCallback?.({ event: 'explorer_progress', data });
+    });
+  }
+
+  it('首次见到 task_id 插入任务条目（字段来自事件），后续事件只更新', () => {
+    renderStream();
+    emitExplorer({
+      session_id: 'sid-fe4',
+      task_id: 'exp-1',
+      stage: 'discover',
+      status: 'progress',
+      context: { progress: 30, query: '北京学校分布' },
+    });
+    let tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      taskId: 'exp-1',
+      stage: 'discover',
+      status: 'discovering',
+      progress: 30,
+      query: '北京学校分布',
+    });
+
+    emitExplorer({
+      session_id: 'sid-fe4',
+      task_id: 'exp-1',
+      stage: 'geocode',
+      status: 'progress',
+      context: { progress: 80 },
+    });
+    tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(1); // 更新而非重复插入
+    expect(tasks[0]).toMatchObject({ stage: 'geocode', status: 'geocoding', progress: 80 });
+
+    emitExplorer({
+      session_id: 'sid-fe4',
+      task_id: 'exp-1',
+      stage: 'validate',
+      status: 'completed',
+      context: { progress: 100 },
+    });
+    tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].status).toBe('completed');
+  });
+
+  it('Celery PENDING 首帧（stage=pending）插入 idle 条目而不是非法 stage', () => {
+    renderStream();
+    emitExplorer({
+      session_id: 'sid-fe4',
+      task_id: 'exp-2',
+      stage: 'pending',
+      status: 'started',
+      context: { progress: 0 },
+    });
+    const tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].stage).toBe('discover');
+    expect(tasks[0].status).toBe('idle');
+  });
+
+  it('第二个 task_id 各自插入，互不覆盖', () => {
+    renderStream();
+    emitExplorer({ session_id: 'sid-fe4', task_id: 'exp-a', stage: 'fetch', status: 'progress', context: { progress: 10 } });
+    emitExplorer({ session_id: 'sid-fe4', task_id: 'exp-b', stage: 'parse', status: 'progress', context: { progress: 50 } });
+    const tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(2);
+    expect(tasks.map((t) => t.taskId)).toEqual(['exp-a', 'exp-b']);
+)
   });
 });

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -721,22 +721,56 @@ export function useSSEStream(
           }),
         );
       } else if (event.event === 'explorer_progress') {
+        // 后端事件字段（orchestrator.stream_progress）：task_id / stage
+        // （含 "pending"，Celery PENDING 时 meta 为空）/ status（started |
+        // progress | decision_point | completed | failed）/ context.progress。
+        // 首次见到 task_id 时先插入任务条目（explorerTasks 此前恒空导致进度
+        // 永不可见），后续更新走 updateExplorerTask。
         const taskId = data.task_id as string;
-        const stage = data.stage as import('@/lib/types/explorer').ExplorerStage;
+        if (typeof taskId !== 'string' || !taskId) return;
+        const rawStage = typeof data.stage === 'string' ? data.stage : 'pending';
+        const stage = (rawStage === 'pending' ? 'discover' : rawStage) as import('@/lib/types/explorer').ExplorerStage;
         const status = data.status as string;
         const context = (data.context as Record<string, unknown>) || {};
-        useHudStore.getState().updateExplorerTask(taskId, {
-          stage,
-          status:
-            status === 'completed'
-              ? 'completed'
-              : status === 'failed'
-              ? 'failed'
-              : status === 'decision_point'
-              ? 'decision_required'
-              : (`${stage}ing` as any),
-          progress: (context?.progress as number) || 0,
-        });
+        // stage → 进行时状态（geocode/validate 需去 e，不能裸拼 +ing）
+        const ACTIVE_STATUS: Record<string, import('@/lib/types/explorer').ExplorerStatus> = {
+          discover: 'discovering',
+          fetch: 'fetching',
+          parse: 'parsing',
+          geocode: 'geocoding',
+          validate: 'validating',
+        };
+        const nextStatus: import('@/lib/types/explorer').ExplorerStatus =
+          status === 'completed'
+            ? 'completed'
+            : status === 'failed'
+            ? 'failed'
+            : status === 'decision_point'
+            ? 'decision_required'
+            : rawStage === 'pending'
+            ? 'idle'
+            : (ACTIVE_STATUS[rawStage] ?? 'idle');
+        const progress = (context?.progress as number) || 0;
+        const store = useHudStore.getState();
+        if (!store.explorerTasks.some((tk) => tk.taskId === taskId)) {
+          store.addExplorerTask({
+            taskId,
+            status: nextStatus,
+            stage,
+            progress,
+            query:
+              (typeof context.query === 'string' && context.query) ||
+              `深度探索 ${taskId.slice(0, 8)}`,
+            startedAt: Date.now(),
+            updatedAt: Date.now(),
+          });
+        } else {
+          store.updateExplorerTask(taskId, {
+            stage,
+            status: nextStatus,
+            progress,
+          });
+        }
       }
     },
     [setSessionId, sessionIdRef, sessionTokenRef, rememberSessionToken, markToolCallStatus]


### PR DESCRIPTION
## 问题（P1，rebase 后剩余范围）

`use-sse-stream.ts` 的 `explorer_progress` 处理只调 `updateExplorerTask`（仅 map 更新、不插入），`addExplorerTask` 全库零调用方 -> `explorerTasks` 恒空。master #493（c451877）修复了后端整链路状态/SSE（orchestrator 逐阶段下发事件），但前端这条路径无人修--**后端事件到达后进度仍然永远不可见**。

附带缺陷：状态由裸拼 \`+ing\` 生成，产生非法状态 \`"geocodeing"\`（合法值为 \`"geocoding"\`）；`ExplorerProgressPanel` 组件存在但全库零引用。

## 修复

- SSE 首见 task_id 先 `addExplorerTask` 插入条目，后续 update（多任务隔离、不重复插入）
- 显式 stage->status 映射表，与 c451877 的后端事件契约逐一对齐（pending/各阶段/终态 completed/failed/decision_required）
- `ExplorerProgressPanel` 零侵入挂到任务中心 tab 顶部

## Rebase 说明

原 PR 的另一半（模板库「假应用」）已被 master #490（88923db）以更完整实现取代，且原实现依赖列表接口不会返回的 payload（summary DTO 剥离），对真实后端是静默 no-op，故放弃。详见评论区 rebase 说明。

## 验证

- vitest use-sse-stream + tasks-tab **45 passed**；`npm run typecheck` exit=0
- 分支 = 4f9030b + explorer 修复 + 携带的 #502 typecheck 修复（先合入方生效、后合入方 no-op）

来源：全库深度审查（8 个独立修复 PR 之一）。