### PR TITLE
fix(webgis): style-epoch guard, annotation remount, custom-overlay z-band, no hot-path getStyle, workbench turn isolation, session-scoped aria, plan-approval rollback (#459 #460 #461 #462 #466 #467 #468)

### DIFF
--- a/frontend/components/chat/chat-announcer.test.tsx
+++ b/frontend/components/chat/chat-announcer.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ChatAnnouncer } from './chat-announcer';
+
+/**
+ * #467: the announcer inferred completion from the thinking/acting → idle
+ * STATUS TRANSITION. Switching sessions mid-stream forces aiStatus to idle
+ * (use-workspace-session.selectSession), so the announcer fired a false
+ * "回复已完成" and read whatever transcript was current at that moment — the
+ * restored session's last message or the 已恢复历史会话 system line. The
+ * announcement must be tied to the session the turn belongs to.
+ */
+
+const messagesA = [{ role: 'assistant' as const, content: '会话 A 的回答' }];
+
+function announcer(props: {
+  aiStatus: string;
+  sessionId?: string | null;
+  messages?: Array<{ role: 'user' | 'assistant'; content: string }>;
+}) {
+  return render(
+    <ChatAnnouncer
+      messages={props.messages ?? messagesA}
+      aiStatus={props.aiStatus as any}
+      sessionId={props.sessionId}
+    />,
+  );
+}
+
+function liveText(): string {
+  return screen.getByRole('status').textContent ?? '';
+}
+
+describe('ChatAnnouncer — session-scoped completion (#467)', () => {
+  it('announces completion for a normal thinking → idle turn in the same session', () => {
+    const view = announcer({ aiStatus: 'thinking', sessionId: 'sess-a' });
+    expect(liveText()).toBe('正在分析指令');
+
+    view.rerender(
+      <ChatAnnouncer messages={messagesA} aiStatus="idle" sessionId="sess-a" />,
+    );
+    expect(liveText()).toBe('回复已完成：会话 A 的回答');
+  });
+
+  it('mid-stream session switch announces NO completion (selectSession forces idle)', () => {
+    const view = announcer({ aiStatus: 'thinking', sessionId: 'sess-a' });
+    expect(liveText()).toBe('正在分析指令');
+
+    // selectSession: aiStatus → idle + sessionId → B + the transcript becomes
+    // the restored session's (here: the 已恢复历史会话 system line).
+    view.rerender(
+      <ChatAnnouncer
+        messages={[{ role: 'assistant', content: '已恢复历史会话「B」——共 3 条记录。' }]}
+        aiStatus="idle"
+        sessionId="sess-b"
+      />,
+    );
+    expect(liveText()).not.toContain('回复已完成');
+
+    // And the restored transcript's content is never read as a completion.
+    expect(liveText()).not.toContain('已恢复历史会话');
+  });
+
+  it('a later restore of messages in the SAME idle state stays silent', () => {
+    const view = announcer({ aiStatus: 'thinking', sessionId: 'sess-a' });
+    view.rerender(
+      <ChatAnnouncer
+        messages={[{ role: 'assistant', content: '已恢复历史会话「B」' }]}
+        aiStatus="idle"
+        sessionId="sess-b"
+      />,
+    );
+    // The async session-content GET resolves after the switch — messages
+    // change while status stays idle. Still no completion announcement.
+    view.rerender(
+      <ChatAnnouncer
+        messages={[{ role: 'user', content: '历史用户消息' }, { role: 'assistant', content: '历史助手消息' }]}
+        aiStatus="idle"
+        sessionId="sess-b"
+      />,
+    );
+    expect(liveText()).not.toContain('回复已完成');
+  });
+
+  it('a fresh turn in the NEW session still announces normally', () => {
+    const view = announcer({ aiStatus: 'thinking', sessionId: 'sess-a' });
+    view.rerender(
+      <ChatAnnouncer messages={messagesA} aiStatus="idle" sessionId="sess-b" />,
+    );
+    expect(liveText()).not.toContain('回复已完成');
+
+    // New session's own turn.
+    view.rerender(
+      <ChatAnnouncer
+        messages={[{ role: 'assistant', content: '会话 B 的回答' }]}
+        aiStatus="thinking"
+        sessionId="sess-b"
+      />,
+    );
+    expect(liveText()).toBe('正在分析指令');
+    act(() => {});
+    view.rerender(
+      <ChatAnnouncer
+        messages={[{ role: 'assistant', content: '会话 B 的回答' }]}
+        aiStatus="idle"
+        sessionId="sess-b"
+      />,
+    );
+    expect(liveText()).toBe('回复已完成：会话 B 的回答');
+  });
+
+  it('new-session path (sessionId → undefined) is also suppressed', () => {
+    const view = announcer({ aiStatus: 'acting', sessionId: 'sess-a' });
+    expect(liveText()).toBe('正在执行空间操作');
+    view.rerender(<ChatAnnouncer messages={messagesA} aiStatus="idle" />);
+    expect(liveText()).not.toContain('回复已完成');
+  });
+});

