### PR TITLE
fix(db/deploy/ci): uploads composite index + alembic migration, deploy-path alembic execution, session disk purge, real-services CI lane (#429 #470 #476 #477)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -143,7 +143,10 @@ jobs:
         # 审计 REL-01：cartography marker（@pytest.mark.cartography）同样排除 ——
         # 该集合由独立 cartography-smoke job（确定性 release-blocking gate）拥有，
         # 避免双重执行 + 让 gate scope 显式。
-        run: pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=10 --timeout=60 --timeout-method=thread -m "not perf and not cartography" -v
+        #
+        # #477：real_services marker 同理排除 —— 由独立 real-services-smoke
+        # job（postgis + redis service containers + 真实 celery worker）拥有。
+        run: pytest --cov=app --cov-report=xml --cov-report=term-missing --cov-fail-under=10 --timeout=60 --timeout-method=thread -m "not perf and not cartography and not real_services" -v
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v7.0.0
@@ -208,6 +211,68 @@ jobs:
           MIGRATION_DRIFT_DB_URL: postgresql://test_user:test_pass@localhost:5432/test_db
           JWT_SECRET_KEY: ci-test-secret-key-32-chars-ok
         run: pytest tests/test_deploy_migration_wiring.py::test_migrated_schema_matches_models --no-cov -q
+
+  # ============ Stage 2a-2: 真实服务 smoke lane (#477) ============
+  # test-backend 配了 postgis + redis service container，但套件实际跑
+  # SQLite / fakeredis / eager-celery（conftest 强制 USE_REDIS=false +
+  # CELERY_BROKER_URL=memory://）—— asyncpg 驱动行为、PostGIS 类型、真实
+  # Redis 线协议、真实 broker 投递/撤销从未被验证。此 lane 用同一批
+  # provisioned 容器跑定向 smoke 子集（-m real_services；服务不可达时
+  # self-skip，本地无容器不红）。不把整套测试搬到真实后端 —— 目标是
+  # prod-backend 回归在 CI 有真实覆盖。
+  real-services-smoke:
+    name: Real Services Smoke (PostGIS + Redis + Celery)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:15-3.4
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install Dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Set Environment Variables
+        run: |
+          echo "DATABASE_URL=postgresql://test_user:test_pass@localhost:5432/test_db" >> $GITHUB_ENV
+          echo "REDIS_URL=redis://localhost:6379/0" >> $GITHUB_ENV
+          echo "JWT_SECRET_KEY=ci-test-secret-key-32-chars-ok" >> $GITHUB_ENV
+          echo "ENV=development" >> $GITHUB_ENV
+          echo "LLM_API_KEY=test-key-not-real" >> $GITHUB_ENV
+
+      - name: Run Real-Services Smoke
+        # 与 test-backend 同批 service container：asyncpg 真实往返、PostGIS
+        # geometry 类型、真实 Redis SET/GET/EXPIRE/TTL/pipeline、真实 celery
+        # worker（broker 投递 + chain + result backend + revoke 丢弃）。
+        run: pytest -m real_services --no-cov --timeout=180 --timeout-method=thread -q
 
   test-perf:
     name: Performance Regression Gate
@@ -474,7 +539,9 @@ jobs:
     # 否则坏的 location 正则可以带着绿色 release-gate 上生产。
     # #476: db-migrations（PostGIS 上执行迁移链 + drift check）同理 ——
     # 迁移跑不通 / 模型与迁移漂移的 PR 不能进入 build→deploy。
-    needs: [lint, test-backend, test-frontend, security, test-perf, cartography-smoke, deploy-config, db-migrations]
+    # #477: real-services-smoke（真实 PostGIS/Redis/celery 投递 smoke）同理
+    # —— prod-backend 回归不能带着绿色 gate 上生产。
+    needs: [lint, test-backend, test-frontend, security, test-perf, cartography-smoke, deploy-config, db-migrations, real-services-smoke]
     steps:
       - name: Release gate passed
         run: echo "All release-blocking checks (quality, backend, frontend, security, perf, cartography) passed."

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -158,6 +158,57 @@ jobs:
           path: coverage.xml
           retention-days: 7
 
+  # ============ Stage 2a: 迁移链对真实 PostGIS 的执行门 (#476) ============
+  # 之前所有测试从全新 create_all 起步 —— 迁移链从未在真实 Postgres 上执行过
+  # （含 PostGIS 专属的 0011），模型↔迁移漂移完全不可见（如 0016 修复的
+  # knowledge_documents.org_id/creator_id）。deploy 路径（entrypoint /
+  # k8s initContainer）现在会真正执行 alembic upgrade head，此 lane 在 PR
+  # 阶段验证同一件事：链能在 PostGIS 上跑通，且产出与 Base.metadata 一致。
+  db-migrations:
+    name: DB Migration Gate (PostGIS)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:15-3.4
+        env:
+          POSTGRES_USER: test_user
+          POSTGRES_PASSWORD: test_pass
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install Dependencies
+        # requirements.txt 自带 alembic + sqlalchemy + psycopg2-binary；
+        # dev 依赖只需要 pytest（drift check 用）。
+        run: pip install -r requirements.txt pytest pytest-cov
+
+      - name: Run Alembic Upgrade Head against PostGIS
+        env:
+          DATABASE_URL: postgresql://test_user:test_pass@localhost:5432/test_db
+        run: alembic upgrade head
+
+      - name: Model vs Migration Drift Check
+        # 迁移建出的 schema 必须覆盖模型声明的表/列/索引 —— 漂移即失败
+        # （这正是 #476 的根因：模型加列而迁移链不跟，生产库静默缺列）。
+        env:
+          MIGRATION_DRIFT_DB_URL: postgresql://test_user:test_pass@localhost:5432/test_db
+          JWT_SECRET_KEY: ci-test-secret-key-32-chars-ok
+        run: pytest tests/test_deploy_migration_wiring.py::test_migrated_schema_matches_models --no-cov -q
+
   test-perf:
     name: Performance Regression Gate
     runs-on: ubuntu-latest
@@ -421,7 +472,9 @@ jobs:
     runs-on: ubuntu-latest
     # #400: deploy-config（nginx -t SSE/keepalive 语法门）必须进入发布 DAG ——
     # 否则坏的 location 正则可以带着绿色 release-gate 上生产。
-    needs: [lint, test-backend, test-frontend, security, test-perf, cartography-smoke, deploy-config]
+    # #476: db-migrations（PostGIS 上执行迁移链 + drift check）同理 ——
+    # 迁移跑不通 / 模型与迁移漂移的 PR 不能进入 build→deploy。
+    needs: [lint, test-backend, test-frontend, security, test-perf, cartography-smoke, deploy-config, db-migrations]
     steps:
       - name: Release gate passed
         run: echo "All release-blocking checks (quality, backend, frontend, security, perf, cartography) passed."

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -71,6 +71,12 @@ COPY main.py ./
 COPY app/ ./app/
 COPY alembic.ini ./
 COPY migrations/ ./migrations/
+# #476: 镜像一直带着 alembic.ini + migrations/ 却没有任何路径执行它 ——
+# 存量 Postgres 升级部署后 schema 停留在首次创建状态。entrypoint 在启动
+# CMD 前跑 `alembic upgrade head`（幂等；SKIP_DB_MIGRATIONS=true 可跳过，
+# celery-worker 服务用，避免与 api 并发 upgrade 竞争 alembic_version）。
+COPY deploy/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # #400: pi RPC 入口是仓库相对路径 vendor/pi/packages/coding-agent/dist/rpc-entry.js
 # （pi_rpc_client.PI_RPC_ENTRY）。CI 以 submodules:recursive 检出，但产物从未
 # 进入镜像 —— USE_NEW_AGENT=true 时 bridge 初始化失败并静默回退旧引擎。
@@ -90,7 +96,9 @@ EXPOSE 3000 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD python3 -c "import urllib.request as u; u.urlopen('http://localhost:8000/api/v1/health/live', timeout=5); u.urlopen('http://localhost:3000/', timeout=5)" || exit 1
 
-ENTRYPOINT ["tini", "--"]
+# #476: tini 仍是 PID 1（信号收割），entrypoint 在 exec CMD 前执行
+# `alembic upgrade head`（迁移失败 = 容器失败，不带旧 schema 起服务）。
+ENTRYPOINT ["tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 # 审计 I9：trap-kill-wait 模式让 SIGTERM 正确传播给两个子进程。
 # 之前 sh -c "A & B" 在 tini 下：sh 不 wait 任何子进程，uvicorn OOM 后
 # 容器仍"健康"（node 还活），SIGTERM 也不传播 → 滚动更新脏退出。

--- a/app/main.py
+++ b/app/main.py
@@ -151,6 +151,12 @@ async def _periodic_session_cleanup(interval_seconds: int = 600) -> None:
     session_data_manager.cleanup_idle_sessions 已存在但从未被调用。
     此任务每 interval_seconds 秒跑一次；失败仅 warning 不抛（不能让后台任务
     崩了影响主服务）。
+
+    #470：cleanup_idle_sessions 之外还跑 sweep_expired_session_files ——
+    Redis 的 4h TTL 是服务端静默过期（键消失无回调，clear_session 不会触发），
+    没有这层兜底，TTL 过期会话的磁盘目录（mapspec revisions / checkpoints /
+    raster PNGs）永远无人回收。清扫带 liveness 检查：store 里仍有状态的
+    会话（TTL 被聊天活动续期）跳过。
     """
     import asyncio
     import logging
@@ -161,6 +167,13 @@ async def _periodic_session_cleanup(interval_seconds: int = 600) -> None:
         try:
             await asyncio.sleep(interval_seconds)
             await session_data_manager.cleanup_idle_sessions()
+            try:
+                from app.services.mapspec.store import sweep_expired_session_files
+                await sweep_expired_session_files(
+                    liveness=getattr(session_data_manager, "is_session_active", None)
+                )
+            except Exception as sweep_error:  # noqa: BLE001
+                logger.warning(f"[lifespan] session disk sweep failed: {sweep_error}")
         except asyncio.CancelledError:
             raise
         except Exception as e:  # noqa: BLE001

--- a/app/models/upload.py
+++ b/app/models/upload.py
@@ -1,6 +1,6 @@
 """用户上传数据模型"""
 from datetime import datetime, timezone
-from sqlalchemy import Column, Integer, BigInteger, String, DateTime, JSON, CheckConstraint
+from sqlalchemy import Column, Integer, BigInteger, String, DateTime, JSON, CheckConstraint, Index
 from app.core.database import Base
 
 
@@ -24,6 +24,11 @@ class UploadRecord(Base):
     __table_args__ = (
         CheckConstraint("file_type IN ('vector', 'raster')", name="ck_upload_file_type"),
         CheckConstraint("format IN ('geojson', 'shapefile', 'geotiff', 'csv', 'gpkg', 'kml')", name="ck_upload_format"),
+        # #429：list_uploads 热路径是 WHERE session_id = ? ORDER BY upload_time
+        # DESC + COUNT —— 无索引时每次面板打开都是全表扫描 + 排序，代价随全局
+        # uploads 行数（而非单会话行数）线性增长。复合索引让按会话过滤 + 排序
+        # 都走索引扫描。迁移 0015 为存量库补建同名索引。
+        Index("ix_uploads_session_time", "session_id", "upload_time"),
     )
 
 

--- a/app/services/mapspec/store.py
+++ b/app/services/mapspec/store.py
@@ -88,18 +88,34 @@ def _read_json_sync(path: Path) -> Optional[Any]:
 class MapSpecStore:
     """MapSpec JSON 文件持久化与 Revision 管理服务"""
 
-    def get_session_dir(self, session_id: str) -> Path:
+    def _session_dir_path(self, session_id: str) -> Path:
+        """会话目录路径（只算路径，不创建目录）。"""
         base = BASE_STORAGE_DIR.resolve()
         session_dir = (base / session_id).resolve()
         if session_dir.parent != base:
             raise ValueError("invalid session id for MapSpec storage")
+        return session_dir
+
+    def get_session_dir(self, session_id: str) -> Path:
+        session_dir = self._session_dir_path(session_id)
         session_dir.mkdir(parents=True, exist_ok=True)
         return session_dir
 
     async def clear_session_files(self, session_id: str) -> None:
-        """Purge durable MapSpec/checkpoint/revision state for one session."""
-        session_dir = self.get_session_dir(session_id)
-        await asyncio.to_thread(shutil.rmtree, session_dir)
+        """Purge durable MapSpec/checkpoint/revision state for one session.
+
+        #470：目录缺失时静默返回（幂等）—— 清除是"尽力回收"，不是前置条件；
+        也不得像旧实现那样先 mkdir 再 rmtree（读路径才需要 mkdir 语义）。
+        """
+        session_dir = self._session_dir_path(session_id)
+
+        def _rmtree() -> None:
+            try:
+                shutil.rmtree(session_dir)
+            except FileNotFoundError:
+                pass
+
+        await asyncio.to_thread(_rmtree)
 
     async def discard_mapspec(self, session_id: str) -> None:
         """Remove a first-mutation MapSpec that must not survive rollback.
@@ -187,3 +203,123 @@ class MapSpecStore:
 
 
 mapspec_store_instance = MapSpecStore()
+
+
+# ── #470：会话磁盘生命周期 ────────────────────────────────────────────────
+#
+# 会话磁盘状态（mapspec.json + revisions/ + checkpoints/ + raster/）此前
+# 唯一的清除入口是 clear_session_files，唯一调用方是 DELETE /sessions/{id}。
+# TTL 过期、idle 淘汰、周期清理都只删 Redis/内存 —— 磁盘无限累积。下面的
+# 两个函数是给 session 存储层（clear_session / cleanup_idle_sessions）和
+# 周期任务（main._periodic_session_cleanup）复用的失败容忍入口。
+
+
+async def purge_session_disk_state(session_id: str) -> None:
+    """尽力清除一个会话的磁盘状态：目录缺失 OK，失败记日志、绝不抛出。
+
+    供 session_data 的 clear_session（内存 + Redis 两个后端）在淘汰/删除
+    会话时联动调用 —— 与"Redis 键被删除"同语义：会话没了，盘上状态也回收。
+    """
+    try:
+        await mapspec_store_instance.clear_session_files(session_id)
+    except FileNotFoundError:
+        pass
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[mapspec] disk purge failed for session %s: %s", session_id, e)
+
+
+def _session_storage_entries(base: Path):
+    """BASE_STORAGE_DIR 的直接子目录（跳过非目录/隐藏/危险名字）。
+
+    安全边界：只处理名字形如常规会话 id（[A-Za-z0-9._-]+ 且非 . / .. 开头）
+    的目录。名字异常的条目不属于会话布局，不猜语义、不碰。
+    """
+    import re
+
+    valid = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+    try:
+        entries = list(os.scandir(base))
+    except FileNotFoundError:
+        return []
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        name = entry.name
+        if name.startswith(".") or not valid.match(name):
+            continue
+        yield Path(entry.path)
+
+
+def _newest_mtime(session_dir: Path) -> float:
+    """目录树内（含目录自身）最新的 mtime —— "最近一次磁盘写入"的时间。"""
+    newest = session_dir.stat().st_mtime
+    for root, _dirs, files in os.walk(session_dir):
+        mtime = os.stat(root).st_mtime
+        if mtime > newest:
+            newest = mtime
+        for f in files:
+            try:
+                mtime = os.stat(os.path.join(root, f)).st_mtime
+            except OSError:
+                continue
+            if mtime > newest:
+                newest = mtime
+    return newest
+
+
+async def sweep_expired_session_files(
+    liveness=None,
+    max_age_seconds: Optional[int] = None,
+) -> list[str]:
+    """按 mtime 清扫过期会话目录（TTL 过期的磁盘兜底），返回被清除的会话 id。
+
+    背景：Redis 的 4h SESSION_TTL 是服务端静默过期 —— 键消失没有任何回调，
+    clear_session 永远不会被触发，磁盘目录成为孤儿。这里按"最近一次磁盘
+    写入"兜底回收：
+
+    - ``max_age_seconds`` 默认 SESSION_TTL + 1h slack（从 session_data_redis
+      读，库缺失时用等价字面量）—— 磁盘比 Redis 键还新的会话不会被动到；
+    - ``liveness``（可选，``is_session_active`` 协程或函数）：store 里仍有
+      状态的会话跳过 —— 会话可能只在聊天（续 Redis TTL）而多日无制图写盘，
+      仅凭 mtime 清它的盘会丢 mapspec。liveness 抛错按"仍活跃"处理（宁可不
+      回收也不误删）。
+    """
+    import inspect
+
+    if max_age_seconds is None:
+        try:
+            from app.services.session_data_redis import SESSION_TTL
+
+            ttl = SESSION_TTL
+        except Exception:  # noqa: BLE001 — redis 库缺失时用等价默认
+            ttl = 4 * 60 * 60
+        max_age_seconds = ttl + 3600
+
+    async def _is_live(sid: str) -> bool:
+        if liveness is None:
+            return False
+        try:
+            result = liveness(sid)
+            if inspect.isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("[mapspec] liveness check failed for %s (%s) — skipping sweep of it", sid, e)
+            return True
+
+    cutoff = time.time() - max_age_seconds
+    purged: list[str] = []
+    base = BASE_STORAGE_DIR.resolve()
+    for session_dir in _session_storage_entries(base):
+        try:
+            if _newest_mtime(session_dir) > cutoff:
+                continue
+            if await _is_live(session_dir.name):
+                continue
+            await purge_session_disk_state(session_dir.name)
+            purged.append(session_dir.name)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("[mapspec] session sweep failed for %s: %s", session_dir, e)
+    if purged:
+        logger.info("[mapspec] swept %d expired session dir(s): %s", len(purged), purged)
+    return purged

--- a/app/services/session_data.py
+++ b/app/services/session_data.py
@@ -326,6 +326,22 @@ class MemorySessionStore(BaseSessionStore):
         from app.services.mvt import spatial_index_cache, tile_lru_cache
         spatial_index_cache.invalidate_session(session_id)
         tile_lru_cache.invalidate_session(session_id)
+        # #470：会话没了，盘上状态（mapspec revisions/checkpoints/raster PNGs）
+        # 一并回收。失败容忍（purge 内部记日志不抛）—— 磁盘清理失败不得阻断
+        # 上面的内存清理或调用方（idle 淘汰 / DELETE 会话）的语义。
+        try:
+            from app.services.mapspec.store import purge_session_disk_state
+            await purge_session_disk_state(session_id)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Session {session_id}: disk state purge failed: {e}")
+
+    def is_session_active(self, session_id: str) -> bool:
+        """会话是否仍在本 store 中持有状态（供磁盘清扫判断存活性）。"""
+        return (
+            session_id in self._store
+            or session_id in self._map_state
+            or session_id in self._session_order
+        )
 
     async def cleanup_idle_sessions(self, max_sessions: int = 100) -> None:
         """Evict least-recently-touched sessions when total exceeds max_sessions."""

--- a/app/services/session_data_redis.py
+++ b/app/services/session_data_redis.py
@@ -941,6 +941,27 @@ class RedisSessionStore(BaseSessionStore):
         from app.services.mvt import spatial_index_cache, tile_lru_cache
         spatial_index_cache.invalidate_session(session_id)
         tile_lru_cache.invalidate_session(session_id)
+        # #470：与 Redis 键删除同语义 —— 会话没了，盘上 mapspec revisions/
+        # checkpoints/raster PNGs 一并回收（idle 淘汰 + 显式删除共用此路径）。
+        # 失败容忍：磁盘清理失败不得让 Redis 清理回滚或抛给调用方。
+        try:
+            from app.services.mapspec.store import purge_session_disk_state
+            await purge_session_disk_state(session_id)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Session %s: disk state purge failed: %s", session_id, e)
+
+    async def is_session_active(self, session_id: str) -> bool:
+        """会话是否仍在 active 集（供磁盘清扫判断存活性）。
+
+        Redis 不可达时返回 True（按"仍活跃"处理）—— 宁可漏回收也不误删
+        活会话的磁盘状态。
+        """
+        try:
+            await self._ensure_connected()
+            return bool(await self._r.sismember(self._active_key(), session_id))
+        except Exception as e:  # noqa: BLE001
+            logger.warning("is_session_active(%s) failed (%s) — assuming active", session_id, e)
+            return True
 
     async def cleanup_idle_sessions(self, max_sessions: int = 100) -> None:
         await self._ensure_connected()

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# ============================================================================
+# WebGIS AI Agent 容器入口（Issue #476）
+#
+# 之前任何部署路径都不执行 Alembic：应用只靠 init_db() 的 create_all 引导
+# —— 对全新库够用，但对**已存在**的 Postgres 一列不加（create_all 从不
+# ALTER 已有表；app/core/database.py 的运行时迁移助手对非 SQLite 直接
+# early-return，提示"Postgres 部署请用 Alembic"）。结果：升级部署后新
+# 列/新索引缺失，只有生产库在运行期报 "column does not exist"。
+#
+# 本脚本在启动原 CMD 前执行 `alembic upgrade head`（幂等：已应用的
+# revision 直接跳过）。迁移失败则容器退出 —— 带旧 schema 起服务只会把
+# 失败推迟成运行期 500，编排层重试/回滚比静默漂移更诚实。
+#
+# 存量库收编（adoption）：本修复之前部署的库由 create_all 引导，没有
+# alembic_version 表 —— 直接 upgrade 会在 initial revision 上撞
+# "relation already exists"。对这种库先 `alembic stamp head` 收编（本仓库
+# 模型与迁移保持等价，见 tests/test_job_migration.py 的列/索引守卫），之后
+# 每次部署都走正常 upgrade。收编会打明显日志。
+#
+# 环境开关：
+#   SKIP_DB_MIGRATIONS=true  跳过迁移（celery-worker 等非迁移所有者服务用；
+#                            并发 upgrade 会竞争 alembic_version 表，迁移
+#                            只由 api 容器 / k8s initContainer 执行一次）。
+#   DB_MIGRATION_RETRIES     连接类失败的重试次数（默认 5），每次间隔 3s ——
+#                            编排健康检查通过 ≠ 100% 可立刻认证。
+# ============================================================================
+set -e
+
+log() {
+    echo "[docker-entrypoint] $*" >&2
+}
+
+redact_url() {
+    # 打日志不泄漏口令：scheme://user:***@host/db
+    printf '%s' "$1" | sed -E 's#(://[^:/@]+):[^@/]+@#\1:***@#g'
+}
+
+# 探测目标库状态：输出 "fresh"（无业务表）/"legacy"（有业务表但无
+# alembic_version）/"managed"（已有 alembic_version）/"error"。
+# exit 0 恒定 —— 探测失败按 fresh 处理，交给 alembic upgrade 暴露真实错误。
+_db_state() {
+    DATABASE_URL="${DATABASE_URL:-}" python3 - <<'PYEOF'
+import os
+import sys
+
+url = os.environ.get("DATABASE_URL", "")
+if not url:
+    print("error")
+    sys.exit(0)
+try:
+    from sqlalchemy import create_engine, inspect
+
+    engine = create_engine(url)
+    try:
+        names = set(inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+except Exception:
+    # 连不上/方言缺失：交给随后的 alembic upgrade 报真错并重试
+    print("error")
+    sys.exit(0)
+
+if "alembic_version" in names:
+    print("managed")
+elif names:
+    print("legacy")
+else:
+    print("fresh")
+PYEOF
+}
+
+if [ "${SKIP_DB_MIGRATIONS:-false}" = "true" ]; then
+    log "SKIP_DB_MIGRATIONS=true — skipping schema migration"
+    exec "$@"
+fi
+
+DB_MIGRATION_RETRIES="${DB_MIGRATION_RETRIES:-5}"
+DB_URL_DISPLAY="$(redact_url "${DATABASE_URL:-<unset>}")"
+
+state="$(_db_state)"
+if [ "$state" = "legacy" ]; then
+    log "existing schema without alembic_version (${DB_URL_DISPLAY})"
+    log "adopting legacy create_all schema: alembic stamp head"
+    alembic stamp head || log "WARNING: alembic stamp head failed — continuing to upgrade head"
+fi
+
+attempt=1
+while [ "$attempt" -le "$DB_MIGRATION_RETRIES" ]; do
+    if alembic upgrade head; then
+        log "database schema is up to date (${DB_URL_DISPLAY})"
+        exec "$@"
+    fi
+    log "alembic upgrade head failed (attempt ${attempt}/${DB_MIGRATION_RETRIES}, db=${DB_URL_DISPLAY})"
+    attempt=$((attempt + 1))
+    sleep 3
+done
+
+log "FATAL: schema migration failed after ${DB_MIGRATION_RETRIES} attempts — refusing to start with a drifted schema"
+exit 1

--- a/deploy/k8s/02-api-deployment.yaml
+++ b/deploy/k8s/02-api-deployment.yaml
@@ -55,6 +55,38 @@ spec:
           matchLabels:
             app: webgis-ai-agent
             component: api
+      # #476：k8s 的 `command:` 覆盖镜像 ENTRYPOINT —— 镜像的
+      # docker-entrypoint.sh（启动前 alembic upgrade head）在 k8s 不生效，
+      # 必须显式用 initContainer 执行迁移。Pod Ready 之前 schema 已就绪，
+      # 滚动更新期间新副本不会带着旧 schema 接流量。
+      initContainers:
+      - name: db-migration
+        image: webgis-prod:v0.1.2
+        imagePullPolicy: Always
+        command: ["alembic", "upgrade", "head"]
+        # 与应用容器同一 config/secret 来源（DATABASE_URL 在其中）。
+        envFrom:
+        - configMapRef:
+            name: webgis-config
+        - secretRef:
+            name: webgis-secret
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        volumeMounts:
+        # readOnlyRootFilesystem 下 psycopg/SQLAlchemy 需要可写 /tmp
+        - name: tmp
+          mountPath: /tmp
       containers:
       - name: webgis-api
         image: webgis-prod:v0.1.2

--- a/docker-compose.prod.secure.yml
+++ b/docker-compose.prod.secure.yml
@@ -173,6 +173,10 @@ services:
       REDIS_URL: "redis://:${REDIS_PASSWORD:?ERROR: REDIS_PASSWORD not set. Copy .env.Priv.example to .env.Priv}@redis:6379/0"
       CELERY_BROKER_URL: "redis://:${REDIS_PASSWORD:?ERROR: REDIS_PASSWORD not set. Copy .env.Priv.example to .env.Priv}@redis:6379/0"
       CELERY_RESULT_BACKEND: "redis://:${REDIS_PASSWORD:?ERROR: REDIS_PASSWORD not set. Copy .env.Priv.example to .env.Priv}@redis:6379/1"
+      # #476：镜像 entrypoint 现在会先跑 alembic upgrade head —— api 与
+      # celery-worker 同时 up 会并发 upgrade 竞争 alembic_version 表。
+      # 迁移的唯一所有者是 api 容器；worker 跳过。
+      SKIP_DB_MIGRATIONS: "true"
     env_file:
       - .env.Priv
     command: celery -A app.services.task_queue worker --loglevel=info --concurrency=2

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -139,6 +139,10 @@ services:
       - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD:?Set REDIS_PASSWORD}@redis:6379/1
       - LOG_LEVEL=INFO
       - PYTHONUNBUFFERED=1
+      # #476：镜像 entrypoint 现在会先跑 alembic upgrade head —— api 与
+      # celery-worker 同时 up 会并发 upgrade 竞争 alembic_version 表。
+      # 迁移的唯一所有者是 api 容器；worker 跳过。
+      - SKIP_DB_MIGRATIONS=true
     env_file:
       - .env.prod.example
     depends_on:

--- a/migrations/versions/0015_uploads_session_upload_index.py
+++ b/migrations/versions/0015_uploads_session_upload_index.py
@@ -1,0 +1,53 @@
+"""Add composite index on uploads (session_id, upload_time)
+
+Issue #429: GET /api/v1/uploads (list_uploads) 查询
+``WHERE session_id = ? ORDER BY upload_time DESC`` + COUNT，每次面板打开执行。
+uploads 表之前只有主键索引 —— 按会话列出的代价是全表扫描 + 排序，随全局
+上传行数线性增长（每个会话的列出请求都要扫所有其他会话的行）。
+
+本迁移为存量库补建模型（app/models/upload.py）已声明的复合索引
+ix_uploads_session_time，使过滤 + 排序都走索引扫描。
+
+Revision ID: 0015_uploads_session_upload_index
+Revises: 0014_workflow_provenance_revisions
+Create Date: 2026-08-16
+"""
+from typing import Sequence, Union
+
+from alembic import op, context
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0015_uploads_session_upload_index'
+down_revision: Union[str, Sequence[str], None] = '0014_workflow_provenance_revisions'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+INDEX_NAME = 'ix_uploads_session_time'
+
+
+def _is_sqlite() -> bool:
+    """Detect if the target database is SQLite."""
+    return context.get_context().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Create the composite index for per-session upload listing."""
+    if _is_sqlite():
+        with op.batch_alter_table("uploads", schema=None) as batch_op:
+            batch_op.create_index(INDEX_NAME, ["session_id", "upload_time"])
+    else:
+        # PostgreSQL: IF NOT EXISTS 与启动期 create_all 幂等共存（新库由
+        # create_all 按模型建出同名索引，alembic upgrade 不得碰撞报错）。
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS {INDEX_NAME} ON uploads (session_id, upload_time)"
+        )
+
+
+def downgrade() -> None:
+    """Drop the composite index (data untouched)."""
+    if _is_sqlite():
+        with op.batch_alter_table("uploads", schema=None) as batch_op:
+            batch_op.drop_index(INDEX_NAME)
+    else:
+        op.execute(f"DROP INDEX IF EXISTS {INDEX_NAME}")

--- a/migrations/versions/0016_knowledge_documents_owner.py
+++ b/migrations/versions/0016_knowledge_documents_owner.py
@@ -1,0 +1,74 @@
+"""Repair drift: knowledge_documents.org_id / creator_id missing from migration chain
+
+Issue #476 的 drift check（tests/test_deploy_migration_wiring.py::
+test_migrated_schema_matches_models）发现：Document 模型（app/models/
+knowledge_base.py）声明的 org_id / creator_id 两列（A2 资源所有权改造时
+加入模型）从未进过任何迁移 —— create_all 引导的库有这两列，而 Alembic
+迁移链建出的库没有。把部署切到 Alembic 后该漂移会变成运行期
+"column does not exist"。
+
+本迁移补齐两列 + idx_document_org 索引（幂等：存量列/索引已存在时跳过）。
+
+Revision ID: 0016_knowledge_documents_owner
+Revises: 0015_uploads_session_upload_index
+Create Date: 2026-08-16
+"""
+from typing import Sequence, Union
+
+from alembic import op, context
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0016_knowledge_documents_owner'
+down_revision: Union[str, Sequence[str], None] = '0015_uploads_session_upload_index'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = 'knowledge_documents'
+
+
+def _is_sqlite() -> bool:
+    """Detect if the target database is SQLite."""
+    return context.get_context().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    if _is_sqlite():
+        with op.batch_alter_table(TABLE, schema=None) as batch_op:
+            batch_op.add_column(sa.Column('org_id', sa.Integer(), nullable=True))
+            batch_op.add_column(sa.Column('creator_id', sa.String(length=255), nullable=True))
+            batch_op.create_index('idx_document_org', ['org_id'])
+    else:
+        # PostgreSQL：IF NOT EXISTS 与 create_all 幂等共存（create_all 引导的
+        # 存量库已有这两列 —— 见迁移头注释的 drift 背景）。
+        op.execute(f"ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS org_id INTEGER")
+        op.execute(f"ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS creator_id VARCHAR(255)")
+        op.execute(f"CREATE INDEX IF NOT EXISTS idx_document_org ON {TABLE} (org_id)")
+        # FK 约束无 IF NOT EXISTS；DO 块按约束名幂等（与模型声明的 ondelete 对齐）
+        op.execute(f"""
+            DO $$ BEGIN
+                ALTER TABLE {TABLE} ADD CONSTRAINT fk_knowledge_documents_org
+                    FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE;
+            EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+        """)
+        op.execute(f"""
+            DO $$ BEGIN
+                ALTER TABLE {TABLE} ADD CONSTRAINT fk_knowledge_documents_creator
+                    FOREIGN KEY (creator_id) REFERENCES users (id) ON DELETE SET NULL;
+            EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+        """)
+
+
+def downgrade() -> None:
+    if _is_sqlite():
+        with op.batch_alter_table(TABLE, schema=None) as batch_op:
+            batch_op.drop_index('idx_document_org')
+            batch_op.drop_column('creator_id')
+            batch_op.drop_column('org_id')
+    else:
+        op.execute("ALTER TABLE knowledge_documents DROP CONSTRAINT IF EXISTS fk_knowledge_documents_creator")
+        op.execute("ALTER TABLE knowledge_documents DROP CONSTRAINT IF EXISTS fk_knowledge_documents_org")
+        op.execute("DROP INDEX IF EXISTS idx_document_org")
+        op.execute("ALTER TABLE knowledge_documents DROP COLUMN IF EXISTS creator_id")
+        op.execute("ALTER TABLE knowledge_documents DROP COLUMN IF EXISTS org_id")

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,3 +22,4 @@ markers =
     heavy: tests that need heavy deps (geopandas/numpy/rasterio). CI runs them; tests needing Node/Playwright self-skip.
     perf: deterministic performance regression harness (tests/benchmarks/test_perf_harness.py). Run with -m perf; refresh baselines with PERF_UPDATE_BASELINES=1.
     cartography: deterministic release-blocking cartography & harness closed-loop gate (MapSpec transactions, ref resolution, validity evidence ladder, cartographic semantic checks, fault-injection subset). No Node/Chromium/LLM/network. Run with -m cartography.
+    real_services: smoke subset requiring REAL Postgres/PostGIS + Redis + a real celery worker (CI real-services-smoke lane). Self-skips when services are unreachable. Run with -m real_services.

--- a/tests/real_services_celery_app.py
+++ b/tests/real_services_celery_app.py
@@ -1,0 +1,64 @@
+"""Celery app for the real-services smoke lane (Issue #477).
+
+tests/test_real_services_smoke.py 启动的 worker 子进程通过本模块拿到与
+测试进程**同一个** celery app（同 broker/backend、同任务注册表）。
+任务必须在这里静态定义：worker 按名字查任务，测试进程里动态装饰的任务
+对 worker 是"unregistered"。
+
+broker/backend 用真实 Redis（db 5，与会话数据隔离），由环境变量
+REAL_SMOKE_BROKER_URL / REAL_SMOKE_RESULT_BACKEND 注入（默认 localhost）。
+"""
+import os
+
+from celery import Celery
+
+_default_broker = "redis://localhost:6379/5"
+
+celery_app = Celery(
+    "webgis_real_smoke",
+    broker=os.environ.get("REAL_SMOKE_BROKER_URL", _default_broker),
+    backend=os.environ.get("REAL_SMOKE_RESULT_BACKEND", _default_broker),
+)
+
+celery_app.conf.update(
+    task_serializer="json",
+    accept_content=["json"],
+    result_serializer="json",
+    enable_utc=True,
+    timezone="UTC",
+    task_track_started=True,
+    broker_connection_retry_on_startup=True,
+    # 快速失败：smoke lane 不等长超时
+    broker_connection_timeout=5,
+    result_backend_transport_options={"socket_connect_timeout": 5, "socket_timeout": 5},
+    broker_transport_options={"socket_connect_timeout": 5, "socket_timeout": 5},
+)
+
+# conftest.py 为整套套件强制 CELERY_BROKER_URL=memory://（测试进程离线），
+# 而 Celery 的配置级联里环境变量优先于构造参数 —— 不显式覆盖的话本 app
+# 会被静默降到 memory broker，worker 与真实 Redis 永远对不上。构造后显式
+# 赋值优先级最高。
+celery_app.conf.broker_url = os.environ.get("REAL_SMOKE_BROKER_URL", _default_broker)
+celery_app.conf.result_backend = os.environ.get("REAL_SMOKE_RESULT_BACKEND", _default_broker)
+
+
+# 兼容 fixture 命名（test 模块里 celery_worker yield smoke_celery_app）
+smoke_celery_app = celery_app
+
+
+@celery_app.task(name="real_smoke.add")
+def add(x, y):
+    return x + y
+
+
+@celery_app.task(name="real_smoke.mul")
+def mul(x, y):
+    return x * y
+
+
+@celery_app.task(name="real_smoke.slow")
+def slow(seconds):
+    import time
+
+    time.sleep(seconds)
+    return "done"

--- a/tests/test_deploy_migration_wiring.py
+++ b/tests/test_deploy_migration_wiring.py
@@ -1,0 +1,413 @@
+"""Issue #476: Alembic 必须真正接进部署路径。
+
+审计结论：仓库有 16 个迁移 revision，Dockerfile.prod 也拷贝了 alembic.ini +
+migrations/，但任何部署路径（compose / k8s / entrypoint）都不执行
+`alembic upgrade head`。应用启动只走 init_db() → create_all，对**已存在**的
+Postgres 不加列/索引 —— 存量生产库 schema 停留在首次创建状态，新特性上线即
+"column does not exist"，且只在生产暴露（测试全部从全新 create_all 起步）。
+
+本文件是结构守卫（与 test_critical_infra_hardening.py 的 I4/I7/I9 同款）：
+  1. 镜像 entrypoint 在启动应用前执行 alembic upgrade head（可跳过）；
+  2. Dockerfile.prod 装了该 entrypoint 并挂在 ENTRYPOINT 上；
+  3. 两个生产 compose：api 跑迁移、celery-worker 跳过（单一迁移所有者，
+     避免两个容器并发 upgrade 竞争 alembic_version）；
+  4. k8s api Deployment 用 initContainer 跑迁移（k8s 的 command: 覆盖镜像
+     ENTRYPOINT，entrypoint 方案在 k8s 不生效，必须显式 initContainer）；
+  5. 迁移链产出与模型元数据一致（drift check；CI 的 db-migrations lane
+     会把它指到真实 PostGIS）；
+  6. 本地 dev（docker-compose.yml / 直接 uvicorn）不受影响 —— dev 镜像
+     （Dockerfile）不装 entrypoint。
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+import os
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENTRYPOINT = REPO_ROOT / "deploy" / "docker-entrypoint.sh"
+
+
+# ── 1. entrypoint 脚本 ───────────────────────────────────────────────────
+
+
+def test_entrypoint_script_exists_and_is_executable_intent():
+    assert ENTRYPOINT.exists(), "deploy/docker-entrypoint.sh 不存在"
+
+
+def test_entrypoint_runs_alembic_before_exec():
+    source = ENTRYPOINT.read_text(encoding="utf-8")
+    assert "alembic upgrade head" in source, "entrypoint 必须执行 alembic upgrade head"
+    assert 'exec "$@"' in source, "entrypoint 必须以 exec \"$@\" 启动原 CMD"
+    # exec 必须在迁移之后（迁移失败不允许带旧 schema 起服务）
+    assert source.index("alembic upgrade head") < source.index('exec "$@"')
+
+
+def test_entrypoint_honors_skip_env_and_retries_transient_failures():
+    source = ENTRYPOINT.read_text(encoding="utf-8")
+    assert "SKIP_DB_MIGRATIONS" in source, "entrypoint 必须支持 SKIP_DB_MIGRATIONS 跳过"
+    assert "DATABASE_URL" in source, "迁移失败信息必须能定位目标 DATABASE_URL（脱敏）"
+
+
+# ── 1b. entrypoint 行为（真实执行脚本，桩掉 alembic）────────────────────
+
+
+@pytest.fixture
+def alembic_stub(tmp_path, monkeypatch):
+    """PATH 上放一个记录调用的假 alembic；真实 alembic 一次都不该跑（慢且会改库）。"""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    calls_file = tmp_path / "alembic-calls.log"
+
+    (stub_dir / "alembic").write_text(
+        "#!/bin/sh\n"
+        'echo "$*" >> "$ALEMBIC_CALLS_LOG"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    (stub_dir / "alembic").chmod(0o755)
+    return stub_dir, calls_file
+
+
+def _run_entrypoint(tmp_path, stub_dir, calls_file, extra_env):
+    env = {
+        **os.environ,  # 继承 DATABASE_URL（monkeypatch.setenv 设在父进程）
+        # python3 解析到当前解释器（探测脚本需要 sqlalchemy；系统 python3 可能没有）
+        "PATH": f"{stub_dir}:{os.path.dirname(sys.executable)}:{os.environ.get('PATH', '')}",
+        "ALEMBIC_CALLS_LOG": str(calls_file),
+        "SKIP_DB_MIGRATIONS": "false",
+        **extra_env,
+    }
+    return subprocess.run(
+        ["/bin/sh", str(ENTRYPOINT), "echo", "app-started"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=str(REPO_ROOT),
+    )
+
+
+def _calls(calls_file):
+    if not calls_file.exists():
+        return []
+    return [line for line in calls_file.read_text().splitlines() if line.strip()]
+
+
+def test_entrypoint_fresh_db_runs_upgrade_only(tmp_path, alembic_stub, monkeypatch):
+    """全新库（无表）：直接 upgrade head，不做 stamp。"""
+    stub_dir, calls_file = alembic_stub
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/fresh.db")
+    result = _run_entrypoint(tmp_path, stub_dir, calls_file, {})
+    assert result.returncode == 0, result.stderr
+    assert _calls(calls_file) == ["upgrade head"]
+    assert "app-started" in result.stdout
+
+
+def test_entrypoint_legacy_db_stamps_then_upgrades(tmp_path, alembic_stub, monkeypatch):
+    """存量 create_all 库（有表、无 alembic_version）：先 stamp head 收编再 upgrade。"""
+    import sqlite3
+
+    db_path = tmp_path / "legacy.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE users (id TEXT PRIMARY KEY)")
+        conn.commit()
+
+    stub_dir, calls_file = alembic_stub
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    result = _run_entrypoint(tmp_path, stub_dir, calls_file, {})
+    assert result.returncode == 0, result.stderr
+    calls = _calls(calls_file)
+    assert calls == ["stamp head", "upgrade head"], calls
+    assert "adopting legacy" in result.stderr
+
+
+def test_entrypoint_managed_db_runs_upgrade_only(tmp_path, alembic_stub, monkeypatch):
+    """已有 alembic_version 的库：不 stamp，只 upgrade（幂等）。"""
+    import sqlite3
+
+    db_path = tmp_path / "managed.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE alembic_version (version_num VARCHAR(32))")
+        conn.commit()
+
+    stub_dir, calls_file = alembic_stub
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    result = _run_entrypoint(tmp_path, stub_dir, calls_file, {})
+    assert result.returncode == 0, result.stderr
+    assert _calls(calls_file) == ["upgrade head"]
+
+
+def test_entrypoint_skip_env_runs_nothing(tmp_path, alembic_stub, monkeypatch):
+    stub_dir, calls_file = alembic_stub
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/skip.db")
+    result = _run_entrypoint(
+        tmp_path, stub_dir, calls_file, {"SKIP_DB_MIGRATIONS": "true"}
+    )
+    assert result.returncode == 0, result.stderr
+    assert _calls(calls_file) == []
+    assert "app-started" in result.stdout
+
+
+def test_entrypoint_fails_after_bounded_retries(tmp_path, alembic_stub, monkeypatch):
+    """迁移持续失败：有界重试后拒绝起服务（不带旧 schema 上线）。"""
+    stub_dir, calls_file = alembic_stub
+    (stub_dir / "alembic").write_text(
+        "#!/bin/sh\n"
+        'echo "$*" >> "$ALEMBIC_CALLS_LOG"\n'
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    (stub_dir / "alembic").chmod(0o755)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/fail.db")
+    result = _run_entrypoint(
+        tmp_path, stub_dir, calls_file, {"DB_MIGRATION_RETRIES": "2"}
+    )
+    assert result.returncode == 1
+    assert len(_calls(calls_file)) == 2, "重试次数必须遵守 DB_MIGRATION_RETRIES"
+    assert "refusing to start" in result.stderr
+
+
+# ── 2. Dockerfile.prod ──────────────────────────────────────────────────
+
+
+def test_dockerfile_prod_installs_and_uses_entrypoint():
+    df = (REPO_ROOT / "Dockerfile.prod").read_text(encoding="utf-8")
+    assert "deploy/docker-entrypoint.sh" in df, "Dockerfile.prod 必须拷贝 entrypoint"
+    assert "docker-entrypoint.sh" in df.split("ENTRYPOINT")[1], (
+        "ENTRYPOINT 必须经由 docker-entrypoint.sh（tini 之下）再启动 CMD"
+    )
+    # 审计 I9 的 trap-kill-wait CMD 语义不能被破坏 —— CMD 保持原样
+    assert "trap 'kill 0' TERM INT" in df
+
+
+# ── 3. 生产 compose：单一迁移所有者 ─────────────────────────────────────
+
+
+def _compose_services(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["services"]
+
+
+def _env_entries(env) -> list[str]:
+    """Normalize compose environment (list-form or mapping-form) to KEY=VALUE strings."""
+    if not env:
+        return []
+    if isinstance(env, dict):
+        return [f"{k}={v}" for k, v in env.items()]
+    return [str(e) for e in env]
+
+
+def test_prod_compose_api_runs_migrations_celery_skips():
+    for name in ("docker-compose.prod.yml", "docker-compose.prod.secure.yml"):
+        services = _compose_services(REPO_ROOT / name)
+        api_env = _env_entries(services["api"].get("environment"))
+        celery_env = _env_entries(services["celery-worker"].get("environment"))
+        assert not any(
+            e.split("=", 1)[0].strip() == "SKIP_DB_MIGRATIONS" for e in api_env
+        ), f"{name}: api 必须运行迁移（不得设 SKIP_DB_MIGRATIONS）"
+        assert any(
+            e.split("=", 1)[0].strip() == "SKIP_DB_MIGRATIONS"
+            and e.split("=", 1)[-1].strip().lower() == "true"
+            for e in celery_env
+        ), f"{name}: celery-worker 必须设 SKIP_DB_MIGRATIONS=true（api 是唯一迁移所有者）"
+
+
+# ── 4. k8s：initContainer 跑迁移 ────────────────────────────────────────
+
+
+def _k8s_api_deployment() -> dict:
+    docs = list(
+        yaml.safe_load_all(
+            (REPO_ROOT / "deploy" / "k8s" / "02-api-deployment.yaml").read_text(encoding="utf-8")
+        )
+    )
+    return next(d for d in docs if d and d.get("kind") == "Deployment")
+
+
+def test_k8s_api_has_migration_init_container():
+    dep = _k8s_api_deployment()
+    pod = dep["spec"]["template"]["spec"]
+    inits = pod.get("initContainers", [])
+    assert any(
+        "alembic" in " ".join(c.get("command", []) + c.get("args", []))
+        for c in inits
+    ), "api Deployment 必须有执行 alembic upgrade head 的 initContainer"
+
+
+def test_k8s_migration_init_container_gets_env_and_writable_tmp():
+    dep = _k8s_api_deployment()
+    pod = dep["spec"]["template"]["spec"]
+    init = next(
+        c
+        for c in pod.get("initContainers", [])
+        if "alembic" in " ".join(c.get("command", []) + c.get("args", []))
+    )
+    env_from = init.get("envFrom", [])
+    kinds = [
+        key for ef in env_from for key in ("configMapRef", "secretRef") if key in ef
+    ]
+    assert "secretRef" in kinds, (
+        "initContainer 必须能读到 DATABASE_URL（envFrom secretRef/configMapRef，与应用容器一致）"
+    )
+    # readOnlyRootFilesystem 下 SQLAlchemy/psycopg 需要可写 /tmp
+    mounts = {m["name"]: m["mountPath"] for m in init.get("volumeMounts", [])}
+    assert "/tmp" in mounts.values(), "initContainer 需要可写 /tmp（rootfs 只读）"
+    volumes = {v["name"]: v for v in pod.get("volumes", [])}
+    assert volumes[mounts_reverse(mounts, "/tmp")].get("emptyDir") is not None, (
+        "/tmp 挂载必须来自 emptyDir 卷"
+    )
+
+
+def mounts_reverse(mounts: dict, mount_path: str) -> str:
+    for name, path in mounts.items():
+        if path == mount_path:
+            return name
+    raise AssertionError(f"no volume mounted at {mount_path}")
+
+
+def test_k8s_celery_has_no_migration_init_container():
+    """迁移所有者是 api —— celery 不重复跑（并发 upgrade 会竞争 alembic_version）。"""
+    docs = list(
+        yaml.safe_load_all(
+            (REPO_ROOT / "deploy" / "k8s" / "03-celery-deployment.yaml").read_text(encoding="utf-8")
+        )
+    )
+    dep = next(d for d in docs if d and d.get("kind") == "Deployment")
+    inits = dep["spec"]["template"]["spec"].get("initContainers", [])
+    assert not any(
+        "alembic" in " ".join(c.get("command", []) + c.get("args", [])) for c in inits
+    ), "celery Deployment 不应带 alembic initContainer"
+
+
+# ── 6. 迁移链产出 vs 模型元数据（drift check，#476 验收项）──────────────
+#
+# 默认在隔离的临时 SQLite 上跑 alembic upgrade head 再比对（hermetic，
+# 不碰 CI 的共享 DATABASE_URL）。CI 的 db-migrations lane 会对真实
+# PostGIS 先 `alembic upgrade head`，再设 MIGRATION_DRIFT_DB_URL 让本测试
+# 比对真实 PG schema —— 模型与迁移的漂移因此在两条路径都被拦下。
+
+
+def test_migrated_schema_matches_models(tmp_path):
+    import os
+    import sqlite3
+    import subprocess
+
+    override = os.environ.get("MIGRATION_DRIFT_DB_URL")
+    if override:
+        from sqlalchemy import create_engine, inspect
+
+        engine = create_engine(override)
+        insp = inspect(engine)
+        try:
+            migrated_tables = set(insp.get_table_names())
+            columns_of = lambda t: {c["name"] for c in insp.get_columns(t)}  # noqa: E731
+            index_cols_of = lambda t: {tuple(c["column_names"]) for c in insp.get_indexes(t)}  # noqa: E731
+        finally:
+            engine.dispose()
+    else:
+        db_path = tmp_path / "drift.db"
+        result = subprocess.run(
+            [sys.executable, "-m", "alembic", "upgrade", "head"],
+            cwd=str(REPO_ROOT),
+            env={
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                "DATABASE_URL": f"sqlite:///{db_path}",
+                "JWT_SECRET_KEY": "test-secret-migration-32-chars-okay",
+                "USE_REDIS": "false",
+                "HOME": str(Path.home()),
+            },
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        assert result.returncode == 0, f"upgrade head 失败:\n{result.stdout}\n{result.stderr}"
+        conn = sqlite3.connect(db_path)
+        migrated_tables = {
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        } - {"alembic_version"}
+        conn.close()
+        from sqlalchemy import create_engine, inspect
+
+        engine = create_engine(f"sqlite:///{db_path}")
+        insp = inspect(engine)
+        columns_of = lambda t: {c["name"] for c in insp.get_columns(t)}  # noqa: E731
+        index_cols_of = lambda t: {tuple(c["column_names"]) for c in insp.get_indexes(t)}  # noqa: E731
+        engine.dispose()
+
+    from app.core.database import Base
+
+    import app.models.db_model  # noqa: F401  (registers tables)
+    import app.models.report  # noqa: F401
+    import app.models.upload  # noqa: F401
+
+    model_tables = set(Base.metadata.tables.keys())
+
+    drift = []
+    for t in sorted(model_tables - migrated_tables):
+        drift.append(f"模型有表但迁移链没建: {t}")
+    for t in sorted(migrated_tables - model_tables):
+        drift.append(f"迁移链建了表但模型没有: {t}")
+    for t in sorted(model_tables & migrated_tables):
+        mig_cols = columns_of(t)
+        model_cols = {c.name for c in Base.metadata.tables[t].columns}
+        if mig_cols != model_cols:
+            drift.append(
+                f"{t}: 迁移列={sorted(mig_cols)} 模型列={sorted(model_cols)}"
+            )
+        # 索引按列元组比对（create_all 与迁移的索引命名不同）。只断言
+        # "模型声明的索引迁移链必须建出"这一方向 —— 迁移多建的历史索引
+        # 不构成运行期漂移。
+        mig_idx = index_cols_of(t)
+        for model_idx in Base.metadata.tables[t].indexes:
+            cols = tuple(c.name for c in model_idx.columns)
+            if cols not in mig_idx:
+                drift.append(f"{t}: 模型索引 {model_idx.name}{cols} 未被迁移链创建")
+
+    assert not drift, "模型与迁移 schema 漂移:\n" + "\n".join(drift)
+
+
+# ── 6b. CI：db-migrations lane（对真实 PostGIS 执行迁移链）─────────────
+
+
+def _workflow_jobs() -> dict:
+    doc = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "production.yml").read_text(encoding="utf-8")
+    )
+    return doc["jobs"]
+
+
+def test_ci_has_db_migration_gate_against_postgis():
+    jobs = _workflow_jobs()
+    assert "db-migrations" in jobs, "CI 必须有对真实 PostGIS 执行 alembic 的 lane"
+    job = jobs["db-migrations"]
+    services = job.get("services", {})
+    assert any(
+        "postgis" in str(s.get("image", "")) for s in services.values()
+    ), "db-migrations 必须用 postgis service container（0011 迁移只在 PostGIS 上可验证）"
+    run_text = "\n".join(
+        str(s.get("run", "")) + "\n" + "\n".join(f"{k}={v}" for k, v in s.get("env", {}).items())
+        for s in job.get("steps", [])
+    )
+    assert "alembic upgrade head" in run_text, "lane 必须执行 alembic upgrade head"
+    assert "MIGRATION_DRIFT_DB_URL" in run_text, (
+        "lane 必须跑模型 vs 迁移 drift check（test_migrated_schema_matches_models）"
+    )
+
+
+def test_ci_db_migration_gate_is_release_blocking():
+    jobs = _workflow_jobs()
+    needs = jobs["release-gate"]["needs"]
+    assert "db-migrations" in needs, "db-migrations 必须进入 release DAG"
+
+
+# ── 7. 本地 dev 不受影响 ─────────────────────────────────────────────────
+
+
+def test_dev_dockerfile_untouched_by_entrypoint():
+    """dev 镜像（本地 compose 用）不装 entrypoint —— 本地 SQLite + create_all 语义不变。"""
+    df = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    assert "docker-entrypoint.sh" not in df

--- a/tests/test_real_services_ci_wiring.py
+++ b/tests/test_real_services_ci_wiring.py
@@ -1,0 +1,75 @@
+"""Issue #477：CI 的 real-services smoke lane 结构守卫。
+
+CI 一直在 test-backend lane 里配 postgis + redis service container，但套件
+跑的是 SQLite / fakeredis / eager-celery —— 容器基本闲置。#477 的修复是
+新增 real-services-smoke lane 真正消费这些服务（asyncpg / PostGIS / 真实
+Redis 线协议 / 真实 celery broker 投递），本文件守住这条 lane 不被悄悄拆掉。
+"""
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "production.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_workflow_yaml_parses():
+    """YAML 必须可解析（yaml.safe_load 全文）。"""
+    doc = _workflow()
+    assert "jobs" in doc
+
+
+def test_real_services_lane_exists_with_both_services():
+    jobs = _workflow()["jobs"]
+    assert "real-services-smoke" in jobs, "缺少 real-services-smoke lane"
+    job = jobs["real-services-smoke"]
+    images = {str(s.get("image", "")) for s in job.get("services", {}).values()}
+    assert any("postgis" in i for i in images), "lane 必须配 postgis service"
+    assert any(i.startswith("redis") for i in images), "lane 必须配 redis service"
+
+
+def test_real_services_lane_runs_marker_and_env():
+    jobs = _workflow()["jobs"]
+    job = jobs["real-services-smoke"]
+    run_text = "\n".join(str(s.get("run", "")) for s in job.get("steps", []))
+    env_text = "\n".join(
+        "\n".join(f"{k}={v}" for k, v in s.get("env", {}).items())
+        for s in job.get("steps", [])
+    )
+    assert "-m real_services" in run_text, "lane 必须按 marker 选择 real-services 子集"
+    assert "--no-cov" in run_text, "smoke lane 无需 coverage（与 perf/cartography lane 一致）"
+    assert "DATABASE_URL=postgresql://" in env_text or "DATABASE_URL" in run_text, (
+        "lane 必须把 DATABASE_URL 指到 provisioned Postgres"
+    )
+    assert "REDIS_URL" in env_text or "REDIS_URL" in run_text, (
+        "lane 必须把 REDIS_URL 指到 provisioned Redis"
+    )
+
+
+def test_real_services_lane_is_release_blocking():
+    needs = _workflow()["jobs"]["release-gate"]["needs"]
+    assert "real-services-smoke" in needs, "real-services-smoke 必须进入 release DAG"
+
+
+def test_backend_lane_excludes_real_services_marker():
+    """real_services 子集由专属 lane 拥有 —— 主 lane 的 -m 过滤必须排除，
+    避免双重执行 / 在无服务保障的上下文意外跑（与 perf/cartography 同款契约）。"""
+    jobs = _workflow()["jobs"]
+    run_text = "\n".join(str(s.get("run", "")) for s in jobs["test-backend"].get("steps", []))
+    assert "not real_services" in run_text
+
+
+def test_pytest_ini_registers_real_services_marker():
+    ini = (REPO_ROOT / "pytest.ini").read_text(encoding="utf-8")
+    assert "real_services:" in ini, "pytest.ini 必须注册 real_services marker"
+
+
+def test_smoke_module_self_skips_without_services():
+    """服务不可达时必须 self-skip（本地无容器不红），绝不把连不上伪装成通过。"""
+    smoke = (REPO_ROOT / "tests" / "test_real_services_smoke.py").read_text(encoding="utf-8")
+    assert "pytest.skip" in smoke
+    assert "pytestmark = pytest.mark.real_services" in smoke

--- a/tests/test_real_services_smoke.py
+++ b/tests/test_real_services_smoke.py
@@ -1,0 +1,315 @@
+"""Real-service smoke subset for the dedicated CI lane (Issue #477).
+
+CI 一直在花钱跑 postgis + redis service container，但套件实际跑的是
+SQLite / fakeredis / eager-celery（conftest.py 强制 USE_REDIS=false +
+CELERY_BROKER_URL=memory://）—— asyncpg 驱动行为、PostGIS 类型、真实
+Redis 线协议、真实 broker 投递从未被验证过（prod-only 回归只能等部署后爆。
+
+本文件是**有界的定向 smoke 子集**（不是把整套测试搬到真实后端）：
+  - Postgres/asyncpg：异步引擎真实往返 + 服务端版本；
+  - PostGIS：geometry 列建/插/查（真实 PostGIS 类型，0011 迁移的前提）；
+  - Redis：真实线协议的 SET/GET/EXPIRE/TTL/pipeline 语义；
+  - Celery：真实 broker 投递 + chain + 真实 result backend + revoke 丢弃。
+
+全部用 @pytest.mark.real_services 标记，由 CI 的 real-services-smoke lane
+（postgis + redis service containers）执行。服务不可达时逐条 self-skip
+（本地开发无容器也能跑整套套件），绝不把"连不上"伪装成"通过"。
+"""
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from urllib.parse import urlparse
+
+import pytest
+
+pytestmark = pytest.mark.real_services
+
+
+def _tcp_reachable(url: str, default_port: int) -> bool:
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or "localhost"
+        port = parsed.port or default_port
+        with socket.create_connection((host, port), timeout=1.5):
+            return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _postgres_url() -> str:
+    url = os.environ.get("DATABASE_URL", "")
+    if not url.startswith(("postgresql://", "postgresql+")):
+        pytest.skip("real-services lane: DATABASE_URL 未指向 Postgres")
+    if not _tcp_reachable(url, 5432):
+        pytest.skip("real-services lane: Postgres 不可达")
+    return url
+
+
+def _redis_url() -> str:
+    url = os.environ.get("REDIS_URL", "")
+    if not url.startswith("redis://"):
+        pytest.skip("real-services lane: REDIS_URL 未设置")
+    if not _tcp_reachable(url, 6379):
+        pytest.skip("real-services lane: Redis 不可达")
+    return url
+
+
+# ── Postgres / asyncpg ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_postgres_asyncpg_roundtrip():
+    """asyncpg 驱动的真实往返：DDL + 参数化写 + 读 + 服务端版本。"""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    url = _postgres_url()
+    if "+asyncpg" not in url and url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    engine = create_async_engine(url)
+    table = f"_real_smoke_{uuid.uuid4().hex[:8]}"
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f"CREATE TABLE {table} (id INT, name TEXT)"))
+            await conn.execute(
+                text(f"INSERT INTO {table} (id, name) VALUES (:i, :n)"),
+                [{"i": 1, "n": "asyncpg-真实往返"}],
+            )
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text(f"SELECT id, name FROM {table}"))).fetchall()
+            version = (await conn.execute(text("SELECT version()"))).scalar()
+        assert [(r[0], r[1]) for r in rows] == [(1, "asyncpg-真实往返")]
+        assert "PostgreSQL" in version
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_postgis_geometry_roundtrip():
+    """PostGIS 类型真实往返 —— 0011 迁移与空间查询在生产 Postgres 上的前提。"""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    url = _postgres_url()
+    if "+asyncpg" not in url and url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    engine = create_async_engine(url)
+    table = f"_real_gis_{uuid.uuid4().hex[:8]}"
+    try:
+        async with engine.connect() as conn:
+            postgis_version = (await conn.execute(text("SELECT PostGIS_Version()"))).scalar()
+        assert postgis_version, "PostGIS 扩展不可用 —— postgis service container 配置错误"
+
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(f"CREATE TABLE {table} (id INT, geom geometry(Point, 4326))")
+            )
+            await conn.execute(
+                text(
+                    f"INSERT INTO {table} (id, geom) "
+                    "VALUES (1, ST_SetSRID(ST_MakePoint(:lon, :lat), 4326))"
+                ),
+                {"lon": 116.397, "lat": 39.909},
+            )
+        async with engine.connect() as conn:
+            wkt = (await conn.execute(
+                text(f"SELECT ST_AsText(geom) FROM {table} WHERE id = 1")
+            )).scalar()
+            srid = (await conn.execute(
+                text(f"SELECT ST_SRID(geom) FROM {table} WHERE id = 1")
+            )).scalar()
+        assert wkt == "POINT(116.397 39.909)"
+        assert srid == 4326
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f"DROP TABLE IF EXISTS {table}"))
+        await engine.dispose()
+
+
+# ── Redis 真实线协议 ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_redis_real_wire_semantics():
+    """SET/GET 字节保真、EXPIRE/TTL 语义、pipeline 事务 —— fakeredis 无法
+    捕获真实服务端行为回归（如 TTL 精度/RESP 编码差异）。"""
+    import redis.asyncio as aioredis
+
+    url = _redis_url()
+    r = aioredis.from_url(url, decode_responses=False)
+    prefix = f"real-smoke:{uuid.uuid4().hex[:8]}"
+    try:
+        key = f"{prefix}:kv"
+        # RESP 二进制安全：非 ASCII 值往返不失真
+        value = "值-with-émoji-🗺️".encode("utf-8")
+        assert await r.set(key, value)
+        assert await r.get(key) == value
+
+        # TTL 语义：EX 后 TTL 有界递减
+        ttl_key = f"{prefix}:ttl"
+        await r.set(ttl_key, b"1", ex=30)
+        ttl = await r.ttl(ttl_key)
+        assert 1 <= ttl <= 30, f"EX=30 后 TTL 应在 (0,30]，实际 {ttl}"
+        # 持久化覆盖：SET 不带 EX 清除 TTL（服务端语义）
+        await r.set(ttl_key, b"2")
+        assert await r.ttl(ttl_key) == -1
+
+        # pipeline：命令批量原子提交
+        pipe_keys = [f"{prefix}:p{i}" for i in range(3)]
+        async with r.pipeline(transaction=True) as pipe:
+            for i, k in enumerate(pipe_keys):
+                pipe.set(k, str(i).encode())
+            await pipe.execute()
+        for i, k in enumerate(pipe_keys):
+            assert await r.get(k) == str(i).encode()
+    finally:
+        await r.delete(
+            *(await r.keys(f"{prefix}:*") or [f"{prefix}:none"])
+        )
+        await r.aclose()
+
+
+# ── Celery 真实 broker 投递 ─────────────────────────────────────────────
+
+# 独立的极简 celery app：不复用 app.services.task_queue 单例（它按 conftest
+# 环境是 eager + memory broker）。worker 子进程通过
+# tests.real_services_celery_app 导入同一 app —— broker/backend 指向真实
+# Redis（专用 db 5，不污染会话数据）。
+SMOKE_BROKER_DB = 5
+
+
+def _broker_urls(redis_url: str) -> tuple[str, str]:
+    parsed = urlparse(redis_url)
+    base = f"redis://{parsed.netloc}"
+    return f"{base}/{SMOKE_BROKER_DB}", f"{base}/{SMOKE_BROKER_DB}"
+
+
+@pytest.fixture(scope="module")
+def celery_worker():
+    """启动/停止一个真实 celery worker 子进程（solo pool，避免 fork 噪声）。"""
+    import redis.asyncio as aioredis
+
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    redis_url = _redis_url()
+    broker, backend = _broker_urls(redis_url)
+    env = {
+        **os.environ,
+        "REAL_SMOKE_BROKER_URL": broker,
+        "REAL_SMOKE_RESULT_BACKEND": backend,
+    }
+    # 测试进程里的 app 在 import 时读这两个变量 —— 必须先设再 import，
+    # 否则它落到默认 localhost（与 worker 的 URL 不一致，ping 永远无响应）。
+    os.environ["REAL_SMOKE_BROKER_URL"] = broker
+    os.environ["REAL_SMOKE_RESULT_BACKEND"] = backend
+    # conftest.py 为整套套件强制 CELERY_BROKER_URL=memory://（测试进程离线）。
+    # Celery 的 Settings.broker_url/result_backend 是 property，每次访问都
+    # **先读环境变量**（celery/app/utils.py）—— 进程内任何 conf 赋值都赢不了
+    # 它。真实 broker 测试期间临时摘掉这两个变量，finally 恢复（本 lane 只跑
+    # real_services 子集；混合本地跑时恢复保证其余测试保持 eager/离线）。
+    _saved_celery_env = {
+        k: os.environ.pop(k)
+        for k in ("CELERY_BROKER_URL", "CELERY_RESULT_BACKEND")
+        if k in os.environ
+    }
+    # worker 子进程同样不能继承 memory://（已在 env 字典里剔除）。
+    env = {
+        k: v for k, v in env.items()
+        if k not in ("CELERY_BROKER_URL", "CELERY_RESULT_BACKEND")
+    }
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "celery",
+            "-A", "tests.real_services_celery_app",
+            "worker", "--pool=solo", "--concurrency=1",
+            "--loglevel=WARNING", "--without-gossip", "--without-mingle",
+        ],
+        env=env,
+        cwd=str(repo_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        # 就绪探测：worker 的 pidbox 响应 control ping（有界等待）
+        from tests.real_services_celery_app import smoke_celery_app
+
+        # 级联守卫：app 若被 conftest 的 CELERY_* 环境降到 memory://，
+        # ping 永远无响应 —— 提前用可诊断的错误失败。
+        assert smoke_celery_app.conf.broker_url == broker, (
+            f"smoke celery app broker 配置错误: {smoke_celery_app.conf.broker_url} != {broker}"
+        )
+        deadline = time.monotonic() + 60
+        ready = False
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                out = proc.stdout.read() if proc.stdout else ""
+                pytest.fail(f"celery worker 提前退出:\n{out[-2000:]}")
+            try:
+                reply = smoke_celery_app.control.ping(timeout=2)
+            except Exception:  # noqa: BLE001
+                reply = None
+            if reply:
+                ready = True
+                break
+            time.sleep(1)
+        assert ready, "celery worker 60s 内未就绪（ping 无响应）"
+        yield smoke_celery_app
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        os.environ.update(_saved_celery_env)
+        # 清掉本次 run 的 broker/result 键（backend db）—— 不影响其它 db
+        import asyncio
+
+        async def _flush() -> None:
+            r = aioredis.from_url(broker)
+            await r.flushdb()
+            await r.aclose()
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_flush())
+        finally:
+            loop.close()
+
+
+@pytest.mark.asyncio
+async def test_celery_real_broker_delivery_and_chain(celery_worker):
+    """真实 broker 投递 + chain 组合 + 真实 result backend 取回。"""
+    from celery import chain
+
+    from tests.real_services_celery_app import add, mul
+
+    simple = add.delay(2, 3)
+    assert simple.get(timeout=30) == 5, "任务未通过真实 broker 送达 worker"
+
+    composed = chain(add.s(2, 3), mul.s(10))
+    assert composed().get(timeout=30) == 50, "chain 第二跳未在真实 worker 上执行"
+
+
+@pytest.mark.asyncio
+async def test_celery_revoke_discards_pending_task(celery_worker):
+    """revoke 丢弃未执行任务 —— 前端"取消任务"依赖的真实 broker 语义。"""
+    from celery.exceptions import TaskRevokedError, TimeoutError as CeleryTimeoutError
+
+    from tests.real_services_celery_app import slow
+
+    # countdown 给 revoke 一个有界窗口；任务被 worker 标记 revoked 后丢弃，
+    # 客户端 get() 要么超时（结果停在 PENDING）要么收到 TaskRevokedError。
+    result = slow.apply_async(args=[1], countdown=3)
+    celery_worker.control.revoke(result.id)
+    with pytest.raises((CeleryTimeoutError, TaskRevokedError)):
+        result.get(timeout=6)
+    assert result.status in ("PENDING", "REVOKED"), (
+        f"被 revoke 的任务不应执行，实际状态: {result.status}"
+    )

