### PR TITLE
fix(test): mapspec 逐出测试不再依赖 clear_session 的磁盘清理（#505 跟进）

### DIFF
--- a/tests/unit/test_mapspec_store.py
+++ b/tests/unit/test_mapspec_store.py
@@ -295,7 +295,12 @@ async def test_auto_checkpoint_fails_truthfully_when_live_ref_was_evicted(clean_
   checkpoint = await snapshot(
       mapspec, session_dir, session_data_manager, checkpoint_id=None
   )
-  await session_data_manager.clear_session(clean_session)
+  # Simulate eviction of the session's in-memory live refs only (what a
+  # process restart or LRU memory eviction leaves behind). Since #505
+  # clear_session() also purges on-disk state (checkpoints included, #470),
+  # so it can no longer model "live refs gone but checkpoint metadata
+  # intact" — that contract is exactly what this test pins down.
+  session_data_manager._store.pop(clean_session, None)
 
   restored = await rollback(
       session_dir, checkpoint["checkpoint_id"], session_data_manager


### PR DESCRIPTION
## 问题

最终收敛验证发现一个**新**确定性失败（非基线内 16 个 benchmarks 计时类失败）：

```
tests/unit/test_mapspec_store.py::test_auto_checkpoint_fails_truthfully_when_live_ref_was_evicted
KeyError: 'checkpoint_mode'
```

## 根因

#505（#470）之后 `clear_session()` 除了清内存还联动 `purge_session_disk_state()` —— 会话的磁盘 checkpoints 一并回收。该测试此前用 `clear_session()` 模拟“live ref 被逐出”，隐式依赖“只清内存、不删盘上 checkpoint”的旧行为；磁盘 checkpoint 被清后 rollback 走 "Checkpoint not found" 分支，返回体不再含 `checkpoint_mode` → KeyError。

## 修复

逐出语义改为只丢弃内存中的 ref store（`_store.pop`，等价于进程重启/LRU 内存丢失），磁盘 checkpoint 元数据保留 —— 恰是该测试要钉住的“live refs 没了但 checkpoint 完好”的 truthful failure 契约（success=False + presentation_only + missing_refs）。

## 验证

- `tests/unit/test_mapspec_store.py`：19 passed（修复前 1 failed/18 passed）
- ruff 通过