### PR TITLE
fix(deploy): 生产 env 文件、k8s redis 探针、证书路径、弱默认与端口绑定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,11 @@ ENV PYTHONPATH=/app
 # 镜像减小 + 攻击面缩小。
 # 注：使用 bookworm 包名（libgdal32 libgeos-c1v5 libproj25），与 Dockerfile.prod 一致；
 # 之前误用 trixie 的 t64 后缀包名（libgdal32t64 libgeos3.11.1t64）在 bookworm 上不存在。
+# 审计 P2：运行时只需 nodejs（Next standalone server），无 npm 调用
+# （与 Dockerfile.prod 一致），不装 npm 以减小镜像与攻击面。
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libexpat1 libgdal32 libgeos-c1v5 libproj25 \
-    nodejs npm && rm -rf /var/lib/apt/lists/*
+    nodejs && rm -rf /var/lib/apt/lists/*
 
 # Copy frontend standalone output
 COPY --from=frontend-builder /app/frontend/.next/standalone ./frontend/.next/standalone

--- a/deploy/k8s/05-deps-optional.yaml
+++ b/deploy/k8s/05-deps-optional.yaml
@@ -158,8 +158,14 @@ spec:
               name: webgis-secret
               key: REDIS_PASSWORD
         livenessProbe:
+          # 审计 P1：kubelet 只在容器的 command/args 里展开 $(VAR_NAME)，
+          # exec 探针的 command 不做展开 —— 之前的
+          # ["redis-cli","-a","$(REDIS_PASSWORD)","ping"] 把字面量
+          # $(REDIS_PASSWORD) 当密码，探针必败 → 容器被反复杀死重启。
+          # 改用 sh -c 由容器 shell 展开 REDISCLI_AUTH（同 compose 侧写法，
+          # 也避免 -a 把密码暴露在进程列表）。
           exec:
-            command: ["redis-cli", "-a", "$(REDIS_PASSWORD)", "ping"]
+            command: ["sh", "-c", "REDISCLI_AUTH=$REDIS_PASSWORD redis-cli ping"]
           initialDelaySeconds: 10
           periodSeconds: 5
         volumeMounts:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,10 @@
 # ============================================================
 # WebGIS AI Agent 生产环境 Docker Compose
-# 使用: docker-compose -f docker-compose.prod.yml up -d
+# 使用: docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+#
+# 凭证放 .env.prod（gitignored，从入库模板 .env.prod.example 复制后填写，
+# 真实密码严禁写进 .env.prod.example 等可提交文件）。
+# --env-file .env.prod 同时供 ${VAR} 插值（env_file 只传容器，不参与插值）。
 # ============================================================
 services:
   # PostgreSQL 数据库（含 PostGIS）
@@ -10,7 +14,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${DB_USER:-webgis_prod}
-      POSTGRES_PASSWORD: ${DB_PWD:?Set DB_PWD in .env.prod.example}
+      POSTGRES_PASSWORD: ${DB_PWD:?Set DB_PWD in .env.prod}
       POSTGRES_DB: ${DB_NAME:-webgis_prod}
       PGDATA: /var/lib/postgresql/data/pgdata
     ports:
@@ -45,7 +49,7 @@ services:
       --appendonly
       --maxmemory 256mb
       --maxmemory-policy noeviction
-      --requirepass ${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env.prod.example}
+      --requirepass ${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env.prod}
     volumes:
       - redis_prod_data:/data
     healthcheck:
@@ -92,7 +96,8 @@ services:
       # 之前 mount /app/frontend/out/uploads 但应用写 ./data/uploads/，导致上传丢失。
       - DATA_DIR=/app
     env_file:
-      - .env.prod.example
+      # .env.prod 不入库（.gitignore 已忽略）；入库的只有 .env.prod.example 模板。
+      - .env.prod
     depends_on:
       db:
         condition: service_healthy
@@ -140,7 +145,8 @@ services:
       - LOG_LEVEL=INFO
       - PYTHONUNBUFFERED=1
     env_file:
-      - .env.prod.example
+      # .env.prod 不入库（.gitignore 已忽略）；入库的只有 .env.prod.example 模板。
+      - .env.prod
     depends_on:
       db:
         condition: service_healthy
@@ -179,7 +185,11 @@ services:
       - "${HTTPS_PORT:-443}:443"
     volumes:
       - ./deploy/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./deploy/ssl:/etc/nginx/ssl:ro
+      # 审计 P2：与 secure 版和 nginx.conf 期望一致 —— nginx.conf 引用
+      # /etc/nginx/ssl/server.crt|server.key。请把 server.crt / server.key
+      # 放到 ./deploy/nginx/ssl/（.gitignore 已忽略 *.crt/*.key），否则
+      # nginx 启动即 crash（找不到证书）。之前误挂 ./deploy/ssl。
+      - ./deploy/nginx/ssl:/etc/nginx/ssl:ro
       - nginx_log:/var/log/nginx
     depends_on:
       - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,8 @@ services:
       target: backend-builder
     container_name: webgis-api
     ports:
-      - "${API_PORT:-18000}:8000"
+      # 审计 P2：无鉴权 API / metrics 不应暴露给局域网（db/redis 已限 127.0.0.1）。
+      - "127.0.0.1:${API_PORT:-18000}:8000"
     environment:
       # 方式1: 通过完整 DATABASE_URL（推荐）
       - DATABASE_URL=${DATABASE_URL:-}
@@ -66,12 +67,12 @@ services:
       - DB_HOST=${DB_HOST:-db}
       - DB_PORT=${DB_PORT:-5432}
       - DB_USER=${DB_USER:-postgres}
-      - DB_PASSWORD=${DB_PASSWORD:-postgres}
+      - DB_PASSWORD=${DB_PASSWORD:?Set DB_PASSWORD in .env}
       - DB_NAME=${DB_NAME:-webgis}
       # Redis 配置
       - REDIS_URL=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}@${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/0
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}@${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/0
-      - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:-dev_redis_pass}@${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/1
+      - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}@${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/1
     depends_on:
       db:
         condition: service_healthy
@@ -104,7 +105,7 @@ services:
       - DB_HOST=${DB_HOST:-db}
       - DB_PORT=${DB_PORT:-5432}
       - DB_USER=${DB_USER:-postgres}
-      - DB_PASSWORD=${DB_PASSWORD:-postgres}
+      - DB_PASSWORD=${DB_PASSWORD:?Set DB_PASSWORD in .env}
       - DB_NAME=${DB_NAME:-webgis}
       # Redis 配置
       - REDIS_URL=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env}@${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/0

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,7 +96,7 @@ kubectl create secret generic webgis-secret --namespace=webgis-prod \
 | Compose 文件 | 凭证文件 | 用途 |
 |--------------|----------|------|
 | `docker-compose.yml` | `.env`（从 `.env.example` 复制） | 本地开发 |
-| `docker-compose.prod.yml` | `.env.production`（gitignored） | 标准生产 |
+| `docker-compose.prod.yml` | `.env.prod`（从 `.env.prod.example` 复制，gitignored；`--env-file .env.prod` 供 `${VAR}` 插值） | 标准生产 |
 | `docker-compose.prod.secure.yml` | `.env.Priv`（从 `.env.Priv.example` 复制，gitignored） | 加固生产（推荐） |
 
 所有变体的 `${VAR:?...}` 语法会在关键凭证缺失时强制 fail，拒绝用弱默认值启动。

--- a/frontend/components/sidebar/data-sources-tab.test.tsx
+++ b/frontend/components/sidebar/data-sources-tab.test.tsx
@@ -192,8 +192,8 @@ const fetchRef = () => vi.mocked(dataFabricApi.fetchRefGeoJSON);
 const GEOJSON = {
   type: 'FeatureCollection' as const,
   features: [
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
   ],
 };
 


### PR DESCRIPTION
## 问题（2×P1 + 4×P2）

1. **[P1] env 文件**：`docker-compose.prod.yml:95,139` 把入库模板 `.env.prod.example` 当 env_file，且报错提示引导把真实密码写进可提交文件；`$\{DB_PWD\}` 插值也不读 env_file，照做后 db 仍起不来。
2. **[P1] k8s 探针**：`deploy/k8s/05-deps-optional.yaml:162` redis livenessProbe 用 `[redis-cli,-a,$(REDIS_PASSWORD),ping]`——k8s exec 探针不做 `$(VAR)` 展开 → 认证必败，探针持续失败重启循环。
3. **[P2]** 证书挂载路径与 secure 版不一致（`./deploy/ssl` vs `./deploy/nginx/ssl`），nginx.conf 需 server.crt → 起即 crash-loop。
4. **[P2]** dev compose 残留弱默认密码回退（`dev_redis_pass`/`postgres`），与文件内审计注释矛盾。
5. **[P2]** dev API 端口绑 0.0.0.0，无鉴权 `/metrics` 对局域网可见（db/redis 均已限 127.0.0.1）。
6. **[P2]** dev runner 装了运行时不需要的 npm（Dockerfile.prod 已正确只装 nodejs）。

## 修复

- env_file 改为不入库的 `.env.prod`（.gitignore:22 已覆盖），头部注释统一 `--env-file .env.prod` 用法说明，`docs/DEPLOYMENT.md` 同步
- 探针改 `[sh,-c,REDISCLI_AUTH=$REDIS_PASSWORD redis-cli ping]` + 注释说明 kubelet 展开边界
- 证书路径统一 `./deploy/nginx/ssl`（对齐 secure 版与 nginx.conf）
- 删除全部 `:-` 弱回退，统一 `:?` 守卫
- API 端口加 `127.0.0.1:` 前缀
- runner 只装 nodejs（已 grep 确认运行时无 npm 调用）

## 验证

- Docker 29.7.2：`docker compose -f docker-compose.prod.yml --env-file <tmp> config -q` OK；缺变量时 `:?` 守卫报新提示全部生效
- `yaml.safe_load`/`safe_load_all` 校验全部改动 YAML 通过；程序化确认探针命令
- 注：dev compose 既有 `${WEBGIS_DEV_MOUNT:+- ...}` 条件挂载产生 null 项的问题是独立既有缺陷（master 基线同现），未越界修复，建议另开 PR

来源：全库深度审查（8 个独立修复 PR 之一）。