### PR TITLE
perf(cartography/map): prefix-sum Fisher-Jenks (~976x), chunked off-loop GeoJSON export with byte cap, auth-gated export button (#441 #427 #469)

### DIFF
--- a/app/api/routes/map.py
+++ b/app/api/routes/map.py
@@ -169,8 +169,10 @@ async def upload_map_export(
 
         # /review P1-5: SVGs can carry <script>/event-handlers/javascript: hrefs.
         # Parse with defusedxml (XXE-safe), strip dangerous elements/attrs.
+        # PERF #427: defusedxml DOM 解析最多 50MB —— 在 worker 线程执行，
+        # 避免阻塞事件循环上所有并发 SSE 流（#386 同类遗留）。
         if ext == ".svg":
-            content = _sanitize_svg(content)
+            content = await asyncio.to_thread(_sanitize_svg, content)
 
         # 写入临时文件再原子移动，防止进程崩溃留下残缺文件
         with tempfile.NamedTemporaryFile(dir=EXPORT_DIR, delete=False, suffix=ext) as tmp:
@@ -301,6 +303,93 @@ class GeoJSONExportRequest(BaseModel):
     filename: str = "export"
 
 
+def _dumps_pretty(obj: Any) -> str:
+    """Canonical GeoJSON export serialization format (single-value fragment)."""
+    return json.dumps(obj, ensure_ascii=False, indent=2)
+
+
+def _reindent(text: str, pad: str) -> str:
+    """Shift a serialized JSON fragment one indent level deeper (all lines
+    after the first get `pad` prefixed) — exactly how json.dumps(indent=2)
+    lays out nested values."""
+    if "\n" not in text:
+        return text
+    first, *rest = text.split("\n")
+    return first + "".join("\n" + pad + line for line in rest)
+
+
+# Top-level lists bigger than this are encoded in bounded worker-thread batches
+# (below it a single dumps is cheaper than the thread dispatches).
+_GEOJSON_CHUNK_MIN_ITEMS = 2000
+_GEOJSON_BATCH_ITEMS = 512
+
+
+def _encode_batch(elements: list, pad: str) -> list:
+    """Serialize one batch of top-level list elements at one indent level.
+
+    Runs in a worker thread: each C-encoder call holds the GIL for only a few
+    ms, so the event loop can keep servicing timers/SSE between batches."""
+    return [_reindent(_dumps_pretty(el), pad) for el in elements]
+
+
+def _encode_value(value: Any, pad: str) -> str:
+    """Serialize a non-chunked top-level value at one indent level."""
+    return _reindent(_dumps_pretty(value), pad)
+
+
+async def _serialize_geojson(data: Any) -> bytes:
+    """Chunked, byte-identical replacement for json.dumps(data, indent=2).
+
+    #427: Python 3.13's C JSON encoder holds the GIL for the WHOLE encode, so
+    even ``asyncio.to_thread(json.dumps, ...)`` leaves the event loop stalled
+    for the full duration (measured: 26 MB body → 0.5 s loop gap; 45 MB →
+    2.3 s). Top-level list values (GeoJSON ``features``) are therefore encoded
+    in bounded batches in a worker thread with an await between batches: each
+    batch holds the GIL for only a few ms, keeping loop gaps <100 ms.
+
+    Output is byte-identical to ``json.dumps(data, ensure_ascii=False,
+    indent=2)`` — pinned by tests/test_event_loop_offload_427.py across
+    FeatureCollections (chunked and small), empty containers, non-ASCII,
+    floats and nested shapes.
+    """
+    if not isinstance(data, dict) or not data:
+        return (await asyncio.to_thread(_dumps_pretty, data)).encode("utf-8")
+
+    parts: list = ["{"]
+    items = list(data.items())
+    for idx, (key, val) in enumerate(items):
+        comma = "," if idx < len(items) - 1 else ""
+        key_frag = json.dumps(key, ensure_ascii=False)
+        if isinstance(val, list) and len(val) > _GEOJSON_CHUNK_MIN_ITEMS:
+            # Chunked path: elements live at indent depth 2 (4 spaces).
+            parts.append(f"\n  {key_frag}: [")
+            total = len(val)
+            for start in range(0, total, _GEOJSON_BATCH_ITEMS):
+                batch = await asyncio.to_thread(
+                    _encode_batch, val[start : start + _GEOJSON_BATCH_ITEMS], "    "
+                )
+                for j, frag in enumerate(batch):
+                    pos = start + j
+                    parts.append(
+                        "\n    " + frag + ("," if pos < total - 1 else "")
+                    )
+            parts.append(f"\n  ]{comma}")
+        else:
+            vfrag = await asyncio.to_thread(_encode_value, val, "  ")
+            parts.append(f"\n  {key_frag}: {vfrag}{comma}")
+    parts.append("\n}")
+
+    body = await asyncio.to_thread(lambda: "".join(parts).encode("utf-8"))
+    return body
+
+
+def _write_export_file(filepath: str, content: bytes) -> None:
+    """同步文件写 —— 与序列化一样移出事件循环。"""
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    with open(filepath, "wb") as f:
+        f.write(content)
+
+
 @router.post("/export/geojson", tags=["地图制图"])
 async def export_geojson(req: GeoJSONExportRequest, _user: dict = Depends(get_current_user)):
     """接收 GeoJSON 数据并持久化为可下载文件。"""
@@ -313,18 +402,24 @@ async def export_geojson(req: GeoJSONExportRequest, _user: dict = Depends(get_cu
     if not geo_type:
         raise HTTPException(status_code=400, detail="GeoJSON 缺少 type 字段")
 
+    # PERF #427: GeoJSON 体无界且可达数十 MB —— 分块序列化在 worker 线程执行
+    #（C encoder 整体持有 GIL，to_thread 单次调用仍会阻塞事件循环 ~秒级），
+    # 每块仅持有 GIL 数毫秒，事件循环间隙 <100ms（#386 同类遗留）。
     try:
-        content = json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
+        content = await _serialize_geojson(data)
     except (TypeError, ValueError) as e:
         raise HTTPException(status_code=400, detail=f"GeoJSON 序列化失败: {e}")
+
+    # PERF #427: GeoJSON 导出体此前完全无界（文件上传分支有 50MB 上限）。
+    # 对序列化结果施加同一 MAX_EXPORT_SIZE 预算，超限返回 413。
+    if len(content) > MAX_EXPORT_SIZE:
+        raise HTTPException(status_code=413, detail="GeoJSON 过大，上限 50MB")
 
     safe_name = os.path.basename(req.filename).replace(" ", "_")
     filename = f"{safe_name}_{uuid.uuid4().hex[:12]}.geojson"
     filepath = os.path.join(EXPORT_DIR, filename)
 
-    os.makedirs(EXPORT_DIR, exist_ok=True)
-    with open(filepath, "wb") as f:
-        f.write(content)
+    await asyncio.to_thread(_write_export_file, filepath, content)
 
     # 审计 P0：记录文件所有权
     _set_export_owner(filename, _user.get("user_id", "unknown"))

--- a/app/services/cartography_service.py
+++ b/app/services/cartography_service.py
@@ -15,7 +15,18 @@ class CartographyService:
 
     @classmethod
     def _jenks_natural_breaks(cls, values: np.ndarray, k: int) -> List[float]:
-        """Fisher-Jenks 自然断点算法 (O(n²k) 动态规划实现)"""
+        """Fisher-Jenks 自然断点算法 (O(n²k) 动态规划实现)
+
+        #441: 类内平方和 (SSM) 不再对每个 (类数, j, i) 三元组重新切片求和
+        （旧实现 ~2n² 次 numpy 调用，在 n=1000 采样上限处一次 classify 需
+        40-60 秒），而是用「前缀和」推导：区间 [i, j] 的 SSE 可由 cumsum(值)
+        与 cumsum(值²) 在 O(1) 内得出，再把每个类数 c 的内层 argmin 向量化
+        为一次 (i, j) 矩阵运算。
+
+        等价性：DP 结构、回溯与平局规则（取首个最小值，等价于旧实现的
+        严格 `<` 比较）保持不变；断点值仍从原始（未平移）数组取，因此与
+        旧实现的分类边界完全一致（tests/test_jenks_441.py 用旧算法逐字
+        副本在多组对抗数据上验证）。"""
         arr = np.sort(values)
         n = len(arr)
         if n <= k:
@@ -26,37 +37,47 @@ class CartographyService:
         if n > 1000:
             rng = np.random.default_rng(42)
             arr = np.sort(rng.choice(arr, size=1000, replace=False))
+            n = 1000
 
-        # SSM[i][j] = 从 arr[i..j] 组成单个类的加权平方偏差
-        def ssm(i: int, j: int) -> float:
-            s = arr[i : j + 1]
-            return float(np.sum((s - s.mean()) ** 2))
+        # 方差对平移不变：先减去 arr[0] 再做前缀和，避免「大偏移 + 小离散度」
+        # 数据（如 1e12 量级坐标）在 cum2 - cum²/cnt 中发生灾难性抵消。
+        # 断点从原始 arr 回填，平移不影响返回值。
+        v = arr - arr[0]
+        # cum[i] = sum(v[:i]) → 区间 [i, j] 的和/平方和均为 O(1) 差分查询
+        cum = np.concatenate(([0.0], np.cumsum(v)))
+        cum2 = np.concatenate(([0.0], np.cumsum(v * v)))
+
+        # SSE[i, j] = S2 - S²/cnt  (i ≤ j；j < i 的格子置 inf 表示非法切分)
+        idx = np.arange(n)
+        cnt = idx[None, :] - idx[:, None] + 1.0
+        s = cum[None, 1:] - cum[:-1, None]
+        s2 = cum2[None, 1:] - cum2[:-1, None]
+        ssm = np.where(cnt > 0, s2 - (s * s) / np.maximum(cnt, 1.0), np.inf)
 
         # DP: mat[c][j] = 把 arr[0..j] 分为 c 类的最小总方差
-        mat = [[float("inf")] * n for _ in range(k + 1)]
-        back = [[0] * n for _ in range(k + 1)]
+        mat = np.full((k + 1, n), np.inf)
+        back = np.zeros((k + 1, n), dtype=np.int64)
 
         # 1 类：直接取区间方差
-        for j in range(n):
-            mat[1][j] = ssm(0, j)
+        mat[1, :] = ssm[0, :]
 
+        inf_col = np.full(n, np.inf)
         for c in range(2, k + 1):
-            for j in range(c - 1, n):
-                best_cost = float("inf")
-                best_split = c - 1
-                for i in range(c - 1, j + 1):
-                    cost = mat[c - 1][i - 1] + ssm(i, j)
-                    if cost < best_cost:
-                        best_cost = cost
-                        best_split = i
-                mat[c][j] = best_cost
-                back[c][j] = best_split
+            # costs[i, j] = mat[c-1][i-1] + ssm(i, j)；i < c-1 的候选置 inf。
+            # np.argmax/argmin 取首个最小值 ⇒ 与旧实现 `cost < best_cost`
+            # 的平局语义一致。
+            col = inf_col.copy()
+            col[c - 1 :] = mat[c - 1, c - 2 : n - 1]
+            costs = col[:, None] + ssm
+            best = np.argmin(costs, axis=0)
+            mat[c, :] = costs[best, idx]
+            back[c, :] = best
 
         # 回溯断点
         breaks = [float(arr[-1])]
         j = n - 1
         for c in range(k, 1, -1):
-            split_idx = back[c][j]
+            split_idx = int(back[c][j])
             breaks.append(float(arr[split_idx - 1]))
             j = split_idx - 1
         breaks.append(float(arr[0]))

--- a/frontend/components/sidebar/map-studio-tab.export-auth.test.tsx
+++ b/frontend/components/sidebar/map-studio-tab.export-auth.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+/**
+ * #469 — 导出按钮的登录门控。
+ *
+ * POST /api/v1/export 需要认证（map.py get_current_user），但「发布并导出」
+ * 按钮从不检查登录态：匿名（默认模式）用户每次点击都会 401，且
+ * runExport 捕获后仅返回 {ok:false}，命令 settled failed，用户看不到任何
+ * 提示 —— 导出功能在默认模式下静默失效。
+ *
+ * 契约：
+ *  - 匿名：按钮 disabled + 可见的登录提示文案；点击不派发 export_map。
+ *  - 已登录：按钮可用，点击派发 export_map。
+ *  - 登录/登出状态变化时按钮随之切换（subscribeAuth 通知）。
+ */
+const dispatchAction = vi.fn();
+
+const mockState: Record<string, any> = {
+  exportSettings: {
+    isExportMode: false,
+    title: '',
+    subtitle: '',
+    author: '',
+    dataSource: '',
+    showWatermark: true,
+    showCompass: true,
+    showScale: true,
+    showLegend: true,
+    showMetadata: true,
+    showGraticules: false,
+    paperSize: 'screen',
+    orientation: 'landscape',
+    dpi: 96,
+    format: 'png',
+  },
+  updateExportSettings: vi.fn(),
+  exports: [],
+  setExports: vi.fn(),
+  leftPanelOpen: true,
+};
+
+vi.mock('@/lib/store/useHudStore', () => ({
+  useHudStore: (selector: (s: any) => any) => selector(mockState),
+}));
+
+vi.mock('@/lib/contexts/map-action-context', () => ({
+  useMapAction: () => ({ dispatchAction }),
+}));
+
+// Auth store mock: mutable current user + a real listener set so
+// useSyncExternalStore reacts to sign-in/out like production.
+let mockUser: { id: string; username: string } | null = null;
+const authListeners = new Set<() => void>();
+vi.mock('@/lib/auth/tokenStore', () => ({
+  getAuthUser: () => mockUser,
+  subscribeAuth: (fn: () => void) => {
+    authListeners.add(fn);
+    return () => authListeners.delete(fn);
+  },
+}));
+
+import { MapStudioTab } from './map-studio-tab';
+
+const signedInUser = { id: 'u1', username: 'ops' };
+
+function signIn() {
+  mockUser = signedInUser;
+  act(() => authListeners.forEach((fn) => fn()));
+}
+
+function signOut() {
+  mockUser = null;
+  act(() => authListeners.forEach((fn) => fn()));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState.leftPanelOpen = true;
+  mockState.exports = [];
+  mockUser = null;
+});
+
+afterEach(() => {
+  signOut();
+});
+
+describe('MapStudioTab — 导出按钮登录门控 (#469)', () => {
+  it('匿名时按钮 disabled 且展示登录提示，点击不派发 export_map', () => {
+    render(<MapStudioTab />);
+
+    const btn = screen.getByRole('button', { name: /发布并导出|登录后可导出/ });
+    expect(btn).toBeDisabled();
+    // 登录引导必须可见（不是只有 title tooltip）
+    expect(screen.getByText(/设置 → 账户 登录/)).toBeInTheDocument();
+
+    fireEvent.click(btn);
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  it('已登录时按钮可用，点击派发 export_map 及当前导出设置', () => {
+    render(<MapStudioTab />);
+    signIn();
+
+    const btn = screen.getByRole('button', { name: /发布并导出/ });
+    expect(btn).toBeEnabled();
+
+    fireEvent.click(btn);
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith({
+      command: 'export_map',
+      params: expect.objectContaining({ format: 'png' }),
+    });
+  });
+
+  it('登录 → 登出状态切换时按钮随之启用/禁用', () => {
+    render(<MapStudioTab />);
+
+    let btn = screen.getByRole('button', { name: /发布并导出|登录后可导出/ });
+    expect(btn).toBeDisabled();
+
+    signIn();
+    btn = screen.getByRole('button', { name: /发布并导出/ });
+    expect(btn).toBeEnabled();
+
+    signOut();
+    btn = screen.getByRole('button', { name: /发布并导出|登录后可导出/ });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/frontend/components/sidebar/map-studio-tab.tsx
+++ b/frontend/components/sidebar/map-studio-tab.tsx
@@ -1,15 +1,25 @@
 'use client';
 
-import { useState, useEffect, useId, type ReactNode } from 'react';
+import { useState, useEffect, useId, useSyncExternalStore, type ReactNode } from 'react';
 import { useHudStore } from '@/lib/store/useHudStore';
 import type { ExportItem, ExportSettings } from '@/lib/store/hud-types';
 import { useMapAction } from '@/lib/contexts/map-action-context';
-import { Download, Printer, History, ChevronDown } from 'lucide-react';
+import { Download, Printer, History, ChevronDown, Lock } from 'lucide-react';
 import { API_BASE } from '@/lib/api/config';
+import { getAuthUser, subscribeAuth } from '@/lib/auth/tokenStore';
 import { IconButton } from '@/components/shared/icon-button';
 import { ConfirmAction } from '@/components/shared/confirm-action';
 import { EmptyState } from '@/components/shared/empty-state';
 import { devOnly } from '@/lib/utils/logger';
+
+/** #469：导出走 tokenStore 的响应式登录态（登录/登出即时刷新按钮门控）。 */
+function useAuthUser() {
+  return useSyncExternalStore(
+    subscribeAuth,
+    getAuthUser,
+    () => null,
+  );
+}
 
 const iconForType: Record<string, string> = {
   png: '🖼',
@@ -109,6 +119,7 @@ export function MapStudioTab() {
   const exports = useHudStore((s) => s.exports);
   const setExports = useHudStore((s) => s.setExports);
   const { dispatchAction } = useMapAction();
+  const authUser = useAuthUser();
 
   // Helper to update specific fields
   const handleChange = (key: keyof typeof exportSettings, value: string | number | boolean) => {
@@ -476,21 +487,39 @@ export function MapStudioTab() {
       {/* Action Footer for layout */}
       {activeSubTab === 'layout' && (
         <div className="shrink-0 border-t border-edge-subtle bg-transparent p-3">
+          {/* #469：POST /api/v1/export 需要认证。匿名（默认模式）点击必定 401
+              且此前静默失败 —— 未登录时禁用按钮并给出可见的登录引导，
+              而不是让每次导出无声地失败。 */}
           <button
-            className="w-full rounded-md py-1.5 text-body font-semibold text-ink-on-accent transition-opacity hover:opacity-90"
+            className="w-full rounded-md py-1.5 text-body font-semibold text-ink-on-accent transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
             style={{
               background: 'linear-gradient(135deg, var(--agent-accent), color-mix(in srgb, var(--agent-accent) 87%, transparent))',
               boxShadow: '0 4px 12px color-mix(in srgb, var(--agent-accent) 15%, transparent)'
             }}
+            disabled={!authUser}
+            title={authUser ? undefined : '导出功能需要登录账号（设置 → 账户）'}
             onClick={() => {
+              if (!authUser) return;
               dispatchAction({
                 command: 'export_map',
                 params: { ...exportSettings }
               });
             }}
           >
-            发布并导出 {exportSettings.format.toUpperCase()}
+            {authUser ? (
+              <>发布并导出 {exportSettings.format.toUpperCase()}</>
+            ) : (
+              <span className="inline-flex items-center justify-center gap-1.5">
+                <Lock size={13} aria-hidden />
+                登录后可导出 {exportSettings.format.toUpperCase()}
+              </span>
+            )}
           </button>
+          {!authUser && (
+            <p className="mt-1.5 text-center text-caption text-ink-muted">
+              导出需要登录账号 — 请先在 设置 → 账户 登录
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/frontend/lib/map-kit/exporter.ts
+++ b/frontend/lib/map-kit/exporter.ts
@@ -2,7 +2,7 @@ import type { Map } from 'maplibre-gl';
 import type { LegendSpec } from './types';
 import { resolveStyle, type LayoutStyle } from './layout-style';
 import { API_BASE } from '@/lib/api/config';
-import { apiFetch } from '@/lib/api/transport';
+import { apiFetch, isApiError } from '@/lib/api/transport';
 import { devOnly } from '@/lib/utils/logger';
 // Re-export the shared oversample helper so existing callers importing from
 // './exporter' keep working, while the single source of truth lives in
@@ -1252,9 +1252,18 @@ export async function runExport(
     }
   } catch (e) {
     devOnly.error('[MapExporter] Canvas extraction/export failed', e);
-    const errorMsg = e instanceof Error ? e.message : String(e);
+    // #469：上传接口需要认证 —— 会话过期/token 失效时给出明确的登录指引，
+    // 而不是把 401 淹没在通用失败文案里（匿名路径已由导出按钮门控）。
+    const authRequired = isApiError(e) && (e.status === 401 || e.status === 403);
+    const errorMsg = authRequired
+      ? '导出需要登录（认证失败或会话已过期）'
+      : e instanceof Error
+        ? e.message
+        : String(e);
     getHudState().setPendingSystemMessage(
-      `[系统通知] 专题地图排版合成失败。错误原因: ${e}。请向用户致歉并结束流程。`,
+      authRequired
+        ? '[系统通知] 导出失败：导出功能需要登录账号（认证失败或会话已过期）。请到 设置 → 账户 重新登录后再导出。'
+        : `[系统通知] 专题地图排版合成失败。错误原因: ${e}。请向用户致歉并结束流程。`,
     );
     return { ok: false, format: (format ?? 'png').toLowerCase(), error: errorMsg };
   } finally {

--- a/tests/test_event_loop_offload_427.py
+++ b/tests/test_event_loop_offload_427.py
@@ -1,0 +1,278 @@
+"""Regression tests for #427: map.py GeoJSON/SVG export serialization off the
+event loop + GeoJSON export body size cap.
+
+Siblings of #386 that the original sweep missed (only the PDF branch of
+``map.py`` was offloaded by d8c0ab1):
+
+  1. ``POST /api/v1/export/geojson`` ran ``json.dumps(data, indent=2)`` inline
+     on an unbounded ``Any`` GeoJSON body — measured 576 ms loop stall for an
+     11 MB export, 2.3 s for 45 MB.
+  2. ``POST /api/v1/export`` (SVG branch) ran ``_sanitize_svg`` (defusedxml
+     DOM parse of up to 50 MB) inline.
+  3. The GeoJSON export body had NO size cap at all (file uploads are capped
+     at 50 MB via MAX_EXPORT_SIZE).
+
+Technique mirrors tests/test_event_loop_offload_386.py: the slow work is
+faked with a sync ``time.sleep`` that records its thread id, and the test
+asserts the main event loop stays responsive *while* the work is running.
+"""
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import map as map_mod
+
+_main_thread = threading.get_ident()
+
+
+async def _assert_loop_responsive_while(awaitable_factory, delay: float = 0.8):
+    """Run awaitable_factory() and assert a 0.05s timer fires mid-flight.
+
+    Deterministic: with the work offloaded the task is still running when the
+    timer completes; with the work on the loop the task finishes before the
+    test's own sleep resumes, so ``assert not task.done()`` fails.
+    """
+    task = asyncio.create_task(awaitable_factory())
+    await asyncio.sleep(0.15)          # let it enter the slow work
+    assert not task.done(), "work finished before the test could observe it"
+
+    ticks = []
+
+    async def _tick():
+        await asyncio.sleep(0.05)
+        ticks.append(True)
+
+    tick = asyncio.create_task(_tick())
+    await asyncio.sleep(0.15)
+    assert tick.done() and ticks, "event loop was blocked during the work"
+    assert not task.done(), "event loop was blocked during the work"
+    return await task
+
+
+def _req(geojson):
+    return map_mod.GeoJSONExportRequest(geojson=geojson, filename="test_export")
+
+
+# ─── Site 1: export_geojson json.dumps must run in a worker thread ──────────
+
+
+@pytest.mark.asyncio
+async def test_geojson_dumps_off_loop(monkeypatch, tmp_path):
+    observed = {}
+
+    def _slow_dumps(*a, **kw):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return "{}"
+
+    monkeypatch.setattr(map_mod.json, "dumps", _slow_dumps)
+    monkeypatch.setattr(map_mod, "EXPORT_DIR", str(tmp_path))
+    monkeypatch.setattr(map_mod, "_set_export_owner", lambda *a, **k: None)
+
+    res = await _assert_loop_responsive_while(
+        lambda: map_mod.export_geojson(_req({"type": "Point", "coordinates": [0, 0]}),
+                                       _user={"user_id": "u1"})
+    )
+    assert observed["thread"] != _main_thread, "json.dumps ran on the event loop thread"
+    assert res["format"] == "geojson"
+
+
+@pytest.mark.asyncio
+async def test_geojson_large_payload_no_loop_lag(monkeypatch, tmp_path):
+    """Real (unmocked) serialization of a ~45 MB FeatureCollection: loop
+    ticker gaps during the export must stay < 100 ms (issue acceptance),
+    normalized for machine noise.
+
+    Why normalized: this box (and CI) can be CPU-saturated by unrelated
+    processes, which delays ANY loop timer even with no blocking work. The
+    test therefore first measures the ticker's max gap while the loop is
+    idle, and asserts the during-export gap stays within
+    max(idle noise, 100 ms) + slack.
+
+    Why chunking is required (not just to_thread): Python 3.13's C JSON
+    encoder holds the GIL for the entire encode, so a single
+    asyncio.to_thread(json.dumps, ...) still stalls the loop for the full
+    ~1 s of a 45 MB body — measured inline AND naive-to_thread gaps ≈ full
+    dumps duration, chunked gaps ≈ per-batch GIL holds (a few ms).
+    """
+    feature = {
+        "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [116.397128, 39.916527]},
+        "properties": {"name": "x" * 180, "value": 42.0, "desc": "y" * 60},
+    }
+    payload = {"type": "FeatureCollection", "features": [feature] * 90000}
+    body_len = len(json.dumps(payload))  # built outside the measured window
+    assert body_len > 30_000_000  # sanity: ~45 MB pretty-printed, near the cap
+
+    monkeypatch.setattr(map_mod, "EXPORT_DIR", str(tmp_path))
+    monkeypatch.setattr(map_mod, "_set_export_owner", lambda *a, **k: None)
+
+    async def _max_ticker_gap(during):
+        stamps = []
+        stop = [False]
+
+        async def _ticker():
+            while not stop[0]:
+                stamps.append(time.perf_counter())
+                await asyncio.sleep(0.02)
+
+        ticker = asyncio.create_task(_ticker())
+        await asyncio.sleep(0.1)
+        if during is not None:
+            await during()
+        else:
+            await asyncio.sleep(0.3)  # idle window of comparable length
+        await asyncio.sleep(0.05)
+        stop[0] = True
+        await ticker
+        gaps = [b - a for a, b in zip(stamps, stamps[1:])]
+        return max(gaps) if gaps else 0.0
+
+    idle_gap = await _max_ticker_gap(None)
+    export_gap = await _max_ticker_gap(
+        lambda: map_mod.export_geojson(_req(payload), _user={"user_id": "u1"})
+    )
+
+    bound = max(idle_gap, 0.1) + 0.05
+    assert export_gap < bound, (
+        f"loop stalled {export_gap * 1000:.0f} ms during GeoJSON export "
+        f"(idle noise {idle_gap * 1000:.0f} ms, bound {bound * 1000:.0f} ms) — "
+        "serialization must not run as one GIL-holding chunk on/over the loop"
+    )
+
+
+# ─── Chunked serializer: byte-identical to json.dumps(indent=2) ─────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "doc",
+    [
+        # small FeatureCollection (single-dumps path)
+        {"type": "FeatureCollection", "features": [
+            {"type": "Feature", "geometry": None, "properties": {"name": "a"}},
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [1, 2]},
+             "properties": {}},
+        ]},
+        # empty containers
+        {"type": "FeatureCollection", "features": []},
+        {"a": {}, "b": [], "c": None},
+        # non-FeatureCollection GeoJSON
+        {"type": "Point", "coordinates": [0.0, -0.5]},
+        # non-ascii keys/values, floats, bools
+        {"名前": "北京市", "值": 3.14, "flag": True, "nil": None, "科学": 6.02e23},
+        # features NOT last (trailing comma handling) + extra list
+        {"features": [{"x": 1}], "type": "FeatureCollection", "values": [1, 2, 3]},
+        # top-level list crossing the chunk threshold (scalars)
+        {"type": "FeatureCollection", "features": [{"i": i, "v": i * 0.5}
+                                                   for i in range(2501)]},
+        # top-level list of lists crossing the threshold (nested reindent)
+        {"type": "GeometryCollection", "geometries": [[[i, i + 1], [i + 2, i + 3]]
+                                                      for i in range(2100)]},
+    ],
+)
+async def test_serialize_geojson_byte_identical(doc):
+    """The chunked serializer must reproduce json.dumps(indent=2) byte-for-byte
+    (indent layout, separators, escaping, float repr) on both the batched and
+    non-batched paths."""
+    expected = json.dumps(doc, ensure_ascii=False, indent=2).encode("utf-8")
+    got = await map_mod._serialize_geojson(doc)
+    assert got == expected
+
+
+@pytest.mark.asyncio
+async def test_geojson_oversized_body_413(monkeypatch, tmp_path):
+    """GeoJSON export body must be bounded: serialized output larger than
+    MAX_EXPORT_SIZE (50 MB, same cap as file uploads) → 413, nothing written."""
+    monkeypatch.setattr(map_mod, "EXPORT_DIR", str(tmp_path))
+    monkeypatch.setattr(map_mod, "_set_export_owner", lambda *a, **k: None)
+    # Shrink the cap so the test payload exceeds it without building 50 MB.
+    monkeypatch.setattr(map_mod, "MAX_EXPORT_SIZE", 1_000)
+
+    big = {"type": "Point", "coordinates": [0, 0], "pad": "x" * 5_000}
+    with pytest.raises(HTTPException) as exc_info:
+        await map_mod.export_geojson(_req(big), _user={"user_id": "u1"})
+    assert exc_info.value.status_code == 413
+
+    assert list(tmp_path.iterdir()) == [], "oversized GeoJSON must not be written to disk"
+
+
+@pytest.mark.asyncio
+async def test_geojson_cap_matches_upload_cap():
+    """The GeoJSON cap must be the same 50 MB budget as file uploads."""
+    assert map_mod.MAX_EXPORT_SIZE == 50 * 1024 * 1024
+
+
+@pytest.mark.asyncio
+async def test_geojson_dumps_type_error_still_400(monkeypatch, tmp_path):
+    """json.dumps TypeError (non-serializable member) must still map to 400
+    after offloading."""
+
+    def _boom(*a, **kw):
+        raise TypeError("Object of type set is not JSON serializable")
+
+    monkeypatch.setattr(map_mod.json, "dumps", _boom)
+    monkeypatch.setattr(map_mod, "EXPORT_DIR", str(tmp_path))
+    with pytest.raises(HTTPException) as exc_info:
+        await map_mod.export_geojson(_req({"type": "Point"}), _user={"user_id": "u1"})
+    assert exc_info.value.status_code == 400
+
+
+# ─── Site 2: upload_map_export SVG sanitization must run in a worker thread ──
+
+
+@pytest.mark.asyncio
+async def test_svg_sanitize_off_loop(monkeypatch, tmp_path):
+    """defusedxml DOM parse of a ≤50 MB SVG must run in a worker thread."""
+    import io
+
+    from fastapi import UploadFile
+
+    observed = {}
+
+    def _slow_sanitize(content):
+        observed["thread"] = threading.get_ident()
+        time.sleep(0.8)
+        return content
+
+    monkeypatch.setattr(map_mod, "_sanitize_svg", _slow_sanitize)
+    monkeypatch.setattr(map_mod, "EXPORT_DIR", str(tmp_path))
+    monkeypatch.setattr(map_mod, "_set_export_owner", lambda *a, **k: None)
+
+    file = UploadFile(file=io.BytesIO(b"<svg/>"), filename="map.svg")
+    try:
+        res = await _assert_loop_responsive_while(
+            lambda: map_mod.upload_map_export(file, title="t", _user={"user_id": "u1"})
+        )
+        assert res["success"] is True
+        assert observed["thread"] != _main_thread, "_sanitize_svg ran on the event loop thread"
+        assert (tmp_path / res["filename"]).exists()
+    finally:
+        await file.close()
+
+
+@pytest.mark.asyncio
+async def test_svg_sanitize_http_error_propagates(monkeypatch, tmp_path):
+    """HTTPException(400) raised inside the offloaded sanitizer must surface
+    as-is (not be swallowed into a 500)."""
+    import io
+
+    from fastapi import UploadFile
+
+    def _reject(content):
+        raise HTTPException(status_code=400, detail="SVG 解析失败")
+
+    monkeypatch.setattr(map_mod, "_sanitize_svg", _reject)
+    monkeypatch.setattr(map_mod, "EXPORT_DIR", str(tmp_path))
+
+    file = UploadFile(file=io.BytesIO(b"not-svg"), filename="map.svg")
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await map_mod.upload_map_export(file, _user={"user_id": "u1"})
+        assert exc_info.value.status_code == 400
+    finally:
+        await file.close()

--- a/tests/test_jenks_441.py
+++ b/tests/test_jenks_441.py
@@ -1,0 +1,199 @@
+"""Regression tests for #441 — Fisher-Jenks prefix-sum rewrite.
+
+``CartographyService._jenks_natural_breaks`` used to recompute the class SSE
+``np.sum((arr[i:j+1]-mean)**2)`` from scratch for every (class, j, i) triple
+(~2n² fresh numpy calls → ~40-60 s at the n=1000 subsample cap). The fix
+derives the SSE in O(1) from cumulative sums and vectorizes the argmin.
+
+These tests pin the two contracts from the issue:
+
+  1. EQUIVALENCE — class boundaries are IDENTICAL to the old implementation on
+     the same inputs. The old algorithm is kept below verbatim
+     (``_jenks_reference``) and compared across adversarial datasets: random
+     floats, duplicates-heavy, constant data, n < k, n == k, the n=1000 DP,
+     the n>1000 subsample cap, negative values, and huge-magnitude offsets
+     (catastrophic-cancellation bait — the reason the rewrite shifts by
+     arr[0] before forming prefix sums).
+  2. PERFORMANCE — n=1000 classify (both k=5 and k=7, the cap every large
+     layer lands at) finishes with a median wall time well under the issue's
+     100 ms target. The bound is deliberately generous (target × 3 = 300 ms
+     per classify) so it stays deterministic on slow CI; the OLD code needs
+     tens of seconds per classify and fails this gate by >100×.
+"""
+import statistics
+import time
+
+import numpy as np
+import pytest
+
+from app.services.cartography_service import CartographyService
+
+
+# ─── Reference: verbatim copy of the pre-#441 implementation ────────────────
+
+
+def _jenks_reference(values: np.ndarray, k: int):
+    """Old master (4f9030b) implementation — O(n²) numpy calls, kept ONLY for
+    equivalence testing. Never call with n > ~1000: it takes ~tens of seconds
+    at the cap (that slowness is the bug being tested)."""
+    arr = np.sort(values)
+    n = len(arr)
+    if n <= k:
+        # Too few points for k classes — return all unique values as breaks
+        uniq = sorted(set(arr.tolist()))
+        return uniq if len(uniq) >= 2 else [uniq[0], uniq[0]]
+    # Cap sample size for performance (Jenks is O(n²k))
+    if n > 1000:
+        rng = np.random.default_rng(42)
+        arr = np.sort(rng.choice(arr, size=1000, replace=False))
+
+    def ssm(i: int, j: int) -> float:
+        s = arr[i : j + 1]
+        return float(np.sum((s - s.mean()) ** 2))
+
+    mat = [[float("inf")] * n for _ in range(k + 1)]
+    back = [[0] * n for _ in range(k + 1)]
+
+    for j in range(n):
+        mat[1][j] = ssm(0, j)
+
+    for c in range(2, k + 1):
+        for j in range(c - 1, n):
+            best_cost = float("inf")
+            best_split = c - 1
+            for i in range(c - 1, j + 1):
+                cost = mat[c - 1][i - 1] + ssm(i, j)
+                if cost < best_cost:
+                    best_cost = cost
+                    best_split = i
+            mat[c][j] = best_cost
+            back[c][j] = best_split
+
+    breaks = [float(arr[-1])]
+    j = n - 1
+    for c in range(k, 1, -1):
+        split_idx = back[c][j]
+        breaks.append(float(arr[split_idx - 1]))
+        j = split_idx - 1
+    breaks.append(float(arr[0]))
+    breaks.sort()
+    return list(dict.fromkeys(breaks))
+
+
+# ─── Equivalence: boundaries identical to the reference ─────────────────────
+
+_CASES = [
+    # (name, values, k)
+    ("random-uniform", np.random.default_rng(1).uniform(0, 100, 200), 5),
+    ("random-normal", np.random.default_rng(2).normal(50, 12, 200), 5),
+    ("random-normal-k7", np.random.default_rng(3).normal(-3, 1.5, 150), 7),
+    ("random-sorted-input", np.sort(np.random.default_rng(4).uniform(0, 1, 120)), 4),
+    (
+        "duplicates-heavy",
+        np.random.default_rng(5).choice([1.0, 2.0, 2.0, 2.5, 7.0], size=300),
+        4,
+    ),
+    (
+        "duplicates-heavy-k7",
+        np.random.default_rng(6).choice([0.0, 0.0, 1.0, 1.0, 1.0, 9.0], size=250),
+        7,
+    ),
+    ("constant-data", np.full(50, 3.14), 5),
+    ("two-distinct", [10.0] * 40 + [20.0] * 40, 5),
+    ("n-lt-k", [1.0, 5.0, 2.0], 5),
+    ("n-eq-k", [4.0, -1.0, 9.0, 0.5, 3.0], 5),
+    ("n-just-above-k", np.random.default_rng(7).uniform(0, 50, 6), 5),
+    ("negatives", np.random.default_rng(8).normal(-100, 5, 200), 5),
+    ("huge-magnitude-1e9", 1e9 + np.random.default_rng(9).uniform(0, 100, 200), 5),
+    ("huge-magnitude-1e12", 1e12 + np.random.default_rng(10).uniform(0, 1, 200), 5),
+    ("tiny-spread", 1e-6 + np.random.default_rng(11).uniform(0, 1e-7, 150), 5),
+]
+
+
+@pytest.mark.parametrize("name,values,k", _CASES, ids=[c[0] for c in _CASES])
+def test_jenks_breaks_identical_to_reference(name, values, k):
+    """New prefix-sum implementation must return IDENTICAL breaks (not just
+    close): same DP structure, same first-minimum tie-breaking, same values
+    pulled from the original (unshifted) array."""
+    arr = np.asarray(values, dtype=float)
+    expected = _jenks_reference(arr.copy(), k)
+    got = CartographyService._jenks_natural_breaks(arr.copy(), k)
+    assert got == expected, f"{name}: new breaks {got} != reference {expected}"
+
+
+def test_jenks_constant_data_returns_single_break():
+    """Degenerate case: every class SSE is 0 — old code dedupes to [v]."""
+    assert CartographyService._jenks_natural_breaks(np.full(30, 2.5), 5) == [2.5]
+
+
+def test_jenks_classify_route_matches_reference():
+    """classify(values, 'natural_breaks') must agree with the reference too
+    (this is the caller-facing path every thematic/graduated map uses)."""
+    vals = np.random.default_rng(12).normal(10, 3, 180).tolist()
+    expected = _jenks_reference(np.array(vals), 5)
+    assert CartographyService.classify(vals, method="natural_breaks", k=5) == expected
+
+
+@pytest.mark.timeout(240)
+def test_jenks_breaks_identical_at_n1000():
+    """Equivalence at the full n=1000 DP (the size every large layer hits).
+    Slow: the reference needs tens of seconds here — that is the bug."""
+    vals = np.random.default_rng(13).normal(50, 12, 1000)
+    for k in (5, 7):
+        expected = _jenks_reference(vals.copy(), k)  # ~2x 40-60 s on old code
+        got = CartographyService._jenks_natural_breaks(vals.copy(), k)
+        assert got == expected, f"k={k}: new breaks {got} != reference {expected}"
+
+
+@pytest.mark.timeout(240)
+def test_jenks_breaks_identical_through_subsample_cap():
+    """Equivalence of the n>1000 → rng(42) 1000-sample cap path: both
+    implementations must select the SAME subsample (seed 42) and then produce
+    identical breaks on it."""
+    vals = np.random.default_rng(14).normal(0, 1, 1200)
+    expected = _jenks_reference(vals.copy(), 5)
+    got = CartographyService._jenks_natural_breaks(vals.copy(), 5)
+    assert got == expected
+
+
+# ─── Performance gate (#441 acceptance: n=1000 classify < 100 ms) ───────────
+
+
+@pytest.mark.perf
+def test_jenks_n1000_median_under_budget():
+    """Median of 5 runs at n=1000 must stay under 300 ms per classify
+    (issue target 100 ms × 3 headroom for slow CI). The OLD implementation
+    takes ~40-60 s per classify at this size and fails by >100×.
+
+    The n=1000 subsample cap must NOT be widened to pass this test — the
+    sample count is pinned by asserting the cap still triggers at n>1000
+    (see test below)."""
+    vals = np.random.default_rng(7).normal(50, 12, 1000)
+    for k in (5, 7):
+        CartographyService._jenks_natural_breaks(vals.copy(), k)  # warm-up
+        times = []
+        for _ in range(5):
+            t0 = time.perf_counter()
+            CartographyService._jenks_natural_breaks(vals.copy(), k)
+            times.append(time.perf_counter() - t0)
+        median_s = statistics.median(times)
+        assert median_s < 0.3, (
+            f"k={k}: median classify time {median_s * 1000:.1f} ms exceeds the "
+            "300 ms budget (#441 target: <100 ms at n=1000)"
+        )
+
+
+def test_jenks_subsample_cap_still_1000():
+    """Guard against fake speedups: the >1000 subsample cap (documented
+    approximation) must keep capping at exactly 1000 samples. A 100-element
+    cap would make any implementation fast and wrong."""
+    vals = np.random.default_rng(15).normal(0, 1, 5000)
+    # The implementation subsamples AFTER sorting — replicate that exactly.
+    sorted_vals = np.sort(vals)
+    capped = np.sort(np.random.default_rng(42).choice(sorted_vals, size=1000, replace=False))
+
+    # The cap must bind: breaks of the full 5000-value array must equal the
+    # breaks of the deterministic rng(42) 1000-sample of it.
+    full = CartographyService._jenks_natural_breaks(vals.copy(), 5)
+    direct = CartographyService._jenks_natural_breaks(capped.copy(), 5)
+    assert full == direct


### PR DESCRIPTION
## Issues
- Fixes #441 (P2 perf: Jenks natural breaks recomputes every class sum — ~60 s per classify at the 1000-sample cap)
- Fixes #427 (P2: map.py GeoJSON/SVG export serialization on the event loop; GeoJSON body unbounded; sibling of #386)
- Fixes #469 (P3 UI: Export button ungated but POST /export requires auth — anonymous exports fail silently)

## #441 — prefix-sum Fisher-Jenks
SSE inner loop rewritten with prefix sums of values/values² (variance-preserving shift by arr[0] kills catastrophic cancellation on 1e12 data) + vectorized per-class argmin. DP structure, tie-breaking, backtrack, 1000-sample cap unchanged.
**Benchmarks (n=1000, 5-run medians): k=5: 40 821 ms → 41.8 ms (~976×); k=7: 70 146 ms → 82.2 ms.** Breaks bit-identical to the old algorithm (verbatim reference copy in tests/test_jenks_441.py) across 21 tests incl. duplicates, constant data, n<k, n==k, negatives, 1e9/1e12 offsets, subsample-cap pin (no fake speedup). `-m perf` gate <300 ms.

## #427 — chunked off-loop export
Key finding: plain `to_thread` is insufficient — py3.13's C JSON encoder holds the GIL for the whole encode (measured 720-803 ms loop gaps on a 44 MB body). Implemented chunked serializer (512-feature batches in a worker thread with awaits; byte-identical output pinned by 8 parametrized tests), SVG sanitize offloaded, GeoJSON body bounded at 50 MB → 413. Max loop gap 32-43 ms (acceptance <100 ms). 15 tests in tests/test_event_loop_offload_427.py.

## #469 — auth-gated export
Export button gated on reactive auth state (useSyncExternalStore over tokenStore): anonymous → disabled with lock label + 「设置 → 账户 登录」hint; exporter.ts surfaces a dedicated login-required system message on 401/403. 3 component tests (RED: 2 failures on ungated button).

## Validation
76/76 backend tests (incl. ~200 s slow equivalence); 251/251 frontend tests in affected batches; `ruff` + `tsc --noEmit` clean.