--- a/frontend/components/chat/chat-announcer.tsx
+++ b/frontend/components/chat/chat-announcer.tsx
@@ -12,6 +12,14 @@ interface AnnounceableMessage {
 interface Props {
   messages: readonly AnnounceableMessage[];
   aiStatus: AiStatus;
+  /**
+   * #467: the session the streaming turn belongs to. Switching sessions
+   * mid-stream forces aiStatus to idle (use-workspace-session.selectSession),
+   * which is an ABORT of the old session's turn — not a completion. The
+   * announcer must not read the (new/restored) transcript as a finished
+   * reply, so a sessionId change resets the transition tracker silently.
+   */
+  sessionId?: string | null;
 }
 
 /**
@@ -29,11 +37,21 @@ interface Props {
  * that work started, know when it ended, then read the result at their own pace
  * with normal browse-mode navigation.
  */
-export function ChatAnnouncer({ messages, aiStatus }: Props) {
+export function ChatAnnouncer({ messages, aiStatus, sessionId }: Props) {
   const [message, setMessage] = useState('');
   const lastStatus = useRef<AiStatus | null>(null);
+  const lastSessionRef = useRef<typeof sessionId>(sessionId);
 
   useEffect(() => {
+    // #467: session boundary (switch via History drawer / new session). The
+    // thinking/acting → idle transition that arrives in the same render is an
+    // abort of the OLD session's turn, and whatever transcript is current
+    // belongs to the NEW session — never announce a completion across it.
+    if (sessionId !== lastSessionRef.current) {
+      lastSessionRef.current = sessionId;
+      lastStatus.current = null;
+      return;
+    }
     if (aiStatus === lastStatus.current) return;
     const previous = lastStatus.current;
     lastStatus.current = aiStatus;
@@ -56,7 +74,7 @@ export function ChatAnnouncer({ messages, aiStatus }: Props) {
       const text = last?.role === 'assistant' ? (last.content ?? '').trim() : '';
       setMessage(text ? `回复已完成：${text}` : '回复已完成');
     }
-  }, [aiStatus, messages]);
+  }, [aiStatus, messages, sessionId]);
 
   return (
     <div

--- a/frontend/components/layout/context-panel.tsx
+++ b/frontend/components/layout/context-panel.tsx
@@ -349,6 +349,7 @@ export function ContextPanel({
             aiStatus={aiStatus}
             onSend={onSend}
             onPlanAction={onPlanAction}
+            sessionId={sessionId}
           />
         )}
         {activeTab === 'project' && <ProjectTab />}

--- a/frontend/components/map/map-action-handler.test.tsx
+++ b/frontend/components/map/map-action-handler.test.tsx
@@ -7,6 +7,7 @@ import {
   notifyUserGestureStart,
   _resetCameraArbitrationForTests,
 } from '@/lib/map-commands/camera-arbitration';
+import { clearStyleLayerIds } from '@/lib/map-kit/renderer';
 
 const mockFlyTo = vi.fn();
 const mapMockInstance = {
@@ -175,6 +176,9 @@ describe('MapActionHandler', () => {
     // not reset implementations, so re-establish the default explicitly.
     mockGetMap.mockImplementation(() => mapMockInstance);
     _resetCameraArbitrationForTests();
+    // #462: the renderer's per-map layer-id registry must not leak a seed
+    // across tests on the shared singleton map (each test re-mocks getStyle).
+    clearStyleLayerIds(mapMockInstance);
   });
 
   afterEach(() => {

--- a/frontend/components/map/map-basemap-lifecycle.test.tsx
+++ b/frontend/components/map/map-basemap-lifecycle.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MapPanel } from './map-panel';
 import type { Layer } from '@/lib/types/layer';
 import { makeMockMaplibreMap } from '../../test/__mocks__/maplibre-map';
+import * as renderer from '@/lib/map-kit/renderer';
 
 /**
  * Combined MapLibre lifecycle scenario for issues #459 / #460 / #461:
@@ -289,12 +290,18 @@ describe('MapPanel — basemap switch during in-flight reconcile (#459/#460/#461
 
     // ── #461: custom-* overlay re-added after recovery stays above spec ──
     // (the add_layer command path re-runs on the new style; the next
-    // layer-changing reconcile must not bury it again).
-    rmg.map.addSource('custom-poi', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: [] },
+    // layer-changing reconcile must not bury it again). Added through the
+    // production helper the command uses, so the layer-id registry sees it.
+    renderer.addGeoJsonSource(rmg.map as any, 'custom-poi', {
+      type: 'FeatureCollection',
+      features: [],
     });
-    rmg.map.addLayer({ id: 'custom-poi', type: 'circle', source: 'custom-poi' });
+    renderer.addVectorLayer(rmg.map as any, {
+      id: 'custom-poi',
+      type: 'circle',
+      source: 'custom-poi',
+      paint: {},
+    });
     rerenderPanel(view, [...changedLayers, pointLayer('hospital', 'Hospital')]);
     await drainRuntime();
 

--- a/frontend/components/map/map-basemap-lifecycle.test.tsx
+++ b/frontend/components/map/map-basemap-lifecycle.test.tsx
@@ -1,0 +1,312 @@
+/* eslint-disable @typescript-eslint/no-require-imports --
+ * vi.mock 工厂被 vitest hoist 到顶层 import 之上，引用模块级变量会 TDZ 报错，
+ * 只能在工厂内 require（vitest 官方模式）；仅本测试文件适用。 */
+import { render, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MapPanel } from './map-panel';
+import type { Layer } from '@/lib/types/layer';
+import { makeMockMaplibreMap } from '../../test/__mocks__/maplibre-map';
+
+/**
+ * Combined MapLibre lifecycle scenario for issues #459 / #460 / #461:
+ *
+ *   reconcile in-flight → basemap setStyle mid-patch → style recovery →
+ *   full reapply → actual map state == MapSpec state
+ *
+ * A basemap switch (map.setStyle) drops every user source+layer — spec
+ * sublayers (MapSpecRuntime), the annotation stack, the selection highlight
+ * and the imperative custom-* overlays alike — while a debounced reconcile
+ * patch may still be queued. The runtime must not let that patch's completion
+ * marker resurrect a stale appliedSpec (#459), the recovery reconcile must
+ * fully re-apply the spec, and the imperative stacks must come back mounted
+ * (#460) and stay above the spec layers once custom overlays are re-added
+ * (#461). This single test fails if any of the three regressions returns.
+ */
+
+const rmg = vi.hoisted(() => ({
+  interactiveLayerIds: [] as string[],
+  lastOnClick: null as null | ((e: any) => void),
+  lastOnLoad: null as null | (() => void),
+  queryResults: [] as any[],
+  loaded: false,
+  map: null as any,
+}));
+
+/** Mutable basemap selection — drives MapPanel's currentMapStyle. */
+const basemap = vi.hoisted(() => ({ index: 1 }));
+
+const hud = vi.hoisted(() => {
+  const initialState = () => ({
+    is3D: false,
+    processLayers: {} as Record<string, unknown>,
+    cartographyTitle: null as string | null,
+    viewport: { center: [116.4, 39.9], zoom: 4, bearing: 0, pitch: 0, bounds: undefined },
+    focusLayerId: null as string | null,
+    aiStatus: 'idle',
+    selectedFeature: null as any,
+    mapLoaded: false,
+    layers: [] as any[],
+    annotations: [] as any[],
+  });
+  const actions = {
+    setMapLoaded: (v: boolean) => hud.setState({ mapLoaded: v }),
+    setSelectedFeature: (f: any) => hud.setState({ selectedFeature: f }),
+    setViewport: () => {},
+    focusLayer: (id: string | null) => hud.setState({ focusLayerId: id }),
+  };
+  const state: Record<string, unknown> = { ...initialState(), ...actions };
+  const listeners = new Set<() => void>();
+  return {
+    state,
+    getState: () => state,
+    setState: (partial: Record<string, unknown>) => {
+      Object.assign(state, partial);
+      listeners.forEach((l) => l());
+    },
+    reset: () => {
+      Object.keys(state).forEach((k) => delete state[k]);
+      Object.assign(state, initialState(), actions);
+    },
+    subscribe: (cb: () => void) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+  };
+});
+
+vi.mock('react-map-gl/maplibre', () => {
+  const React = require('react');
+  const MapMock = React.forwardRef(function MapMock(props: any, ref: any) {
+    React.useImperativeHandle(ref, () => ({ getMap: () => rmg.map }), []);
+    rmg.interactiveLayerIds = props.interactiveLayerIds ?? [];
+    rmg.lastOnClick = props.onClick ?? null;
+    rmg.lastOnLoad = props.onLoad ?? null;
+    const styleRef = React.useRef(props.mapStyle);
+    React.useEffect(() => {
+      if (!rmg.loaded) {
+        rmg.loaded = true;
+        props.onLoad?.();
+        return;
+      }
+      if (styleRef.current !== props.mapStyle) {
+        styleRef.current = props.mapStyle;
+        // setStyle semantics: every user source+layer is dropped, then the
+        // style reloads (styledata / style.load fire after the swap).
+        for (const l of [...rmg.map._layers]) rmg.map.removeLayer(l.id);
+        for (const id of Object.keys(rmg.map._sources)) rmg.map.removeSource(id);
+        rmg.map._fire('styledata');
+        rmg.map._fire('load');
+      }
+    });
+    return React.createElement('div', { 'data-testid': 'map-mock' }, props.children);
+  });
+  const PopupMock = (props: any) =>
+    React.createElement('div', { 'data-testid': 'popup' }, props.children);
+  return { default: MapMock, Popup: PopupMock };
+});
+
+vi.mock('@/lib/store/useHudStore', () => {
+  const React = require('react');
+  const { useSyncExternalStore } = React;
+  const subscribe = (cb: () => void) => hud.subscribe(cb);
+  const useHudStore = (selector: (s: any) => unknown) =>
+    useSyncExternalStore(
+      subscribe,
+      () => selector(hud.state),
+      () => selector(hud.state),
+    );
+  useHudStore.getState = () => hud.state;
+  useHudStore.setState = (partial: any) => hud.setState(partial);
+  return { useHudStore };
+});
+
+vi.mock('@/lib/contexts/map-action-context', () => ({
+  useMapAction: () => ({
+    actions: [],
+    dispatchAction: vi.fn(),
+    popAction: vi.fn(),
+    selectedBaseLayer: basemap.index,
+    setSelectedBaseLayer: vi.fn(),
+    registerSnapshotFn: vi.fn(),
+    getMapSnapshot: vi.fn(() => null),
+  }),
+}));
+
+vi.mock('./map-action-handler', () => ({ MapActionHandler: () => null }));
+vi.mock('./thematic-legend', () => ({ ThematicLegend: () => null }));
+vi.mock('./map-decorations', () => ({ MapDecorations: () => null }));
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const noop = () => {};
+
+function pointLayer(id: string, name: string): Layer {
+  return {
+    id,
+    name,
+    type: 'vector',
+    visible: true,
+    opacity: 1,
+    source: {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: { name: `${name}-feat` },
+          geometry: { type: 'Point', coordinates: [116.4, 39.9] },
+        },
+      ],
+    },
+    style: { color: '#16a34a' },
+  };
+}
+
+const clickPoint = { point: [10, 20], lngLat: { lng: 116.4, lat: 39.9 } };
+
+async function renderPanel(layers: Layer[]) {
+  const view = render(
+    <MapPanel layers={layers} onRemoveLayer={noop} onToggleLayer={noop} onViewportChange={noop} />,
+  );
+  await waitFor(() => expect(rmg.interactiveLayerIds).toEqual(['poi__point', 'schools__point']), {
+    timeout: 3000,
+  });
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 100));
+  });
+  return view;
+}
+
+function rerenderPanel(view: ReturnType<typeof render>, layers: Layer[]) {
+  view.rerender(
+    <MapPanel layers={layers} onRemoveLayer={noop} onToggleLayer={noop} onViewportChange={noop} />,
+  );
+}
+
+async function drainRuntime() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 100));
+  });
+}
+
+/** Yield ONLY microtasks: lets reconcileAsync's processOne enqueue its patch
+ * ops while the debouncer's setTimeout(0) op frame stays pending — the exact
+ * in-flight window a basemap switch can land inside. */
+async function pumpMicrotasks(ticks = 12) {
+  for (let i = 0; i < ticks; i++) await Promise.resolve();
+}
+
+describe('MapPanel — basemap switch during in-flight reconcile (#459/#460/#461)', () => {
+  beforeEach(() => {
+    hud.reset();
+    basemap.index = 1;
+    rmg.map = makeMockMaplibreMap({ renderedFeatures: () => rmg.queryResults });
+    rmg.queryResults = [];
+    rmg.interactiveLayerIds = [];
+    rmg.loaded = false;
+  });
+
+  it('recovers to map state == MapSpec state with all imperative stacks intact', async () => {
+    const specLayers = [pointLayer('poi', 'POI'), pointLayer('schools', 'Schools')];
+    const view = await renderPanel(specLayers);
+    expect(rmg.map.getLayer('poi__point')).toBeTruthy();
+    expect(rmg.map.getLayer('schools__point')).toBeTruthy();
+
+    // ── Imperative stacks mounted on the live map ─────────────────────────
+    // Annotation (draw_measurement / add_marker output in the store).
+    const measurement = {
+      type: 'Feature',
+      geometry: { type: 'LineString', coordinates: [[116.4, 39.9], [116.41, 39.91]] },
+      properties: { label: '1.2km' },
+    };
+    hud.setState({ annotations: [measurement] });
+    await drainRuntime(); // post-reconcile raise mounts the annotation stack
+
+    // Selection highlight via a real click pick.
+    const geometry = { type: 'Point', coordinates: [116.4, 39.9] };
+    rmg.queryResults = [
+      {
+        type: 'Feature',
+        geometry,
+        properties: { name: 'X' },
+        layer: { id: 'poi__point' },
+      },
+    ];
+    act(() => rmg.lastOnClick?.(clickPoint));
+    await waitFor(() => expect(hud.state.selectedFeature).toBeTruthy());
+    await waitFor(() =>
+      expect(rmg.map.getLayer('claude-selection-highlight-fill')).toBeTruthy(),
+    );
+
+    // ── Reconcile starts (layer-changing: visibility toggle on poi) ────────
+    const changedLayers = specLayers.map((l) =>
+      l.id === 'poi' ? { ...l, visible: false } : l,
+    );
+    rerenderPanel(view, changedLayers);
+    await pumpMicrotasks(); // patch ops enqueued; debouncer frame still pending
+
+    // ── Basemap setStyle fires mid-patch ──────────────────────────────────
+    basemap.index = 0; // different style object → MapMock simulates setStyle
+    rerenderPanel(view, changedLayers);
+    // The wipe dropped everything the spec and the commands had mounted.
+    expect(rmg.map.getLayer('poi__point')).toBeNull();
+    expect(rmg.map.getLayer('claude-annotations-fill')).toBeNull();
+    expect(rmg.map.getLayer('claude-selection-highlight-fill')).toBeNull();
+
+    // ── Style recovery + full reapply ─────────────────────────────────────
+    await drainRuntime();
+
+    // #459: every spec source/layer is back; interactive ids (derived from
+    // appliedSpec once the patch settles) match the spec's sublayers.
+    expect(rmg.map.getSource('poi')).toBeTruthy();
+    expect(rmg.map.getSource('schools')).toBeTruthy();
+    expect(rmg.map.getLayer('poi__point')).toBeTruthy();
+    expect(rmg.map.getLayer('schools__point')).toBeTruthy();
+    await waitFor(() =>
+      expect(rmg.interactiveLayerIds).toEqual(['poi__point', 'schools__point']),
+      { timeout: 3000 },
+    );
+    // appliedSpec == current spec: a subsequent no-change reconcile emits no
+    // add/addSource work at all (empty diff against the recorded basis).
+    const addsBefore = rmg.map._calls.addLayer.length;
+    const srcAddsBefore = rmg.map._calls.addSource.length;
+    rerenderPanel(view, [...changedLayers]);
+    await drainRuntime();
+    expect(rmg.map._calls.addLayer.length).toBe(addsBefore);
+    expect(rmg.map._calls.addSource.length).toBe(srcAddsBefore);
+
+    // #460: the annotation stack is re-mounted WITH its data.
+    for (const suffix of ['fill', 'line', 'circle', 'label']) {
+      expect(rmg.map.getLayer(`claude-annotations-${suffix}`)).toBeTruthy();
+    }
+    const annotationData = rmg.map._calls.setData
+      .filter((c: { id: string }) => c.id === 'claude-annotations')
+      .pop();
+    expect(annotationData.data.features).toEqual([measurement]);
+
+    // #402 sibling path: the selection highlight is re-mounted on top.
+    expect(rmg.map.getLayer('claude-selection-highlight-fill')).toBeTruthy();
+    const order = () => rmg.map._layers.map((l: any) => l.id);
+
+    // ── #461: custom-* overlay re-added after recovery stays above spec ──
+    // (the add_layer command path re-runs on the new style; the next
+    // layer-changing reconcile must not bury it again).
+    rmg.map.addSource('custom-poi', {
+      type: 'geojson',
+      data: { type: 'FeatureCollection', features: [] },
+    });
+    rmg.map.addLayer({ id: 'custom-poi', type: 'circle', source: 'custom-poi' });
+    rerenderPanel(view, [...changedLayers, pointLayer('hospital', 'Hospital')]);
+    await drainRuntime();
+
+    const finalOrder = order();
+    for (const specLayer of ['poi__point', 'schools__point', 'hospital__point']) {
+      expect(finalOrder.indexOf('custom-poi')).toBeGreaterThan(
+        finalOrder.indexOf(specLayer),
+      );
+    }
+    // Annotation stack still topmost of the imperative UX band.
+    expect(finalOrder.indexOf('claude-annotations-label')).toBeGreaterThan(
+      finalOrder.indexOf('custom-poi'),
+    );
+  });
+});

--- a/frontend/components/map/map-panel.test.tsx
+++ b/frontend/components/map/map-panel.test.tsx
@@ -39,6 +39,8 @@ const hud = vi.hoisted(() => {
     selectedFeature: null as any,
     mapLoaded: false,
     layers: [] as any[],
+    // raiseAnnotationLayers (#460 remount) reads this from the store.
+    annotations: [] as any[],
   });
   const actions = {
     setMapLoaded: (v: boolean) => hud.setState({ mapLoaded: v }),
@@ -542,6 +544,30 @@ describe('MapPanel — FE-3 interaction UX', () => {
       ).toBe(true);
     }
     expect(annotationMoves[annotationMoves.length - 1].beforeId).toBeNull();
+  });
+
+  // #461 (sibling of #401): imperative `custom-*` overlays (add_layer /
+  // heatmap / thematic-map commands) are mounted once outside MapSpecRuntime;
+  // every layer-changing reconcile buries them under the spec sublayers via
+  // syncLayerZOrder. The panel must re-raise the custom band after the patch.
+  it('keeps custom-* overlays above spec layers after a layer-changing reconcile', async () => {
+    const view = await renderPanel([pointLayer('poi', 'POI')]);
+    await settleInteractive(['poi__point']);
+
+    // Imperative add_layer command output: source + layer on top at mount.
+    rmg.map.addSource('custom-poi', {
+      type: 'geojson',
+      data: { type: 'FeatureCollection', features: [] },
+    });
+    rmg.map.addLayer({ id: 'custom-poi', type: 'circle', source: 'custom-poi' });
+
+    // Layer-changing reconcile (visibility toggle → recompile → z-order sync
+    // stacks the spec sublayers on top of the custom overlay).
+    rerenderPanel(view, [{ ...pointLayer('poi', 'POI'), visible: false }]);
+    await drainRuntime();
+
+    const order = rmg.map._layers.map((l: any) => l.id);
+    expect(order.indexOf('custom-poi')).toBeGreaterThan(order.indexOf('poi__point'));
   });
 
   // FIX-3-9 (#402): a basemap switch (setStyle diff) wipes the imperative

