### PR TITLE
fix(fe): align SSE hook test types with truthful handleSend boolean

### DIFF
--- a/frontend/lib/hooks/use-sse-adversarial.test.ts
+++ b/frontend/lib/hooks/use-sse-adversarial.test.ts
@@ -75,7 +75,7 @@ describe('Frontend SSE Adversarial Stress Tests', () => {
     );
 
     // 1. Start send on session A
-    let sendPromiseA: Promise<void> | undefined;
+    let sendPromiseA: Promise<boolean> | undefined;
     act(() => {
       sendPromiseA = result.current.handleSend('hello session A');
     });

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -502,7 +502,7 @@ describe('canonical MapSpec runtime patch', () => {
       )
     );
 
-    let sendPromise: Promise<void> | undefined;
+    let sendPromise: Promise<boolean> | undefined;
     act(() => {
       sendPromise = result.current.handleSend('cancel me');
     });


### PR DESCRIPTION
Follow-up to #504/#468: handleSend now returns Promise<boolean>; two test files still declared Promise<void> locals, breaking tsconfig.test.json typecheck on master. Widened the locals; 26/26 affected tests green; both tsc configs clean. (Complements #502 which fixed the #486-introduced error.)