### PR TITLE
fix(fe): repair master frontend typecheck broken by #486

### DIFF
--- a/frontend/components/sidebar/data-sources-tab.test.tsx
+++ b/frontend/components/sidebar/data-sources-tab.test.tsx
@@ -192,8 +192,8 @@ const fetchRef = () => vi.mocked(dataFabricApi.fetchRefGeoJSON);
 const GEOJSON = {
   type: 'FeatureCollection' as const,
   features: [
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
-    { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.4, 39.9] } },
+    { type: 'Feature' as const, properties: {}, geometry: { type: 'Point', coordinates: [116.5, 39.95] } },
   ],
 };
 


### PR DESCRIPTION
## 问题

master 上 `npm run typecheck` 失败（`tsc -p tsconfig.test.json --noEmit`）：

```
components/sidebar/data-sources-tab.test.tsx(223,34): error TS2345:
Type '{ type: string; ... }[]' is not assignable to type 'GeoJSONFeature[]'
  Type 'string' is not assignable to type '"Feature"'
```

引入于 4f9030b (#486)：GEOJSON mock 常量只对外层 `type: 'FeatureCollection'` 加了 `as const`，内层 `type: 'Feature'` 字面量被拓宽为 `string`，不满足 `GeoJSONFeature['type']`。

## 影响

Frontend Tests (TypeScript Check) 在 **master 合入 #486 之后的所有 PR CI** 上失败（含 #494–#501），与各 PR 自身改动无关。

## 修复

内层字面量补 `as const`（2 行）。

## 验证

- `npm run typecheck` exit=0（master 上为 exit=2）
- `npx vitest run components/sidebar/data-sources-tab.test.tsx` 8/8 通过