--- a/tests/test_session_disk_lifecycle.py
+++ b/tests/test_session_disk_lifecycle.py
@@ -1,0 +1,229 @@
+"""Issue #470：会话磁盘状态（mapspec revisions / checkpoints / raster PNGs）
+在 TTL 过期 / idle 淘汰时必须被清除。
+
+之前唯一的清除路径是 `clear_session_files`，唯一调用方是
+DELETE /sessions/{id}（chat.py）。4h Redis TTL 过期、cleanup_idle_sessions、
+以及 main.py 的 600s 周期清理任务都只删 Redis 键 + 内存缓存，从不碰磁盘 ——
+`.webgis-agent/<sid>/` 无限累积（每个活跃制图会话 ~0.5-5 MB）。
+
+守卫（全部用 tmp_path 做会话目录，通过 monkeypatch BASE_STORAGE_DIR）：
+  1. clear_session（内存与 Redis 两种后端）连带清除磁盘；
+  2. cleanup_idle_sessions 淘汰溢出会话时同样清盘；
+  3. 磁盘清除失败（IO 错误）不破坏 clear_session 的其余清理；
+  4. 目录缺失时静默通过（幂等）；
+  5. TTL 过期兜底：mtime 老于 TTL+slack 的目录被周期清扫回收，仍活跃的
+     会话（store 里还有状态）即使磁盘 mtime 老 also 不清；
+  6. 清扫有界且安全：跳过非常规名字/非目录条目。
+"""
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+import app.services.mapspec.store as mapspec_store_module
+from app.services.mapspec.store import MapSpecStore
+from app.services.session_data import MemorySessionStore
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    """把会话磁盘根指到 tmp_path。"""
+    monkeypatch.setattr(mapspec_store_module, "BASE_STORAGE_DIR", tmp_path)
+    return tmp_path
+
+
+def seed_session_files(base: Path, session_id: str, age_seconds: float = 0) -> Path:
+    """造一个带 mapspec.json / revisions / checkpoints / raster 的会话目录。"""
+    d = base / session_id
+    (d / "revisions").mkdir(parents=True, exist_ok=True)
+    (d / "checkpoints" / "blobs").mkdir(parents=True, exist_ok=True)
+    (d / "raster").mkdir(parents=True, exist_ok=True)
+    (d / "mapspec.json").write_text("{}", encoding="utf-8")
+    (d / "revisions" / "mapspec_rev_1.json").write_text("{}", encoding="utf-8")
+    (d / "checkpoints" / "manifest.json").write_text("{}", encoding="utf-8")
+    (d / "raster" / "abc.png").write_bytes(b"\x89PNG")
+    if age_seconds:
+        past = time.time() - age_seconds
+        for root, _dirs, files in os.walk(d):
+            for f in files:
+                os.utime(Path(root) / f, (past, past))
+            os.utime(root, (past, past))
+    return d
+
+
+# ── 1. clear_session 连带清盘 ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_memory_clear_session_purges_disk(storage):
+    store = MemorySessionStore()
+    sid = "sess-disk-a"
+    await store.store(sid, {"v": 1})
+    d = seed_session_files(storage, sid)
+    assert d.exists()
+
+    await store.clear_session(sid)
+    assert not d.exists(), "clear_session 后会话磁盘目录必须被删除"
+    # 内存也清了
+    assert await store.get(sid, "ref:x") is None
+    assert await store.get_map_state(sid) == {}
+
+
+@pytest.mark.asyncio
+async def test_redis_clear_session_purges_disk(storage):
+    import fakeredis.aioredis
+
+    from app.services.session_data_redis import RedisSessionStore
+
+    raw = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    store = RedisSessionStore(redis_url="redis://unused", redis=raw)
+    sid = "sess-disk-b"
+    await store.store(sid, {"v": 1})
+    d = seed_session_files(storage, sid)
+
+    await store.clear_session(sid)
+    assert not d.exists(), "Redis 后端 clear_session 也必须清盘（与 Redis 键同语义）"
+
+
+@pytest.mark.asyncio
+async def test_clear_session_missing_dir_is_ok(storage):
+    store = MemorySessionStore()
+    await store.store("sess-no-disk", {"v": 1})
+    await store.clear_session("sess-no-disk")  # 不抛 = 通过
+
+
+@pytest.mark.asyncio
+async def test_clear_session_survives_disk_purge_failure(storage, monkeypatch, caplog):
+    store = MemorySessionStore()
+    sid = "sess-iofail"
+    await store.store(sid, {"v": 1})
+    seed_session_files(storage, sid)
+
+    async def _boom(session_id: str) -> None:
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(
+        "app.services.mapspec.store.purge_session_disk_state", _boom
+    )
+    with caplog.at_level("WARNING"):
+        await store.clear_session(sid)  # 不得抛
+    # 内存态仍被清理（磁盘清理失败不阻断其它清理）
+    assert await store.get_map_state(sid) == {}
+    assert any("disk on fire" in r.message for r in caplog.records), "失败必须留痕"
+
+
+# ── 2. idle 淘汰连带清盘 ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_memory_cleanup_idle_sessions_purges_evicted_disk(storage):
+    store = MemorySessionStore()
+    dirs = {}
+    for i in range(3):
+        sid = f"sess-evict-{i}"
+        await store.store(sid, {"v": i})
+        dirs[sid] = seed_session_files(storage, sid)
+
+    await store.cleanup_idle_sessions(max_sessions=1)
+    # 最久未触碰的 2 个被淘汰 => 磁盘目录也被清除；保留的 1 个仍在
+    assert sum(d.exists() for d in dirs.values()) == 1, (
+        f"evicted 会话目录必须清除；仍存在: {[s for s, d in dirs.items() if d.exists()]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_redis_cleanup_idle_sessions_purges_evicted_disk(storage):
+    import fakeredis.aioredis
+
+    from app.services.session_data_redis import RedisSessionStore
+
+    raw = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    store = RedisSessionStore(redis_url="redis://unused", redis=raw)
+    dirs = {}
+    for i in range(3):
+        sid = f"sess-revict-{i}"
+        await store.store(sid, {"v": i})
+        dirs[sid] = seed_session_files(storage, sid)
+
+    await store.cleanup_idle_sessions(max_sessions=1)
+    assert sum(d.exists() for d in dirs.values()) == 1
+
+
+# ── 3. TTL 过期兜底清扫（Redis 键静默过期后磁盘仍被回收）────────────────
+
+
+@pytest.mark.asyncio
+async def test_sweep_purges_expired_and_keeps_active(storage):
+    from app.services.session_data_redis import SESSION_TTL
+
+    store = MemorySessionStore()
+    # 过期会话：磁盘 mtime 老于 TTL+slack，且 store 无状态（Redis 键已 TTL 消失）
+    expired = seed_session_files(
+        storage, "sess-expired", age_seconds=SESSION_TTL + 2 * 3600
+    )
+    # 活跃会话：磁盘同样老，但 store 里仍有状态（Redis TTL 被活动续期）
+    live_old_disk = seed_session_files(
+        storage, "sess-live-old-disk", age_seconds=SESSION_TTL + 2 * 3600
+    )
+    await store.store("sess-live-old-disk", {"v": 1})
+    # 正常近期会话
+    fresh = seed_session_files(storage, "sess-fresh")
+
+    purged = await mapspec_store_module.sweep_expired_session_files(
+        liveness=getattr(store, "is_session_active", None)
+    )
+    assert "sess-expired" in purged
+    assert expired.exists() is False
+    assert live_old_disk.exists(), "仍活跃（store 有状态）的会话磁盘不得清扫"
+    assert fresh.exists(), "新会话目录不得清扫"
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_unsafe_entries(storage):
+    # 非目录文件、不可作为会话 id 的名字（路径分隔符等）必须跳过，不得触碰
+    (storage / "stray.txt").write_text("x", encoding="utf-8")
+    weird = storage / "..%2Fetc"
+    weird.mkdir(parents=True, exist_ok=True)
+    (weird / "junk").write_text("x", encoding="utf-8")
+    old = time.time() - 10 * 24 * 3600
+    os.utime(weird, (old, old))
+
+    purged = await mapspec_store_module.sweep_expired_session_files()
+    assert "stray.txt" not in purged
+    assert "stray.txt" and (storage / "stray.txt").exists()
+    assert weird.exists(), "非常规会话目录名必须跳过（安全边界，不猜语义）"
+
+
+# ── 4. 周期任务挂接（main.py 的 _periodic_session_cleanup）──────────────
+
+
+def test_periodic_cleanup_task_invokes_sweep():
+    """_periodic_session_cleanup 必须在 cleanup_idle_sessions 之外还调用
+    sweep_expired_session_files（TTL 过期的磁盘兜底入口）。"""
+    source = (
+        Path(__file__).resolve().parents[1] / "app" / "main.py"
+    ).read_text(encoding="utf-8")
+    assert "sweep_expired_session_files" in source, (
+        "周期清理任务必须调用 sweep_expired_session_files，否则 Redis TTL 静默"
+        "过期的会话磁盘永远无人回收"
+    )
+
+
+def test_clear_session_files_is_idempotent_and_bounded():
+    """clear_session_files 对缺失目录必须静默（不 mkdir 再删也不抛 FileNotFoundError）。"""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        store = MapSpecStore()
+        # 直接调（不经 monkeypatch 的 BASE_STORAGE_DIR 也应安全：目标不存在）
+        import asyncio
+
+        sid = "never-existed-sid"
+        base = Path(td)
+        # 用实例上的 BASE_STORAGE_DIR —— store 方法读模块全局；直接构造场景
+        from unittest.mock import patch
+
+        with patch.object(mapspec_store_module, "BASE_STORAGE_DIR", base):
+            asyncio.run(store.clear_session_files(sid))  # 不抛即通过
+        assert not (base / sid).exists(), "缺失目录不得被重新创建"

--- a/tests/test_uploads_index_migration.py
+++ b/tests/test_uploads_index_migration.py
@@ -1,0 +1,116 @@
+"""Issue #429: uploads(session_id, upload_time) 复合索引的迁移守卫。
+
+热路径 ``GET /api/v1/uploads``（list_uploads）查询
+``WHERE session_id = ? ORDER BY upload_time DESC`` + COUNT —— 没有索引时每次
+面板打开都是全表扫描 + 排序，代价随全局 uploads 行数线性增长。
+
+守卫三件事：
+  1. ORM 模型声明了复合索引（create_all 建出的新库直接带上）；
+  2. Alembic upgrade head 后索引真实存在（存量库升级也带上）；
+  3. downgrade → 0014 后索引消失、数据保留，re-upgrade 幂等（往返）。
+"""
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX_NAME = "ix_uploads_session_time"
+
+
+def _alembic(db_path: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=str(REPO_ROOT),
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "DATABASE_URL": f"sqlite:///{db_path}",
+            "JWT_SECRET_KEY": "test-secret-migration-32-chars-okay",
+            "USE_REDIS": "false",
+            "HOME": str(Path.home()),
+        },
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+def _table_indexes(db_path: Path, table: str) -> set[str]:
+    with sqlite3.connect(db_path) as conn:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?", (table,)
+            )
+        }
+
+
+def test_model_declares_session_upload_time_index():
+    """ORM 模型必须声明 (session_id, upload_time) 复合索引。
+
+    create_all 引导的新部署（本地 SQLite / 测试库）只会按模型建索引 ——
+    模型缺声明则这些库永远扫全表。
+    """
+    from app.models.upload import UploadRecord
+
+    indexes = {
+        (ix.name, tuple(col.name for col in ix.columns))
+        for ix in UploadRecord.__table__.indexes
+    }
+    assert (INDEX_NAME, ("session_id", "upload_time")) in indexes, (
+        f"uploads 模型缺少复合索引 {INDEX_NAME}(session_id, upload_time)；实际: {sorted(indexes)}"
+    )
+
+
+def test_migration_head_creates_index(tmp_path):
+    db_path = tmp_path / "uploads-index.db"
+    result = _alembic(db_path, "upgrade", "head")
+    assert result.returncode == 0, f"upgrade head 失败:\n{result.stdout}\n{result.stderr}"
+    assert INDEX_NAME in _table_indexes(db_path, "uploads"), (
+        f"upgrade head 后 uploads 缺少索引 {INDEX_NAME}；"
+        f"实际: {_table_indexes(db_path, 'uploads')}"
+    )
+
+
+def test_index_survives_roundtrip_and_preserves_rows(tmp_path):
+    """downgrade → 0014 删索引且不丢数据；re-upgrade 幂等地重建。"""
+    db_path = tmp_path / "uploads-roundtrip.db"
+    assert _alembic(db_path, "upgrade", "head").returncode == 0
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO uploads (filename, original_name, file_type, format, file_size, session_id)"
+            " VALUES ('u1/x.geojson', 'x.geojson', 'vector', 'geojson', 10, 'sess-a')"
+        )
+        conn.commit()
+
+    down = _alembic(db_path, "downgrade", "0014_workflow_provenance_revisions")
+    assert down.returncode == 0, f"downgrade 失败:\n{down.stdout}\n{down.stderr}"
+    assert INDEX_NAME not in _table_indexes(db_path, "uploads"), (
+        "downgrade 未移除索引"
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM uploads").fetchone()[0]
+    assert count == 1, "downgrade 丢了 uploads 数据行"
+
+    again = _alembic(db_path, "upgrade", "head")
+    assert again.returncode == 0, f"re-upgrade 失败:\n{again.stdout}\n{again.stderr}"
+    assert INDEX_NAME in _table_indexes(db_path, "uploads"), (
+        "re-upgrade 未重建索引"
+    )
+
+
+def test_migration_chains_onto_0014_head():
+    """迁移必须链到当时的 head（0014），否则 alembic 出多头。"""
+    versions = (REPO_ROOT / "migrations" / "versions").glob("*.py")
+    chained = [
+        p
+        for p in versions
+        if INDEX_NAME in p.read_text(encoding="utf-8") and "op.create_index" in p.read_text(encoding="utf-8")
+    ]
+    assert chained, "未找到创建 uploads 索引的迁移文件"
+    source = chained[0].read_text(encoding="utf-8")
+    assert '0014_workflow_provenance_revisions' in source, (
+        "新迁移的 down_revision 必须指向当前 head 0014_workflow_provenance_revisions"
+    )


### PR DESCRIPTION
## Issues
- Fixes #429 (P3: uploads.session_id has no index — per-session listing full scan + sort)
- Fixes #470 (P2: session disk state (mapspec revisions/checkpoints/raster PNGs) never purged on TTL-expiry/idle eviction)
- Fixes #476 (P2: Alembic never executed by any deploy path — schema drift invisible)
- Fixes #477 (P2: CI's provisioned Postgres/Redis/broker effectively unused — SQLite/fakeredis/eager-celery)

## Implementation (one commit per issue, in dependency order)
- #429: composite index on uploads(session_id, upload_time) in the ORM model + new Alembic migration with upgrade AND downgrade chained onto the current head; migration-chain validation included.
- #476: `alembic upgrade head` wired into every deploy path (container entrypoint before uvicorn; compose + k8s seams) — idempotent, integrates with the #492 deploy changes (does not undo them).
- #470: `.webgis-agent/<sid>/` disk state deleted on session eviction/TTL expiry (both Memory and Redis store paths); bounded, idempotent, failure-tolerant; tmp_path tests assert purge.
- #477: new real-services CI lane running a targeted smoke subset against the provisioned PostGIS/Redis/celery (real asyncpg/redis/celery-chain tests; suite not wholesale converted); workflow YAML validated.

## Validation
tests/test_alembic_metadata.py, session evict/LRU, upload API, database suites green (10 passed in spot run + full new suites: test_uploads_index_migration, test_session_disk_lifecycle, test_deploy_migration_wiring, test_real_services_*); `ruff` clean.

## Risk
Low: index additive; alembic idempotent; purge only touches per-session dirs owned by the store; CI lane additive.