### PR TITLE
fix(fe): repair use-sse-stream.test.ts seam from #496 conflict resolution

### DIFF
--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -691,6 +691,9 @@ describe('useSSEStream — plan approval rollback (#468)', () => {
       await new Promise((r) => setTimeout(r, 20));
     });
     expect(planMsg().status).toBe('pending');
+  });
+});
+
 describe('useSSEStream explorer_progress（回归：任务条目首见插入，进度可见）', () => {
   beforeEach(() => {
     bridgeMock.onEventCallback = null;
@@ -767,6 +770,5 @@ describe('useSSEStream explorer_progress（回归：任务条目首见插入，�
     const tasks = useHudStore.getState().explorerTasks;
     expect(tasks).toHaveLength(2);
     expect(tasks.map((t) => t.taskId)).toEqual(['exp-a', 'exp-b']);
-)
   });
 });


### PR DESCRIPTION
The #496 rebase conflict resolution dropped the #468 describe's closing braces and left a stray ')' at the explorer block tail (TS1005/TS1128 on master). Restores the closers; both tsc configs clean; 26/26 tests in the file green.