### PR TITLE
fix(agent): async web_search, planner SSE keepalive, subagent context isolation, honest spatial_reasoning, live tool names, full slim caps (#434 #435 #436 #437 #438 #439)

### DIFF
--- a/app/services/chat/context_assembler.py
+++ b/app/services/chat/context_assembler.py
@@ -138,6 +138,7 @@ class ChatContextAssembler:
         org_id: Optional[int] = None,
         tools_payload_chars: int = 0,
         tools_payload: Optional[str] = None,
+        include_plan_block: bool = True,
     ) -> ContextAssemblyResult:
         """
         Assemble the complete LLM request message list from session state,
@@ -160,6 +161,12 @@ class ChatContextAssembler:
 
         ``tools_payload_chars``（兼容旧调用——测试/benchmark 传字符数）：仅在
         ``tools_payload`` 未提供时使用 chars/4 近似，语义不变。
+
+        ``include_plan_block``（#436）：False 时跳过活跃计划块的注入。子代理
+        引擎复用父 session_id，若不关闭会把**父会话**的活跃计划（含"未完成
+        步骤"警告、子代理未必可见的工具族提示）注入子代理上下文 —— 计划推进
+        属于主代理（输出侧 #407 已隔离），输入侧同样不得继承。主引擎保持
+        默认 True，行为不变。
         """
         if not messages:
             return ContextAssemblyResult(
@@ -243,7 +250,7 @@ class ChatContextAssembler:
         from app.services.chat.planner import get_plan
 
         plan = get_plan(session_id)
-        if plan is not None:
+        if plan is not None and include_plan_block:
             # design-v3 §4：计划块单一渲染来源（plan_orchestrator.render_plan_block）。
             from app.services.chat.plan_orchestrator import render_plan_block
             head.append({"role": "system", "content": render_plan_block(plan)})

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -71,6 +71,17 @@ _LLM_TOKEN_KEEPALIVE_S = 15.0
 _KEEPALIVE_EVENT: tuple[str, dict] = ("keep_alive", {"message": "ping"})
 _QUEUE_END = object()  # pump-completed sentinel
 
+# ── #435: planner-phase heartbeat ─────────────────────────────────────────────
+# The planning turn makes a NON-streaming LLM call (llm_client flat 120s
+# timeout). Between the task_start event and the first token/tool event the
+# stream used to be fully silent — idle-timeout proxies (~30-60s) reset such
+# connections and the resume path reconnect-looped until the planner
+# returned. #409 covered the token stream (15s pump) and the parallel tool
+# wave (5s pump); this budget covers the planner await. 10s keeps several
+# heartbeats under any plausible proxy idle timeout while staying far below
+# the 120s planner ceiling.
+_PLANNER_KEEPALIVE_S = 10.0
+
 
 async def _stream_with_token_keepalive(
     stream: AsyncGenerator[tuple[str, dict], None],
@@ -1322,7 +1333,30 @@ class ChatExecutionEngine:
                     task_start_data["owner_token"] = owner_token
                 yield sse_event("task_start", task_start_data)
 
-                plan = await self._maybe_plan(session_id, message, messages)
+                # #435: 规划阶段是一次非流式 LLM 调用（最长 120s）。裸 await
+                # 会让 task_start 与首个 token/tool 事件之间完全静默，空闲
+                # 超时代理掐断连接（#409 只覆盖 token 流与工具波）。这里把
+                # 等待放进带心跳的泵：每 _PLANNER_KEEPALIVE_S 秒无结果就发一个
+                # keep_alive（经 sse_event 生成，invariant #6）。_maybe_plan
+                # 自身不抛异常（内部兜底降级返回 None）；消费方断开时取消
+                # 等待任务，保持与裸 await 相同的取消语义。
+                plan_wait = asyncio.create_task(
+                    self._maybe_plan(session_id, message, messages)
+                )
+                try:
+                    while not plan_wait.done():
+                        await asyncio.wait({plan_wait}, timeout=_PLANNER_KEEPALIVE_S)
+                        if not plan_wait.done():
+                            yield sse_event("keep_alive", {"message": "ping"})
+                            logger.debug("SSE Heartbeat sent for planner phase")
+                    plan = plan_wait.result()
+                finally:
+                    if not plan_wait.done():
+                        plan_wait.cancel()
+                        try:
+                            await plan_wait
+                        except BaseException:  # noqa: BLE001 — consumer already exiting
+                            pass
                 plan_existed_this_turn = plan is not None
                 if not plan_existed_this_turn:
                     from app.services.chat import planner as _planner_ctx

--- a/app/services/chat/execution_engine.py
+++ b/app/services/chat/execution_engine.py
@@ -499,6 +499,9 @@ class ChatExecutionEngine:
             project_id=project_id,
             user_id=user_id,
             tools_payload=tools_payload,
+            # #436：子代理不继承父会话的活跃计划块（输出侧 #407 已隔离，这里
+            # 切掉输入侧）。getattr 兜底：__new__ 构造的测试引擎无该属性。
+            include_plan_block=not getattr(self, "is_subagent_engine", False),
         )
         return res.to_messages()
 
@@ -547,6 +550,17 @@ class ChatExecutionEngine:
         async with lock:
             if session_id in self._sessions:
                 return self._sessions[session_id]
+            if getattr(self, "is_subagent_engine", False):
+                # #436：子代理上下文输入侧隔离。子引擎复用父 session_id（refs /
+                # map_state 工作区互通，by design），但父会话的持久化历史绝不
+                # 载入子代理消息列表 —— 否则预算截断后的父 transcript（~6000
+                # tokens）每轮重编码，且父 tool_result 中的不可信网页内容扩大
+                # 子代理的注入面。输出侧（子代理回写父库）已由 #407 抑制；这里
+                # 切掉读取侧。子代理上下文 = system prompt + 自己的任务（+ 自己
+                # 的轮次，缓存在子引擎自己的 _sessions LRU 里）。
+                fresh = [{"role": "system", "content": self._build_system_prompt()}]
+                self._sessions[session_id] = fresh
+                return fresh
             loaded = await self._load_session_from_db(session_id, user_id=user_id)
             if loaded is None:
                 # F23: DB 抖动时本轮降级为仅 system prompt 的临时历史，

--- a/app/services/chat/prompt.py
+++ b/app/services/chat/prompt.py
@@ -75,7 +75,7 @@ SYSTEM_PROMPT = """你是一名 WebGIS 空间分析助手。用户与一张 MapL
 - **空间聚集性检验与热点发现**：用户询问"是否聚集"或寻找聚类时，优先使用基于 H3 网格的 `h3_lisa` 来发现空间聚类和显著的热点/冷点（必须先通过 `h3_binning` 处理）。如果不是网格数据，可以用 `moran_i` 或 `hotspot_analysis`。
 - **单次任务上限**：单轮对话内工具调用尽量控制在 5 次以内。优先给出核心结果 and 洞察。
 - **密度建模与选址基础**：需要生成连续概率面或为后续叠加分析做准备时，用 `kde_surface`。注意：`kde_surface` 生成的是覆盖全域的格网要素，默认不建议作为首选可视化方式。
-- **缓冲/服务区**：固定半径用 `buffer_analysis`；多环带用 `multi_ring_buffer`；可达性分析用 `service_area`。
+- **缓冲/服务区**：固定半径用 `buffer_analysis`；多环带用 `multi_ring_buffer`；可达性分析用 `network_service_area`（真实路网等时圈，多时间断点）。
 - **属性筛选**：简单筛选用 `apply_layer_filter` (实时)，需要导出新要素集或进行链式分析时用 `attribute_filter`。
 - **比例尺适配**：分析半径应适配视口：街区级 100–500m，城市级 1–5km，区域级 >5km。建议在调用前先检查当前缩放级别。
 

--- a/app/services/llm_result_formatter.py
+++ b/app/services/llm_result_formatter.py
@@ -37,6 +37,80 @@ _PRESERVED_META_KEYS = (
 )
 
 
+# ── #439: 最终体积闸（Zero-Big-Data-Context 的最后一道防线） ──────────────────
+# slim_tool_result 是工具结果进入 LLM 上下文前的唯一闸口
+# (tool_dispatch_service.llm_payload)。旧实现只对特定形状/键
+# (geojson/image/features) 做了削减：
+#   (a) 纯字符串结果超长时原样返回（return result_str 兜底）；
+#   (b) dict 分支里 data/rows/chart 等非 geojson 键全量保留
+#       （web_search 每次就这样塞进 ~10KB snippets）。
+# 这里加一道与形状/键名无关的总量钳制：任何 LLM-bound payload ≤ MSG_MAX_CHARS。
+_SLIM_KEY_VALUE_MAX_CHARS = 600   # 非保留字符串值的初始钳制长度
+_SLIM_LIST_MAX_ITEMS = 20         # 列表初始保留条数
+_SLIM_DICT_MAX_KEYS = 30          # dict 初始保留键数（与 _truncate_properties 同思路）
+_SLIM_HARD_FLOOR = 40             # 折半下限；到顶仍超预算则硬切并打标
+_SLIM_TRUNCATION_SUFFIX = "…[已截断]"
+_SLIM_MAX_DEPTH = 8
+
+
+def _clamp_sized_value(v: Any, str_limit: int, list_limit: int, depth: int = 0) -> Any:
+    """递归钳制一个 JSON-ish 值：字符串→str_limit，列表→list_limit 条
+    （省略数打标），dict→前 list 个键（省略数打标）。数值/布尔/None 原样。
+    正常大小的元数据（bbox 四元组、feature_count、短 message 等）在任何
+    轮次都不会被触碰。
+    """
+    if depth > _SLIM_MAX_DEPTH:
+        return _SLIM_TRUNCATION_SUFFIX
+    if isinstance(v, str):
+        if len(v) > str_limit:
+            return v[: str_limit - 1] + "…"
+        return v
+    if isinstance(v, list):
+        out = [
+            _clamp_sized_value(item, str_limit, list_limit, depth + 1)
+            for item in v[:list_limit]
+        ]
+        omitted = len(v) - list_limit
+        if omitted > 0:
+            out.append(f"(…另有 {omitted} 项因上下文预算省略)")
+        return out
+    if isinstance(v, dict):
+        out = {}
+        for i, (k, val) in enumerate(v.items()):
+            if i >= _SLIM_DICT_MAX_KEYS:
+                out["__more_keys__"] = len(v) - _SLIM_DICT_MAX_KEYS
+                break
+            out[k] = _clamp_sized_value(val, str_limit, list_limit, depth + 1)
+        return out
+    return v
+
+
+def _serialize_under_budget(value: Any) -> str:
+    """序列化并强制 ≤ MSG_MAX_CHARS（#439 总量闸）。
+
+    策略：先用宽松钳制（600 字符/20 条/30 键）序列化——常规结果完全不受
+    影响；仍超预算则对字符串/列表限额逐轮折半（JSON 始终保持合法），
+    到下限仍超（病态宽而浅的结构）才硬切并追加截断标记，保证不变量
+    绝对成立。
+    """
+    str_limit = _SLIM_KEY_VALUE_MAX_CHARS
+    list_limit = _SLIM_LIST_MAX_ITEMS
+    while True:
+        try:
+            payload = json.dumps(
+                _clamp_sized_value(value, str_limit, list_limit),
+                ensure_ascii=False,
+            )
+        except (TypeError, ValueError):
+            return str(value)[: MSG_MAX_CHARS - len(_SLIM_TRUNCATION_SUFFIX)] + _SLIM_TRUNCATION_SUFFIX
+        if len(payload) <= MSG_MAX_CHARS:
+            return payload
+        if str_limit <= _SLIM_HARD_FLOOR and list_limit <= 1:
+            return payload[: MSG_MAX_CHARS - len(_SLIM_TRUNCATION_SUFFIX)] + _SLIM_TRUNCATION_SUFFIX
+        str_limit = max(_SLIM_HARD_FLOOR, str_limit // 2)
+        list_limit = max(1, list_limit // 2)
+
+
 def _slim_cartographic_review(value: Any) -> Optional[dict]:
     """Keep actionable review evidence bounded for the agent/frontend."""
     if not isinstance(value, dict):
@@ -128,7 +202,9 @@ def slim_tool_result(result: Any, result_str: str, session_geojson_ref: Optional
         review = _slim_cartographic_review(result.get("cartographic_review"))
         if review is not None:
             slim["cartographic_review"] = review
-        return json.dumps(slim, ensure_ascii=False)
+        # #439：summary 分支同样过总量闸 —— 病态超长的 summary/保留键也不能
+        # 突破上下文预算。
+        return _serialize_under_budget(slim)
 
     if len(result_str) <= MSG_MAX_CHARS:
         return result_str
@@ -169,9 +245,14 @@ def slim_tool_result(result: Any, result_str: str, session_geojson_ref: Optional
         elif result.get("type") == "heatmap_raster":
             slim["note"] = "栅格热力图已推送至前端，bbox=" + str(result.get("bbox"))
 
-        return json.dumps(slim, ensure_ascii=False)
+        # #439：非 geojson 键（data/rows/chart/untrusted blocks…）不再全量放行，
+        # 统一过总量闸；geojson 摘要路径行为不变（正常大小不触发钳制）。
+        return _serialize_under_budget(slim)
 
-    return result_str
+    # #439 (a)：纯字符串/裸列表兜底 —— 超长时也必须截断到预算内。
+    if isinstance(result, str):
+        return result[: MSG_MAX_CHARS - len(_SLIM_TRUNCATION_SUFFIX)] + _SLIM_TRUNCATION_SUFFIX
+    return _serialize_under_budget(result)
 
 
 def slim_event_result(result: Any) -> Any:

--- a/app/tools/map_view.py
+++ b/app/tools/map_view.py
@@ -79,7 +79,7 @@ def register_map_view_tools(registry: ToolRegistry):
             "\n何时用：用户说『把地图移到 XX』『定位到 XX』『看一下 XX 周边』，已经知道目标坐标。"
             "\n何时不用：(1) 想看某一个图层的范围 — 用 zoom_to_layer；"
             "(2) 只想改俯仰/旋转角度 — 用 set_map_view；"
-            "(3) 不知道目标坐标 — 先 geocode_address 拿到坐标再调本工具。"
+            "(3) 不知道目标坐标 — 先 geocode_cn 拿到坐标再调本工具。"
             "\n关键约束：经纬度必须是十进制度数；zoom 推荐 10-14（城市级），16+ 街区级。"
         ),
         args_model=FlyToLocationArgs,

--- a/app/tools/osm.py
+++ b/app/tools/osm.py
@@ -321,7 +321,7 @@ def register_osm_tools(registry: ToolRegistry):
            description=(
                "OSM 道路网络查询：按区域+道路等级拉取 LineString 路网 GeoJSON。"
                "\n何时用：路径规划/可达性分析需要路网底图；按等级筛选 (highway/primary 主干道) 做密度统计。"
-               "\n何时不用：仅需路径规划终端结果 — 用 search_route_cn (高德路径) 或 isochrone_analysis (等时圈)；"
+               "\n何时不用：仅需路径规划终端结果 — 用 plan_route (高德路径) 或 isochrone_analysis (等时圈)；"
                "需要实时路况 — 用 get_traffic_status。"
                "\n关键约束：road_type 是 OSM highway tag 值，常见: motorway/primary/secondary/tertiary/residential/footway。"
            ),

--- a/app/tools/spatial_reasoning.py
+++ b/app/tools/spatial_reasoning.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional
 from pydantic import BaseModel, Field, ValidationError
 
 from app.tools.registry import ToolRegistry, tool
+from app.tools._utils import std_error_response
 from app.services.chat.llm_client import LLMConfig, call_llm
 from app.core.config import settings
 from app.lib.geo_processor.core import _repair_json
@@ -157,22 +158,45 @@ def _build_user_prompt(query: str, context: dict, depth: str) -> str:
     return "\n".join(lines)
 
 
+def _real_llm_enabled() -> bool:
+    import os
+    return os.environ.get("SPATIAL_REASONING_USE_REAL_LLM", "").lower() == "true"
+
+
+def _unavailable_result() -> dict:
+    """#437：真实推演未启用时的诚实结果。
+
+    旧实现默认返回一条与查询无关的编造结论（confidence=0.75、无 mock 标记），
+    经 plan-mode execute_plan / admin /tools/execute（tier-3 门控路径）持久化
+    进历史后会驱动用户可见的结论，且 is_suspicious_result 无法识别。现在默认
+    返回显式标记的「不可用」错误（success=False → is_suspicious_result 命中，
+    计划步骤不会据此打勾），并带 correction_hint 引导下一步（Exception As
+    Thought）。真实推演只在 SPATIAL_REASONING_USE_REAL_LLM=true 时发生。
+    """
+    return std_error_response(
+        "spatial_reasoning 真实推演未启用（SPATIAL_REASONING_USE_REAL_LLM 未设置为 true），"
+        "无法对该查询给出可靠结论；本工具不会在未启用时编造结论。",
+        code="TOOL_UNAVAILABLE",
+        error_type="FeatureDisabled",
+        correction_hint=(
+            "如需规则推演，请设置环境变量 SPATIAL_REASONING_USE_REAL_LLM=true "
+            "（并配置 LLM_API_KEY / LLM_BASE_URL）后重试；或改用基于真实图层的 "
+            "数据工具（如 buffer_analysis / nearest_facility / spatial_query）完成分析。"
+        ),
+    )
+
+
 async def _call_llm(system_prompt: str, user_prompt: str) -> dict:
     """空间推理 LLM 调用。
 
-    默认返回结构化 mock 响应（符合 spec "mock in place"）。
-    当环境变量 SPATIAL_REASONING_USE_REAL_LLM=true 时，
-    调用真实 LLM 服务（app.services.chat.llm_client.call_llm）。
+    #437：未启用真实 LLM 时返回显式标记的「不可用」结果，绝不返回编造的
+    模拟结论。启用（SPATIAL_REASONING_USE_REAL_LLM=true）后调用真实 LLM
+    服务（app.services.chat.llm_client.call_llm）。
     """
-    # Feature flag: real LLM integration is ready but disabled by default
-    # per spec ("planned, mock in place"). Set SPATIAL_REASONING_USE_REAL_LLM=true
-    # to enable production LLM calls.
-    import os
-    if os.environ.get("SPATIAL_REASONING_USE_REAL_LLM", "").lower() == "true":
-        return await _call_llm_real(system_prompt, user_prompt)
-
-    logger.debug("_call_llm using mock response (SPATIAL_REASONING_USE_REAL_LLM not set)")
-    return _mock_result()
+    if not _real_llm_enabled():
+        logger.debug("_call_llm real reasoning disabled (SPATIAL_REASONING_USE_REAL_LLM not set)")
+        return _unavailable_result()
+    return await _call_llm_real(system_prompt, user_prompt)
 
 
 def _parse_llm_json(content: str) -> Optional[dict]:
@@ -238,21 +262,6 @@ async def _call_llm_real(system_prompt: str, user_prompt: str) -> dict:
         return _error_result(f"LLM 调用失败: {type(e).__name__}")
 
 
-def _mock_result() -> dict:
-    """Structured mock response for spatial reasoning (default path)."""
-    return {
-        "type": "spatial_reasoning",
-        "conclusion": "基于现有规则库，该位置适合商业选址，但需考虑竞争饱和度。",
-        "reasoning_chain": [
-            {"step": 1, "fact": "社区店辐射半径 500-800m", "source": "commercial"},
-            {"step": 2, "fact": "便利店竞争饱和度超过 3 家后盈利能力下降", "source": "commercial"},
-        ],
-        "confidence": 0.75,
-        "uncertainty": "缺乏具体人流量数据，竞争饱和度基于周边POI估算",
-        "recommendations": ["进一步获取周边 exact 人流量数据", "分析工作日午餐客流与办公人口比例"],
-    }
-
-
 def _error_result(message: str) -> dict:
     """Return a structured error response matching SpatialReasoningResult schema."""
     return {
@@ -279,6 +288,11 @@ async def spatial_reasoning(
 
     try:
         llm_result = await _call_llm(system_prompt, user_prompt)
+        # #437：诚实错误（success=False，含 correction_hint）直通 —— 不进
+        # SpatialReasoningResult 校验（那会丢掉 correction_hint 并把「不可用」
+        # 包装成一条空壳结论）。
+        if isinstance(llm_result, dict) and llm_result.get("success") is False:
+            return llm_result
         result = SpatialReasoningResult.model_validate(llm_result)
         return result.model_dump()
     except (ValueError, TypeError, RuntimeError, OSError) as e:

--- a/app/tools/web_crawler.py
+++ b/app/tools/web_crawler.py
@@ -6,6 +6,7 @@
 
 LLM 拿到 snippets 后自己提取地名/事件，再调 geocode_cn 之类的工具落到地图上。
 """
+import asyncio
 import json
 import logging
 from pydantic import BaseModel, Field
@@ -91,11 +92,15 @@ async def _baidu_qianfan_search(query: str, limit: int) -> dict:
 
 
 def _ddg_search(query: str, limit: int) -> dict:
+    """同步 DuckDuckGo 搜索。#434：只允许在 worker 线程内运行（见 _ddg_search_async），
+    禁止在事件循环上直接调用 —— DDGS 底层是同步 HTTP 客户端，一次往返 1-5s+，
+    会冻结所有并发 SSE 流。
+    """
     if DDGS is None:
         return {"error": "duckduckgo_search 库未安装"}
     try:
         results = []
-        with DDGS() as ddgs:
+        with DDGS(timeout=_DDG_TIMEOUT_S) as ddgs:
             for r in ddgs.text(keywords=query, region="cn-zh", max_results=limit):
                 results.append({
                     "title": r.get("title", ""),
@@ -111,6 +116,33 @@ def _ddg_search(query: str, limit: int) -> dict:
         }
     except (ConnectionError, TimeoutError, RuntimeError) as e:
         return {"error": f"DuckDuckGo 调用失败: {e}"}
+
+
+# #434 网络隔离：DuckDuckGo 兜底通路卸载到 worker 线程 + 真实超时预算。
+# - _DDG_TIMEOUT_S：传给 DDGS 客户端的单请求超时（秒）；
+# - _DDG_WALL_CLOCK_S：外层硬性墙钟预算，覆盖库内部的重试/退避 —— 同步
+#   worker 线程无法被终止，超预算后放弃等待返回错误（与 registry #406 的
+#   线程槽位语义一致），避免一次挂死的搜索无界占用回合。
+_DDG_TIMEOUT_S = 10.0
+_DDG_WALL_CLOCK_S = 20.0
+
+
+async def _ddg_search_async(query: str, limit: int) -> dict:
+    """#434 计算隔离：DDG 兜底必须 off-loop。"""
+    try:
+        async with asyncio.timeout(_DDG_WALL_CLOCK_S):
+            return await asyncio.to_thread(_ddg_search, query, limit)
+    except TimeoutError:
+        logger.warning(
+            "[web_search] DuckDuckGo exceeded wall-clock budget %.0fs, abandoning wait",
+            _DDG_WALL_CLOCK_S,
+        )
+        return {
+            "error": (
+                f"DuckDuckGo 搜索超时（>{_DDG_WALL_CLOCK_S:.0f}s），已放弃等待。"
+                "请缩小搜索词后重试，或配置 BAIDU_QIANFAN_TOKEN 后改用 provider='baidu'。"
+            )
+        }
 
 
 _UNTRUSTED_OPEN = "<UNTRUSTED_WEB_CONTENT>"
@@ -212,7 +244,7 @@ def register_crawler_tools(registry: ToolRegistry):
         if chosen == "baidu":
             result = await _baidu_qianfan_search(query, limit)
         else:
-            result = _ddg_search(query, limit)
+            result = await _ddg_search_async(query, limit)
         return _wrap_payload(result)
 
     @tool(registry, name="search_and_extract_poi",
@@ -228,7 +260,7 @@ def register_crawler_tools(registry: ToolRegistry):
         if settings.BAIDU_QIANFAN_TOKEN:
             result = await _baidu_qianfan_search(query, limit)
         else:
-            result = _ddg_search(query, limit)
+            result = await _ddg_search_async(query, limit)
 
         # 兼容旧 schema：保留 type=poi_web_search 标识 + message 引导
         if "error" in result:

--- a/tests/test_critical_backend_correctness.py
+++ b/tests/test_critical_backend_correctness.py
@@ -478,10 +478,16 @@ async def test_c5_dispatch_task_cancelled_on_disconnect(monkeypatch):
 
     reached_wait = asyncio.Event()
 
+    real_wait = asyncio.wait
+
     async def fast_wait(fs, timeout=None, return_when=None):
         # 标记已进入 dispatch 等待，并立即返回（done 为空，模拟工具仍在跑）。
         # ADR-0052：并行 wave 现在用 return_when=FIRST_COMPLETED 并把取消 token 的
         # 等待任务一起放进 wait 集合（抢占式取消），替身必须接受该参数。
+        # #435：planner 阶段的心跳泵也走 asyncio.wait（只传 timeout）——那种
+        # 调用放行给真实实现，否则 reached_wait 会在派发波之前提前点燃。
+        if return_when is None:
+            return await real_wait(fs, timeout=timeout)
         reached_wait.set()
         return set(), set(fs)
     monkeypatch.setattr(asyncio, "wait", fast_wait)

--- a/tests/test_prompt_tool_name_integrity_438.py
+++ b/tests/test_prompt_tool_name_integrity_438.py
@@ -1,0 +1,118 @@
+"""#438: every tool name referenced by the system prompt or tool descriptions
+must resolve to a registered tool (or a legacy alias).
+
+The tool migrations (#204-#208) renamed tools but the prompt text and
+cross-references inside other tools' descriptions were not fully swept:
+prompt.py told the model to use `service_area` (registry: network_service_area
+/ service_area_simple), map_view.py referenced `geocode_address` (registry:
+geocode / geocode_cn) and osm.py referenced `search_route_cn` (registry:
+plan_route). An LLM following them literally produced UNKNOWN_TOOL errors and
+wasted rounds on self-healing.
+
+The checker below scans the real registry (init_tools) and asserts:
+
+  1. every backticked identifier-shaped token in SYSTEM_PROMPT + all tool /
+     param descriptions resolves via the registry or LEGACY_TOOL_NAME_MAP
+     (modulo a curated NON_TOOL allowlist of documented non-tool terms);
+  2. the swept legacy names never reappear anywhere in those texts.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.services.tool_dispatch_service import LEGACY_TOOL_NAME_MAP
+
+# Backticked terms that are identifier-shaped but documented non-tools:
+# ref ids, param names, sentinel tags, SSE event names, GeoJSON keywords.
+NON_TOOL_BACKTICKED_TERMS = {
+    "ref_id",
+    "render_type",
+    "return_geometry",
+    "untrusted_layer_name",
+    "untrusted_feature_property",
+    "untrusted_layer_alias",
+    "untrusted_layer_type",
+    "untrusted_base_layer",
+    "untrusted_region_name",
+    "untrusted_user_action",
+    "tool_executed",
+    "tool_failed",
+    "layer_toggled",
+    "layer_removed",
+    "base_layer_changed",
+    "upload_completed",
+}
+
+# Names removed by the #204-#208 migrations that must never be referenced
+# again in prompt/description text (the residue this issue swept).
+FORBIDDEN_LEGACY_NAMES = {"service_area", "geocode_address", "search_route_cn"}
+
+
+def _build_corpus(registry):
+    """SYSTEM_PROMPT + every tool description + every param description."""
+    from app.services.chat.prompt import SYSTEM_PROMPT
+
+    texts = [("SYSTEM_PROMPT", SYSTEM_PROMPT)]
+    schemas = registry.get_schemas_subset(set(registry.all_metadata().keys()))
+    for s in schemas:
+        fn = s["function"]
+        texts.append((f"tool:{fn['name']}", fn.get("description") or ""))
+        props = (fn.get("parameters") or {}).get("properties", {})
+        for pname, pdef in props.items():
+            if isinstance(pdef, dict) and isinstance(pdef.get("description"), str):
+                texts.append((f"param:{fn['name']}.{pname}", pdef["description"]))
+    return texts
+
+
+def _known_names(registry):
+    return set(registry.all_metadata().keys()) | set(LEGACY_TOOL_NAME_MAP.keys())
+
+
+@pytest.fixture(scope="module")
+def registry():
+    from app.tools import init_tools
+    from app.tools.registry import ToolRegistry
+
+    r = ToolRegistry()
+    init_tools(r)
+    return r
+
+
+def test_registry_loaded(registry):
+    assert len(registry.all_metadata()) > 100  # live registry, not a stub
+
+
+def test_backticked_tool_references_resolve(registry):
+    corpus = _build_corpus(registry)
+    known = _known_names(registry)
+    violations = []
+    for where, text in corpus:
+        for seg in re.findall(r"`([^`]+)`", text):
+            for ident in re.findall(r"\b[a-z][a-z0-9_]{2,}\b", seg):
+                if "_" not in ident:
+                    continue
+                if ident in known or ident in NON_TOOL_BACKTICKED_TERMS:
+                    continue
+                violations.append(f"{where}: `{ident}`")
+    assert not violations, (
+        "Backticked tool-name references that resolve to no registered tool "
+        "/ alias (LLM would hit UNKNOWN_TOOL):\n" + "\n".join(violations)
+    )
+
+
+def test_swept_legacy_names_absent_everywhere(registry):
+    corpus = _build_corpus(registry)
+    for name in FORBIDDEN_LEGACY_NAMES:
+        pattern = re.compile(rf"\b{name}\b")
+        for where, text in corpus:
+            assert not pattern.search(text), (
+                f"{where} still references swept legacy tool name {name!r}"
+            )
+
+
+def test_replacement_names_are_registered(registry):
+    known = _known_names(registry)
+    for name in ("network_service_area", "geocode_cn", "plan_route"):
+        assert name in known, name

--- a/tests/test_slim_tool_result_caps_439.py
+++ b/tests/test_slim_tool_result_caps_439.py
@@ -1,0 +1,162 @@
+"""#439: slim_tool_result caps must hold for every result shape.
+
+slim_tool_result is the last line of defense for the Zero-Big-Data-Context
+invariant (CODE_REVIEW invariant #2) — the sole downstream gate before a
+tool result enters the LLM context (tool_dispatch_service). Two bypass
+routes existed:
+
+  (a) plain-string results longer than MSG_MAX_CHARS were returned
+      untruncated (the bare ``return result_str`` fallback);
+  (b) the dict branch dropped only geojson/image/features keys, so large
+      payloads under other keys (``data`` / ``rows`` / ``chart`` ...) passed
+      into the context uncapped — web_search already pushes ~10 KB of
+      snippets per call this way.
+
+After the fix every LLM-bound payload is capped at MSG_MAX_CHARS regardless
+of shape/key, stays valid JSON when the input was structured, and the
+geojson summarization path is unchanged.
+"""
+from __future__ import annotations
+
+import json
+
+from app.services.llm_result_formatter import (
+    MSG_MAX_CHARS,
+    slim_tool_result,
+)
+
+
+def _dumps(x) -> str:
+    return json.dumps(x, ensure_ascii=False)
+
+
+def test_plain_string_result_capped():
+    """Acceptance #439: a 100 KB plain-string result yields payload ≤ cap."""
+    huge = "X" * 100_000
+    out = slim_tool_result(huge, huge, None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    assert "截断" in out or "…" in out, "payload must be marked as truncated"
+
+
+def test_dict_data_key_capped():
+    """Acceptance #439: a 100 KB ``data`` key yields payload ≤ cap (valid JSON)."""
+    result = {"type": "web_search", "count": 500, "data": [{"snippet": "s" * 200} for _ in range(500)]}
+    assert len(_dumps(result)) > 100_000
+    out = slim_tool_result(result, _dumps(result), None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    parsed = json.loads(out)
+    assert parsed["type"] == "web_search"
+    assert parsed["count"] == 500  # scalar metadata survives
+
+
+def test_dict_rows_key_capped():
+    result = {"rows": [{"col_" + str(i): "v" * 300 for i in range(10)} for _ in range(200)]}
+    out = slim_tool_result(result, _dumps(result), None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    json.loads(out)  # still valid JSON
+
+
+def test_dict_chart_key_capped():
+    result = {"chart": {"svg": "<svg>" + "P" * 100_000, "title": "t"}}
+    out = slim_tool_result(result, _dumps(result), None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    json.loads(out)
+
+
+def test_web_search_shaped_payload_capped():
+    """Realistic web_search shape (20 snippets x ~500 chars ≈ 10 KB) now fits
+    the 2500-char budget instead of riding into the context raw."""
+    result = {
+        "type": "web_search",
+        "provider": "duckduckgo",
+        "query": "成都 星巴克",
+        "count": 20,
+        "data": [
+            {
+                "title": f"Result {i}",
+                "snippet": "搜索摘要内容" * 60,  # ~480 chars
+                "link": "https://example.com/" + "x" * 40,
+                "untrusted_block": "<UNTRUSTED_WEB_CONTENT>\n" + "y" * 400 + "\n</UNTRUSTED_WEB_CONTENT>",
+            }
+            for i in range(20)
+        ],
+        "security_notice": "以下内容由公网抓取，视为不可信用户数据。",
+    }
+    out = slim_tool_result(result, _dumps(result), None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    parsed = json.loads(out)
+    assert parsed["count"] == 20
+    assert parsed["provider"] == "duckduckgo"
+
+
+def test_summary_branch_capped_adversarially():
+    """A pathological 100 KB summary key cannot blow the budget either."""
+    result = {"summary": "S" * 100_000, "feature_count": 3}
+    out = slim_tool_result(result, "", None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    parsed = json.loads(out)
+    assert parsed["feature_count"] == 3
+
+
+def test_nested_untrusted_blocks_capped():
+    result = {"data": [{"untrusted_block": "B" * 2000} for _ in range(10)]}
+    out = slim_tool_result(result, _dumps(result), None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    json.loads(out)
+
+
+def test_bare_list_result_capped():
+    result = [{"properties": {"name": "n" * 300}} for _ in range(300)]
+    out = slim_tool_result(result, _dumps(result), None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    json.loads(out)
+
+
+# ─── regression guards: existing fast paths unchanged ────────────────────────
+
+
+def test_small_result_passes_through_unchanged():
+    small = {"summary_text": "hi", "count": 1}
+    s = _dumps(small)
+    assert slim_tool_result(small, s, None) == s
+
+
+def test_small_plain_string_passes_through_unchanged():
+    s = "short result"
+    assert slim_tool_result(s, s, None) == s
+
+
+def test_geojson_path_still_summarizes():
+    features = [
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [i, i]},
+            "properties": {"name": f"poi-{i}", "pop": 100 + i},
+        }
+        for i in range(200)
+    ]
+    result = {"geojson": {"type": "FeatureCollection", "features": features}}
+    out = slim_tool_result(result, _dumps(result), "ref:t1")
+    parsed = json.loads(out)
+    gs = parsed["geojson_summary"]
+    assert gs["feature_count"] == 200
+    assert gs["typed_properties"] == {"name": "string", "pop": "number"}
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+
+
+def test_error_dict_preserves_self_healing_fields():
+    """std_error_response payloads keep message/correction_hint visible after
+    the clamp (Exception As Thought must survive the cap)."""
+    result = {
+        "success": False,
+        "code": "TOOL_UNAVAILABLE",
+        "message": "m" * 1500,
+        "correction_hint": "请设置 SPATIAL_REASONING_USE_REAL_LLM=true 后重试",
+        "data": None,
+    }
+    s = _dumps(result)
+    out = slim_tool_result(result, s, None)
+    assert len(out) <= MSG_MAX_CHARS, len(out)
+    parsed = json.loads(out)
+    assert parsed["correction_hint"] == "请设置 SPATIAL_REASONING_USE_REAL_LLM=true 后重试"
+    assert parsed["success"] is False

--- a/tests/test_spatial_reasoning.py
+++ b/tests/test_spatial_reasoning.py
@@ -119,35 +119,33 @@ async def test_spatial_reasoning_tool_output_format():
     assert isinstance(result["recommendations"], list)
 
 
-# ─── _call_llm default (mock) tests ─────────────────────────────
+# ─── _call_llm default (real reasoning disabled) tests ──────────
 
 
-def test_call_llm_default_returns_mock():
-    """Without feature flag, _call_llm returns the deterministic mock."""
-    from app.tools.spatial_reasoning import _mock_result
+def test_call_llm_default_returns_honest_unavailable():
+    """Without the feature flag, _call_llm returns an explicitly marked
+    unavailable result (#437) — never an unmarked canned conclusion."""
+    from app.tools.spatial_reasoning import _unavailable_result
 
-    result = _mock_result()
-    assert result["type"] == "spatial_reasoning"
-    assert result["confidence"] == 0.75
-    assert len(result["reasoning_chain"]) == 2
-    assert "商业选址" in result["conclusion"]
+    result = _unavailable_result()
+    assert result.get("success") is False
+    assert result.get("code") == "TOOL_UNAVAILABLE"
+    assert "correction_hint" in result
+    assert "confidence" not in result  # no fabricated confidence
+    assert "商业选址" not in str(result)  # no canned conclusion text
 
 
 @pytest.mark.asyncio
-async def test_call_llm_mock_without_env_flag():
-    """Default path uses mock regardless of LLM service availability."""
+async def test_call_llm_unavailable_without_env_flag(monkeypatch):
+    """Default path returns the honest unavailable marker regardless of LLM
+    service availability (#437)."""
     from app.tools.spatial_reasoning import _call_llm
 
-    # Ensure flag is NOT set
-    import os
-    old = os.environ.pop("SPATIAL_REASONING_USE_REAL_LLM", None)
-    try:
-        result = await _call_llm("system", "user")
-        assert result["confidence"] == 0.75
-        assert "商业选址" in result["conclusion"]
-    finally:
-        if old is not None:
-            os.environ["SPATIAL_REASONING_USE_REAL_LLM"] = old
+    monkeypatch.delenv("SPATIAL_REASONING_USE_REAL_LLM", raising=False)
+    result = await _call_llm("system", "user")
+    assert result.get("success") is False
+    assert result.get("code") == "TOOL_UNAVAILABLE"
+    assert "confidence" not in result
 
 
 # ─── _call_llm_real integration tests (feature-flagged) ──────────

--- a/tests/test_spatial_reasoning_honesty_437.py
+++ b/tests/test_spatial_reasoning_honesty_437.py
@@ -1,0 +1,127 @@
+"""#437: spatial_reasoning must not return an unmarked canned conclusion.
+
+Before the fix, with default env (SPATIAL_REASONING_USE_REAL_LLM unset) the
+tool returned a hardcoded mock — conclusion "基于现有规则库，该位置适合商业
+选址…" with a fabricated confidence of 0.75 — regardless of the query. It is
+reachable through plan-mode execute_plan and the admin /tools/execute route
+(tier-3 gated paths), where the fabricated result is persisted into history
+and can drive user-facing conclusions, and is_suspicious_result could not
+flag it.
+
+Contract after the fix: with default env the tool returns an explicitly
+marked unavailable result (success=False, honest message, correction_hint —
+Exception As Thought); real reasoning only when the feature flag is set.
+
+Deterministic: no network — the real-LLM path is exercised with a mocked
+provider.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services.tool_dispatch_service import is_suspicious_result
+from app.tools.registry import ToolRegistry, confirm_tier3
+from app.tools.spatial_reasoning import register_spatial_reasoning
+
+
+@pytest.fixture
+def registry():
+    r = ToolRegistry()
+    register_spatial_reasoning(r)
+    return r
+
+
+_VALID_LLM_JSON = (
+    '{"type": "spatial_reasoning", "conclusion": "真实推演结论", '
+    '"reasoning_chain": [{"step": 1, "fact": "规则事实", "source": "commercial"}], '
+    '"confidence": 0.8, "uncertainty": "有限", "recommendations": ["建议"]}'
+)
+
+
+# ─── default env: honest unavailability, never a canned conclusion ───────────
+
+
+@pytest.mark.asyncio
+async def test_default_env_dispatch_returns_honest_unavailable(registry, monkeypatch):
+    monkeypatch.delenv("SPATIAL_REASONING_USE_REAL_LLM", raising=False)
+    with confirm_tier3():
+        result = await registry.dispatch(
+            "spatial_reasoning",
+            {"query": "某位置是否适合建地铁站", "reasoning_depth": "standard"},
+        )
+    assert isinstance(result, dict)
+    # Explicitly marked as not-a-result (never an unmarked canned conclusion).
+    assert result.get("success") is False, result
+    # No fabricated confidence or canned conclusion text.
+    assert result.get("confidence") != 0.75
+    assert "商业选址" not in str(result.get("message", result.get("error", "")))
+    # is_suspicious_result must flag it so plan-mode steps do not tick off it.
+    assert is_suspicious_result(result) is True
+
+
+@pytest.mark.asyncio
+async def test_default_env_result_carries_correction_hint(registry, monkeypatch):
+    """Exception As Thought: the unavailable result guides the LLM to a next
+    action (enable the flag / use real data tools) instead of dead-ending."""
+    monkeypatch.delenv("SPATIAL_REASONING_USE_REAL_LLM", raising=False)
+    with confirm_tier3():
+        result = await registry.dispatch(
+            "spatial_reasoning", {"query": "任意问题"}
+        )
+    hint = result.get("correction_hint", "")
+    assert hint, "unavailable result must carry a correction_hint"
+    assert "SPATIAL_REASONING_USE_REAL_LLM" in hint
+
+
+@pytest.mark.asyncio
+async def test_default_env_result_independent_of_query(registry, monkeypatch):
+    """The unavailable result must be the same honest marker for any query —
+    in particular it must not fabricate query-specific conclusions."""
+    monkeypatch.delenv("SPATIAL_REASONING_USE_REAL_LLM", raising=False)
+    outs = []
+    with confirm_tier3():
+        for q in ("医院选址分析", "暴雨内涝推演", "学区房溢价"):
+            outs.append(
+                await registry.dispatch("spatial_reasoning", {"query": q})
+            )
+    assert outs[0].get("success") is False
+    assert all(o.get("message") == outs[0].get("message") for o in outs)
+
+
+# ─── feature flag set: real reasoning path intact ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_flag_set_dispatch_returns_real_llm_result(registry, monkeypatch):
+    monkeypatch.setenv("SPATIAL_REASONING_USE_REAL_LLM", "true")
+    mock_response = {
+        "choices": [{"message": {"content": _VALID_LLM_JSON}}]
+    }
+    with patch(
+        "app.tools.spatial_reasoning.call_llm", return_value=mock_response
+    ), confirm_tier3():
+        result = await registry.dispatch(
+            "spatial_reasoning", {"query": "真实推演问题"}
+        )
+    assert result["type"] == "spatial_reasoning"
+    assert result["conclusion"] == "真实推演结论"
+    assert result["confidence"] == 0.8
+    assert result.get("success") is not False
+
+
+@pytest.mark.asyncio
+async def test_flag_set_llm_failure_returns_error_not_conclusion(registry, monkeypatch):
+    """With the flag on but the provider failing, the result is an explicit
+    error (confidence 0.0), never a canned success."""
+    monkeypatch.setenv("SPATIAL_REASONING_USE_REAL_LLM", "true")
+    with patch(
+        "app.tools.spatial_reasoning.call_llm",
+        side_effect=RuntimeError("provider down"),
+    ), confirm_tier3():
+        result = await registry.dispatch(
+            "spatial_reasoning", {"query": "q"}
+        )
+    assert result.get("confidence") == 0.0
+    assert "商业选址" not in str(result)

--- a/tests/test_sse_planner_keepalive_435.py
+++ b/tests/test_sse_planner_keepalive_435.py
@@ -1,0 +1,199 @@
+"""#435: SSE keepalive during the planner LLM call (planner-phase sibling of
+#409).
+
+In ``chat_stream``, the planning phase runs between the ``task_start`` event
+and the first token/tool event with zero SSE output: ``_maybe_plan`` makes a
+non-streaming planner LLM call (flat 120s timeout). On planning turns the
+stream was silent for up to 120s — idle-timeout proxies (~30-60s) reset
+exactly such silent streams, and the resume path then reconnect-loops until
+the planner returns. #409 covered the token stream (15s pump) and the
+parallel tool wave (5s pump) but not the planner await.
+
+Deterministic: the planner wait is faked with asyncio.sleep; the heartbeat
+interval is monkeypatched to tens of milliseconds (no wall-clock waits).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.chat import execution_engine as ee_mod
+from app.services.chat_engine import ChatEngine
+from app.tools.registry import ToolRegistry
+from app.utils.sse import sse_event_type
+
+
+def _event_type(block: str) -> str:
+    return sse_event_type(block)
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    """Real ChatEngine with DB/title side effects stubbed (planner left real
+    enough to be replaced per-test)."""
+    eng = ChatEngine(ToolRegistry())
+
+    async def fake_get_or_create_session(session_id, user_id=None):
+        return []
+
+    monkeypatch.setattr(eng, "_get_or_create_session", fake_get_or_create_session)
+    monkeypatch.setattr(eng, "_generate_title", AsyncMock())
+    monkeypatch.setattr(eng, "_save_msg_async", AsyncMock())
+    return eng
+
+
+async def _collect(agen) -> list[str]:
+    out: list[str] = []
+    async for item in agen:
+        out.append(item)
+    return out
+
+
+def _fast_stream(*args, **kwargs):
+    async def _gen():
+        yield ("token", {"content": "a"})
+        yield ("done", {"message": {"content": "a"}})
+
+    return _gen()
+
+
+# ─── engine-level: heartbeat while the planner thinks ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_planner_wait_emits_keepalive_before_first_token(engine, monkeypatch):
+    """#435: a slow planner call must not silence the stream — keep_alive
+    events arrive between task_start and the first token event."""
+    monkeypatch.setattr(ee_mod, "_PLANNER_KEEPALIVE_S", 0.02)
+
+    async def slow_planner(*a, **kw):
+        await asyncio.sleep(0.10)  # >> heartbeat interval, << test budget
+        return None
+
+    monkeypatch.setattr(engine, "_maybe_plan", slow_planner)
+    monkeypatch.setattr(engine, "_call_llm_stream", _fast_stream)
+
+    events = await _collect(engine.chat_stream("做一个成都 POI 分析", session_id="s-plan-kv"))
+
+    types = [_event_type(e) for e in events]
+    assert "task_start" in types and "token" in types, types
+    ka = [i for i, t in enumerate(types) if t == "keep_alive"]
+    assert ka, f"no keep_alive during the planner wait: {types}"
+    assert types.index("task_start") < ka[0], "heartbeat must come after task_start"
+    assert ka[0] < types.index("token"), "heartbeat must come before the first token"
+    assert types[-1] == "done"
+
+
+@pytest.mark.asyncio
+async def test_planner_wait_heartbeats_repeat_for_long_planner(engine, monkeypatch):
+    """A planner silent for several heartbeat intervals emits repeated
+    keep_alive events (a single ping would not carry a 60s+ wait past a 30s
+    idle proxy)."""
+    monkeypatch.setattr(ee_mod, "_PLANNER_KEEPALIVE_S", 0.02)
+
+    async def very_slow_planner(*a, **kw):
+        await asyncio.sleep(0.12)
+        return None
+
+    monkeypatch.setattr(engine, "_maybe_plan", very_slow_planner)
+    monkeypatch.setattr(engine, "_call_llm_stream", _fast_stream)
+
+    events = await _collect(engine.chat_stream("plan", session_id="s-plan-kv2"))
+    ka = sum(1 for e in events if _event_type(e) == "keep_alive")
+    assert ka >= 2, f"expected repeated heartbeats, got {ka}"
+
+
+@pytest.mark.asyncio
+async def test_fast_planner_no_spurious_heartbeat(engine, monkeypatch):
+    """A planner that returns quickly must not change the event stream shape:
+    no keep_alive fires between task_start and the first token."""
+    monkeypatch.setattr(ee_mod, "_PLANNER_KEEPALIVE_S", 5.0)
+
+    async def fast_planner(*a, **kw):
+        return None
+
+    monkeypatch.setattr(engine, "_maybe_plan", fast_planner)
+    monkeypatch.setattr(engine, "_call_llm_stream", _fast_stream)
+
+    events = await _collect(engine.chat_stream("hi", session_id="s-plan-fast"))
+    types = [_event_type(e) for e in events]
+    assert "keep_alive" not in types, types
+    assert types[0] == "task_start"
+
+
+@pytest.mark.asyncio
+async def test_planner_exception_still_degrades_to_no_plan(engine, monkeypatch):
+    """_maybe_plan normally swallows its own exceptions; if it ever raises,
+    the keepalive wrapper must propagate the exception (not swallow it into a
+    hanging or silent stream) — same contract as the bare await it replaces."""
+    monkeypatch.setattr(ee_mod, "_PLANNER_KEEPALIVE_S", 0.02)
+
+    async def exploding_planner(*a, **kw):
+        await asyncio.sleep(0.05)
+        raise RuntimeError("planner exploded")
+
+    monkeypatch.setattr(engine, "_maybe_plan", exploding_planner)
+    monkeypatch.setattr(engine, "_call_llm_stream", _fast_stream)
+
+    with pytest.raises(RuntimeError, match="planner exploded"):
+        await _collect(engine.chat_stream("q", session_id="s-plan-err"))
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_planner_wait(engine, monkeypatch):
+    """Client disconnect during the planner wait must cancel the planner
+    coroutine — the wrapper must not leave the LLM call running detached
+    (semantics of the bare await it replaces)."""
+    monkeypatch.setattr(ee_mod, "_PLANNER_KEEPALIVE_S", 0.02)
+
+    cancelled = {"flag": False}
+
+    async def slow_planner(*a, **kw):
+        try:
+            await asyncio.sleep(2.0)
+            return None
+        except asyncio.CancelledError:
+            cancelled["flag"] = True
+            raise
+
+    monkeypatch.setattr(engine, "_maybe_plan", slow_planner)
+    monkeypatch.setattr(engine, "_call_llm_stream", _fast_stream)
+
+    gen = engine.chat_stream("q", session_id="s-plan-disc")
+    # Drive the generator until it is provably inside the planner wait: the
+    # first keep_alive is yielded by the wait pump, so the planner task is
+    # guaranteed to be in flight at that suspension point.
+    saw_heartbeat = False
+    deadline = asyncio.get_event_loop().time() + 2.0
+    while not saw_heartbeat:
+        assert asyncio.get_event_loop().time() < deadline, "no keep_alive arrived"
+        if _event_type(await gen.__anext__()) == "keep_alive":
+            saw_heartbeat = True
+    assert saw_heartbeat
+    await gen.aclose()
+
+    await asyncio.sleep(0.05)
+    assert cancelled["flag"], "planner coroutine was not cancelled on disconnect"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_payload_is_sse_event_shaped(engine, monkeypatch):
+    """The heartbeat must be produced via the sse_event helper (invariant #6:
+    SSE Event Format Consistency) — 'event: keep_alive\\ndata: {...}\\n\\n'."""
+    monkeypatch.setattr(ee_mod, "_PLANNER_KEEPALIVE_S", 0.02)
+
+    async def slow_planner(*a, **kw):
+        await asyncio.sleep(0.08)
+        return None
+
+    monkeypatch.setattr(engine, "_maybe_plan", slow_planner)
+    monkeypatch.setattr(engine, "_call_llm_stream", _fast_stream)
+
+    events = await _collect(engine.chat_stream("q", session_id="s-plan-shape"))
+    heartbeats = [e for e in events if _event_type(e) == "keep_alive"]
+    assert heartbeats
+    for block in heartbeats:
+        assert block.startswith("event: keep_alive\ndata: ")
+        assert block.endswith("\n\n")

--- a/tests/test_subagent_context_isolation_436.py
+++ b/tests/test_subagent_context_isolation_436.py
@@ -1,0 +1,208 @@
+"""#436: subagent context isolation on the INPUT side (sibling of #407).
+
+#407 fixed the output side: a subagent engine never persists its transcript
+into the parent conversation. But the input side leaked: the sub engine
+reuses the parent's session_id, and
+
+  - ``_get_or_create_session`` → ``_load_session_from_db`` has no subagent
+    bypass, so the parent's persisted history (budget-truncated to ~6000
+    tokens) is loaded into the subagent's message list;
+  - ``ChatContextAssembler.assemble`` injects
+    ``render_plan_block(get_plan(session_id))`` — the PARENT's active plan,
+    including "unfinished steps" admonitions and tool_family hints for
+    tools the subagent may not even have.
+
+The subagent tool contract states the subagent sees only its task. Tests
+below spawn a subagent against a parent session that has history + an
+active plan and assert the assembled LLM prompt contains neither.
+
+Deterministic: LLM call, history DB read and saves are faked; no network.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.chat import planner as planner_mod
+from app.services.subagent import SubagentDispatcher
+from app.services.chat_engine import ChatEngine
+from app.tools.registry import ToolRegistry
+
+_PARENT_MARKER = "PARENT-HISTORY-MARKER-XYZ"
+
+
+@pytest.fixture
+def parent_plan():
+    plan = planner_mod.Plan(
+        intent="PARENT-PLAN-INTENT-MARKER 分析全国医院分布",
+        domains=["core"],
+        steps=[
+            planner_mod.PlanStep(n=1, goal="PARENT-STEP load hospitals", tool_family="core"),
+            planner_mod.PlanStep(n=2, goal="PARENT-STEP buffer analysis", tool_family="core"),
+        ],
+    )
+    planner_mod.set_plan("sess-parent-436", plan)
+    yield plan
+    planner_mod.clear_plan("sess-parent-436")
+
+
+@pytest.fixture
+def captured_llm_prompts(monkeypatch):
+    """Capture the composed message list the sub engine sends to the LLM."""
+    captured: list[list[dict]] = []
+
+    async def fake_call_llm(self, messages, tools):  # noqa: ANN001
+        captured.append(messages)
+        return {"choices": [{"message": {"content": "子任务完成：已处理。", "reasoning": ""}}]}
+
+    monkeypatch.setattr(ChatEngine, "_call_llm", fake_call_llm)
+    return captured
+
+
+# ─── unit: _get_or_create_session bypasses the DB history load ───────────────
+
+
+@pytest.mark.asyncio
+async def test_subengine_does_not_load_parent_history(monkeypatch):
+    engine = ChatEngine(ToolRegistry(), is_subagent_engine=True)
+
+    async def spy_load(session_id, user_id=None):
+        spy_load.called = True
+        return [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": _PARENT_MARKER},
+            {"role": "assistant", "content": "parent answer"},
+        ]
+
+    spy_load.called = False
+    monkeypatch.setattr(engine, "_load_session_from_db", spy_load)
+
+    messages = await engine._get_or_create_session("sess-parent-436")
+
+    assert not spy_load.called, "subagent engine loaded the parent's DB history"
+    assert len(messages) == 1
+    assert messages[0]["role"] == "system"
+    assert _PARENT_MARKER not in str(messages)
+
+
+@pytest.mark.asyncio
+async def test_main_engine_still_loads_parent_history(monkeypatch):
+    """The bypass must be scoped to subagent engines only — a main engine on
+    the same session still hydrates from the DB."""
+    engine = ChatEngine(ToolRegistry())
+
+    async def fake_load(session_id, user_id=None):
+        return [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": _PARENT_MARKER},
+        ]
+
+    monkeypatch.setattr(engine, "_load_session_from_db", fake_load)
+    messages = await engine._get_or_create_session("sess-parent-436-main")
+    assert any(_PARENT_MARKER in str(m) for m in messages)
+
+
+# ─── unit: assembler plan-block gate ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_assembler_plan_block_gate(parent_plan):
+    from app.services.chat.context_assembler import ChatContextAssembler
+
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "task"},
+    ]
+    with_block = await ChatContextAssembler().assemble(
+        "sess-parent-436", list(messages)
+    )
+    assert any("执行计划" in str(m.get("content", "")) for m in with_block.to_messages())
+
+    without_block = await ChatContextAssembler().assemble(
+        "sess-parent-436", list(messages), include_plan_block=False
+    )
+    rendered = "\n".join(str(m.get("content", "")) for m in without_block.to_messages())
+    assert "执行计划" not in rendered
+    assert "PARENT-PLAN-INTENT-MARKER" not in rendered
+
+
+# ─── integration: dispatcher.run end-to-end prompt isolation ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawned_subagent_prompt_excludes_parent_history_and_plan(
+    parent_plan, captured_llm_prompts, monkeypatch
+):
+    monkeypatch.setattr(
+        ChatEngine, "_save_msg_async", AsyncMock()
+    )  # defensive: no DB writes during test
+    dispatcher = SubagentDispatcher(ToolRegistry(), "sess-parent-436")
+
+    # Parent's DB history would be loaded here if the bypass were missing.
+    async def fake_load(self, session_id, user_id=None):  # noqa: ANN001
+        return [
+            {"role": "system", "content": self._build_system_prompt()},
+            {"role": "user", "content": _PARENT_MARKER},
+            {"role": "assistant", "content": "parent 的旧回答"},
+            {"role": "user", "content": f"{_PARENT_MARKER} 第二轮"},
+        ]
+
+    monkeypatch.setattr(ChatEngine, "_load_session_from_db", fake_load)
+
+    result = await dispatcher.run(
+        task="为海淀区每个医院找最近的地铁站",
+        domains=["network"],
+    )
+
+    assert result.success, result.error
+    assert captured_llm_prompts, "LLM was never called"
+    prompt_text = "\n".join(
+        str(m.get("content", "")) for m in captured_llm_prompts[0]
+    )
+
+    # Task itself must be present (wrapped subagent prompt).
+    assert "为海淀区每个医院找最近的地铁站" in prompt_text
+    # Parent's persisted history must be absent.
+    assert _PARENT_MARKER not in prompt_text, (
+        "subagent context contains the parent's persisted history"
+    )
+    # Parent's active plan block must be absent.
+    assert "执行计划" not in prompt_text, (
+        "subagent context contains the parent's active plan block"
+    )
+    assert "PARENT-PLAN-INTENT-MARKER" not in prompt_text
+    assert "PARENT-STEP" not in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_subagent_context_size_independent_of_parent_history(
+    captured_llm_prompts, monkeypatch
+):
+    """Acceptance: assembled context length is independent of N parent turns."""
+    monkeypatch.setattr(ChatEngine, "_save_msg_async", AsyncMock())
+
+    async def make_parent_history(n_turns: int):
+        async def fake_load(self, session_id, user_id=None):  # noqa: ANN001
+            msgs = [{"role": "system", "content": self._build_system_prompt()}]
+            for i in range(n_turns):
+                msgs.append({"role": "user", "content": f"{_PARENT_MARKER} turn {i}"})
+                msgs.append({"role": "assistant", "content": f"answer {i}"})
+            return msgs
+
+        return fake_load
+
+    sizes = []
+    for n_turns in (2, 40):
+        captured_llm_prompts.clear()
+        monkeypatch.setattr(
+            ChatEngine, "_load_session_from_db", await make_parent_history(n_turns)
+        )
+        dispatcher = SubagentDispatcher(ToolRegistry(), "sess-parent-436")
+        res = await dispatcher.run(task="子任务", domains=["core"])
+        assert res.success
+        sizes.append(len(str(captured_llm_prompts[0])))
+
+    assert sizes[0] == sizes[1], (
+        f"subagent context size depends on parent history length: {sizes}"
+    )

--- a/tests/test_web_search_offload_434.py
+++ b/tests/test_web_search_offload_434.py
@@ -1,0 +1,186 @@
+"""Regression tests for #434: web_search's DuckDuckGo fallback must never block
+the event loop and must be bounded by a real timeout.
+
+Before the fix, ``web_search`` (an ``async def`` dispatched with the ASYNC
+policy, i.e. awaited directly on the loop) called the fully synchronous
+``DDGS().text()`` inline — every DDG search (the default path whenever
+``BAIDU_QIANFAN_TOKEN`` is unset) froze all concurrent SSE streams for the
+full HTTP round-trip, with no outer wall-clock bound. ``search_and_extract_poi``
+shared the same fallback.
+
+These tests mirror tests/test_event_loop_offload_386.py: fake a slow DDG
+search with ``time.sleep``, drive it through real ``registry.dispatch``, and
+assert a concurrent asyncio ticker keeps firing while the search runs and
+that the work happened on a worker thread (not the loop thread). A separate
+test asserts the wall-clock budget turns a hung DDG call into an error dict.
+
+Run cost: ~2s total (0.6-0.8s fake sleeps), no network.
+"""
+import asyncio
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+_main_thread = threading.get_ident()
+
+
+class _SlowDDGS:
+    """Fake duckduckgo_search client that blocks for `delay` seconds.
+
+    Records the thread it ran on so tests can prove the sync HTTP work was
+    pushed off the event loop.
+    """
+
+    observed: dict = {}
+    delay: float = 0.8
+    hang: bool = False  # hang=True → sleep far beyond any budget (timeout test)
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def text(self, keywords, **kwargs):
+        _SlowDDGS.observed["thread"] = threading.get_ident()
+        _SlowDDGS.observed.setdefault("calls", []).append(keywords)
+        if _SlowDDGS.hang:
+            time.sleep(5.0)
+        else:
+            time.sleep(_SlowDDGS.delay)
+        return [
+            {"title": "Slow Result", "body": "snippet", "href": "https://example.com"}
+        ]
+
+
+def _fresh_registry():
+    from app.tools.registry import ToolRegistry
+    from app.tools.web_crawler import register_crawler_tools
+
+    registry = ToolRegistry()
+    register_crawler_tools(registry)
+    return registry
+
+
+async def _assert_loop_responsive_during(awaitable_factory):
+    """Same technique as tests/test_event_loop_offload_386.py.
+
+    With the DDG work on the loop, the fake's time.sleep blocks everything and
+    the 0.05s ticker cannot complete; with the work offloaded the dispatch task
+    is still running when the ticker fires.
+    """
+    _SlowDDGS.observed = {}
+    task = asyncio.create_task(awaitable_factory())
+    await asyncio.sleep(0.15)  # let dispatch reach the slow work
+    assert not task.done(), "work finished before the test could observe it"
+
+    ticks = []
+
+    async def _tick():
+        await asyncio.sleep(0.05)
+        ticks.append(True)
+
+    tick = asyncio.create_task(_tick())
+    await asyncio.sleep(0.15)
+    assert tick.done() and ticks, "event loop was blocked during the DDG search"
+    assert not task.done(), "event loop was blocked during the DDG search"
+    return await task
+
+
+# ─── Site 1: web_search DDG fallback (default path, no Qianfan token) ────────
+
+
+@pytest.mark.asyncio
+async def test_web_search_ddg_off_loop():
+    """DDG fallback inside web_search must run in a worker thread."""
+    registry = _fresh_registry()
+    with patch("app.tools.web_crawler.settings") as s, \
+         patch("app.tools.web_crawler.DDGS", _SlowDDGS):
+        s.BAIDU_QIANFAN_TOKEN = ""  # auto → ddg fallback
+        result = await _assert_loop_responsive_during(
+            lambda: registry.dispatch("web_search", {"query": "成都 星巴克"})
+        )
+    assert _SlowDDGS.observed.get("thread") != _main_thread, (
+        "DDG search ran on the event loop thread"
+    )
+    assert result.get("provider") == "duckduckgo"
+    assert result["count"] == 1
+    assert "security_notice" in result
+
+
+# ─── Site 2: search_and_extract_poi shares the same DDG fallback ─────────────
+
+
+@pytest.mark.asyncio
+async def test_search_and_extract_poi_ddg_off_loop():
+    registry = _fresh_registry()
+    with patch("app.tools.web_crawler.settings") as s, \
+         patch("app.tools.web_crawler.DDGS", _SlowDDGS):
+        s.BAIDU_QIANFAN_TOKEN = ""
+        result = await _assert_loop_responsive_during(
+            lambda: registry.dispatch("search_and_extract_poi", {"query": "成都 星巴克"})
+        )
+    assert _SlowDDGS.observed.get("thread") != _main_thread, (
+        "DDG search ran on the event loop thread"
+    )
+    assert result.get("type") == "poi_web_search"
+    assert result["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_ddg_provider_off_loop():
+    """provider='ddg' must go through the same offloaded path."""
+    registry = _fresh_registry()
+    with patch("app.tools.web_crawler.settings") as s, \
+         patch("app.tools.web_crawler.DDGS", _SlowDDGS):
+        s.BAIDU_QIANFAN_TOKEN = "bce-v3/tok"  # token set, but provider forced to ddg
+        result = await _assert_loop_responsive_during(
+            lambda: registry.dispatch(
+                "web_search", {"query": "q", "provider": "ddg"}
+            )
+        )
+    assert _SlowDDGS.observed.get("thread") != _main_thread, (
+        "DDG search ran on the event loop thread"
+    )
+    assert result.get("provider") == "duckduckgo"
+
+
+# ─── Wall-clock budget: a hung DDG call must yield an error, not an
+#     unbounded wait (the sync client's internal retries cannot be trusted) ───
+
+
+@pytest.mark.asyncio
+async def test_ddg_timeout_returns_error(monkeypatch):
+    import app.tools.web_crawler as mod
+
+    monkeypatch.setattr(mod, "_DDG_WALL_CLOCK_S", 0.3)
+    _SlowDDGS.observed = {}
+    _SlowDDGS.hang = True
+    registry = _fresh_registry()
+    try:
+        with patch("app.tools.web_crawler.settings") as s, \
+             patch("app.tools.web_crawler.DDGS", _SlowDDGS):
+            s.BAIDU_QIANFAN_TOKEN = ""
+            started = time.monotonic()
+            result = await registry.dispatch("web_search", {"query": "q"})
+        elapsed = time.monotonic() - started
+        assert "error" in result, f"expected timeout error dict, got {result}"
+        assert "超时" in result["error"]
+        assert elapsed < 3.0, f"dispatch waited {elapsed:.1f}s despite the 0.3s budget"
+        # The loop must stay free while the abandoned worker thread hangs.
+        ticks = []
+
+        async def _tick():
+            await asyncio.sleep(0.05)
+            ticks.append(True)
+
+        tick = asyncio.create_task(_tick())
+        await asyncio.sleep(0.2)
+        assert tick.done() and ticks, "event loop blocked by abandoned DDG thread"
+    finally:
+        _SlowDDGS.hang = False


### PR DESCRIPTION
## Issues
- Fixes #434 (P2: web_search runs synchronous DuckDuckGo HTTP on the event loop — async tool, no timeout)
- Fixes #435 (P2: no keepalive during the planner LLM call — up to 120 s stream silence; sibling of #409)
- Fixes #436 (P2: subagent inherits parent's persisted history and active plan block; input-side sibling of #407)
- Fixes #437 (P3: spatial_reasoning returns hardcoded mock conclusion with fabricated confidence via plan-mode/admin paths)
- Fixes #438 (P3: system prompt and tool descriptions reference unregistered tool names)
- Fixes #439 (P3: slim_tool_result caps bypassed for plain strings and non-geojson dict keys)

## Implementation (one commit per issue)
- #434: DuckDuckGo fallback offloaded off the event loop with a wall-clock budget (386 pattern); event-loop-lag regression test.
- #435: SSE keepalive heartbeats emitted while awaiting the planner LLM call (via `_sse_event`; CODE_REVIEW invariant #3).
- #436: subagent context assembly excludes parent persisted history + active plan block (input-side isolation; output-side #407 fix intact).
- #437: mock conclusion removed — honest structured unavailable result with correction_hint (Exception As Thought) through plan-mode/admin dispatch paths.
- #438: prompt/tool-description tool names aligned to the registry (test parses prompt + descriptions and asserts every referenced tool is registered).
- #439: slim caps extended to plain strings and non-geojson dict keys (data/rows/chart…); geojson path unchanged.

## Validation
53 targeted tests + new suites (web_search offload, subagent isolation, jenks-independent); `ruff` clean; Zero Big Data Context / Compute Isolation / SSE keepalive invariants re-audited.

## Risk
Low-medium: #437 changes plan-mode/admin output for spatial_reasoning from fabricated-confidence to honest unavailability (intended); #435 changes SSE stream only by adding heartbeats (format via _sse_event).