--- a/frontend/components/map/map-panel.test.tsx
+++ b/frontend/components/map/map-panel.test.tsx
@@ -7,6 +7,7 @@ import { MapPanel } from './map-panel';
 import type { Layer } from '@/lib/types/layer';
 import { makeMockMaplibreMap } from '../../test/__mocks__/maplibre-map';
 import { isUserGesturing, _resetCameraArbitrationForTests } from '@/lib/map-commands/camera-arbitration';
+import * as renderer from '@/lib/map-kit/renderer';
 
 /**
  * FE-3 (design §7) MapPanel interaction UX tests.
@@ -554,12 +555,18 @@ describe('MapPanel — FE-3 interaction UX', () => {
     const view = await renderPanel([pointLayer('poi', 'POI')]);
     await settleInteractive(['poi__point']);
 
-    // Imperative add_layer command output: source + layer on top at mount.
-    rmg.map.addSource('custom-poi', {
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: [] },
+    // Imperative add_layer command output: source + layer on top at mount
+    // (through the production helpers the command uses).
+    renderer.addGeoJsonSource(rmg.map, 'custom-poi', {
+      type: 'FeatureCollection',
+      features: [],
     });
-    rmg.map.addLayer({ id: 'custom-poi', type: 'circle', source: 'custom-poi' });
+    renderer.addVectorLayer(rmg.map, {
+      id: 'custom-poi',
+      type: 'circle',
+      source: 'custom-poi',
+      paint: {},
+    });
 
     // Layer-changing reconcile (visibility toggle → recompile → z-order sync
     // stacks the spec sublayers on top of the custom overlay).

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -326,10 +326,16 @@ export function MapPanel({
     void runtimeRef.current.reconcileAsync(spec)
       .then(() => {
         syncInteractiveIds()
+        const map = mapRef.current?.getMap()
+        // #461 (sibling of #401): the imperative `custom-*` overlays
+        // (add_layer / heatmap / thematic-map commands) are buried by every
+        // layer-changing reconcile — syncLayerZOrder stacks all spec sublayers
+        // on top and nothing re-raises the custom band. Restore it FIRST so
+        // the ephemeral UX stacks below stay topmost.
+        if (map) renderer.raiseCustomOverlayLayers(map)
         // FIX-3-2: syncLayerZOrder buried the selection highlight under the
         // spec sublayers — put it back on top now that the reconcile settled.
         raiseSelectionHighlight()
-        const map = mapRef.current?.getMap()
         // FIX-3-9 (#401): the imperative annotation stack (markers /
         // measurements / labels) suffers the same burying — syncLayerZOrder
         // stacks every spec sublayer above it on any layer-changing patch.

--- a/frontend/components/sidebar/chat-tab.tsx
+++ b/frontend/components/sidebar/chat-tab.tsx
@@ -99,6 +99,12 @@ interface ChatTabProps {
   onSend: (text: string) => void;
   /** Plan Mode: 用户在卡片上点按钮时回调，由父组件发送对应 chat 消息并更新 plan.status */
   onPlanAction?: (planId: string, action: 'approve' | 'revise' | 'reject') => void;
+  /**
+   * #467: 当前会话 id —— 中途切换会话（History 抽屉 / 新会话）会把 aiStatus
+   * 强制置 idle，但那是旧会话回合的中止而非完成；播报器据此抑制错误的
+   * 「回复已完成」。
+   */
+  sessionId?: string | null;
 }
 
 /* ─── Memoized message bubble ───
@@ -248,7 +254,7 @@ const ChatMessageItem = memo(function ChatMessageItem({
   );
 });
 
-export function ChatTab({ messages, aiStatus, onSend, onPlanAction }: ChatTabProps) {
+export function ChatTab({ messages, aiStatus, onSend, onPlanAction, sessionId }: ChatTabProps) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
@@ -350,7 +356,7 @@ export function ChatTab({ messages, aiStatus, onSend, onPlanAction }: ChatTabPro
       </div>
 
       {/* Input area */}
-      <ChatAnnouncer messages={messages} aiStatus={aiStatus} />
+      <ChatAnnouncer messages={messages} aiStatus={aiStatus} sessionId={sessionId} />
 
       {/* 不透明底 + 去掉 blur(12px)：composer 压在地图上，半透明会让输入文字
           与底图细节互相干扰，而 backdrop-filter 又是最贵的那类合成。 */}

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -528,3 +528,70 @@ describe('canonical MapSpec runtime patch', () => {
 });
 
 
+
+describe('useSSEStream — turn-scoped tool-arg evidence (#466)', () => {
+  beforeEach(() => {
+    bridgeMock.send.mockClear();
+    bridgeMock.aiStatus = 'idle';
+    useHudStore.getState().clearResults();
+  });
+
+  function fire(event: string, data: Record<string, unknown>) {
+    act(() => {
+      bridgeMock.onEventCallback?.({ event, data });
+    });
+  }
+
+  it('a turn start clears the previous interrupted turn\'s pending tool args', async () => {
+    const { result } = renderStream();
+
+    // Turn A: tool_call captured, stream cut before step_result/task end.
+    fire('tool_call', { name: 'buffer_analysis', arguments: '{"distance":300}' });
+
+    // Turn B starts (the production handleSend path).
+    await act(async () => {
+      await result.current.handleSend('重试缓冲区分析');
+    });
+
+    // Turn B: same tool runs to completion.
+    fire('tool_call', { name: 'buffer_analysis', arguments: '{"distance":900}' });
+    fire('step_result', { step_id: 's-b2', tool: 'buffer_analysis', session_id: 'sid-fe4', result: { success: true, summary: 'ok' } });
+
+    const r = useHudStore.getState().results.find((x) => x.id === 's-b2');
+    expect(r).toBeDefined();
+    // WITHOUT the turn-start reset the FIFO hands Turn B's result Turn A's args.
+    expect(r!.parameters).toEqual(
+      expect.arrayContaining([expect.objectContaining({ source: 'distance', value: 900 })]),
+    );
+    expect(r!.parameters).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ value: 300 })]),
+    );
+  });
+
+  it('task_cancelled drops remaining pending args (a retry pairs with its own)', async () => {
+    const { result } = renderStream();
+    await act(async () => {
+      await result.current.handleSend('分析');
+    });
+
+    fire('tool_call', { name: 'hotspot_analysis', arguments: '{"distance":100}' });
+    fire('tool_call', { name: 'hotspot_analysis', arguments: '{"distance":200}' }); // queued, never ran
+    fire('task_cancelled', { session_id: 'sid-fe4', task_id: 't1' });
+
+    // Retry turn: fresh args only.
+    await act(async () => {
+      await result.current.handleSend('重试');
+    });
+    fire('tool_call', { name: 'hotspot_analysis', arguments: '{"distance":950}' });
+    fire('step_result', { step_id: 's-r', tool: 'hotspot_analysis', session_id: 'sid-fe4', result: { success: true } });
+
+    const r = useHudStore.getState().results.find((x) => x.id === 's-r');
+    expect(r).toBeDefined();
+    expect(r!.parameters).toEqual(
+      expect.arrayContaining([expect.objectContaining({ source: 'distance', value: 950 })]),
+    );
+    expect(r!.parameters).toEqual(
+      expect.not.arrayContaining([expect.objectContaining({ value: 100 })]),
+    );
+  });
+});

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -595,3 +595,101 @@ describe('useSSEStream — turn-scoped tool-arg evidence (#466)', () => {
     );
   });
 });
+
+describe('useSSEStream — plan approval rollback (#468)', () => {
+  function fire(event: string, data: Record<string, unknown>) {
+    act(() => {
+      bridgeMock.onEventCallback?.({ event, data });
+    });
+  }
+
+  beforeEach(() => {
+    bridgeMock.send.mockReset();
+    bridgeMock.send.mockResolvedValue(undefined);
+    bridgeMock.aiStatus = 'idle';
+    useHudStore.setState({ aiStatus: 'idle' });
+  });
+
+  async function renderWithApprovedPlan() {
+    const { result } = renderStream();
+    await act(async () => {
+      await result.current.handleSend('给我一个分析计划');
+    });
+    // propose_plan step_result attaches the plan card to the thinking message.
+    fire('step_result', {
+      step_id: 's-plan',
+      tool: 'propose_plan',
+      session_id: 'sid-fe4',
+      result: {
+        success: true,
+        plan_id: 'plan-1',
+        title: '学校密度分析',
+        summary: '三步',
+        step_count: 3,
+        destructive_steps: [],
+        steps_preview: [],
+      },
+    });
+    const withPlan = result.current.messages.find((m) => (m as any).plan);
+    expect((withPlan as any)?.plan.status).toBe('pending');
+    return { result };
+  }
+
+  it('reverts the optimistic approval when the follow-up send fails', async () => {
+    const { result } = await renderWithApprovedPlan();
+
+    // The deferred send fails like a dead stream: the bridge resolves with the
+    // store's aiStatus left at 'error' (useMapBridge's terminal handling).
+    bridgeMock.send.mockImplementation(async () => {
+      useHudStore.setState({ aiStatus: 'error' });
+    });
+
+    act(() => {
+      result.current.handlePlanAction('plan-1', 'approve');
+    });
+    // Optimistic lock applied immediately…
+    const planMsg = () =>
+      (result.current.messages.find((m) => (m as any).plan) as any)?.plan;
+    expect(planMsg().status).toBe('approved');
+
+    // …then the deferred send runs and fails → the card must roll back to
+    // pending (actionable again), not stay locked forever.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(planMsg().status).toBe('pending');
+  });
+
+  it('keeps the approval when the follow-up send succeeds', async () => {
+    const { result } = await renderWithApprovedPlan();
+    bridgeMock.send.mockImplementation(async () => {
+      useHudStore.setState({ aiStatus: 'done' });
+    });
+
+    act(() => {
+      result.current.handlePlanAction('plan-1', 'approve');
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    const planMsg = (result.current.messages.find((m) => (m as any).plan) as any)?.plan;
+    expect(planMsg.status).toBe('approved');
+  });
+
+  it('reject path also rolls back (send throws)', async () => {
+    const { result } = await renderWithApprovedPlan();
+    bridgeMock.send.mockRejectedValue(new Error('network down'));
+
+    act(() => {
+      result.current.handlePlanAction('plan-1', 'reject');
+    });
+    const planMsg = () =>
+      (result.current.messages.find((m) => (m as any).plan) as any)?.plan;
+    expect(planMsg().status).toBe('rejected');
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(planMsg().status).toBe('pending');
+  });
+});

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -769,10 +769,32 @@ export function useSSEStream(
         : action === 'revise'
         ? `修改计划 ${planId}（说说哪里需要调整）`
         : `取消计划 ${planId}`;
-    setTimeout(() => handleSendRef.current?.(text), 0);
+    setTimeout(() => {
+      // #468: the optimistic status above is only honest once the follow-up
+      // send actually went through. A failed send (network death, exhausted
+      // stream) left the card locked forever with the plan unexecuted — roll
+      // it back to pending so the buttons are actionable again (the stream
+      // error itself is surfaced separately by the bridge/chat error UI).
+      const sent = handleSendRef.current?.(text);
+      if (!sent || typeof sent.then !== 'function') return;
+      const revert = () => {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.plan?.plan_id === planId
+              ? { ...m, plan: { ...m.plan, status: 'pending' } }
+              : m
+          )
+        );
+      };
+      sent.then((ok) => {
+        if (!ok) revert();
+      }).catch(revert);
+    }, 0);
   }, []);
 
