### PR TITLE
fix(monitoring/rag): real-metrics alert rules + consistency gate, tenant-scoped document totals, vector-first delete ordering (#473 #484 #485)

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -211,11 +211,18 @@ def verify_token(token: str) -> Optional[dict]:
 
     注意：本函数只做密码学校验，**不检查 `ver` 是否与 DB 一致**。
     需要 ver 校验的路径用 `get_current_user_with_version` 依赖。
+
+    #473：校验失败（签名/exp/格式错误）会递增
+    auth_jwt_validation_errors_total —— Auth_JWT_Errors 告警的真实数据源；
+    之前该指标从未被暴露，告警是永久静默的。
     """
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         return payload
     except jwt.PyJWTError:
+        from app.core.auth_metrics import inc_jwt_validation_error
+
+        inc_jwt_validation_error()
         return None
 
 

--- a/app/core/auth_metrics.py
+++ b/app/core/auth_metrics.py
@@ -1,0 +1,35 @@
+"""Auth-related Prometheus metrics.
+
+#473：deploy/alerts-rules.json 的 Auth_JWT_Errors 告警此前引用
+`auth_jwt_validation_errors_total`，但应用从未暴露该指标 —— 规则永远
+evaluate 为空。此模块把该计数器变为真实指标（注册进 prometheus_client
+默认 REGISTRY，随 instrumentator 的 /metrics 端点一起暴露），由
+app/core/auth.py 的 token 校验失败路径递增。
+
+测试 tests/test_alerts_metrics_consistency.py 会以本模块的存在为告警
+表达式的一致性前提 —— 删除它会让 CI 失败。
+"""
+import logging
+
+from prometheus_client import Counter
+
+logger = logging.getLogger(__name__)
+
+# JWT 校验失败（签名/exp/格式错误）。无 label：告警聚合不需要维度，
+# 也避免攻击者用随机 label 值撑高 cardinality。
+AUTH_JWT_VALIDATION_ERRORS = Counter(
+    "auth_jwt_validation_errors_total",
+    "Total number of JWT tokens that failed cryptographic validation "
+    "(bad signature, expired, malformed).",
+)
+
+
+def inc_jwt_validation_error() -> None:
+    """Record one rejected JWT (fire-and-forget; metrics must never break auth)."""
+    try:
+        AUTH_JWT_VALIDATION_ERRORS.inc()
+    except Exception:  # noqa: BLE001
+        logger.debug("auth_jwt_validation_errors_total inc failed", exc_info=True)
+
+
+__all__ = ["AUTH_JWT_VALIDATION_ERRORS", "inc_jwt_validation_error"]

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -122,6 +122,20 @@ async def delete_document(
     """
     删除指定文档的所有chunk和相关向量。
     审计 S41：先校验所有权，非本人/本组织的文档拒绝删除。
+
+    #485 删除顺序与补偿语义（vector-first）：
+
+    1. 只读所有权校验（不改任何状态）。
+    2. **先**清理向量索引（engine.delete_document：软删标记 + 可能的压缩）。
+       - 失败 → 记日志并返回 False，**DB 行原样保留**，调用方重试即可恢复
+         （owner_check 仍能找到行，重新走一遍同样的流程）。
+    3. 向量清理成功后**再**删除 DB 行（Chunk → Document）。
+       - 此时若 DB 删除失败 → 返回 False；搜索结果已不含该文档（向量已软删），
+         DB 行仍在，重试依然安全：FaissVectorStore.mark_deleted 对已清理的
+         document_id 是幂等 no-op，不会破坏状态。
+
+    旧实现的顺序相反（先删 DB 行、后清理向量且不受保护）：向量清理一旦失败，
+    向量永久孤儿化，且重试会因 owner_check 查不到行而直接 False —— 不可恢复。
     """
     from sqlalchemy import delete, select
 
@@ -129,19 +143,21 @@ async def delete_document(
     from app.services.rag.engine import TenantContext, get_knowledge_engine
     from app.tools._utils import async_db_session
 
+    # ── 1. 只读所有权校验 ────────────────────────────────────────────────
+    # Delete is creator-only (docstring: "仅删除属于自己的文档"). The
+    # previous org-scoped check let any member of an org delete another
+    # member's document — inconsistent with templates/projects, which
+    # are creator-or-admin. org_id stays on the TenantContext below for
+    # the vector-store cleanup, but it must NOT broaden the SQL guard.
+    if user_id is None:
+        # No authenticated creator identity -> cannot authorize delete.
+        return False
+
     try:
         async with async_db_session() as db:
-            # Delete is creator-only (docstring: "仅删除属于自己的文档"). The
-            # previous org-scoped check let any member of an org delete another
-            # member's document — inconsistent with templates/projects, which
-            # are creator-or-admin. org_id stays on the TenantContext below for
-            # the vector-store cleanup, but it must NOT broaden the SQL guard.
-            owner_check = select(Document).where(Document.id == document_id)
-            if user_id is not None:
-                owner_check = owner_check.where(Document.creator_id == user_id)
-            else:
-                # No authenticated creator identity -> cannot authorize delete.
-                return False
+            owner_check = select(Document.id).where(
+                Document.id == document_id, Document.creator_id == user_id
+            )
             existing = (await db.execute(owner_check)).scalar_one_or_none()
             if existing is None:
                 logger.warning(
@@ -149,16 +165,44 @@ async def delete_document(
                     document_id, user_id, org_id,
                 )
                 return False
+    except Exception as e:
+        logger.error(f"[RAG] delete_document owner check failed: {e}", exc_info=True)
+        return False
 
+    # ── 2. 向量清理先行：失败则 DB 行保留，可重试 ─────────────────────────
+    tenant = TenantContext(user_id=user_id, org_id=str(org_id) if org_id is not None else None)
+    engine = get_knowledge_engine()
+    try:
+        vector_ok = await engine.delete_document(document_id, tenant=tenant)
+    except Exception as e:
+        # DB rows are untouched — the caller can retry the whole delete.
+        logger.error(
+            f"[RAG] delete_document vector cleanup failed for {document_id}; "
+            f"DB rows kept for retry: {e}",
+            exc_info=True,
+        )
+        return False
+    if vector_ok is False:
+        logger.warning(
+            "[RAG] delete_document vector cleanup returned False for %s; DB rows kept for retry",
+            document_id,
+        )
+        return False
+
+    # ── 3. DB 行删除（向量已清理；失败可安全重试，mark_deleted 幂等）──────
+    try:
+        async with async_db_session() as db:
             await db.execute(delete(Chunk).where(Chunk.document_id == document_id))
             await db.execute(delete(Document).where(Document.id == document_id))
     except Exception as e:
-        logger.error(f"[RAG] delete_document failed: {e}", exc_info=True)
+        logger.error(
+            f"[RAG] delete_document DB cleanup failed for {document_id} after vector "
+            f"cleanup succeeded; retry is safe (mark_deleted is idempotent): {e}",
+            exc_info=True,
+        )
         return False
 
-    tenant = TenantContext(user_id=user_id, org_id=str(org_id) if org_id is not None else None)
-    engine = get_knowledge_engine()
-    return await engine.delete_document(document_id, tenant=tenant)
+    return True
 
 
 async def list_documents(

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -174,15 +174,24 @@ async def list_documents(
     from app.tools._utils import async_db_session
 
     async with async_db_session() as db:
+        # #484：count 与 items 必须共享同一租户过滤 —— 之前 count 是全表
+        # `count(Document)`，导致分页 total 按全局文档数计算（翻页越界），
+        # 并向每个租户泄露全平台文档总量。过滤条件单源化为一个 where 列表，
+        # 两边引用同一份，杜绝再次漂移。
+        tenant_filters = []
+        if org_id is not None:
+            tenant_filters.append(Document.org_id == org_id)
+        elif user_id is not None:
+            tenant_filters.append(Document.creator_id == user_id)
+
         count_stmt = select(func.count()).select_from(Document)
-        total_result = await db.execute(count_stmt)
-        total = total_result.scalar_one()
+        if tenant_filters:
+            count_stmt = count_stmt.where(*tenant_filters)
+        total = (await db.execute(count_stmt)).scalar_one()
 
         stmt = select(Document).order_by(Document.created_at.desc()).offset(offset).limit(limit)
-        if org_id is not None:
-            stmt = stmt.where(Document.org_id == org_id)
-        elif user_id is not None:
-            stmt = stmt.where(Document.creator_id == user_id)
+        if tenant_filters:
+            stmt = stmt.where(*tenant_filters)
         result = await db.execute(stmt)
         items = result.scalars().all()
         return {

--- a/deploy/alerts-rules.json
+++ b/deploy/alerts-rules.json
@@ -5,7 +5,7 @@
       "rules": [
         {
           "alert": "WebGIS_API_Down",
-          "expr": "up{job='webgis-api'} == 0",
+          "expr": "up{job=\"webgis-api\"} == 0",
           "for": "2m",
           "labels": {
             "severity": "critical"
@@ -17,146 +17,122 @@
         },
         {
           "alert": "High_Error_Rate",
-          "expr": "sum(rate(http_requests_status_code{service='webgis-api',status=~'5..'}[5m])) / sum(rate(http_requests_total{service='webgis-api'}[5m])) > 0.05",
+          "expr": "sum(rate(http_requests_total{job=\"webgis-api\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"webgis-api\"}[5m])) > 0.05",
           "for": "5m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
             "summary": "API 错误率过高",
-            "description": "过去 5 分钟内错误率超过 5%"
+            "description": "过去 5 分钟内 5xx 错误率超过 5%。数据源：instrumentator 默认指标 http_requests_total（label: handler/method/status，status 为 2xx/4xx/5xx 分组值）"
           }
         },
         {
           "alert": "Slow_Response_P95",
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{service='webgis-api'}[5m])) by (le)) > 2",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_highr_seconds_bucket{job=\"webgis-api\"}[5m]))) > 2",
           "for": "5m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
             "summary": "API 响应慢",
-            "description": "P95 响应时间超过 2 秒"
+            "description": "P95 响应时间超过 2 秒。数据源：instrumentator 高分辨率直方图 http_request_duration_highr_seconds（多桶、无业务 label）"
           }
         },
         {
           "alert": "Slow_Response_P99",
-          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{service='webgis-api'}[5m])) by (le)) > 5",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_highr_seconds_bucket{job=\"webgis-api\"}[5m]))) > 5",
           "for": "5m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
             "summary": "API 响应极慢",
-            "description": "P99 响应时间超过 5 秒"
+            "description": "P99 响应时间超过 5 秒。数据源：instrumentator 高分辨率直方图 http_request_duration_highr_seconds"
           }
         },
         {
-          "alert": "High_CPU_Usage",
-          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace='webgis-prod',container='webgis-api'}[5m])) by (pod) / sum(kube_pod_container_resource_limits{namespace='webgis-prod',container='webgis-api',resource='cpu'}) by (pod) > 0.85",
+          "alert": "High_API_CPU_Usage",
+          "expr": "rate(process_cpu_seconds_total{job=\"webgis-api\"}[5m]) > 1.7",
           "for": "5m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
-            "summary": "API 服务CPU使用率过高",
-            "description": "Pod {{ $labels.pod }} CPU 使用率超过 85%，已持续 5 分钟"
+            "summary": "API 进程 CPU 使用率过高",
+            "description": "API 进程持续 5 分钟消耗超过 1.7 核（docker-compose.prod*.yml 中 api 服务 cpus 限额 2.0 的 85%）。数据源：prometheus_client 默认 process 采集器，随 /metrics 暴露"
           }
         },
         {
-          "alert": "High_Memory_Usage",
-          "expr": "sum(container_memory_working_set_bytes{namespace='webgis-prod',container='webgis-api'}) by (pod) / sum(kube_pod_container_resource_limits{namespace='webgis-prod',container='webgis-api',resource='memory'}) by (pod) > 0.85",
+          "alert": "High_API_Memory_Usage",
+          "expr": "process_resident_memory_bytes{job=\"webgis-api\"} > 1.7e9",
           "for": "5m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
-            "summary": "API 服务内存使用率过高",
-            "description": "Pod {{ $labels.pod }} 内存使用率超过 85%，已持续 5 分钟"
-          }
-        },
-        {
-          "alert": "High_CPU_Usage_Celery",
-          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace='webgis-prod',container='webgis-celery'}[5m])) by (pod) / sum(kube_pod_container_resource_limits{namespace='webgis-prod',container='webgis-celery',resource='cpu'}) by (pod) > 0.8",
-          "for": "10m",
-          "labels": {
-            "severity": "warning"
-          },
-          "annotations": {
-            "summary": "Celery 服务CPU使用率过高",
-            "description": "Pod {{ $labels.pod }} CPU 使用率超过 80%，已持续 10 分钟"
-          }
-        },
-        {
-          "alert": "High_Memory_Usage_Celery",
-          "expr": "sum(container_memory_working_set_bytes{namespace='webgis-prod',container='webgis-celery'}) by (pod) / sum(kube_pod_container_resource_limits{namespace='webgis-prod',container='webgis-celery',resource='memory'}) by (pod) > 0.8",
-          "for": "10m",
-          "labels": {
-            "severity": "warning"
-          },
-          "annotations": {
-            "summary": "Celery 服务内存使用率过高",
-            "description": "Pod {{ $labels.pod }} 内存使用率超过 80%，已持续 10 分钟"
+            "summary": "API 进程内存使用率过高",
+            "description": "API 进程 RSS 超过 1.7GB（docker-compose.prod*.yml 中 api 服务 memory 限额 2g 的约 85%）。数据源：prometheus_client 默认 process 采集器，随 /metrics 暴露"
           }
         },
         {
           "alert": "Database_Connection_Failure",
-          "expr": "pg_up == 0",
+          "expr": "pg_up{job=\"postgres\"} == 0",
           "for": "1m",
           "labels": {
             "severity": "critical"
           },
           "annotations": {
             "summary": "数据库连接失败",
-            "description": "PostgreSQL 数据库无响应"
+            "description": "PostgreSQL 数据库无响应。数据源：postgres-exporter（docker-compose.prod*.yml 服务 postgres-exporter，scrape job postgres）"
           }
         },
         {
           "alert": "Redis_Memory_High",
-          "expr": "redis_memory_used_bytes / redis_memory_max_bytes > 0.9",
+          "expr": "redis_memory_used_bytes{job=\"redis\"} / redis_memory_max_bytes{job=\"redis\"} > 0.9",
           "for": "5m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
             "summary": "Redis 内存使用率高",
-            "description": "Redis 内存使用率超过 90%，可能影响性能"
+            "description": "Redis 内存使用率超过 90%，可能影响性能。数据源：redis-exporter（docker-compose.prod*.yml 服务 redis-exporter，scrape job redis）"
           }
         },
         {
           "alert": "Disk_Space_Low",
-          "expr": "(node_filesystem_avail_bytes{mountpoint='/'} / node_filesystem_size_bytes{mountpoint='/'}) < 0.1",
+          "expr": "(node_filesystem_avail_bytes{job=\"node\",mountpoint=\"/\"} / node_filesystem_size_bytes{job=\"node\",mountpoint=\"/\"}) < 0.1",
           "for": "10m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
             "summary": "磁盘空间不足",
-            "description": "磁盘可用空间低于 10%"
+            "description": "宿主机根文件系统可用空间低于 10%。数据源：node-exporter（docker-compose.prod*.yml 服务 node-exporter，scrape job node）"
           }
         },
         {
           "alert": "Celery_Task_Backlog",
-          "expr": "celery_queue_length > 1000 or redis_list_length{key=\"celery:*,queue\"} > 1000",
+          "expr": "redis_key_size{job=\"redis\",key=\"celery\"} > 1000",
           "for": "15m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
             "summary": "Celery 任务积压",
-            "description": "等待处理的任务超过 1000 个，可能导致延迟。注意：本项目使用 Redis 而非 RabbitMQ 作为 broker，请通过 celery_exporter 或自定义指标暴露队列深度。"
+            "description": "等待处理的任务超过 1000 个。数据源：redis-exporter 的 check-keys=celery 导出 redis_key_size{key=\"celery\"}（Redis broker 的 celery 默认队列 list 长度；本项目未配置自定义队列名）"
           }
         },
         {
           "alert": "Auth_JWT_Errors",
-          "expr": "increase(auth_jwt_validation_errors_total[5m]) > 10",
+          "expr": "increase(auth_jwt_validation_errors_total{job=\"webgis-api\"}[5m]) > 10",
           "for": "2m",
           "labels": {
             "severity": "warning"
           },
           "annotations": {
             "summary": "JWT 验证错误频发",
-            "description": "过去 5 分钟内 JWT 验证错误超过 10 次，可能表明攻击或配置问题"
+            "description": "过去 5 分钟内 JWT 校验失败（签名/exp/格式）超过 10 次，可能表明攻击或配置问题。数据源：app/core/auth_metrics.py 暴露的真实计数器，随 /metrics 暴露"
           }
         }
       ]

--- a/deploy/grafana/provisioning/dashboards/dashboard.json
+++ b/deploy/grafana/provisioning/dashboards/dashboard.json
@@ -49,8 +49,8 @@
       },
       "targets": [
         {
-          "expr": "rate(http_requests_total[5m])",
-          "legendFormat": "{{method}} {{path}}",
+          "expr": "sum by (handler, method, status) (rate(http_requests_total{job=\"webgis-api\"}[5m]))",
+          "legendFormat": "{{method}} {{handler}} [{{status}}]",
           "refId": "A"
         }
       ],
@@ -71,7 +71,7 @@
               {"color": "red", "value": 500}
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -88,17 +88,17 @@
       "pluginVersion": "10.3.3",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_highr_seconds_bucket{job=\"webgis-api\"}[5m])))",
           "legendFormat": "p95",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_highr_seconds_bucket{job=\"webgis-api\"}[5m])))",
           "legendFormat": "p99",
           "refId": "B"
         }
       ],
-      "title": "响应延迟 (ms)",
+      "title": "响应延迟 (s)",
       "type": "stat"
     },
     {
@@ -131,7 +131,7 @@
       "pluginVersion": "10.3.3",
       "targets": [
         {
-          "expr": "(1 - rate(http_requests_success_total[5m]) / rate(http_requests_total[5m])) * 100",
+          "expr": "(sum(rate(http_requests_total{job=\"webgis-api\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"webgis-api\"}[5m]))) * 100",
           "legendFormat": "错误率",
           "refId": "A"
         }
@@ -143,17 +143,17 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
+          "color": {"mode": "thresholds"},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {"color": "green", "value": null},
-              {"color": "yellow", "value": 70},
-              {"color": "red", "value": 85}
+              {"color": "yellow", "value": 1000000000},
+              {"color": "red", "value": 1700000000}
             ]
           },
-          "unit": "percent"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -170,12 +170,12 @@
       "pluginVersion": "10.3.3",
       "targets": [
         {
-          "expr": "container_memory_usage_bytes / container_spec_memory_limit_bytes * 100",
-          "legendFormat": "内存使用率",
+          "expr": "process_resident_memory_bytes{job=\"webgis-api\"}",
+          "legendFormat": "rss",
           "refId": "A"
         }
       ],
-      "title": "内存使用率 (%)",
+      "title": "API 进程内存 (RSS)",
       "type": "stat"
     }
   ],

--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -10,6 +10,9 @@ alerting:
         - targets: []
 
 # 加载仓库内已跟踪的告警规则（deploy/alerts-rules.json，compose 中挂载）。
+# #473：规则表达式引用的指标与下面的 scrape job 一一对应 ——
+# tests/test_alerts_metrics_consistency.py 会在 CI 里校验这种对应关系，
+# 引用无数据源指标的规则会让构建失败。
 rule_files:
   - /etc/prometheus/alerts-rules.json
 
@@ -26,12 +29,21 @@ scrape_configs:
     metrics_path: '/metrics'
     scrape_interval: 30s
 
-  # Redis 监控（需要 redis_exporter）
-  # - job_name: 'redis'
-  #   static_configs:
-  #     - targets: ['redis-exporter:9121']
+  # PostgreSQL exporter（#473：pg_up 的数据源，Database_Connection_Failure 告警）。
+  # 服务定义在 docker-compose.prod*.yml 的 postgres-exporter。
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres-exporter:9187']
 
-  # Node Exporter（宿主机器指标）
-  # - job_name: 'node'
-  #   static_configs:
-  #     - targets: ['node-exporter:9100']
+  # Redis exporter（#473：redis_memory_* 与 redis_key_size 的数据源，
+  # Redis_Memory_High / Celery_Task_Backlog 告警）。check-keys=celery 让
+  # exporter 额外导出 celery 默认队列（Redis list key "celery"）的长度。
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis-exporter:9121']
+
+  # Node exporter（#473：node_filesystem_* 的数据源，Disk_Space_Low 告警）。
+  # 只读挂载宿主 /proc /sys /，监控宿主机（容器所在物理机）的磁盘/负载。
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']

--- a/docker-compose.prod.secure.yml
+++ b/docker-compose.prod.secure.yml
@@ -269,6 +269,79 @@ services:
           memory: 512m
           cpus: "0.25"
 
+  # PostgreSQL exporter（#473：pg_up 的数据源 —— Database_Connection_Failure
+  # 告警之前引用 pg_up 但没有任何 exporter 被抓取，是永不触发的装饰性监控）
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+    container_name: webgis-prod-postgres-exporter
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${DB_USER:-webgis_prod}:${DB_PWD:?ERROR: DB_PWD not set. Copy .env.Priv.example to .env.Priv and set DB_PWD.}@db:5432/${DB_NAME:-webgis_prod}?sslmode=disable"
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - webgis-internal
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+        reservations:
+          memory: 128m
+          cpus: "0.1"
+
+  # Redis exporter（#473：redis_memory_* / redis_key_size 的数据源 ——
+  # Redis_Memory_High 与 Celery_Task_Backlog 告警）。check-keys=celery 导出
+  # celery 默认队列（Redis list key "celery"）长度为 redis_key_size。
+  redis-exporter:
+    image: quay.io/prometheuscommunity/redis-exporter:v1.58.0
+    container_name: webgis-prod-redis-exporter
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: redis://redis:6379
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?ERROR: REDIS_PASSWORD not set. Copy .env.Priv.example to .env.Priv and set REDIS_PASSWORD.}"
+      REDIS_EXPORTER_CHECK_KEYS: celery
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - webgis-internal
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+        reservations:
+          memory: 128m
+          cpus: "0.1"
+
+  # Node exporter（#473：node_filesystem_* 的数据源 —— Disk_Space_Low 告警）。
+  # 只读挂载宿主 /proc /sys /，监控容器所在宿主机（Linux）的根文件系统。
+  node-exporter:
+    image: quay.io/prometheuscommunity/node-exporter:v1.7.0
+    container_name: webgis-prod-node-exporter
+    restart: unless-stopped
+    command:
+      - '--path.rootfs=/host'
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+    pid: host
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host:ro,rslave
+    networks:
+      - webgis-internal
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+        reservations:
+          memory: 128m
+          cpus: "0.1"
+
 volumes:
   pg_data_secure:
   redis_data_secure:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -207,6 +207,9 @@ services:
       - "127.0.0.1:19090:9090"
     volumes:
       - ./deploy/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # #473：此前 prod（非 secure）栈没挂载告警规则文件，而 prometheus.yml
+      # 的 rule_files 引用它 —— 规则从未加载，任何告警都不可能触发。
+      - ./deploy/alerts-rules.json:/etc/prometheus/alerts-rules.json:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -223,6 +226,80 @@ services:
         reservations:
           memory: 512m
           cpus: "0.25"
+
+  # PostgreSQL exporter（#473：pg_up 的数据源 —— Database_Connection_Failure
+  # 告警之前引用 pg_up 但没有任何 exporter 被抓取，是永不触发的装饰性监控）
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.15.0
+    container_name: webgis-prod-postgres-exporter
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${DB_USER:-webgis_prod}:${DB_PWD:?Set DB_PWD in .env.prod.example}@db:5432/${DB_NAME:-webgis_prod}?sslmode=disable"
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - webgis-net
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+        reservations:
+          memory: 128m
+          cpus: "0.1"
+
+  # Redis exporter（#473：redis_memory_* / redis_key_size 的数据源 ——
+  # Redis_Memory_High 与 Celery_Task_Backlog 告警）。check-keys=celery 导出
+  # celery 默认队列（Redis list key "celery"）长度为 redis_key_size。
+  redis-exporter:
+    image: quay.io/prometheuscommunity/redis-exporter:v1.58.0
+    container_name: webgis-prod-redis-exporter
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: redis://redis:6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?Set REDIS_PASSWORD in .env.prod.example}
+      REDIS_EXPORTER_CHECK_KEYS: celery
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - webgis-net
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+        reservations:
+          memory: 128m
+          cpus: "0.1"
+
+  # Node exporter（#473：node_filesystem_* 的数据源 —— Disk_Space_Low 告警）。
+  # 只读挂载宿主 /proc /sys /，监控容器所在宿主机（Linux）的根文件系统。
+  node-exporter:
+    image: quay.io/prometheuscommunity/node-exporter:v1.7.0
+    container_name: webgis-prod-node-exporter
+    restart: unless-stopped
+    command:
+      - '--path.rootfs=/host'
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+    pid: host
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/host:ro,rslave
+    networks:
+      - webgis-net
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: "0.5"
+        reservations:
+          memory: 128m
+          cpus: "0.1"
+
 
   # Grafana 可视化面板（可选）
   grafana:

--- a/tests/test_alerts_metrics_consistency.py
+++ b/tests/test_alerts_metrics_consistency.py
@@ -1,0 +1,380 @@
+"""#473 regression gate — alert/dashboard PromQL must match the real metric surface.
+
+Silent alerting blackout class this file prevents: rules written against an
+imagined instrumentation surface (metrics never emitted, labels that do not
+exist, exporters never scraped, single-quoted label matchers that are not even
+valid PromQL). Such rules load into Prometheus and then evaluate to empty/NaN
+forever — nobody gets paged.
+
+The gate cross-checks three inventories:
+
+1. APP-EMITTED METRICS — collected live: a FastAPI app instrumented exactly the
+   way ``app/main.py`` does it (``Instrumentator().instrument(app).expose(...)``,
+   default metric set on the default REGISTRY) is driven with real requests
+   (2xx/4xx/5xx) and its /metrics exposition is parsed into
+   {series_name: {label_names}}. This is precisely what scrape job
+   ``webgis-api`` ingests.
+2. EXPORTER METRICS — the metrics each WIRED exporter provides, keyed by the
+   scrape job that ingests it; the test also asserts the job is enabled in
+   deploy/prometheus.yml and the exporter service exists in BOTH prod compose
+   files, so a rule can only reference an exporter metric whose data path is
+   actually deployed.
+3. PROMETHEUS BUILTINS — ``up`` (one series per scrape job).
+
+Every PromQL expression in deploy/alerts-rules.json and the Grafana dashboard
+must only reference metrics from 1-3, with label selectors restricted to the
+metric's real label names (+ scrape-added job/instance). Drift fails CI.
+"""
+import asyncio
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+
+DEPLOY = Path(__file__).resolve().parents[1] / "deploy"
+
+# ── Inventory 2: wired exporters ──────────────────────────────────────────
+# job -> {service: compose service name, metrics: {metric: allowed labels}}
+# Metric names are the documented surface of each exporter image pinned in
+# docker-compose.prod*.yml. Keep in sync with the compose services.
+EXPORTER_METRICS = {
+    "postgres": {
+        "service": "postgres-exporter",
+        "metrics": {"pg_up": set()},
+    },
+    "redis": {
+        "service": "redis-exporter",
+        "metrics": {
+            "redis_memory_used_bytes": set(),
+            "redis_memory_max_bytes": set(),
+            # exported only because compose sets REDIS_EXPORTER_CHECK_KEYS=celery
+            "redis_key_size": {"key"},
+        },
+    },
+    "node": {
+        "service": "node-exporter",
+        "metrics": {
+            "node_filesystem_avail_bytes": {"device", "fstype", "mountpoint"},
+            "node_filesystem_size_bytes": {"device", "fstype", "mountpoint"},
+        },
+    },
+}
+
+# Labels Prometheus itself attaches to every scraped series.
+SCRAPE_ADDED_LABELS = {"job", "instance"}
+
+# PromQL keywords/functions/aggregations that are not metric names.
+PROMQL_KEYWORDS = {
+    "sum", "min", "max", "avg", "group", "stddev", "stdvar", "count",
+    "count_values", "bottomk", "topk", "quantile", "limitk", "limit_ratio",
+    "by", "without", "on", "ignoring", "group_left", "group_right",
+    "offset", "bool", "and", "or", "unless", "atan2", "start", "end",
+    "rate", "irate", "increase", "delta", "idelta", "deriv",
+    "avg_over_time", "sum_over_time", "min_over_time", "max_over_time",
+    "count_over_time", "quantile_over_time", "stddev_over_time",
+    "stdvar_over_time", "last_over_time", "present_over_time",
+    "changes", "resets", "predict_linear", "holt_winters",
+    "double_exponential_smoothing", "histogram_quantile", "histogram_count",
+    "histogram_sum", "histogram_fraction", "absent", "absent_over_time",
+    "scalar", "vector", "time", "timestamp", "sort", "sort_desc",
+    "sort_by_label", "label_replace", "label_join", "clamp", "clamp_max",
+    "clamp_min", "round", "ln", "log2", "log10", "exp", "sqrt", "floor",
+    "ceil", "sgn", "pi", "day_of_month", "day_of_week", "day_of_year",
+    "days_in_month", "hour", "minute", "month", "year", "inf", "nan",
+}
+
+# Known-phantom names from the pre-#473 rules — must never come back.
+FORBIDDEN_METRICS = {
+    "http_requests_status_code",
+    "http_requests_success_total",
+    "container_cpu_usage_seconds_total",
+    "container_memory_working_set_bytes",
+    "container_memory_usage_bytes",
+    "container_spec_memory_limit_bytes",
+    "kube_pod_container_resource_limits",
+    "celery_queue_length",
+    "redis_list_length",
+}
+
+# Incident classes the alert file must keep covering (anti-decorative guard:
+# deleting a rule to make the consistency check pass is not a fix).
+REQUIRED_ALERTS = {
+    "WebGIS_API_Down",
+    "High_Error_Rate",
+    "Slow_Response_P95",
+    "Slow_Response_P99",
+    "High_API_CPU_Usage",
+    "High_API_Memory_Usage",
+    "Database_Connection_Failure",
+    "Redis_Memory_High",
+    "Disk_Space_Low",
+    "Celery_Task_Backlog",
+    "Auth_JWT_Errors",
+}
+
+
+# ── Inventory 1: live app-emitted metrics ─────────────────────────────────
+
+def parse_prom_exposition(text: str) -> dict[str, set[str]]:
+    """Parse a /metrics exposition into {series_name: {label_names}}."""
+    metrics: dict[str, set[str]] = {}
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name_part = line.rpartition(" ")[0]
+        if "{" in name_part:
+            name, _, labels_part = name_part.partition("{")
+            for match in re.finditer(r'([a-zA-Z_][a-zA-Z0-9_]*)="', labels_part):
+                metrics.setdefault(name, set()).add(match.group(1))
+        else:
+            metrics.setdefault(name_part.strip(), set())
+    return metrics
+
+
+def _drive_fixture_app() -> str:
+    """Instrument an app exactly like app/main.py, hit 2xx/4xx/5xx, scrape."""
+    # Register the app's custom counter into the default REGISTRY (the same
+    # registry the instrumentator exposes) so it appears in the inventory.
+    import app.core.auth_metrics  # noqa: F401
+    from prometheus_fastapi_instrumentator import Instrumentator
+
+    app = FastAPI()
+    Instrumentator().instrument(app).expose(
+        app, endpoint="/metrics", include_in_schema=False
+    )
+
+    @app.get("/ok")
+    async def ok():
+        return {"ok": True}
+
+    @app.get("/boom")
+    async def boom():
+        return JSONResponse({"error": "x"}, status_code=500)
+
+    async def drive() -> str:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            await c.get("/ok")
+            await c.get("/boom")
+            await c.get("/missing")  # 4xx via unmatched handler
+            return (await c.get("/metrics")).text
+
+    return asyncio.run(drive())
+
+
+@pytest.fixture(scope="module")
+def app_emitted_metrics():
+    return parse_prom_exposition(_drive_fixture_app())
+
+
+# ── Parsers ───────────────────────────────────────────────────────────────
+
+def enabled_scrape_jobs() -> set[str]:
+    cfg = yaml.safe_load((DEPLOY / "prometheus.yml").read_text())
+    return {job["job_name"] for job in cfg["scrape_configs"]}
+
+
+def compose_services(compose_file: str) -> dict:
+    root = Path(__file__).resolve().parents[1]
+    return yaml.safe_load((root / compose_file).read_text())["services"]
+
+
+def collect_exprs() -> list[tuple[str, str]]:
+    """All (source, expr) pairs from alert rules and the Grafana dashboard."""
+    pairs: list[tuple[str, str]] = []
+    rules = json.loads((DEPLOY / "alerts-rules.json").read_text())
+    for group in rules["groups"]:
+        for rule in group["rules"]:
+            pairs.append((f"alert {rule.get('alert', '<unnamed>')}", rule["expr"]))
+    dash = json.loads((DEPLOY / "grafana/provisioning/dashboards/dashboard.json").read_text())
+    for panel in dash.get("panels", []):
+        for target in panel.get("targets", []):
+            if target.get("expr"):
+                pairs.append((f"dashboard panel '{panel.get('title')}'", target["expr"]))
+    return pairs
+
+
+GROUPING_CLAUSE = re.compile(r"\b(?:by|without|on|ignoring)\s*\(([^)]*)\)")
+IDENTIFIER = re.compile(r"(?<![0-9a-zA-Z_:])([a-zA-Z_:][a-zA-Z0-9_:]*)")
+METRIC_WITH_SELECTOR = re.compile(r"([a-zA-Z_:][a-zA-Z0-9_:]*)\s*(\{[^}]*\})")
+LABEL_MATCHER = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:=~|!~|!?=)\s*"([^"]*)"')
+
+
+def extract_references(expr: str) -> dict[str, dict[str, str]]:
+    """Extract {metric: {label_name: matched_value}} from a PromQL expr."""
+    refs: dict[str, dict[str, str]] = {}
+    for match in METRIC_WITH_SELECTOR.finditer(expr):
+        metric, selector = match.group(1), match.group(2)
+        labels = {lm.group(1): lm.group(2) for lm in LABEL_MATCHER.finditer(selector)}
+        refs.setdefault(metric, {}).update(labels)
+    stripped = METRIC_WITH_SELECTOR.sub(" ", expr)
+    stripped = GROUPING_CLAUSE.sub(" ", stripped)
+    for token in IDENTIFIER.findall(stripped):
+        if token not in PROMQL_KEYWORDS:
+            refs.setdefault(token, {})
+    return refs
+
+
+# ── The gate ──────────────────────────────────────────────────────────────
+
+def test_alert_rules_reference_only_real_metrics(app_emitted_metrics):
+    jobs = enabled_scrape_jobs()
+    exporter_metric_owner = {
+        metric: job for job, spec in EXPORTER_METRICS.items() for metric in spec["metrics"]
+    }
+    problems: list[str] = []
+    for source, expr in collect_exprs():
+        if "'" in expr:
+            problems.append(f"{source}: single-quoted matcher is invalid PromQL: {expr}")
+        for metric, labels in extract_references(expr).items():
+            if metric in FORBIDDEN_METRICS:
+                problems.append(f"{source}: forbidden phantom metric {metric!r}")
+                continue
+            job = labels.get("job")
+            if job is not None and job not in jobs:
+                problems.append(f"{source}: {metric} selects job={job!r} which is not scraped")
+            if metric == "up":
+                continue  # Prometheus builtin: one series per scrape job
+            if metric in app_emitted_metrics:
+                allowed = app_emitted_metrics[metric] | SCRAPE_ADDED_LABELS
+                if job is not None and job != "webgis-api":
+                    problems.append(
+                        f"{source}: app metric {metric} only exists on job 'webgis-api', not {job!r}"
+                    )
+            elif metric in exporter_metric_owner:
+                owning_job = exporter_metric_owner[metric]
+                spec = EXPORTER_METRICS[owning_job]
+                allowed = spec["metrics"][metric] | SCRAPE_ADDED_LABELS
+                if owning_job not in jobs:
+                    problems.append(
+                        f"{source}: {metric} needs exporter job {owning_job!r} "
+                        "which is not enabled in prometheus.yml"
+                    )
+                if job is not None and job != owning_job:
+                    problems.append(
+                        f"{source}: {metric} belongs to job {owning_job!r}, expr selects {job!r}"
+                    )
+            else:
+                problems.append(
+                    f"{source}: metric {metric!r} is not emitted by the app or any wired "
+                    "exporter — a rule referencing it would never fire"
+                )
+                continue
+            bad_labels = set(labels) - allowed
+            if bad_labels:
+                problems.append(
+                    f"{source}: metric {metric} has no label(s) {sorted(bad_labels)} "
+                    f"(real labels: {sorted(allowed)})"
+                )
+    assert not problems, "Alert/dashboard expressions drifted from reality:\n" + "\n".join(problems)
+
+
+def test_no_service_label_on_http_metrics():
+    # The instrumentator emits handler/method/status — a service= label never exists.
+    for source, expr in collect_exprs():
+        assert "service=" not in expr.replace(" ", ""), (
+            f"{source} uses the non-existent service= label: {expr}"
+        )
+
+
+def test_required_alert_coverage():
+    rules = json.loads((DEPLOY / "alerts-rules.json").read_text())
+    alerts = {r["alert"] for g in rules["groups"] for r in g["rules"]}
+    missing = REQUIRED_ALERTS - alerts
+    assert not missing, f"alert coverage regressed, missing: {sorted(missing)}"
+
+
+def test_exporter_jobs_have_compose_services():
+    services_prod = compose_services("docker-compose.prod.yml")
+    services_secure = compose_services("docker-compose.prod.secure.yml")
+    jobs = enabled_scrape_jobs()
+    for job, spec in EXPORTER_METRICS.items():
+        assert job in jobs, f"exporter job {job!r} not enabled in prometheus.yml"
+        for services, fname in (
+            (services_prod, "docker-compose.prod.yml"),
+            (services_secure, "docker-compose.prod.secure.yml"),
+        ):
+            assert spec["service"] in services, (
+                f"{fname} is missing the {spec['service']!r} service providing job "
+                f"{job!r} metrics — rules referencing it would never fire"
+            )
+
+
+def test_rule_files_are_mounted_in_both_prod_stacks():
+    # #473: docker-compose.prod.yml never mounted alerts-rules.json while
+    # prometheus.yml rule_files referenced it — the non-secure prod stack had
+    # NO alerting at all.
+    for compose_file in ("docker-compose.prod.yml", "docker-compose.prod.secure.yml"):
+        volumes = compose_services(compose_file)["prometheus"]["volumes"]
+        assert any("alerts-rules.json" in v for v in volumes), (
+            f"{compose_file}: prometheus does not mount alerts-rules.json — "
+            "prometheus.yml rule_files points at a file that is not there"
+        )
+
+
+# ── "Can actually fire" checks (CI substitute for staging fault injection) ─
+
+def test_error_rate_and_latency_rules_have_data(app_emitted_metrics):
+    """The series the headline alerts need exist on the scraped surface."""
+    assert "http_requests_total" in app_emitted_metrics
+    assert "status" in app_emitted_metrics["http_requests_total"]
+    assert "http_request_duration_highr_seconds_bucket" in app_emitted_metrics
+    assert "le" in app_emitted_metrics["http_request_duration_highr_seconds_bucket"]
+    assert "process_cpu_seconds_total" in app_emitted_metrics
+    assert "process_resident_memory_bytes" in app_emitted_metrics
+
+
+@pytest.mark.asyncio
+async def test_error_rate_rule_numerator_matches_real_status_values():
+    """High_Error_Rate's status=~"5.." matcher must match the instrumentator's
+    grouped status values ("5xx") — a 5xx storm produces a real numerator."""
+    from prometheus_fastapi_instrumentator import Instrumentator
+
+    app = FastAPI()
+    Instrumentator().instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
+
+    @app.get("/boom")
+    async def boom():
+        return JSONResponse({"error": "x"}, status_code=500)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        await c.get("/boom")
+        text = (await c.get("/metrics")).text
+
+    five_xx = [ln for ln in text.splitlines() if ln.startswith("http_requests_total{") and 'status="5' in ln]
+    assert five_xx, "no 5xx http_requests_total series — High_Error_Rate could never fire"
+    status_values = re.findall(r'status="([^"]+)"', "\n".join(five_xx))
+    assert any(re.fullmatch(r"5..", v) for v in status_values), (
+        f"status values {status_values} do not match the alert matcher 5.."
+    )
+
+    les = {
+        m.group(1)
+        for ln in text.splitlines()
+        if ln.startswith("http_request_duration_highr_seconds_bucket{")
+        for m in [re.search(r'le="([^"]+)"', ln)]
+        if m
+    }
+    assert {"2.0", "5.0", "+Inf"} <= les, (
+        f"latency buckets {sorted(les)} do not cover the P95/P99 alert thresholds"
+    )
+
+    # Auth_JWT_Errors: the counter is registered and exposed on /metrics.
+    assert "auth_jwt_validation_errors_total" in text, (
+        "auth_jwt_validation_errors_total missing from /metrics — "
+        "Auth_JWT_Errors would never fire"
+    )
+
+
+def test_jwt_validation_error_counter_increments():
+    """The Auth_JWT_Errors data source actually counts failures."""
+    from app.core.auth import verify_token
+    from app.core.auth_metrics import AUTH_JWT_VALIDATION_ERRORS
+
+    before = AUTH_JWT_VALIDATION_ERRORS._value.get()  # noqa: SLF001
+    assert verify_token("not-a-jwt") is None
+    assert AUTH_JWT_VALIDATION_ERRORS._value.get() == before + 1  # noqa: SLF001

--- a/tests/test_rag_service_db.py
+++ b/tests/test_rag_service_db.py
@@ -1,0 +1,141 @@
+"""RAG service DB-backed regression tests (#484 tenant-scoped total, #485 delete ordering).
+
+Uses a throwaway sqlite+aiosqlite DB patched into
+``app.core.database.AsyncSessionLocal`` — the global that
+``app.tools._utils.async_db_session`` reads — so the real service code path
+runs against a real (file-backed) database without Postgres.
+"""
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def rag_db(tmp_path, monkeypatch):
+    """sqlite test DB wired into the app's async-session global."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core import database
+    from app.models.db_model import Base
+    from app.tools import _utils
+
+    test_engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'rag_service.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    test_session = async_sessionmaker(bind=test_engine, expire_on_commit=False)
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    @asynccontextmanager
+    async def override_async_db_session():
+        async with test_session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+            finally:
+                await s.close()
+
+    # _utils.async_db_session reads app.core.database.AsyncSessionLocal at
+    # call time, so patching the module attribute is enough.
+    monkeypatch.setattr(database, "AsyncSessionLocal", test_session)
+    monkeypatch.setattr(_utils, "async_db_session", override_async_db_session)
+
+    yield
+
+    await test_engine.dispose()
+
+
+async def _seed_document(db_sessionmaker, *, org_id=None, creator_id=None, title="doc"):
+    from app.models.knowledge_base import Chunk, Document
+
+    doc_id = f"doc_{uuid.uuid4().hex[:12]}"
+    async with db_sessionmaker() as s:
+        d = Document(
+            id=doc_id,
+            title=title,
+            file_type="text",
+            chunk_count=1,
+            status="completed",
+            creator_id=creator_id,
+            org_id=org_id,
+            created_at=datetime.now(timezone.utc),
+        )
+        s.add(d)
+        s.add(Chunk(id=str(uuid.uuid4()), document_id=doc_id, content="c", chunk_index=0))
+        await s.commit()
+    return doc_id
+
+
+# ── #484: tenant-scoped total ────────────────────────────────────────────
+
+
+async def test_list_documents_total_is_org_scoped(rag_db, tmp_path):
+    """#484: org A (2 docs) and org B (3 docs) must each see only their own total."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.services import rag_service
+
+    session = async_sessionmaker(
+        bind=create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'rag_service.db'}"),
+        expire_on_commit=False,
+    )
+    for _ in range(2):
+        await _seed_document(session, org_id=1)
+    for _ in range(3):
+        await _seed_document(session, org_id=2)
+
+    result_a = await rag_service.list_documents(org_id=1)
+    result_b = await rag_service.list_documents(org_id=2)
+
+    assert result_a["total"] == 2, "org A must see exactly its own document count"
+    assert result_b["total"] == 3, "org B must see exactly its own document count"
+    assert {i["title"] for i in result_a["items"]} <= {"doc"}
+
+
+async def test_list_documents_total_is_user_scoped(rag_db, tmp_path):
+    """#484: with no org context, total must be scoped to the creator."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.services import rag_service
+
+    session = async_sessionmaker(
+        bind=create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'rag_service.db'}"),
+        expire_on_commit=False,
+    )
+    for _ in range(2):
+        await _seed_document(session, creator_id="alice")
+    await _seed_document(session, creator_id="bob")
+
+    assert (await rag_service.list_documents(user_id="alice"))["total"] == 2
+    assert (await rag_service.list_documents(user_id="bob"))["total"] == 1
+
+
+async def test_list_documents_pagination_math(rag_db, tmp_path):
+    """#484: total must reflect the filtered extent, not the page size or the table."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.services import rag_service
+
+    session = async_sessionmaker(
+        bind=create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'rag_service.db'}"),
+        expire_on_commit=False,
+    )
+    for _ in range(3):
+        await _seed_document(session, org_id=7)
+    for _ in range(4):
+        await _seed_document(session, org_id=8)  # other tenant noise
+
+    page1 = await rag_service.list_documents(limit=2, offset=0, org_id=7)
+    page2 = await rag_service.list_documents(limit=2, offset=2, org_id=7)
+
+    assert page1["total"] == 3
+    assert len(page1["items"]) == 2
+    assert page2["total"] == 3
+    assert len(page2["items"]) == 1

--- a/tests/test_rag_service_db.py
+++ b/tests/test_rag_service_db.py
@@ -8,6 +8,7 @@ runs against a real (file-backed) database without Postgres.
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
 
 import pytest_asyncio
 
@@ -71,6 +72,148 @@ async def _seed_document(db_sessionmaker, *, org_id=None, creator_id=None, title
         s.add(Chunk(id=str(uuid.uuid4()), document_id=doc_id, content="c", chunk_index=0))
         await s.commit()
     return doc_id
+
+
+def _engine_stub(delete_result=True):
+    """Minimal KnowledgeEngine stand-in whose delete_document is a mock."""
+    stub = type("EngineStub", (), {})()
+    stub.delete_document = AsyncMock(return_value=delete_result)
+    return stub
+
+
+# ── #485: delete ordering / vector failure compensation ──────────────────
+
+
+async def test_delete_document_vector_failure_keeps_rows_and_retry_succeeds(rag_db, tmp_path):
+    """#485: 向量清理失败时 DB 行必须仍在（可重试），重试后两端都删净。"""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.models.knowledge_base import Chunk, Document
+    from app.services import rag_service
+    from app.services.rag import engine as engine_mod
+
+    session = async_sessionmaker(
+        bind=create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'rag_service.db'}"),
+        expire_on_commit=False,
+    )
+    doc_id = await _seed_document(session, creator_id="alice")
+
+    calls = {"n": 0}
+
+    async def flaky_engine_delete(doc_id_arg, tenant=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("vector store metadata I/O failed")
+        return True
+
+    stub = type("E", (), {})()
+    stub.delete_document = flaky_engine_delete
+    with patch.object(engine_mod, "get_knowledge_engine", return_value=stub):
+        # First attempt: vector cleanup fails -> delete must NOT report
+        # success and DB rows must survive for a retry.
+        ok = await rag_service.delete_document(doc_id, user_id="alice")
+        assert ok is False, "vector failure must not report success"
+
+        async with session() as s:
+            doc_row = (await s.execute(select(Document).where(Document.id == doc_id))).scalar_one_or_none()
+            chunk_rows = (await s.execute(select(Chunk).where(Chunk.document_id == doc_id))).scalars().all()
+        assert doc_row is not None, "DB document row must survive vector-cleanup failure"
+        assert len(chunk_rows) == 1, "DB chunk rows must survive vector-cleanup failure"
+
+        # Retry after the transient vector failure succeeds and clears both stores.
+        ok2 = await rag_service.delete_document(doc_id, user_id="alice")
+        assert ok2 is True
+        async with session() as s:
+            doc_row2 = (await s.execute(select(Document).where(Document.id == doc_id))).scalar_one_or_none()
+            chunk_rows2 = (await s.execute(select(Chunk).where(Chunk.document_id == doc_id))).scalars().all()
+        assert doc_row2 is None
+        assert chunk_rows2 == []
+    assert calls["n"] == 2, "retry must reach vector cleanup again"
+
+
+async def test_delete_document_removes_vectors_before_db_rows(rag_db, tmp_path):
+    """#485: 排序契约 —— engine.delete_document 运行时 DB 行必须还在。
+
+    若先删 DB 行，向量清理一旦失败 owner_check 将永远查不到行，重试不可能。
+    """
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.models.knowledge_base import Document
+    from app.services import rag_service
+    from app.services.rag import engine as engine_mod
+
+    session = async_sessionmaker(
+        bind=create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'rag_service.db'}"),
+        expire_on_commit=False,
+    )
+    doc_id = await _seed_document(session, creator_id="alice")
+
+    seen_row_at_vector_time = {}
+
+    async def probe_engine_delete(doc_id_arg, tenant=None):
+        async with session() as s:
+            row = (await s.execute(select(Document).where(Document.id == doc_id))).scalar_one_or_none()
+        seen_row_at_vector_time["row_present"] = row is not None
+        return True
+
+    stub = type("E", (), {})()
+    stub.delete_document = probe_engine_delete
+    with patch.object(engine_mod, "get_knowledge_engine", return_value=stub):
+        ok = await rag_service.delete_document(doc_id, user_id="alice")
+
+    assert ok is True
+    assert seen_row_at_vector_time.get("row_present") is True, (
+        "vector cleanup ran after the DB rows were already deleted — a vector "
+        "failure there would be unretryable (#485)"
+    )
+
+
+async def test_delete_document_success_clears_both_stores(rag_db, tmp_path):
+    """Happy path: both the vector engine and the DB rows are cleaned."""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.models.knowledge_base import Document
+    from app.services import rag_service
+    from app.services.rag import engine as engine_mod
+
+    session = async_sessionmaker(
+        bind=create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'rag_service.db'}"),
+        expire_on_commit=False,
+    )
+    doc_id = await _seed_document(session, creator_id="alice")
+
+    stub = _engine_stub(delete_result=True)
+    with patch.object(engine_mod, "get_knowledge_engine", return_value=stub):
+        ok = await rag_service.delete_document(doc_id, user_id="alice")
+
+    assert ok is True
+    assert stub.delete_document.await_count == 1
+    async with session() as s:
+        assert (await s.execute(select(Document).where(Document.id == doc_id))).scalar_one_or_none() is None
+
+
+async def test_delete_document_denied_for_non_owner(rag_db, tmp_path):
+    """Owner check still holds: a different user's delete must not touch the engine."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.services import rag_service
+    from app.services.rag import engine as engine_mod
+
+    session = async_sessionmaker(
+        bind=create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'rag_service.db'}"),
+        expire_on_commit=False,
+    )
+    doc_id = await _seed_document(session, creator_id="alice")
+
+    stub = _engine_stub(delete_result=True)
+    with patch.object(engine_mod, "get_knowledge_engine", return_value=stub):
+        ok = await rag_service.delete_document(doc_id, user_id="mallory")
+
+    assert ok is False
+    stub.delete_document.assert_not_awaited()
 
 
 # ── #484: tenant-scoped total ────────────────────────────────────────────


### PR DESCRIPTION
## Issues
- Fixes #473 (P2: alert rules reference metrics/labels that don't exist — service=, http_requests_status_code, unscraped exporters; silent alerting blackout)
- Fixes #484 (P3: rag_service.list_documents total is a global unfiltered count — wrong pagination math + cross-tenant count disclosure)
- Fixes #485 (P3: delete_document deletes DB rows before vector cleanup — vector failure orphans vectors, retry impossible)

## Implementation
- **#473** Empirical inventory of the real metric surface (instrumentator 8.1.0: http_requests_total{handler,method,status} with grouped 5xx, latency histogram, process_*). All alert rules rewritten against real metrics; real exporters wired (postgres/redis/node-exporter in both prod composes + scrape jobs; redis check-keys=celery gives a real queue-depth series); real `auth_jwt_validation_errors_total` counter emitted (app/core/auth_metrics.py); the two Celery-container rules deleted (no data source — decorative monitoring removed, not kept); Grafana phantom exprs fixed; two latent bugs found: invalid single-quoted PromQL matchers, and prod compose never mounting the rules file. New gate `tests/test_alerts_metrics_consistency.py` parses every rule/dashboard expr against a live-scraped metrics inventory + exporter/scrape/compose cross-checks — mutation-tested against all six original defect classes.
- **#484** single-sourced tenant filter applied to BOTH count and items queries. Tests: two orgs see exactly their own totals; creator scoping; pagination math.
- **#485** vector-first ordering with documented retry semantics: owner check → vector cleanup (failure keeps DB rows, returns False; mark_deleted idempotent → fully retryable) → DB delete. Tests: injected flaky vector failure leaves rows intact, retry succeeds; ordering probe; non-owner never reaches the engine.

## Validation
91 + 90 tests across RAG/auth/monitoring/deploy suites; `ruff` clean; only allowed paths touched.

## Risk
Low-medium: alert rules now actually fire (previously dead); compose gains exporter containers (resource footprint small); RAG delete order change is semantics-visible only on failure paths (better).