### PR TITLE
fix(api): 消除事件循环阻塞：报告 PDF 渲染 / 大 GeoJSON 序列化 / data-fabric 远程 IO

### DIFF
--- a/app/api/routes/data_fabric.py
+++ b/app/api/routes/data_fabric.py
@@ -216,7 +216,8 @@ async def create_data_source(
         }
     except Exception as e:
         logger.error(f"Failed to create data source: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
+        # 不回显原始异常（可能含连接串/内网地址）；全文仅在服务端日志。
+        raise HTTPException(status_code=400, detail="数据源创建失败")
 
 
 @router.get("/data-fabric/sources", tags=["Data Fabric / 数据织网"])
@@ -355,7 +356,8 @@ async def sync_data_source_catalog(
         }
     except Exception as e:
         logger.error(f"Catalog sync failed for source '{source_id}': {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
+        # 不回显原始异常；全文仅在服务端日志。
+        raise HTTPException(status_code=400, detail="数据源目录同步失败")
 
 
 @router.get("/data-fabric/catalog", tags=["Data Fabric / 数据织网"])
@@ -521,7 +523,8 @@ async def preview_catalog_item(
         return JSONResponse(status_code=413, content={"success": False, **e.to_dict()})
     except Exception as e:
         logger.error(f"Catalog item preview failed for '{item_id}': {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
+        # 不回显原始异常；全文仅在服务端日志。
+        raise HTTPException(status_code=400, detail="目录项预览失败")
 
 
 @router.post("/data-fabric/catalog/{item_id}/query", tags=["Data Fabric / 数据织网"])
@@ -551,7 +554,8 @@ async def query_catalog_item(
         return JSONResponse(status_code=413, content={"success": False, **e.to_dict()})
     except Exception as e:
         logger.error(f"Catalog item query failed for '{item_id}': {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
+        # 不回显原始异常；全文仅在服务端日志。
+        raise HTTPException(status_code=400, detail="目录项查询失败")
 
 
 @router.post("/data-fabric/materialize", tags=["Data Fabric / 数据织网"])
@@ -589,4 +593,5 @@ async def materialize_catalog_item(
         return JSONResponse(status_code=413, content={"success": False, **e.to_dict()})
     except Exception as e:
         logger.error(f"Materialization failed for catalog item '{req.catalog_item_id}': {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=str(e))
+        # 不回显原始异常（可能含连接串/内网地址）；全文仅在服务端日志。
+        raise HTTPException(status_code=400, detail="目录项实例化失败")

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -240,7 +240,12 @@ class RedisSessionStore(BaseSessionStore):
         from app.schemas.ref_descriptor import compute_descriptor
         descriptor = await asyncio.to_thread(compute_descriptor, ref_id, data)
         descriptor_key = self._descriptor_key(session_id, ref_id)
-        
+
+        # P1: 大 GeoJSON 的 json.dumps 在事件循环上要 0.6-4s（同
+        # tool_dispatch_service 的论证），必须在 pipe 外先线程化序列化，
+        # pipe 事务内只做 set。
+        payload_json = await asyncio.to_thread(json.dumps, data, ensure_ascii=False)
+
         try:
             # Insert first. Evicting before the write used to delete live refs
             # and then return an unavailable sentinel if the insert pipeline
@@ -255,7 +260,7 @@ class RedisSessionStore(BaseSessionStore):
                 )
                 pipe.expire(self._state_key(session_id), STATE_TTL)
                 pipe.sadd(self._active_key(), session_id)
-                pipe.set(data_key, json.dumps(data, ensure_ascii=False), ex=DATA_TTL)
+                pipe.set(data_key, payload_json, ex=DATA_TTL)
                 pipe.set(descriptor_key, json.dumps(descriptor.to_dict(), ensure_ascii=False), ex=DATA_TTL)
                 pipe.zadd(order_key, {ref_id: time.time()})
                 pipe.sadd(self._index_key(session_id), ref_id)
@@ -441,7 +446,8 @@ class RedisSessionStore(BaseSessionStore):
 
             raw_str = raw.decode() if isinstance(raw, bytes) else raw
             try:
-                return json.loads(raw_str)
+                # P1: 大 GeoJSON 反序列化同样离线到工作线程（同 store 的 dumps）。
+                return await asyncio.to_thread(json.loads, raw_str)
             except Exception:
                 return raw_str
         except aioredis.RedisError as e:

--- a/frontend/components/sidebar/data-sources-tab.test.tsx
+++ b/frontend/components/sidebar/data-sources-tab.test.tsx
@@ -192,8 +192,8 @@ const fetchRef = () => vi.mocked(dataFabricApi.fetchRefGeoJSON);
 const GEOJSON = {
   type: 'FeatureCollection' as const,
   features: [
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
   ],
 };
 


### PR DESCRIPTION
## 问题（rebase 后剩余范围：1×P1 + 信息泄露）

1. **[P1] GeoJSON 序列化阻塞事件循环**：`session_data_redis.py` store/get 路径的大 GeoJSON `json.dumps/loads` 直接在事件循环执行（store 路径每次成功工具调用都走）。同项目 `tool_dispatch_service.py` 已论证该量级 dumps 需 0.6–4s 并 offload，但此路径漏掉。**master 未动过此文件，问题仍在。**
2. **信息泄露**：`data_fabric.py` 5 处（create/sync/preview/query/materialize）`detail=str(e)` 把可能含连接串/内网地址的异常文本回显给客户端；`sanitize_error_msg` 只做凭据掩码不脱这些。

## 修复

- Redis store：payload 的 `json.dumps` 在 pipe 事务外先 `to_thread`（事务内只 set）；get 的 `json.loads` 同样 `to_thread`
- 5 处响应改通用文案，全文仍由服务端 `exc_info=True` 日志保留

## Rebase 说明

原 PR 另外两半（报告链路 offload、data-fabric 远程 IO offload）已被 master #487（44005e1）/ #486（4f9030b）以更广覆盖取代，故放弃。详见评论区 rebase 说明。

## 验证

- session-data + data-fabric 全套（含 master 新增 `test_event_loop_offload_425/386`）**218 passed**；ruff 通过
- 分支 = 4f9030b + 本修复 + 携带的 #502 typecheck 修复（先合入方生效、后合入方 no-op）

来源：全库深度审查（8 个独立修复 PR 之一）。