### PR TITLE
fix(db): 会话上限按用户分桶驱逐；列表去全量消息加载；报告表去重复索引

### DIFF
--- a/app/models/report.py
+++ b/app/models/report.py
@@ -13,10 +13,12 @@ class Report(Base):
     __tablename__ = "reports"
 
     id = Column(String(36), primary_key=True)
-    session_id = Column(String(255), nullable=False, index=True)
+    # 索引只在 __table_args__ 的显式 Index 声明（idx_report_*），不再加
+    # index=True —— 否则 create_all 路径会对同列建出两份索引。
+    session_id = Column(String(255), nullable=False)
     title = Column(String(500), nullable=False, default="分析报告")
     format = Column(String(20), nullable=False, default="pdf")
-    status = Column(String(20), nullable=False, default="pending", index=True)
+    status = Column(String(20), nullable=False, default="pending")
     file_path = Column(Text, nullable=True)
     file_size = Column(Integer, nullable=True)
     share_code = Column(String(32), unique=True, nullable=True, index=True)

--- a/app/services/history_service_async.py
+++ b/app/services/history_service_async.py
@@ -33,7 +33,7 @@ from app.services.history_store_protocol import HistoryContext, HistoryStoreProt
 
 logger = logging.getLogger(__name__)
 
-MAX_SESSIONS = 1000
+MAX_SESSIONS = 1000  # 会话数上限；多租户下按 user 分桶执行（见 _enforce_cap）
 
 
 def _is_anonymous(user_id: Optional[str]) -> bool:
@@ -228,7 +228,7 @@ class AsyncHistoryService(HistoryStoreProtocol):
                 )
                 self.db.add(conv)
                 await self.db.flush()
-                await self._enforce_cap()
+                await self._enforce_cap(owner)
                 await self.db.commit()
                 # 重新查询以确保加载了关系
                 result = await self.db.execute(stmt)
@@ -307,7 +307,6 @@ class AsyncHistoryService(HistoryStoreProtocol):
             select(Conversation)
             .where(Conversation.user_id == user_id)
             .order_by(Conversation.updated_at.desc())
-            .options(selectinload(Conversation.messages))
             .offset(offset)
             .limit(limit)
         )
@@ -372,14 +371,23 @@ class AsyncHistoryService(HistoryStoreProtocol):
         await self.db.commit()
         return True
 
-    async def _enforce_cap(self) -> None:
-        total_result = await self.db.execute(select(func.count()).select_from(Conversation))
+    async def _enforce_cap(self, user_id: Optional[str] = None) -> None:
+        """会话数上限驱逐 —— 按 user 分桶（多租户隔离）。
+
+        只统计并驱逐当前调用方自己桶内（user_id 相同，匿名调用方为 NULL 桶）
+        最旧的会话，因此其他用户新建会话绝不会驱逐另一用户的历史。
+        """
+        bucket = Conversation.user_id == user_id  # == None 时生成 IS NULL
+        total_result = await self.db.execute(
+            select(func.count()).select_from(Conversation).where(bucket)
+        )
         total = total_result.scalar_one()
         if total <= MAX_SESSIONS:
             return
         overflow = total - MAX_SESSIONS
         stmt = (
             select(Conversation)
+            .where(bucket)
             .order_by(Conversation.updated_at.asc())
             .limit(overflow)
         )

--- a/frontend/components/sidebar/data-sources-tab.test.tsx
+++ b/frontend/components/sidebar/data-sources-tab.test.tsx
@@ -192,8 +192,8 @@ const fetchRef = () => vi.mocked(dataFabricApi.fetchRefGeoJSON);
 const GEOJSON = {
   type: 'FeatureCollection' as const,
   features: [
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
   ],
 };
 

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -143,3 +143,38 @@ async def test_anonymous_string_is_treated_as_anonymous(session_factory):
     async with session_factory() as db:
         sessions = await AsyncHistoryService(db).list_sessions(user_id="anonymous")
     assert sessions == []