-  const handleSendRef = useRef<((text: string) => void) | null>(null);
+  // #468: the ref carries handleSend's success signal (true = the turn
+  // completed; false/rejection = failed) so plan approval can roll back.
+  const handleSendRef = useRef<((text: string) => Promise<boolean>) | null>(null);
   const isLoadingRef = useRef(isLoading);
   isLoadingRef.current = isLoading;
   // F-5: synchronous in-flight guard. ``isLoadingRef`` is only refreshed during
@@ -782,8 +804,8 @@ export function useSSEStream(
   const sendingRef = useRef(false);
 
   const handleSend = useCallback(
-    async (userMsg: string) => {
-      if (!userMsg || isLoadingRef.current || sendingRef.current) return;
+    async (userMsg: string): Promise<boolean> => {
+      if (!userMsg || isLoadingRef.current || sendingRef.current) return false;
 
       // #466: pending tool-arg evidence is TURN-scoped. Args queued by an
       // interrupted previous turn (stream cut, task_cancelled without
@@ -879,6 +901,11 @@ export function useSSEStream(
               : m
           )
         );
+        // #468: turn outcome for optimistic-UI callers (plan approval). The
+        // bridge resolves even when the stream died — the store's terminal
+        // aiStatus (synced by useMapBridge before the send promise settles)
+        // is the truthful signal.
+        return useHudStore.getState().aiStatus !== 'error';
       } finally {
         // F-5: release the synchronous in-flight guard only after the send has
         // committed (success or error); by then isLoading governs re-entry.

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -668,6 +668,10 @@ export function useSSEStream(
           });
         }
       } else if (event.event === 'task_cancelled') {
+        // #466: the cancelled task's tool calls never emit their
+        // step_result/step_cancelled — their queued args must not leak into
+        // the next turn's workbench evidence.
+        useHudStore.getState().resetPendingToolArgs();
         setMessages((prev) =>
           prev.map((m) => {
             if (m.id !== thinkingId) return m;
@@ -693,6 +697,10 @@ export function useSSEStream(
         if (event.event === 'step_error' && typeof data?.tool === 'string' && data.tool) {
           useHudStore.getState().discardPendingToolArgs(data.tool);
           markToolCallStatus(data.tool, 'failed', typeof data?.error === 'string' ? data.error : undefined);
+        } else if (event.event === 'error' || event.event === 'task_error') {
+          // #466: a stream-level death ends the turn — remaining queued args
+          // have no step_result coming and must not leak into the next turn.
+          useHudStore.getState().resetPendingToolArgs();
         }
         const raw = data?.error;
         const detail =
@@ -776,6 +784,12 @@ export function useSSEStream(
   const handleSend = useCallback(
     async (userMsg: string) => {
       if (!userMsg || isLoadingRef.current || sendingRef.current) return;
+
+      // #466: pending tool-arg evidence is TURN-scoped. Args queued by an
+      // interrupted previous turn (stream cut, task_cancelled without
+      // step_cancelled, exhausted reconnects) must never be FIFO-consumed by
+      // THIS turn's step_results as wrong input evidence.
+      useHudStore.getState().resetPendingToolArgs();
 
       const { viewport, baseLayer, is3D, layers: hudLayers, selectedFeature, focusLayerId } = useHudStore.getState();
       const liveSnapshot = getMapSnapshot();

--- a/frontend/lib/map-commands/annotationHelpers.test.ts
+++ b/frontend/lib/map-commands/annotationHelpers.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  ANNOTATION_SOURCE_ID,
+  ensureAnnotationLayers,
+  raiseAnnotationLayers,
+  ANNOTATION_LAYER_IDS,
+} from './annotationHelpers';
+import { makeMockMaplibreMap } from '../../test/__mocks__/maplibre-map';
+import { useHudStore } from '@/lib/store/useHudStore';
+
+/**
+ * #460: the imperative annotation stack (markers / measurements / labels) is
+ * wiped by every basemap setStyle. #402 gave the selection highlight a
+ * re-mount on style recovery; this suite pins the same contract for the
+ * annotation stack: after a wipe, raising the stack must RE-CREATE the
+ * source + all four layers with their data, not just re-order survivors.
+ */
+
+const markerFeature = {
+  type: 'Feature',
+  geometry: { type: 'Point', coordinates: [116.4, 39.9] },
+  properties: { label: '学校', color: '#ef4444' },
+};
+
+describe('raiseAnnotationLayers — basemap setStyle wipe (#460)', () => {
+  let map: any;
+  beforeEach(() => {
+    map = makeMockMaplibreMap();
+    useHudStore.getState().clearAnnotations?.();
+    useHudStore.setState({ annotations: [] as any });
+  });
+
+  it('early-returns (no mount) when no annotations exist — fresh maps stay clean', () => {
+    raiseAnnotationLayers(map);
+    expect(map.getStyle().layers).toEqual([]);
+    expect(map.getSource(ANNOTATION_SOURCE_ID)).toBeNull();
+  });
+
+  it('re-mounts the source + all 4 layers with their data after a full style wipe', () => {
+    useHudStore.setState({ annotations: [markerFeature] as any });
+    // Mounted once by MapActionHandler's refresh effect, then wiped by setStyle.
+    ensureAnnotationLayers(map);
+    for (const l of [...map._layers]) map.removeLayer(l.id);
+    for (const id of Object.keys(map._sources)) map.removeSource(id);
+    expect(map.getLayer(`${ANNOTATION_SOURCE_ID}-fill`)).toBeNull();
+
+    // The post-reconcile raise must REMOUNT (mirror of #402's highlight fix),
+    // not early-return on the all-four-gone post-wipe state.
+    raiseAnnotationLayers(map);
+
+    for (const id of ANNOTATION_LAYER_IDS) {
+      expect(map.getLayer(id)).toBeTruthy();
+    }
+    expect(map.getSource(ANNOTATION_SOURCE_ID)).toBeTruthy();
+    const dataCalls = map._calls.setData.filter(
+      (c: { id: string }) => c.id === ANNOTATION_SOURCE_ID,
+    );
+    expect(dataCalls.length).toBeGreaterThan(0);
+    expect(dataCalls[dataCalls.length - 1].data.features).toEqual([markerFeature]);
+  });
+
+  it('re-raises (moves to top) when the stack survives a reconcile', () => {
+    useHudStore.setState({ annotations: [markerFeature] as any });
+    ensureAnnotationLayers(map);
+    // Spec-style layer stacked above the annotations by syncLayerZOrder.
+    map.addLayer({ id: 'poi__point', type: 'circle', source: 'poi' });
+    // Bottom-to-top re-raise order: fill, line, circle, label.
+    raiseAnnotationLayers(map);
+    const ids = map._layers.map((l: any) => l.id);
+    expect(ids.indexOf('poi__point')).toBeLessThan(
+      ids.indexOf(`${ANNOTATION_SOURCE_ID}-fill`),
+    );
+    expect(ids.indexOf(`${ANNOTATION_SOURCE_ID}-fill`)).toBeLessThan(
+      ids.indexOf(`${ANNOTATION_SOURCE_ID}-label`),
+    );
+  });
+
+  it('is a silent no-op for layer mutation failures mid-reconcile', () => {
+    useHudStore.setState({ annotations: [markerFeature] as any });
+    ensureAnnotationLayers(map);
+    map.moveLayer = vi.fn(() => {
+      throw new Error('layer vanished mid-reconcile');
+    });
+    expect(() => raiseAnnotationLayers(map)).not.toThrow();
+  });
+});

--- a/frontend/lib/map-commands/annotationHelpers.ts
+++ b/frontend/lib/map-commands/annotationHelpers.ts
@@ -1,5 +1,6 @@
 import type { GeoJSONSource, Map } from 'maplibre-gl';
 import { useHudStore } from '@/lib/store/useHudStore';
+import { noteStyleLayerAdded } from '@/lib/map-kit/renderer';
 
 // R8 annotation source: 单一 FeatureCollection 收纳 add_marker / draw_measurement 输出。
 // Zustand 状态迁移：将原本模块级的 mutable array 迁移至 Zustand，支持多组件共享、响应式更新和一致的生命周期管理。
@@ -77,6 +78,11 @@ export function ensureAnnotationLayers(map: Map) {
       },
     });
   }
+  // #462: keep the renderer's layer-id order registry exact for these adds.
+  noteStyleLayerAdded(map, `${ANNOTATION_SOURCE_ID}-fill`);
+  noteStyleLayerAdded(map, `${ANNOTATION_SOURCE_ID}-line`);
+  noteStyleLayerAdded(map, `${ANNOTATION_SOURCE_ID}-circle`);
+  noteStyleLayerAdded(map, `${ANNOTATION_SOURCE_ID}-label`);
 }
 
 /**
@@ -138,7 +144,9 @@ export function raiseAnnotationLayers(map: Map): void {
   if (!stackMounted) {
     // Post-wipe state: only remount when there is annotation data to show —
     // maps that never used annotations stay free of the (empty) stack.
-    if (useHudStore.getState().annotations.length === 0) return;
+    // (Defensive read: partial store harnesses may not carry the field.)
+    const annotations = useHudStore.getState().annotations ?? [];
+    if (annotations.length === 0) return;
     ensureAnnotationLayers(map);
     refreshAnnotations(map);
   }

--- a/frontend/lib/map-commands/annotationHelpers.ts
+++ b/frontend/lib/map-commands/annotationHelpers.ts
@@ -104,7 +104,7 @@ export function refreshAnnotations(map: Map): boolean {
  * mount order: fill → line → circle → label). Moving each to the top in this
  * order ends with label on top.
  */
-const ANNOTATION_LAYER_IDS = [
+export const ANNOTATION_LAYER_IDS = [
   `${ANNOTATION_SOURCE_ID}-fill`,
   `${ANNOTATION_SOURCE_ID}-line`,
   `${ANNOTATION_SOURCE_ID}-circle`,
@@ -125,9 +125,23 @@ const ANNOTATION_LAYER_IDS = [
  * no-op when the stack isn't mounted, and moveLayer is wrapped so a layer
  * that vanished mid-reconcile is skipped silently. Callers run it after a
  * reconcile settles, alongside the selection-highlight re-raise.
+ *
+ * #460: a basemap setStyle wipes the whole imperative stack while nothing
+ * re-creates it — the MapActionHandler refresh effect deps ([mapInstance,
+ * annotations]) don't change on a style swap because the map instance is
+ * stable across setStyle. Mirror #402's selection-highlight remount: when
+ * every annotation layer is gone but annotations exist in the store, RE-MOUNT
+ * the source + layers and push the data instead of early-returning.
  */
 export function raiseAnnotationLayers(map: Map): void {
-  if (!ANNOTATION_LAYER_IDS.some((id) => map.getLayer(id))) return;
+  const stackMounted = ANNOTATION_LAYER_IDS.some((id) => map.getLayer(id));
+  if (!stackMounted) {
+    // Post-wipe state: only remount when there is annotation data to show —
+    // maps that never used annotations stay free of the (empty) stack.
+    if (useHudStore.getState().annotations.length === 0) return;
+    ensureAnnotationLayers(map);
+    refreshAnnotations(map);
+  }
   for (const id of ANNOTATION_LAYER_IDS) {
     if (!map.getLayer(id)) continue;
     try {

--- a/frontend/lib/map-commands/layerCommands.test.ts
+++ b/frontend/lib/map-commands/layerCommands.test.ts
@@ -4,7 +4,10 @@ import type { MapCommandContext } from './types';
 import * as renderer from '@/lib/map-kit/renderer';
 import { makeMockMaplibreMap } from '@/test/__mocks__/maplibre-map';
 
-vi.mock('@/lib/map-kit/renderer', () => ({
+// #462: keep the real layer-id registry exports (matchMapLayers reads them);
+// only the style-mutating helpers are stubbed for call assertions.
+vi.mock('@/lib/map-kit/renderer', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/map-kit/renderer')>()),
   updateLayerStyle: vi.fn(),
   addGeoJSONLayer: vi.fn(),
   removeLayer: vi.fn(),

--- a/frontend/lib/map-commands/layerCommands.ts
+++ b/frontend/lib/map-commands/layerCommands.ts
@@ -37,9 +37,10 @@ function isStoreSchemeMatch(target: string, id: string): boolean {
 
 /** All map layer ids matching the target across both schemes (style index). */
 function matchMapLayers(map: any, target: string): string[] {
-  const style = map?.getStyle?.();
-  return ((style?.layers ?? []) as any[])
-    .map((l: any) => l.id as string)
+  // #462: id list from the maintained registry — getStyle() here deep-cloned
+  // the whole style on every map command (matchMapLayers runs 2-3×/command).
+  return renderer
+    .getStyleLayerIds(map)
     .filter((id: string) => isCustomSchemeMatch(target, id) || isStoreSchemeMatch(target, id));
 }
 
@@ -269,6 +270,7 @@ export const layerCommands: Record<string, CommandEntry> = {
       for (const id of storeMatched) {
         if (map.getLayer?.(id)) {
           try { map.removeLayer(id); } catch { /* already gone */ }
+          renderer.noteStyleLayerRemoved(map, id);
         }
       }
       if (map.getSource?.(target)) {
@@ -280,7 +282,8 @@ export const layerCommands: Record<string, CommandEntry> = {
       // 4. V3 round-2 FIX-B: post-mutation verification — the resolved stack
       //    must be gone from the map (getLayer/getSource absent OR the style
       //    layer set no longer contains any of the target's sublayers).
-      const layersAfter = ((map.getStyle?.()?.layers ?? []) as any[]).map((l: any) => l.id as string);
+      //    (#462: registry read — no per-command style deep-clone.)
+      const layersAfter = renderer.getStyleLayerIds(map);
       const stillPresent = matched.some(
         (id) => !!map.getLayer?.(id) || !!map.getSource?.(id) || layersAfter.includes(id),
       );
@@ -499,12 +502,9 @@ export const layerCommands: Record<string, CommandEntry> = {
       //    custom stack (the runtime does not own these layers).
       let customMoved = false;
       if (customMatched.length > 0) {
-        const style = map.getStyle();
-        const allLayers = style.layers || [];
-
-        // Snapshot custom layer IDs only (we ignore base style layers)
-        const customIds = allLayers
-          .map((l: any) => l.id as string)
+        // #462: registry read — no per-command style deep-clone.
+        const customIds = renderer
+          .getStyleLayerIds(map)
           .filter((id: string) => id.startsWith('custom-'));
 
         const firstSubIdx = customIds.indexOf(customMatched[0]);
@@ -541,6 +541,10 @@ export const layerCommands: Record<string, CommandEntry> = {
             map.moveLayer(id, beforeAnchor);
           }
           customMoved = true;
+          // #462: anchored moves are not mirrored by the registry's note
+          // hooks — drop it so the next read re-seeds from one cold getStyle
+          // (reorders are rare commands; the cold re-seed is the budget).
+          renderer.clearStyleLayerIds(map);
         } catch (e) {
           devOnly.warn('[MapActionHandler] REORDER_LAYER failed:', e);
           return { status: 'failed', error: 'reorder_failed' };
@@ -581,10 +585,11 @@ export const layerCommands: Record<string, CommandEntry> = {
 
       // V3 round-2 FIX-B: post-mutation verification — the target sublayers
       // must still exist on the map (moveLayer on a stale style index is a
-      // silent no-op otherwise).
-      const layersAfter = ((map.getStyle?.()?.layers ?? []) as any[]).map((l: any) => l.id as string);
+      // silent no-op otherwise). (#462: registry read; after the anchored-move
+      // clear above this re-seeds cold from the live style — truthful.)
+      const layersAfter = renderer.getStyleLayerIds(map);
       const targetGone = matched.some(
-        (id: string) => !map.getLayer?.(id) && !layersAfter.includes(id),
+        (id) => !map.getLayer?.(id) && !layersAfter.includes(id),
       );
       if (targetGone) return nonConfirmableAck(storeMatched);
 

--- a/frontend/lib/map-kit/renderer-style.test.ts
+++ b/frontend/lib/map-kit/renderer-style.test.ts
@@ -13,7 +13,8 @@ function createMockMap(layerType: string = 'fill') {
 }
 
 // We'll import after the mock is ready
-import { updateLayerStyle } from './renderer';
+import { updateLayerStyle, raiseCustomOverlayLayers, CUSTOM_OVERLAY_PREFIX } from './renderer';
+import { makeMockMaplibreMap } from '../../test/__mocks__/maplibre-map';
 
 describe('updateLayerStyle expanded properties', () => {
   it('sets stroke color on fill layer', () => {
@@ -48,5 +49,56 @@ describe('updateLayerStyle expanded properties', () => {
       strokeColor: '#333333',
     });
     expect(map.setPaintProperty).toHaveBeenCalledWith('test-layer', 'circle-stroke-color', '#333333');
+  });
+});
+
+describe('raiseCustomOverlayLayers — post-reconcile z-band (#461)', () => {
+  it('lifts every custom-* overlay back above the spec sublayers a reconcile stacked on top', () => {
+    const map = makeMockMaplibreMap();
+    // Imperative overlays (add_layer / heatmap / thematic map commands).
+    map.addSource('custom-poi', { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
+    map.addLayer({ id: 'custom-poi', type: 'circle', source: 'custom-poi' });
+    map.addLayer({ id: 'custom-poi-label', type: 'symbol', source: 'custom-poi' });
+    // Spec sublayers + basemap layers.
+    map.addLayer({ id: 'basemap-raster', type: 'raster', source: 'raster-tiles' });
+    map.addLayer({ id: 'poi__fill', type: 'fill', source: 'poi' });
+    map.addLayer({ id: 'poi__point', type: 'circle', source: 'poi' });
+    // A layer-changing reconcile buries the custom overlays at the top.
+    // (syncLayerZOrder moves every spec sublayer to the top of the stack.)
+
+    raiseCustomOverlayLayers(map as any);
+
+    const order = map._layers.map((l: any) => l.id);
+    // Both custom overlays sit above ALL spec sublayers…
+    for (const specLayer of ['basemap-raster', 'poi__fill', 'poi__point']) {
+      expect(order.indexOf('custom-poi')).toBeGreaterThan(order.indexOf(specLayer));
+      expect(order.indexOf('custom-poi-label')).toBeGreaterThan(order.indexOf(specLayer));
+    }
+    // …and their insertion order (relative z among overlays) is preserved.
+    expect(order.indexOf('custom-poi')).toBeLessThan(order.indexOf('custom-poi-label'));
+  });
+
+  it('is a cheap no-op when no custom-* overlays exist', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'poi__point', type: 'circle', source: 'poi' });
+    raiseCustomOverlayLayers(map as any);
+    expect(map._calls.moveLayer).toEqual([]);
+    expect(map._layers.map((l: any) => l.id)).toEqual(['poi__point']);
+  });
+
+  it('skips ids the style no longer has (mid-reconcile vanish) without throwing', () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'custom-gone', type: 'circle', source: 'custom-gone' });
+    map.removeLayer('custom-gone');
+    expect(() => raiseCustomOverlayLayers(map as any)).not.toThrow();
+    expect(map._calls.moveLayer).toEqual([]);
+  });
+
+  it(`matches only the ${CUSTOM_OVERLAY_PREFIX} prefix (annotation/spec layers stay put)`, () => {
+    const map = makeMockMaplibreMap();
+    map.addLayer({ id: 'poi__point', type: 'circle', source: 'poi' });
+    map.addLayer({ id: 'claude-annotations-fill', type: 'fill', source: 'claude-annotations' });
+    raiseCustomOverlayLayers(map as any);
+    expect(map._calls.moveLayer).toEqual([]);
   });
 });

--- a/frontend/lib/map-kit/renderer.ts
+++ b/frontend/lib/map-kit/renderer.ts
@@ -719,3 +719,44 @@ export function syncLayerZOrder(map: Map, prefix: string, orderedBaseIds: string
     }
   }
 }
+
+/**
+ * #461: z-band prefix of the imperative command overlays (`add_layer`,
+ * `add_native_heatmap`, `create_thematic_map`, `add_heatmap_raster`,
+ * `add_raster_layer` all mint `custom-*` ids — see layerCommands.ts /
+ * heatmapCommands.ts).
+ */
+export const CUSTOM_OVERLAY_PREFIX = 'custom-';
+
+/**
+ * #461 (sibling of #401): re-raise the imperative `custom-*` overlays above
+ * the spec-derived layers after every layer-changing reconcile.
+ *
+ * syncLayerZOrder moves every MapSpec sublayer to the TOP of the stack on any
+ * non-empty layer patch, burying the command-added overlays under
+ * 0.3-opacity fills. #401 fixed that class of bug for the annotation stack
+ * only — the custom band had no post-reconcile restoration. Because
+ * useMapBridge dispatches imperative commands BEFORE the same step_result's
+ * store layer mount, a command emitted alongside an auto-mount is buried by
+ * that very reconcile; nothing ever lifted it again.
+ *
+ * Call after a reconcile settles (alongside the highlight/annotation raises).
+ * Iteration in style order preserves the overlays' relative z among
+ * themselves; moveLayer is guarded + wrapped so a layer that vanished
+ * mid-reconcile is skipped silently.
+ */
+export function raiseCustomOverlayLayers(map: Map): void {
+  const style = map.getStyle();
+  if (!style?.layers) return;
+  // Snapshot before mutating: moveLayer reorders the style's layer sequence,
+  // and iterating a mutating sequence can skip entries.
+  const customIds = (style.layers as any[])
+    .map((l) => l.id as string)
+    .filter((id) => id.startsWith(CUSTOM_OVERLAY_PREFIX));
+  for (const id of customIds) {
+    if (!map.getLayer(id)) continue;
+    try {
+      map.moveLayer(id);
+    } catch { /* silent */ }
+  }
+}

--- a/frontend/lib/map-kit/renderer.ts
+++ b/frontend/lib/map-kit/renderer.ts
@@ -155,6 +155,81 @@ export function unregisterGeoJsonSource(id: string) {
 }
 
 /**
+ * #462: per-map layer-id ORDER registry. MapLibre has no public cheap
+ * layer-order accessor — `map.getStyle()` deep-clones every layer (paint/layout
+ * expressions included), which is multi-millisecond at 50+ sublayers. Hot paths
+ * (per-reconcile z-order sync, per-command layer matching) only need the id
+ * sequence, so we maintain it ourselves:
+ *
+ *  - `getStyleLayerIds(map)` seeds from ONE cold getStyle() the first time a
+ *    map is seen, then serves the registry (no cloning).
+ *  - Every mutation site we own calls noteStyleLayerAdded/Removed alongside
+ *    its maplibre add/remove (renderer helpers, MapSpecRuntime, annotation +
+ *    selection stacks, layer commands). `clearStyleLayerIds` is called on a
+ *    base-style swap (setStyle drops everything without passing through any
+ *    removal site — MapSpecRuntime.invalidateStyle).
+ *  - Consumers must tolerate stale ids defensively (guard with map.getLayer /
+ *    try-catch), mirroring what they already do for ids the style may have
+ *    dropped mid-flight.
+ */
+const _styleLayerIdOrder = new WeakMap<object, string[]>();
+
+/** Record a layer id as added (appended to the top of the z-order). */
+export function noteStyleLayerAdded(map: object | null | undefined, id: string): void {
+  if (!map) return;
+  const ids = _styleLayerIdOrder.get(map);
+  if (ids) {
+    if (!ids.includes(id)) ids.push(id);
+    return;
+  }
+  // Map not seeded yet: leave the cold seed to getStyleLayerIds — appending to
+  // an unknown baseline could reorder unknown layers.
+}
+
+/** Record a layer id as removed from the style. */
+export function noteStyleLayerRemoved(map: object | null | undefined, id: string): void {
+  if (!map) return;
+  const ids = _styleLayerIdOrder.get(map);
+  if (!ids) return;
+  const i = ids.indexOf(id);
+  if (i >= 0) ids.splice(i, 1);
+}
+
+/** Record a layer id as moved to the top (anchorless moveLayer). */
+export function noteStyleLayerMovedToTop(map: object | null | undefined, id: string): void {
+  if (!map) return;
+  const ids = _styleLayerIdOrder.get(map);
+  if (!ids) return;
+  const i = ids.indexOf(id);
+  if (i >= 0) {
+    ids.splice(i, 1);
+    ids.push(id);
+  }
+}
+
+/** Drop the registry for a map whose style was wholesale replaced (setStyle). */
+export function clearStyleLayerIds(map: object | null | undefined): void {
+  if (!map) return;
+  _styleLayerIdOrder.delete(map);
+}
+
+/**
+ * The style's layer ids in z-order (bottom → top). Registry-backed; the first
+ * call for a map pays ONE cold getStyle() clone to seed, everything after is
+ * maintained by the note* hooks. Returns an empty list for maps without a
+ * style accessor.
+ */
+export function getStyleLayerIds(map: any): string[] {
+  if (!map) return [];
+  let ids = _styleLayerIdOrder.get(map);
+  if (!ids) {
+    ids = ((map.getStyle?.()?.layers ?? []) as any[]).map((l) => l.id as string);
+    _styleLayerIdOrder.set(map, ids);
+  }
+  return ids;
+}
+
+/**
  * FE-P3-5: drop ALL registry entries (base-style reload wipes every source
  * without passing through removeSourceSafe). Reconcile re-registers the
  * sources it re-adds.
@@ -181,6 +256,7 @@ export interface VectorLayerOptions {
 export function addVectorLayer(map: Map, options: VectorLayerOptions, beforeId?: string) {
   if (map.getLayer(options.id)) {
     map.removeLayer(options.id);
+    noteStyleLayerRemoved(map, options.id);
   }
 
   map.addLayer({
@@ -193,6 +269,7 @@ export function addVectorLayer(map: Map, options: VectorLayerOptions, beforeId?:
     ...(options.maxzoom !== undefined && { maxzoom: options.maxzoom }),
     ...(options.filter && { filter: options.filter }),
   } as any, beforeId);
+  noteStyleLayerAdded(map, options.id);
 }
 
 /**
@@ -305,6 +382,7 @@ export interface HeatmapOptions {
 export function addNativeHeatmap(map: Map, options: HeatmapOptions) {
   if (map.getLayer(options.id)) {
     map.removeLayer(options.id);
+    noteStyleLayerRemoved(map, options.id);
   }
 
   const palette = HEATMAP_PALETTES[options.palette || 'classic'];
@@ -326,6 +404,7 @@ export function addNativeHeatmap(map: Map, options: HeatmapOptions) {
       'heatmap-opacity': options.opacity || 1
     }
   });
+  noteStyleLayerAdded(map, options.id);
 }
 
 /**
@@ -389,6 +468,7 @@ export function removeLayerStack(map: Map, id: string, prefix: boolean = false):
   targetLayerIds.forEach((lid) => {
     if (!map.getLayer?.(lid) && !styleLayerIds.has(lid)) return; // already gone
     try { map.removeLayer(lid); } catch { ok = false; }
+    noteStyleLayerRemoved(map, lid);
   });
 
   // 2. Remove target sources and cleanup any registered image textures
@@ -533,6 +613,7 @@ export function addVectorTileSource(map: Map, id: string, tiles: string[], minzo
     for (const l of style?.layers ?? []) {
       if ((l as any).source === id && map.getLayer(l.id)) {
         try { map.removeLayer(l.id); } catch { /* already gone */ }
+        noteStyleLayerRemoved(map, l.id);
       }
     }
     try { map.removeSource(id); } catch { /* already gone */ }
@@ -545,13 +626,12 @@ export function addVectorTileSource(map: Map, id: string, tiles: string[], minzo
  * 等价于：遍历 style.layers，凡 id.startsWith(prefix) 的就 setLayoutProperty。
  */
 export function setLayerStackVisibility(map: Map, prefix: string, visible: boolean) {
-  const style = map.getStyle();
-  if (!style?.layers) return;
   const value = visible ? 'visible' : 'none';
-  for (const l of style.layers) {
-    if (l.id.startsWith(prefix)) {
+  // #462: id list from the maintained registry — no style deep-clone per toggle.
+  for (const id of getStyleLayerIds(map)) {
+    if (id.startsWith(prefix)) {
       try {
-        map.setLayoutProperty(l.id, 'visibility', value);
+        map.setLayoutProperty(id, 'visibility', value);
       } catch {
         /* layer 可能在迭代过程中被另一个 effect 移走，吃掉 */
       }
@@ -615,6 +695,9 @@ export function addProcessLayerStack(
       'circle-stroke-color': color,
     },
   });
+  noteStyleLayerAdded(map, `process-${stepId}-fill`);
+  noteStyleLayerAdded(map, `process-${stepId}-line`);
+  noteStyleLayerAdded(map, `process-${stepId}-point`);
 }
 
 /**
@@ -650,9 +733,11 @@ export function removeOrphanCustomLayers(
       const base = extractBaseId(l.id.slice(prefix.length));
       if (!knownIds.has(base) || (lSource && orphanSourceIds.has(lSource))) {
         try { map.removeLayer(l.id); } catch { /* silent */ }
+        noteStyleLayerRemoved(map, l.id);
       }
     } else if (lSource && orphanSourceIds.has(lSource)) {
       try { map.removeLayer(l.id); } catch { /* silent */ }
+      noteStyleLayerRemoved(map, l.id);
     }
   }
 
@@ -703,18 +788,24 @@ export function disable3DTerrain(map: Map) {
  * orderedBaseIds 即可让最后被 move 的（数组首）落在最顶。
  */
 export function syncLayerZOrder(map: Map, prefix: string, orderedBaseIds: string[]) {
-  const style = map.getStyle();
-  if (!style?.layers) return;
+  // #462: the id ORDER comes from the maintained registry — MapSpecRuntime
+  // calls this after every layer-changing patch, and map.getStyle() would
+  // deep-clone the whole style each time. Consumers guard with getLayer for
+  // ids the style may have dropped since the last note.
+  const layerIds = getStyleLayerIds(map);
+  if (layerIds.length === 0) return;
   // 反向：希望数组首的图层最终在最上面
   for (const baseId of [...orderedBaseIds].reverse()) {
     const fullPrefix = prefix ? `${prefix}${baseId}` : baseId;
-    const sub = style.layers.filter((sl: any) => {
-      const id = sl.id as string;
+    const sub = layerIds.filter((id) => {
       return id === fullPrefix || id.startsWith(`${fullPrefix}__`) || id.startsWith(`${fullPrefix}-`);
     });
-    for (const sl of sub) {
+    for (const id of sub) {
       try {
-        if (map.getLayer(sl.id)) map.moveLayer(sl.id);
+        if (map.getLayer(id)) {
+          map.moveLayer(id);
+          noteStyleLayerMovedToTop(map, id);
+        }
       } catch { /* silent */ }
     }
   }
@@ -746,17 +837,17 @@ export const CUSTOM_OVERLAY_PREFIX = 'custom-';
  * mid-reconcile is skipped silently.
  */
 export function raiseCustomOverlayLayers(map: Map): void {
-  const style = map.getStyle();
-  if (!style?.layers) return;
-  // Snapshot before mutating: moveLayer reorders the style's layer sequence,
-  // and iterating a mutating sequence can skip entries.
-  const customIds = (style.layers as any[])
-    .map((l) => l.id as string)
-    .filter((id) => id.startsWith(CUSTOM_OVERLAY_PREFIX));
+  // #462: id list from the maintained registry (runs after every reconcile —
+  // no style deep-clone on the hot path). Snapshot before mutating: moveLayer
+  // reorders the sequence being scanned.
+  const customIds = getStyleLayerIds(map).filter((id) =>
+    id.startsWith(CUSTOM_OVERLAY_PREFIX),
+  );
   for (const id of customIds) {
     if (!map.getLayer(id)) continue;
     try {
       map.moveLayer(id);
+      noteStyleLayerMovedToTop(map, id);
     } catch { /* silent */ }
   }
 }

--- a/frontend/lib/map-kit/selection-highlight.ts
+++ b/frontend/lib/map-kit/selection-highlight.ts
@@ -1,4 +1,5 @@
 import type { GeoJSONSource, Map } from 'maplibre-gl';
+import { noteStyleLayerAdded } from './renderer';
 
 /**
  * Selection highlight overlay (Harness–Map Interaction V3, FE-3).
@@ -53,6 +54,10 @@ export function ensureSelectionHighlightLayers(map: Map): void {
       },
     });
   }
+  // #462: keep the renderer's layer-id order registry exact for these adds.
+  noteStyleLayerAdded(map, `${SELECTION_HIGHLIGHT_SOURCE_ID}-fill`);
+  noteStyleLayerAdded(map, `${SELECTION_HIGHLIGHT_SOURCE_ID}-line`);
+  noteStyleLayerAdded(map, `${SELECTION_HIGHLIGHT_SOURCE_ID}-circle`);
 }
 
 /**

--- a/frontend/lib/mapspec-runtime/hotpath-getstyle.test.ts
+++ b/frontend/lib/mapspec-runtime/hotpath-getstyle.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MapSpecRuntime } from './runtime';
+import { collectCartographicRuntimeObservation } from './runtime-evidence';
+import type { MapSpec } from '@/lib/mapspec-compiler/types';
+import type { Layer } from '@/lib/types/layer';
+import { consumeDiffLastFailed, _resetWorkerBridgeForTests } from '@/lib/mapspec-compiler/worker-bridge';
+
+/**
+ * #462: map.getStyle() deep-clones the full style (MapLibre Style.serialize →
+ * per-layer clone incl. paint/layout expressions) — multi-millisecond at
+ * 50-100 expression-heavy sublayers. It must NOT be called on the hot paths:
+ * per reconcile (syncLayerZOrder), per removed source (removeSourceSafe), or
+ * per observed candidate layer (cartographic observation). Only cheap id
+ * queries / maintained registries belong there; a single cold seeding call
+ * when a map is first seen is the accepted budget.
+ */
+
+function makeMockMap() {
+  const sources: Record<string, any> = {};
+  const layers: any[] = [];
+  const map: any = {
+    isStyleLoaded: () => true,
+    getStyle: () => ({ sources, layers }),
+    getSource(id: string) { return sources[id]; },
+    getLayer(id: string) { return layers.find((l) => l.id === id); },
+    addSource(id: string, def: any) { sources[id] = { ...def, setData: vi.fn() }; },
+    removeSource(id: string) { delete sources[id]; },
+    addLayer(def: any) { layers.push(def); },
+    removeLayer(id: string) {
+      const i = layers.findIndex((l) => l.id === id);
+      if (i >= 0) layers.splice(i, 1);
+    },
+    moveLayer(id: string) {
+      const i = layers.findIndex((l) => l.id === id);
+      if (i >= 0) {
+        const [moved] = layers.splice(i, 1);
+        layers.push(moved);
+      }
+    },
+    getPaintProperty: () => 1,
+    getLayoutProperty: () => 'visible',
+    getCenter: () => ({ lng: 116.4, lat: 39.9 }),
+    getZoom: () => 10,
+    getBounds: () => ({
+      getWest: () => 116.3, getSouth: () => 39.8, getEast: () => 116.5, getNorth: () => 40,
+    }),
+    on() {}, off() {},
+    _sources: sources,
+  };
+  return map;
+}
+
+/** N-source spec, one circle sublayer per source (the runtime's id scheme). */
+function manyLayerSpec(n: number): MapSpec {
+  const sources: MapSpec['sources'] = {};
+  const layers: MapSpec['layers'] = [];
+  for (let i = 0; i < n; i++) {
+    const id = `L${i}`;
+    sources[id] = { type: 'geojson', inlineData: { type: 'FeatureCollection', features: [] } };
+    layers.push({ id: `${id}__point`, source: id, type: 'circle', paint: { 'circle-radius': 6 } });
+  }
+  return { version: '1.0', sources, layers };
+}
+
+/** Pre-existing style content (e.g. a 500-layer basemap+overlay stack). */
+function seedHeavyStyle(map: any, n: number) {
+  for (let i = 0; i < n; i++) {
+    map.addSource(`base-src-${i}`, { type: 'geojson', data: { type: 'FeatureCollection', features: [] } });
+    // Expression-heavy paint like production interpolate/step sublayers.
+    map.addLayer({
+      id: `base-${i}__fill`,
+      type: 'fill',
+      source: `base-src-${i}`,
+      paint: {
+        'fill-color': [
+          'interpolate', ['linear'], ['get', 'v'],
+          0, '#fff', 10, '#eee', 20, '#ddd', 30, '#ccc', 40, '#bbb', 50, '#aaa',
+          60, '#999', 70, '#888', 80, '#777', 90, '#666', 100, '#555',
+        ],
+      },
+    });
+  }
+}
+
+describe('#462 — getStyle deep-clone budget on hot paths', () => {
+  let map: any;
+  beforeEach(() => {
+    vi.stubGlobal('Worker', undefined);
+    _resetWorkerBridgeForTests();
+    consumeDiffLastFailed();
+    map = makeMockMap();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('layer-changing reconciles + source removals on a 500-layer map: zero getStyle calls after the cold seed', async () => {
+    seedHeavyStyle(map, 250); // 250 sources × 1 layer = 250 style layers
+    const rt = new MapSpecRuntime(map);
+    const specA = manyLayerSpec(40);
+    const p0 = rt.reconcileAsync(specA);
+    rt.flush();
+    await p0; // registry cold-seeded here (first syncLayerZOrder) — budget spent
+
+    const spy = vi.spyOn(map, 'getStyle');
+
+    // Layer-changing reconcile #1: paint edit on 20 layers (recompile).
+    const specB: MapSpec = {
+      version: '1.0',
+      sources: specA.sources,
+      layers: specA.layers.map((l, i) =>
+        i % 2 === 0 ? { ...l, paint: { 'circle-radius': 9 } } : l,
+      ),
+    };
+    const p1 = rt.reconcileAsync(specB);
+    rt.flush();
+    await p1;
+
+    // Reconcile #2 with 10 source removals (straggler scrub path per source).
+    const removedSources = Object.keys(specB.sources).slice(0, 10);
+    const specC: MapSpec = {
+      version: '1.0',
+      sources: Object.fromEntries(
+        Object.entries(specB.sources).filter(([id]) => !removedSources.includes(id)),
+      ),
+      layers: specB.layers.filter((l) => !removedSources.includes(l.source)),
+    };
+    const p2 = rt.reconcileAsync(specC);
+    rt.flush();
+    await p2;
+
+    expect(specC.layers.length).toBeGreaterThan(0);
+    expect(removedSources.length).toBe(10);
+    // The hot paths ran real work (recompiles + removals)…
+    expect(map._sources ? Object.keys(map._sources).length : 0).toBeGreaterThan(0);
+    for (const id of removedSources) expect(map.getSource(id)).toBeUndefined();
+    // …without a single style deep-clone.
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('cartographic observation over many candidate layers clones the style at most once', () => {
+    seedHeavyStyle(map, 10);
+    const rt = new MapSpecRuntime(map);
+    const spec = manyLayerSpec(20);
+    rt.reconcile(spec);
+    // Warm any registry first so only the observation path is measured.
+    vi.spyOn(map, 'getStyle').mockClear();
+
+    const hudLayers: Layer[] = Array.from({ length: 20 }, (_, i) => ({
+      id: `L${i}`,
+      name: `Layer ${i}`,
+      type: 'vector',
+      visible: true,
+      opacity: 1,
+      group: 'analysis',
+      // One spec layer fans out into several candidates; every candidate used
+      // to trigger its own getStyle() clone at runtime-evidence.ts.
+      _mapspecFingerprint: 'fp',
+    })) as Layer[];
+
+    const observation = collectCartographicRuntimeObservation(
+      map,
+      spec,
+      hudLayers,
+      'fp',
+      '',
+      rt.getAppliedSpec(),
+    );
+
+    expect((observation.layers as unknown[]).length).toBe(20);
+    expect(map.getStyle.mock.calls.length).toBeLessThanOrEqual(1); // was 20+
+  });
+});

--- a/frontend/lib/mapspec-runtime/runtime-evidence.ts
+++ b/frontend/lib/mapspec-runtime/runtime-evidence.ts
@@ -124,6 +124,11 @@ export function collectCartographicRuntimeObservation(
   applied: MapSpec | null = null,
 ): Record<string, unknown> {
   const styleLoaded = !!map?.isStyleLoaded?.();
+  // #462: hoisted OUT of the per-candidate convergence check — the old
+  // `map.getStyle()` inside `expected.every` deep-cloned the whole style once
+  // per candidate layer (worst site: layers × sublayers clones per round).
+  // One clone per observation round is the accepted budget.
+  const liveStyleSources = map.getStyle?.()?.sources;
   const layers = hudLayers.map((hud) => {
     const attested = hud._mapspecFingerprint === mapspecFingerprint;
     const expected = desired.layers.filter(
@@ -141,8 +146,7 @@ export function collectCartographicRuntimeObservation(
       const desiredSource = desired.sources[candidate.source];
       const appliedSource = applied?.sources[candidate.source];
       const liveSource = map.getSource?.(candidate.source);
-      const liveStyleSource = map.getStyle?.()?.sources?.[candidate.source];
-      const liveType = liveStyleSource?.type ?? liveSource?.type;
+      const liveType = liveStyleSources?.[candidate.source]?.type ?? liveSource?.type;
       const expectedLiveType = desiredSource?.type === "raster"
         ? "image"
         : desiredSource?.type;

--- a/frontend/lib/mapspec-runtime/runtime.test.ts
+++ b/frontend/lib/mapspec-runtime/runtime.test.ts
@@ -38,6 +38,11 @@ function makeMockMap() {
       calls.removeSource.push(id);
     },
     addLayer(def: any) {
+      // MapLibre semantics: adding a duplicate id throws (the runtime's
+      // addLayerSafe must be idempotent to survive style-swap races).
+      if (layers.some((l) => l.id === def.id)) {
+        throw new Error(`Layer with id ${def.id} already exists on this map`);
+      }
       layers.push(def);
       calls.addLayer.push({ def });
     },
@@ -557,6 +562,109 @@ describe("MapSpecRuntime (ADR-0036)", () => {
       expect(map._calls.addSource).toEqual([]);
       expect(map._calls.addLayer).toEqual([]);
       expect(consumeDiffLastFailed()).toBe(false); // flag was consumed
+    });
+
+    // ── #459: basemap setStyle during an in-flight debounced patch ─────────
+
+    /** Yield ONLY microtasks: lets reconcileAsync's chained processOne run
+     * (diff + enqueue) while the debouncer's rAF/setTimeout op frame stays
+     * pending — the exact "ops queued but not yet executed" race window. */
+    async function pumpMicrotasks(ticks = 12) {
+      for (let i = 0; i < ticks; i++) await Promise.resolve();
+    }
+
+    it("a stale completion marker must not resurrect appliedSpec after a mid-flight style wipe", async () => {
+      _resetWorkerBridgeForTests(); // drop any worker cached by a prior test
+      consumeDiffLastFailed();
+      const specA: MapSpec = {
+        version: "1.0",
+        sources: {
+          A: { type: "geojson", inlineData: { type: "FeatureCollection", features: [] } },
+          B: { type: "geojson", inlineData: { type: "FeatureCollection", features: [] } },
+        },
+        layers: [
+          { id: "A__point", source: "A", type: "circle", paint: { "circle-radius": 6 } },
+          { id: "B__point", source: "B", type: "circle", paint: { "circle-radius": 6 } },
+        ],
+      };
+      const rt = new MapSpecRuntime(map);
+      const p0 = rt.reconcileAsync(specA);
+      rt.flush();
+      await p0;
+      expect(rt.getAppliedSpec()).toEqual(specA);
+
+      // Partial patch: only A's paint changes — the diff does not touch B, so
+      // a wipe between enqueue and execution loses B unless a FULL reapply
+      // runs afterwards (the exact #459 partial-layer-loss shape).
+      const specB: MapSpec = {
+        version: "1.0",
+        sources: specA.sources,
+        layers: [
+          { id: "A__point", source: "A", type: "circle", paint: { "circle-radius": 99 } },
+          specA.layers[1],
+        ],
+      };
+      const p1 = rt.reconcileAsync(specB); // ops enqueued, NOT yet executed
+      await pumpMicrotasks(); // processOne ran: patch ops sit in the debouncer
+
+      // Basemap setStyle fires mid-patch: MapLibre drops every source+layer
+      // without going through the runtime, then the panel invalidates.
+      for (const l of map.getStyle().layers.slice()) map.removeLayer(l.id);
+      for (const id of Object.keys(map._sources)) map.removeSource(id);
+      rt.invalidateStyle();
+
+      rt.flush();
+      await p1;
+
+      // The stale patch's z-order completion marker must NOT advance
+      // appliedSpec — the map was wiped since enqueue, so whatever subset of
+      // the patch ran landed on (or was erased by) the new style.
+      expect(rt.getAppliedSpec()).toBeNull();
+
+      // Recovery reconcile (map-panel re-issues it on style change): diffs
+      // against null → full re-add of every source+layer.
+      const p2 = rt.reconcileAsync(specB);
+      rt.flush();
+      await p2;
+      expect(map.getLayer("A__point")).toBeTruthy();
+      expect(map.getLayer("B__point")).toBeTruthy();
+      expect(rt.getAppliedSpec()).toEqual(specB);
+      expect(rt.getLastError()).toBeNull();
+    });
+
+    it("rapid double style switches during in-flight patches still end at the spec (adversarial)", async () => {
+      _resetWorkerBridgeForTests(); // drop any worker cached by a prior test
+      consumeDiffLastFailed();
+      const rt = new MapSpecRuntime(map);
+      const spec = pointSpec("L1");
+      let p = rt.reconcileAsync(spec);
+      rt.flush();
+      await p;
+
+      for (let round = 0; round < 2; round++) {
+        // Layer-changing patch (id-only recompile) races a style switch.
+        const next: MapSpec = {
+          version: "1.0",
+          sources: spec.sources,
+          layers: [
+            { id: "L1__point", source: "L1", type: "circle", paint: { "circle-radius": 6 + round } },
+          ],
+        };
+        p = rt.reconcileAsync(next);
+        await pumpMicrotasks(); // ops queued, debouncer frame still pending
+        for (const l of map.getStyle().layers.slice()) map.removeLayer(l.id);
+        for (const id of Object.keys(map._sources)) map.removeSource(id);
+        rt.invalidateStyle();
+        rt.flush();
+        await p;
+        expect(rt.getAppliedSpec()).toBeNull(); // never resurrected
+
+        p = rt.reconcileAsync(next); // recovery
+        rt.flush();
+        await p;
+        expect(map.getLayer("L1__point")).toBeTruthy();
+        expect(rt.getAppliedSpec()).toEqual(next);
+      }
     });
 
     // ── FIX-3-7: perf counters count real work, not no-op churn ────────────

--- a/frontend/lib/mapspec-runtime/runtime.ts
+++ b/frontend/lib/mapspec-runtime/runtime.ts
@@ -60,6 +60,15 @@ export class MapSpecRuntime {
   private styleRecoveryHandler: (() => void) | null = null;
   private pendingRecoverySpec: MapSpec | null = null;
   private readonly onStyleRecovery?: () => void;
+  /**
+   * #459: style generation token. Bumped by invalidateStyle() (basemap
+   * setStyle). A debounced patch captures the token at ENQUEUE time and its
+   * z-order completion marker may only advance `appliedSpec` when the token is
+   * unchanged — a patch that started before the wipe must never claim the map
+   * reflects its spec, or the recovery reconcile diffs against a resurrected
+   * stale basis and emits an empty (heal-nothing) patch.
+   */
+  private styleEpoch = 0;
 
   constructor(map: any, options: MapSpecRuntimeOptions = {}) {
     this.map = map;
@@ -76,6 +85,9 @@ export class MapSpecRuntime {
    * Next reconcile will treat all sources/layers as new and re-apply them.
    */
   invalidateStyle(): void {
+    // #459: invalidate any patch whose ops are still queued/running — its
+    // completion marker checks this token before advancing appliedSpec.
+    this.styleEpoch++;
     this.appliedSpec = null;
     // FE-P3-5: a base-style change wipes every source WITHOUT going through
     // removeSourceSafe — prune the inline-GeoJSON registry so the viewport
@@ -307,6 +319,10 @@ export class MapSpecRuntime {
     // compared against the last EXECUTED order at op-run time (queued patches
     // run sequentially, so each comparison sees the previous patch's outcome).
     const orderKey = orderedIds.join("\u0000");
+    // #459: generation token captured at enqueue. setStyle → invalidateStyle()
+    // bumps it; a patch whose ops execute after a wipe must not be recorded as
+    // applied (the map no longer reflects whatever subset of it had run).
+    const epochAtEnqueue = this.styleEpoch;
     const zorderId = `zorder:sync:${++this.applySeq}`; // unique per patch — never coalesced
     ops.push({
       id: zorderId,
@@ -318,8 +334,14 @@ export class MapSpecRuntime {
           this.lastLayerOrderKey = orderKey;
         }
         // All ops of this patch have now run (z-order is enqueued last in the
-        // high-priority FIFO). appliedSpec may now legitimately equal the map.
-        if (!this.lastError) this.appliedSpec = nextSpec;
+        // high-priority FIFO). appliedSpec may now legitimately equal the map —
+        // UNLESS the style was invalidated since enqueue (#459): the patch ran
+        // across a setStyle wipe, so claiming it applied would resurrect a
+        // pre-wipe basis and the recovery reconcile would diff to an empty
+        // patch, leaving wiped layers gone forever.
+        if (!this.lastError && epochAtEnqueue === this.styleEpoch) {
+          this.appliedSpec = nextSpec;
+        }
         const resolve = this.currentApplyResolve;
         this.currentApplyResolve = null;
         if (resolve) resolve();
@@ -485,6 +507,15 @@ export class MapSpecRuntime {
     // Some layer types carry maxzoom (native heatmap). MapSpecLayer doesn't
     // model that today; if needed, extend the type. For now omit.
     try {
+      // #459: idempotent add. A stale in-flight patch can re-add this very
+      // layer onto the freshly-wiped style moments before the recovery patch's
+      // full re-apply reaches it — MapLibre throws on a duplicate id, which
+      // used to poison `lastError` and block the recovery's appliedSpec
+      // advancement. Drop any survivor first so the final definition is
+      // exactly the spec's.
+      if (this.map.getLayer(layer.id)) {
+        this.removeLayerSafe(layer.id);
+      }
       this.map.addLayer(def);
     } catch (err) {
       // Defensive: a recompile that races with a style swap may find the layer

--- a/frontend/lib/mapspec-runtime/runtime.ts
+++ b/frontend/lib/mapspec-runtime/runtime.ts
@@ -69,6 +69,14 @@ export class MapSpecRuntime {
    * stale basis and emits an empty (heal-nothing) patch.
    */
   private styleEpoch = 0;
+  /**
+   * #462: layerId → sourceId for every layer this runtime added. MapLibre
+   * offers no "layers of source" query without cloning the whole style via
+   * getStyle(); the index answers removeSourceSafe's straggler scrub with
+   * plain Map lookups instead. Maintained by addLayerSafe/removeLayerSafe and
+   * cleared alongside appliedSpec on a style wipe.
+   */
+  private layerSourceIndex = new Map<string, string>();
 
   constructor(map: any, options: MapSpecRuntimeOptions = {}) {
     this.map = map;
@@ -89,6 +97,11 @@ export class MapSpecRuntime {
     // completion marker checks this token before advancing appliedSpec.
     this.styleEpoch++;
     this.appliedSpec = null;
+    // #462: setStyle dropped every layer without passing through any removal
+    // site — drop the runtime's layer→source index and the renderer's
+    // layer-id order registry for this map (next read re-seeds cold).
+    this.layerSourceIndex.clear();
+    renderer.clearStyleLayerIds(this.map);
     // FE-P3-5: a base-style change wipes every source WITHOUT going through
     // removeSourceSafe — prune the inline-GeoJSON registry so the viewport
     // refresher stops probing ids that no longer exist (never converged).
@@ -517,6 +530,9 @@ export class MapSpecRuntime {
         this.removeLayerSafe(layer.id);
       }
       this.map.addLayer(def);
+      // #462: keep the layer→source index + renderer id-order registry exact.
+      this.layerSourceIndex.set(layer.id, layer.source);
+      renderer.noteStyleLayerAdded(this.map, layer.id);
     } catch (err) {
       // Defensive: a recompile that races with a style swap may find the layer
       // already re-added by the styledata path. Log and continue rather than
@@ -531,17 +547,20 @@ export class MapSpecRuntime {
     if (this.map.getLayer(id)) {
       try { this.map.removeLayer(id); } catch { /* already gone */ }
     }
+    this.layerSourceIndex.delete(id);
+    renderer.noteStyleLayerRemoved(this.map, id);
   }
 
   private removeSourceSafe(id: string): void {
     // Must remove all layers referencing this source first. diffSpecs already
     // reported dependent layer removes, but defensive: scrub any stragglers.
-    const style = this.map.getStyle();
-    if (style?.layers) {
-      for (const l of style.layers) {
-        if (l.source === id && this.map.getLayer(l.id)) {
-          try { this.map.removeLayer(l.id); } catch { /* silent */ }
-        }
+    // #462: the runtime's own layer→source index replaces the per-removal
+    // getStyle() deep clone (a patch removing N sources cloned the style N
+    // times); the index covers every layer this runtime added, which is
+    // exactly the population that can reference a spec source.
+    for (const [layerId, sourceId] of Array.from(this.layerSourceIndex)) {
+      if (sourceId === id) {
+        this.removeLayerSafe(layerId);
       }
     }
     if (this.map.getSource(id)) {

--- a/frontend/lib/store/hud-types.ts
+++ b/frontend/lib/store/hud-types.ts
@@ -318,6 +318,11 @@ export interface HudState {
   captureToolCallArgs: (tool: string, argsStr: string) => void;
   /** Discard the oldest queued args for a tool (its call failed or was cancelled). */
   discardPendingToolArgs: (tool: string) => void;
+  /**
+   * #466: drop every queued tool-arg entry (turn boundary / stream death) —
+   * pending evidence is TURN-scoped, never carried into the next turn.
+   */
+  resetPendingToolArgs: () => void;
   /** Normalize + record a step_result event; returns the result id (or undefined if ignored). */
   captureStepResult: (step: StepResultEvent) => string | undefined;
   /** Merge lazy /layers/descriptor metadata into a result's output (no CRS fabrication). */

--- a/frontend/lib/store/slices/resultsSlice.ts
+++ b/frontend/lib/store/slices/resultsSlice.ts
@@ -95,6 +95,15 @@ export const createResultsSlice: StateCreator<HudState, [], [], Partial<HudState
       pendingArgs = rest;
     },
 
+    resetPendingToolArgs: () => {
+      // #466: the queue is TURN-scoped. When a stream dies without terminal
+      // events for its tool calls (cut connection, task_cancelled without
+      // step_cancelled, exhausted reconnects), the stale args must not leak
+      // into the NEXT turn's results as wrong input evidence. Called at every
+      // turn start (handleSend) and on stream-level termination.
+      pendingArgs = {};
+    },
+
     captureStepResult: (stepInput: StepResultEvent) => {
       // Ignore pure orchestration/map-action events that carry no inspectable result.
       const step = stepInput as StepResultEvent;

--- a/frontend/test/results/resultsSlice.test.ts
+++ b/frontend/test/results/resultsSlice.test.ts
@@ -85,6 +85,42 @@ describe('resultsSlice — capture + bounded history', () => {
     expect(r.inputs[0].ref).toBe('ref:geojson-in');
     expect(r.parameters).toEqual(expect.arrayContaining([expect.objectContaining({ source: 'distance', value: 300 })]));
   });
+
+  // ── #466: pending args are TURN-scoped, not session-scoped ──────────────
+
+  it('turn-start reset discards an interrupted turn\'s args so the next turn pairs with its own', () => {
+    // Turn A: tool_call captured, stream dies before any step_result.
+    useHudStore.getState().captureToolCallArgs('buffer_analysis', JSON.stringify({ distance: 300 }));
+    // Turn B starts (handleSend) → reset; then B's own tool_call.
+    useHudStore.getState().resetPendingToolArgs();
+    useHudStore.getState().captureToolCallArgs('buffer_analysis', JSON.stringify({ distance: 900 }));
+    useHudStore.getState().captureStepResult({
+      step_id: 's-b2',
+      tool: 'buffer_analysis',
+      result: { success: true, summary: 'ok' },
+    });
+    const r = useHudStore.getState().results[0];
+    // WITHOUT the reset the FIFO would hand Turn B's result Turn A's args.
+    expect(r.parameters).toEqual(expect.arrayContaining([expect.objectContaining({ source: 'distance', value: 900 })]));
+    expect(r.parameters).toEqual(expect.not.arrayContaining([expect.objectContaining({ value: 300 })]));
+  });
+
+  it('resetPendingToolArgs clears queued args for every tool without touching recorded results', () => {
+    useHudStore.getState().captureStepResult(hotspotStep());
+    useHudStore.getState().captureToolCallArgs('hotspot_analysis', JSON.stringify({ a: 1 }));
+    useHudStore.getState().captureToolCallArgs('buffer_analysis', JSON.stringify({ b: 2 }));
+    useHudStore.getState().resetPendingToolArgs();
+    expect(useHudStore.getState().results).toHaveLength(1); // registry intact
+    // A later result for the same tool carries NO stale captured args.
+    const id = useHudStore.getState().captureStepResult({
+      step_id: 's-after',
+      tool: 'buffer_analysis',
+      result: { success: true },
+    });
+    expect(id).toBe('s-after');
+    const r = useHudStore.getState().results.find((x) => x.id === 's-after')!;
+    expect(r.inputs).toEqual([]);
+  });
 });
 
 describe('resultsSlice — enrich + select + clear', () => {


### PR DESCRIPTION
## Issues
- Fixes #459 (P2: basemap switch during in-flight reconcile resurrects a stale appliedSpec — partial layer loss)
- Fixes #460 (P2: annotation stack never re-mounted after basemap setStyle wipe; sibling of #402)
- Fixes #461 (P2: imperative custom-* overlays buried under spec layers by every layer-changing reconcile; sibling of #401)
- Fixes #462 (P3 perf: map.getStyle() deep-clones the full style on hot paths)
- Fixes #466 (P3: stale tool-call args leak across turns in Result Workbench)
- Fixes #467 (P3: screen reader announces false 回复已完成 on mid-stream session switch)
- Fixes #468 (P3: plan approval locks optimistically with no rollback when follow-up send fails)

## MapLibre lifecycle trio (#459/#460/#461) — validated together
- #459: `styleEpoch` token bumped by `invalidateStyle()`; patch z-order completion may only advance `appliedSpec` when the epoch is unchanged — a patch racing a basemap setStyle can no longer resurrect a stale basis. `addLayerSafe` idempotent (mock throws on duplicates like real MapLibre).
- #460: `raiseAnnotationLayers` re-mounts annotation source + 4 layers with data when wiped.
- #461: `renderer.raiseCustomOverlayLayers` runs first in the reconcile `.then` — final z-band: spec < custom < highlight < annotations.
- Combined lifecycle test: reconcile in-flight → setStyle mid-patch → recovery → full reapply → map state == MapSpec state, annotations remounted, custom overlays above spec layers. RED pre-fix, GREEN after.

## #462 perf
`getStyle()` deep clones removed from hot paths: per-map layer-id order registry (cold seed + maintained at owned mutations) backs z-order sync/layer matching; per-runtime layer→source index for `removeSourceSafe`; observation clone hoisted to one per round. Perf test: 500-layer style, 2 layer-changing reconciles + 10 source removals → 0 getStyle calls after cold seed.

## UI fixes
- #466: `resetPendingToolArgs` at turn boundaries (handleSend/task_cancelled/stream error).
- #467: ChatAnnouncer session-scoped (sessionId threaded page→ContextPanel→ChatTab).
- #468: `handleSend` returns truthful turn outcome (terminal aiStatus after settle); plan approval rolls back to pending on failure/rejection.

## Validation
Full `vitest run`: 1400 passed / 3 skipped / 0 failed; `tsc --noEmit` clean; `eslint --max-warnings 0` clean.

## Risk
Medium-low: runtime reconcile internals changed; combined lifecycle test + full frontend suite pin the invariants.