+
+
+@pytest.mark.asyncio
+async def test_enforce_cap_buckets_by_user(session_factory):
+    """会话数上限驱逐按 user 分桶：user-a 触发上限只删自己最旧的，不动 user-b。"""
+    from datetime import datetime, timedelta
+
+    from app.models.db_model import Conversation
+    from app.services.history_service_async import MAX_SESSIONS
+
+    base = datetime(2024, 1, 1)
+    async with session_factory() as db:
+        db.add_all(
+            Conversation(
+                id=f"s-a-{i}",
+                user_id="user-a",
+                title="t",
+                updated_at=base + timedelta(minutes=i),
+            )
+            for i in range(MAX_SESSIONS + 2)
+        )
+        # user-b 的会话是全局最旧的 —— 旧的全局驱逐语义会删掉它
+        db.add(
+            Conversation(id="s-b-old", user_id="user-b", title="t", updated_at=base - timedelta(days=1))
+        )
+        await db.commit()
+
+        svc = AsyncHistoryService(db)
+        await svc._enforce_cap(user_id="user-a")
+        await db.commit()
+
+        assert await db.get(Conversation, "s-a-0") is None
+        assert await db.get(Conversation, "s-a-1") is None
+        assert await db.get(Conversation, "s-a-2") is not None
+        assert await db.get(Conversation, "s-b-old") is not None

--- a/tests/unit/test_conversation_toctou.py
+++ b/tests/unit/test_conversation_toctou.py
@@ -54,7 +54,7 @@ async def test_get_or_create_recovers_from_integrity_conflict(monkeypatch):
             raise IntegrityError("stmt", {}, Exception("UNIQUE constraint failed"))
         return _FakeResult([winner])  # SELECT after conflict: found
 
-    async def _fake_enforce_cap():
+    async def _fake_enforce_cap(user_id=None):
         pass
 
     svc.db = _fake_db(_fake_execute)
@@ -81,7 +81,7 @@ async def test_get_or_create_raises_after_exhausting_retries(monkeypatch):
     async def _fake_execute(stmt, *a, **k):
         raise IntegrityError("stmt", {}, Exception("UNIQUE constraint failed"))
 
-    async def _fake_enforce_cap():
+    async def _fake_enforce_cap(user_id=None):
         pass
 
     svc.db = _fake_db(_fake_execute)


### PR DESCRIPTION
## 问题（2×P1 + P2）

1. **[P1] 跨租户驱逐**：`history_service_async.py:375-390` `_enforce_cap` 全局 1000 会话上限按 updated_at 跨所有用户驱逐最旧会话（级联删 Message）→ 多租户下他人新建会话可静默删除另一用户的历史。
2. **[P1] 全量消息加载**：`list_sessions`（:310）`selectinload(Conversation.messages)` 拉全部消息正文/tool_calls JSON，但调用方（`chat.py:808-816`）只用 id/title/时间戳 → 每次会话列表加载全量消息。
3. **[P2] 重复索引**：`app/models/report.py` session_id/status 同时 `index=True` 与显式 `Index(...)`，create_all 路径同列建两份索引（写放大）。

## 修复

- `_enforce_cap(user_id)` 按调用方分桶（匿名为 IS NULL 桶），每用户上限沿用 1000，只删自己最旧会话——单用户部署语义不变，仅不再删他人会话
- 列表查询去掉 eager load；`expire_on_commit=False` 下会话对象仍可懒加载，无回归
- 删 `index=True` 保留显式 Index——**alembic 路径零变化**（生产索引名不变），仅 create_all 不再建重复 `ix_reports_*`

## 验证

- 相关 8 个测试文件：44 → **45 passed**（新增 `test_enforce_cap_buckets_by_user`：user-a 超限只删自己最旧 2 条，全局最旧的 user-b 会话完好）；`test_cross_tenant_isolation.py` 22 passed
- 同步更新 `test_conversation_toctou.py` 两处假桩签名；`ruff check` 通过

### 行为变更说明

全局总闸（全库合计 ≤1000）随分桶取消，现为每用户 ≤1000。如需总闸可后续加。

来源：全库深度审查（8 个独立修复 PR 之一）。