### PR TITLE
fix(webgis): P1 agent/auth contract repairs (#514-#518)

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -24,6 +24,7 @@ from app.models.db_model import Conversation
 from app.services.chat.event_resume import TurnEventBuffer, TurnResumeRegistry
 from app.services.chat_engine import ChatEngine
 from app.services.history_service_async import AsyncHistoryService
+from app.services.explorer.orchestrator import bridge_session_explorer_progress
 from app.services.distributed_lock import session_lock_registry
 from app.services.session_data import session_data_manager
 from app.tools._utils import async_db_session
@@ -745,6 +746,12 @@ async def chat_stream(
                 finally:
                     if not buffer.ended:
                         buffer.mark_ended(aborted=True)
+            # #518 post-turn bridge: 匿名（无 owner）探索任务经聊天流推送进度。
+            # done/error 之后保持连接，直到任务终态（有界，见 bridge 实现）。
+            async for event in bridge_session_explorer_progress(
+                session_key, user_id
+            ):
+                yield event
 
         return StreamingResponse(
             pi_event_generator(),
@@ -780,6 +787,13 @@ async def chat_stream(
             finally:
                 if not buffer.ended:
                     buffer.mark_ended(aborted=True)
+            # #518 post-turn bridge: 匿名（无 owner）探索任务经聊天流推送进度。
+            # done/error 之后保持连接，直到任务终态（有界，见 bridge 实现）。
+            # 位于 sse_event_id_scope 内，事件带 id（前端去重）。
+            async for event in bridge_session_explorer_progress(
+                session_key, user_id
+            ):
+                yield event
 
     return StreamingResponse(
         event_generator(),

--- a/app/main.py
+++ b/app/main.py
@@ -299,7 +299,11 @@ app.add_middleware(
     allow_origins=settings.CORS_ORIGINS,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "Accept"],
+    # X-Session-Token: the anonymous session owner_token credential
+    # (SEC-08). apiFetch sends it today, and MapLibre tile requests
+    # (transformRequest, #514) attach it too — the header must be
+    # preflight-legal for cross-origin dev setups.
+    allow_headers=["Authorization", "Content-Type", "Accept", "X-Session-Token"],
     expose_headers=["X-Request-ID"],
 )
 

--- a/app/services/explorer/orchestrator.py
+++ b/app/services/explorer/orchestrator.py
@@ -71,6 +71,59 @@ def get_chain_run(final_task_id: str) -> Optional[ExplorerChainRun]:
     return run
 
 
+# ─── Issue #518: session → active explorer tasks (post-turn chat-stream bridge) ─
+#
+# Anonymous sessions (no owner registration, S42) can never reach the
+# owner-verified /explorer/stream/{task_id} endpoint. Their only progress
+# channel is the chat SSE stream, which is session-isolated by construction —
+# the post-turn bridge (bridge_session_explorer_progress) streams these
+# owner-less tasks there. The registry is keyed by session_id and LRU-bounded
+# like _chain_runs; entries are pruned once the bridge sees them terminal.
+_session_tasks: "OrderedDict[str, list[tuple[str, str]]]" = OrderedDict()
+_SESSION_TASKS_MAX_ENTRIES = 20_000
+
+# Bounded wall-clock cap for the post-turn bridge: never hold the chat SSE
+# open forever for a stuck task. On expiry the bridge emits an explicit
+# failed terminal event for still-unfinished tasks (no silent hangs).
+_EXPLORER_BRIDGE_MAX_SECONDS = 600
+
+
+def register_session_task(session_id: str, task_id: str, user_id: str) -> None:
+    """Record an explorer task under its session for the post-turn bridge."""
+    if not session_id or not task_id:
+        return
+    entry = _session_tasks.get(session_id)
+    if entry is None:
+        _session_tasks[session_id] = []
+    if not any(tid == task_id for tid, _ in _session_tasks[session_id]):
+        _session_tasks[session_id].append((task_id, user_id))
+    _session_tasks.move_to_end(session_id)
+    while len(_session_tasks) > _SESSION_TASKS_MAX_ENTRIES:
+        _session_tasks.popitem(last=False)
+
+
+def get_session_tasks(session_id: str) -> list[tuple[str, str]]:
+    """Active (task_id, user_id) pairs registered under a session."""
+    if not session_id:
+        return []
+    entry = _session_tasks.get(session_id)
+    if entry:
+        _session_tasks.move_to_end(session_id)
+    return list(entry or [])
+
+
+def remove_session_task(session_id: str, task_id: str) -> None:
+    """Drop a task from the session registry (called once it reaches terminal)."""
+    entry = _session_tasks.get(session_id)
+    if entry is None:
+        return
+    remaining = [(t, u) for t, u in entry if t != task_id]
+    if remaining:
+        _session_tasks[session_id] = remaining
+    else:
+        del _session_tasks[session_id]
+
+
 def collect_stage_ids(result: Any) -> list[str]:
     """Collect every stage task id of a chain result, ordered first→last.
 
@@ -153,6 +206,11 @@ class ExplorerOrchestrator:
         stage_ids = await asyncio.to_thread(_submit_chain)
         celery_task_id = stage_ids[-1]
         register_chain_run(celery_task_id, stage_ids)
+
+        # #518: 会话 → 任务登记（post-turn chat-stream bridge 用）。匿名
+        # 会话没有 owner registration，独立流端点不可达，靠聊天流桥接。
+        if session_id:
+            register_session_task(session_id, celery_task_id, user_id)
 
         # 审计 S42：记录任务所有权 — on the whole-chain id the client polls.
         if user_id:
@@ -324,3 +382,108 @@ class ExplorerOrchestrator:
                 last_heartbeat = now
 
             await asyncio.sleep(1)
+
+    async def stream_session_progress(
+        self,
+        task_ids: list[str],
+    ) -> AsyncGenerator[str, None]:
+        """Merge per-task progress streams (post-turn chat-stream bridge).
+
+        Completes when every task reached a terminal state. A bounded wall-
+        clock cap (`_EXPLORER_BRIDGE_MAX_SECONDS`) force-terminates stragglers
+        with an explicit `failed` terminal event so the chat SSE never hangs
+        open silently. Every event carries its task_id, so the frontend tracks
+        each task independently.
+        """
+        if not task_ids:
+            return
+        import time as _time
+
+        queue: "asyncio.Queue[object]" = asyncio.Queue()
+        sentinel = object()
+
+        async def _push(task_id: str) -> None:
+            try:
+                async for event in self.stream_progress(task_id):
+                    await queue.put(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # 单任务进度流异常 → 显式失败终态（不静默丢弃）。
+                await queue.put(
+                    sse_event("explorer_progress", ExplorerPerceptionEvent(
+                        stage="validate",
+                        task_id=task_id,
+                        status="failed",
+                        context={"final_status": "FAILURE", "error": "progress stream error"},
+                    ))
+                )
+            finally:
+                await queue.put(sentinel)
+
+        workers = [asyncio.create_task(_push(tid)) for tid in task_ids]
+        finished = 0
+        try:
+            deadline = _time.monotonic() + _EXPLORER_BRIDGE_MAX_SECONDS
+            while finished < len(workers):
+                remaining = deadline - _time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    break
+                if item is sentinel:
+                    finished += 1
+                    continue
+                yield item
+            # 有界兜底：超时后为仍未终态的任务发显式 failed 终态。
+            if finished < len(workers):
+                for task_id in task_ids:
+                    try:
+                        status = await self.get_task_status(task_id)
+                    except Exception:
+                        status = {}
+                    if status.get("status") not in ("SUCCESS", "FAILURE", "REVOKED"):
+                        yield sse_event("explorer_progress", ExplorerPerceptionEvent(
+                            stage=status.get("stage") or "validate",
+                            task_id=task_id,
+                            status="failed",
+                            context={
+                                "final_status": "FAILURE",
+                                "error": "bridge timeout",
+                            },
+                        ))
+        finally:
+            for worker in workers:
+                worker.cancel()
+
+
+async def bridge_session_explorer_progress(
+    session_id: str,
+    user_id: Optional[str],
+) -> AsyncGenerator[str, None]:
+    """#518 post-turn chat-stream bridge for owner-less explorer tasks.
+
+    Anonymous sessions (no owner registration, S42) can never reach the
+    owner-verified /explorer/stream endpoint; the chat SSE stream is
+    session-isolated by construction, so their progress is bridged here.
+    Tasks with a registered owner keep the independent stream and are
+    skipped. Completed tasks are pruned from the session registry.
+    """
+    tasks = get_session_tasks(session_id)
+    if not tasks:
+        return
+    ownerless = [
+        task_id for task_id, owner in tasks
+        if not TaskQueueService.verify_owner(task_id, user_id or "")
+    ]
+    if not ownerless:
+        return
+    async for event in _bridge_orchestrator.stream_session_progress(ownerless):
+        yield event
+    for task_id in ownerless:
+        remove_session_task(session_id, task_id)
+
+
+_bridge_orchestrator = ExplorerOrchestrator()

--- a/app/services/explorer/orchestrator.py
+++ b/app/services/explorer/orchestrator.py
@@ -455,8 +455,13 @@ class ExplorerOrchestrator:
                             },
                         ))
         finally:
+            # 取消在飞 worker 并等待其结束：只 cancel() 不 await 会让
+            # 事件循环在 generator 关闭后仍持有 pending task →
+            # "Task was destroyed but it is pending" 警告。gather 吞掉
+            # CancelledError（return_exceptions=True）。
             for worker in workers:
                 worker.cancel()
+            await asyncio.gather(*workers, return_exceptions=True)
 
 
 async def bridge_session_explorer_progress(

--- a/app/services/llm_result_formatter.py
+++ b/app/services/llm_result_formatter.py
@@ -275,7 +275,7 @@ def slim_event_result(result: Any) -> Any:
             west, south, east, north = parts
             bbox = [west, south, east, north]
 
-    exclude = {"geojson", "features", "data_list", "grid"}
+    exclude = {"geojson", "features", "data_list", "grid", "data"}
     slim = {k: v for k, v in result.items() if k not in exclude}
 
     if isinstance(result.get("mapspec"), dict):

--- a/app/services/tool_dispatch_service.py
+++ b/app/services/tool_dispatch_service.py
@@ -327,6 +327,17 @@ class ToolDispatchService:
                 target_data = result["geojson"]
             elif result.get("type") == "FeatureCollection" and "features" in result:
                 target_data = result
+            elif (
+                isinstance(result.get("data"), dict)
+                and result["data"].get("type") == "FeatureCollection"
+                and "features" in result["data"]
+            ):
+                # #517：to_llm_response() 工具族（~29 站点）返回
+                # {success, summary, data: FeatureCollection, ...} 形状，
+                # data 包裹的 FC 同样要入 ref store —— 否则分析结果永远
+                # 不挂载到地图上，LLM 载荷被裁剪到只剩 summary。
+                # 与 kde_contours（顶层 FC）保持同一挂载契约。
+                target_data = result["data"]
             if target_data is not None:
                 geojson_ref = await session_data_manager.store(session_id, target_data, prefix="geojson")
             if result.get("type") == "heatmap_raster":

--- a/app/services/tool_dispatch_service.py
+++ b/app/services/tool_dispatch_service.py
@@ -63,12 +63,17 @@ LEGACY_TOOL_NAME_MAP: dict[str, str] = {
     "add_layer": "webgis_layer_upsert",
     "set_layer_style": "webgis_layer_upsert",
     "update_layer": "webgis_layer_upsert",
-    "remove_layer": "webgis_layer_remove",
+    # remove_layer 不在别名表：#516 其已是 registry 现役工具
+    # (app/tools/layer_manager.py，参数 layer_ref)。别名改写会把合法调用
+    # 重定向到 webgis_layer_remove (layer_id schema)，导致校验失败——
+    # LLM 按目录可见名调用即命中现役工具。
     "delete_layer": "webgis_layer_remove",
     # 视角与导航
     "set_view": "webgis_view_set",
     "move_view": "webgis_view_set",
-    "zoom_to_layer": "webgis_view_set",
+    # zoom_to_layer 不在别名表：#516 其已是 registry 现役工具
+    # (app/tools/map_view.py，参数 layer_ref/padding)。改写为全可选
+    # webgis_view_set 会吞掉 layer_ref 参数使缩放命令永不触发。
     # MapSpec 生命周期与检验
     "init_project": "webgis_project_init",
     "get_state": "webgis_state_get",

--- a/app/tools/explorer_tools.py
+++ b/app/tools/explorer_tools.py
@@ -17,6 +17,33 @@ class DeepExploreArgs(BaseModel):
     auto_threshold: float = Field(0.7, ge=0.0, le=1.0, description="自动执行置信度阈值")
 
 
+async def _resolve_session_owner_user_id(session_id: str) -> str:
+    """解析会话归属 user_id（审计 S42 的可信上下文）。
+
+    registry 在 dispatch 入口注入 `session_id`（来自调度上下文、覆盖 LLM
+    提供的同名参数），因此基于它解析的归属是可信的 —— LLM 无法伪造
+    user_id 参数。匿名会话（user_id IS NULL）解析为 ""：不注册任务归属，
+    其任务无法通过 owner-verified 的 HTTP 端点监控，这是 S42 既有契约。
+    """
+    if not session_id:
+        return ""
+    try:
+        from sqlalchemy import select
+        from app.tools._utils import async_db_session
+        from app.models.db_model import Conversation
+
+        async with async_db_session() as db:
+            row = (
+                await db.execute(
+                    select(Conversation.user_id).where(Conversation.id == session_id)
+                )
+            ).scalar_one_or_none()
+        return row if isinstance(row, str) and row else ""
+    except Exception as e:  # noqa: BLE001 — 归属解析失败不阻断探索启动
+        logger.warning(f"[deep_explore] owner lookup failed for session {session_id}: {e}")
+        return ""
+
+
 def register_explorer_tools(registry: ToolRegistry):
     """注册探索引擎工具"""
     orchestrator = ExplorerOrchestrator()
@@ -29,6 +56,7 @@ def register_explorer_tools(registry: ToolRegistry):
         expected_data_type: str = "poi_list",
         source_hint: list[str] = None,
         auto_threshold: float = 0.7,
+        session_id: str = "",
     ) -> dict:
         """
         执行深度探索。
@@ -44,9 +72,15 @@ def register_explorer_tools(registry: ToolRegistry):
                 source_hint=source_hint,
                 auto_threshold=auto_threshold,
             )
+            # #518：任务必须挂到会话归属下（审计 S42 register_owner），
+            # 否则 /explorer/stream|status|abort 的 verify_owner 恒失败，
+            # 前端独立进度流（streamExplorerProgress）与中止都走不通。
+            user_id = await _resolve_session_owner_user_id(session_id)
             task_id = await orchestrator.start_exploration(
                 query=query,
                 context=context,
+                session_id=session_id,
+                user_id=user_id,
             )
 
             return {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -216,6 +216,7 @@ export default function Home() {
               onViewportChange={bridge.onViewportChange}
               sessionId={sessionId}
               ownerToken={activeSessionToken}
+              sessionTokenRef={sessionTokenRef}
             />
             <ExportMask />
             <MemoSpatialCrosshair />

--- a/frontend/components/chat/auth-image.tsx
+++ b/frontend/components/chat/auth-image.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { API_BASE } from '@/lib/api/config';
+import { apiFetchBlob } from '@/lib/api/transport';
+import { isProtectedDownloadUrl } from '@/lib/api/authenticated-download';
+
+interface AuthImageProps {
+  src: string;
+  alt?: string;
+  className?: string;
+}
+
+/**
+ * Chat-embedded image for protected download routes.
+ *
+ * A bare `<img src="/api/v1/export/download/...">` is a browser-native fetch
+ * that cannot carry the Bearer header, so exported map images embedded by the
+ * agent (`![地图](url)`) were broken images. This component fetches the blob
+ * through the transport (auth + 401 refresh) and renders it from an object
+ * URL. Public URLs (shared report views, external hosts) render directly.
+ */
+export function AuthImage({ src, alt, className }: AuthImageProps) {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const objectUrlRef = useRef<string | null>(null);
+
+  const needsAuth = isProtectedDownloadUrl(src);
+  const path = needsAuth && src.startsWith(API_BASE) ? src.slice(API_BASE.length) : src;
+
+  useEffect(() => {
+    if (!needsAuth) return;
+    let cancelled = false;
+    setFailed(false);
+    setObjectUrl(null);
+    apiFetchBlob(path)
+      .then(({ blob }) => {
+        if (cancelled) return;
+        const url = URL.createObjectURL(blob);
+        objectUrlRef.current = url;
+        setObjectUrl(url);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+  }, [path, needsAuth]);
+
+  if (!needsAuth) {
+    // objectURL/blob and dynamic download URLs can't go through next/image.
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={alt ?? ''} className={className} />;
+  }
+  if (failed) {
+    return (
+      <span className="inline-block rounded-sm border border-edge-subtle px-2 py-1 text-xs text-ink-muted">
+        图片加载失败（请先登录后重试）
+      </span>
+    );
+  }
+  return objectUrl ? (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={objectUrl} alt={alt ?? ''} className={className} />
+  ) : (
+    <span className="inline-block animate-pulse rounded-sm bg-surface-sunken px-2 py-1 text-xs text-ink-muted">
+      加载图片…
+    </span>
+  );
+}

--- a/frontend/components/chat/auth-image.tsx
+++ b/frontend/components/chat/auth-image.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { API_BASE } from '@/lib/api/config';
 import { apiFetchBlob } from '@/lib/api/transport';
 import { isProtectedDownloadUrl } from '@/lib/api/authenticated-download';
+import { toApiPath } from '@/lib/api/first-party';
 
 interface AuthImageProps {
   src: string;
@@ -26,7 +26,9 @@ export function AuthImage({ src, alt, className }: AuthImageProps) {
   const objectUrlRef = useRef<string | null>(null);
 
   const needsAuth = isProtectedDownloadUrl(src);
-  const path = needsAuth && src.startsWith(API_BASE) ? src.slice(API_BASE.length) : src;
+  // apiFetchBlob's buildRequest prepends API_BASE — hand it the origin-
+  // relative path (production builds use relative URLs with API_BASE === '').
+  const path = needsAuth ? toApiPath(src) : src;
 
   useEffect(() => {
     if (!needsAuth) return;

--- a/frontend/components/chat/mini-md.test.tsx
+++ b/frontend/components/chat/mini-md.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { API_BASE } from '@/lib/api/config';
+import MiniMd from './mini-md';
+
+/**
+ * #515 regression: chat-embedded export links/images point at protected
+ * download routes that only accept `Authorization: Bearer`. A bare `<a>` /
+ * `<img>` is a browser-native request → hard 401. MiniMd must intercept
+ * protected links (auth blob download) and images (blob → object URL).
+ */
+const downloadWithAuthMock = vi.fn();
+vi.mock('@/lib/api/authenticated-download', () => ({
+  isProtectedDownloadUrl: (url: string) =>
+    typeof url === 'string' && url.includes('/api/v1/export/download/'),
+  downloadWithAuth: (...args: unknown[]) => downloadWithAuthMock(...args),
+}));
+
+const apiFetchBlobMock = vi.fn();
+vi.mock('@/lib/api/transport', () => ({
+  apiFetchBlob: (...args: unknown[]) => apiFetchBlobMock(...args),
+}));
+
+const exportUrl = (name: string) => `${API_BASE}/api/v1/export/download/${name}`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiFetchBlobMock.mockReset();
+  apiFetchBlobMock.mockResolvedValue({ blob: new Blob(['img'], { type: 'image/png' }), filename: null });
+});
+
+describe('MiniMd protected download handling (#515)', () => {
+  it('intercepts clicks on protected download links and downloads via transport', async () => {
+    downloadWithAuthMock.mockResolvedValue(undefined);
+    render(<MiniMd text={`[下载SVG](${exportUrl('map_export_1.svg')})`} />);
+
+    const link = screen.getByText('下载SVG').closest('a');
+    expect(link).not.toBeNull();
+
+    fireEvent.click(link!);
+
+    await waitFor(() => expect(downloadWithAuthMock).toHaveBeenCalledTimes(1));
+    expect(downloadWithAuthMock).toHaveBeenCalledWith(exportUrl('map_export_1.svg'));
+  });
+
+  it('does not intercept ordinary external links', () => {
+    render(<MiniMd text={`[官网](https://example.com)`} />);
+    const link = screen.getByText('官网').closest('a');
+    expect(link).not.toBeNull();
+    fireEvent.click(link!);
+    expect(downloadWithAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('renders protected images from an authenticated blob (object URL)', async () => {
+    const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:img-1');
+    render(<MiniMd text={`![地图](${exportUrl('map_export_2.png')})`} />);
+
+    await waitFor(() => expect(apiFetchBlobMock).toHaveBeenCalledTimes(1));
+    expect(apiFetchBlobMock).toHaveBeenCalledWith('/api/v1/export/download/map_export_2.png');
+
+    const img = screen.getByRole('img', { name: '地图' }) as HTMLImageElement;
+    expect(img.src).toContain('blob:img-1');
+    createSpy.mockRestore();
+  });
+
+  it('renders plain img for non-protected image URLs', () => {
+    render(<MiniMd text={`![图标](https://example.com/icon.png)`} />);
+    const img = screen.getByRole('img', { name: '图标' }) as HTMLImageElement;
+    expect(img.src).toContain('https://example.com/icon.png');
+    expect(apiFetchBlobMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/components/chat/mini-md.test.tsx
+++ b/frontend/components/chat/mini-md.test.tsx
@@ -16,6 +16,17 @@ vi.mock('@/lib/api/authenticated-download', () => ({
   downloadWithAuth: (...args: unknown[]) => downloadWithAuthMock(...args),
 }));
 
+// AuthImage imports the URL guards from first-party (shared with tile-auth).
+vi.mock('@/lib/api/first-party', () => ({
+  isFirstPartyUrl: (url: string) => typeof url === 'string' && !url.startsWith('https://'),
+  toApiPath: (url: string) => {
+    const u = new URL(url, 'http://localhost:8000');
+    return u.pathname + u.search;
+  },
+  isProtectedDownloadUrl: (url: string) =>
+    typeof url === 'string' && url.includes('/api/v1/export/download/'),
+}));
+
 const apiFetchBlobMock = vi.fn();
 vi.mock('@/lib/api/transport', () => ({
   apiFetchBlob: (...args: unknown[]) => apiFetchBlobMock(...args),

--- a/frontend/components/chat/mini-md.tsx
+++ b/frontend/components/chat/mini-md.tsx
@@ -3,6 +3,9 @@
 import React from 'react';
 import ReactMarkdown, { type UrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { downloadWithAuth, isProtectedDownloadUrl } from '@/lib/api/authenticated-download';
+import { devOnly } from '@/lib/utils/logger';
+import { AuthImage } from './auth-image';
 
 interface MiniMdProps {
   text: string;
@@ -82,12 +85,39 @@ export default function MiniMd({ text }: MiniMdProps) {
               properties: {},
               children: [],
             });
+            // #515: 导出/报告下载链接是受保护路由，裸 <a target=_blank>
+            // 打开的新标签页无法携带 Bearer → 恒 401。拦截点击，改走
+            // transport 的鉴权 blob 下载。
+            const protectedHref = typeof safeHref === 'string' && isProtectedDownloadUrl(safeHref)
+              ? safeHref
+              : null;
+            if (protectedHref) {
+              return (
+                <a
+                  href={safeHref ?? undefined}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-status-accent underline hover:text-status-accent"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    downloadWithAuth(protectedHref).catch((err) => {
+                      devOnly.warn('[MiniMd] 鉴权下载失败:', err);
+                    });
+                  }}
+                >
+                  {children}
+                </a>
+              );
+            }
             return (
               <a href={safeHref ?? undefined} target="_blank" rel="noopener noreferrer" className="text-status-accent underline hover:text-status-accent">
                 {children}
               </a>
             );
           },
+          img: ({ src, alt }) => (
+            <AuthImage src={src ?? ''} alt={alt ?? ''} className="max-w-full h-auto my-2 rounded-md" />
+          ),
           table: ({ children }) => (
             <div className="overflow-x-auto my-2 rounded-md border border-edge-subtle">
               <table className="w-full text-body">{children}</table>

--- a/frontend/components/explorer/explorer-progress-panel.tsx
+++ b/frontend/components/explorer/explorer-progress-panel.tsx
@@ -11,17 +11,19 @@ const STAGE_LABELS: Record<string, string> = {
   validate: "质量验证",
 };
 
+// #518: 原实现用 text-white/* 等暗色玻璃样式，浅色主题下文字几乎不可读。
+// 改为主题 token（ink/status-*），深浅主题都自适应。
 const STATUS_COLORS: Record<ExplorerStatus, string> = {
-  idle: "text-gray-400",
-  discovering: "text-blue-400",
-  fetching: "text-blue-400",
-  parsing: "text-blue-400",
-  geocoding: "text-blue-400",
-  validating: "text-blue-400",
-  decision_required: "text-yellow-400",
-  completed: "text-green-400",
-  failed: "text-red-400",
-  aborted: "text-gray-400",
+  idle: "text-status-neutral",
+  discovering: "text-status-info",
+  fetching: "text-status-info",
+  parsing: "text-status-info",
+  geocoding: "text-status-info",
+  validating: "text-status-info",
+  decision_required: "text-status-warning",
+  completed: "text-status-success",
+  failed: "text-status-critical",
+  aborted: "text-status-neutral",
 };
 
 function TaskCard({ task }: { task: ExplorerTask }) {
@@ -29,9 +31,9 @@ function TaskCard({ task }: { task: ExplorerTask }) {
   const stageLabel = STAGE_LABELS[task.stage] || task.stage;
 
   return (
-    <div className="rounded-lg border border-white/10 bg-white/5 p-3 backdrop-blur-sm">
+    <div className="rounded-lg border border-edge-subtle bg-surface-sunken p-3">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-white/90">{task.query}</span>
+        <span className="text-sm font-medium text-ink">{task.query}</span>
         <span className={`text-xs ${STATUS_COLORS[task.status]}`}>
           {task.status === "completed" ? "完成" :
            task.status === "failed" ? "失败" :
@@ -43,7 +45,7 @@ function TaskCard({ task }: { task: ExplorerTask }) {
       {task.status !== "completed" && task.status !== "failed" && (
         <div className="mt-2">
           <div
-            className="h-1.5 rounded-full bg-white/10 overflow-hidden"
+            className="h-1.5 rounded-full bg-status-neutral-soft overflow-hidden"
             role="progressbar"
             aria-valuenow={progress}
             aria-valuemin={0}
@@ -51,11 +53,11 @@ function TaskCard({ task }: { task: ExplorerTask }) {
             aria-label={`${stageLabel} 进度`}
           >
             <div
-              className="h-1.5 rounded-full bg-blue-400 transition-all duration-500"
+              className="h-1.5 rounded-full bg-status-info transition-all duration-500"
               style={{ width: `${progress}%` }}
             />
           </div>
-          <div className="mt-1 flex justify-between text-xs text-white/50">
+          <div className="mt-1 flex justify-between text-xs text-ink-muted">
             <span>{stageLabel}</span>
             <span>{progress}%</span>
           </div>
@@ -63,14 +65,14 @@ function TaskCard({ task }: { task: ExplorerTask }) {
       )}
 
       {task.rowCount !== undefined && task.status === "completed" && (
-        <div className="mt-2 text-xs text-white/60">
+        <div className="mt-2 text-xs text-ink-muted">
           共 {task.rowCount} 条数据
           {task.successRate !== undefined && ` · 编码成功率 ${(task.successRate * 100).toFixed(0)}%`}
         </div>
       )}
 
       {task.error && (
-        <div className="mt-2 text-xs text-red-400">{task.error}</div>
+        <div className="mt-2 text-xs text-status-critical">{task.error}</div>
       )}
     </div>
   );
@@ -83,7 +85,7 @@ export function ExplorerProgressPanel() {
 
   return (
     <div className="space-y-2">
-      <h3 className="text-xs font-semibold uppercase tracking-wider text-white/40">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-ink-disabled">
         深度搜索
       </h3>
       {tasks.map((task) => (

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -34,6 +34,14 @@ interface MapPanelProps {
   onViewportChange?: (center: [number, number], zoom: number, bearing: number, pitch: number) => void
   sessionId?: string | null
   ownerToken?: string | null
+  /**
+   * SEC-08 anonymous owner_token source (stable ref, read LIVE per request).
+   * The token arrives via SSE after the map is constructed and @vis.gl/
+   * react-maplibre never re-applies transformRequest on prop change, so the
+   * transformRequest closure must read the ref's current value instead of
+   * capturing a snapshot.
+   */
+  sessionTokenRef?: React.MutableRefObject<string | null>
 }
 
 import { useMapAction } from "@/lib/contexts/map-action-context"
@@ -83,6 +91,7 @@ export function MapPanel({
   onViewportChange,
   sessionId,
   ownerToken,
+  sessionTokenRef,
 }: MapPanelProps) {
   void _onRemoveLayer;
   void _onToggleLayer;
@@ -114,10 +123,13 @@ export function MapPanel({
   // #514: MapLibre tile/image fetches are browser-native and cannot carry
   // headers on their own — inject the same credentials apiFetch sends
   // (Bearer for logged-in, X-Session-Token for anonymous owner_token).
+  // The owner_token is read LIVE per request from the stable sessionTokenRef
+  // (SSE owner_token arrival + session switch must take effect without a
+  // MapLibre transformRequest re-apply).
   const transformRequest = useCallback(
     (url: string, resourceType?: string) =>
-      buildTileTransformRequest(ownerToken ?? null)(url, resourceType),
-    [ownerToken],
+      buildTileTransformRequest(() => sessionTokenRef?.current ?? ownerToken ?? null)(url, resourceType),
+    [ownerToken, sessionTokenRef],
   )
 
   const handleFilterChange = useCallback((layerId: string, ranges: number[][]) => {

--- a/frontend/components/map/map-panel.tsx
+++ b/frontend/components/map/map-panel.tsx
@@ -25,6 +25,7 @@ import {
 import { raiseAnnotationLayers } from "@/lib/map-commands/annotationHelpers"
 import { notifyUserGestureStart, notifyUserGestureEnd } from "@/lib/map-commands/camera-arbitration"
 import { devOnly } from "@/lib/utils/logger"
+import { buildTileTransformRequest } from "@/lib/map-kit/tile-auth"
 
 interface MapPanelProps {
   layers: Layer[]
@@ -108,6 +109,15 @@ export function MapPanel({
   const currentMapStyle = useMemo(
     () => getMapStyle(MAP_STYLES[selectedBaseLayer], selectedBaseLayer),
     [selectedBaseLayer]
+  )
+
+  // #514: MapLibre tile/image fetches are browser-native and cannot carry
+  // headers on their own — inject the same credentials apiFetch sends
+  // (Bearer for logged-in, X-Session-Token for anonymous owner_token).
+  const transformRequest = useCallback(
+    (url: string, resourceType?: string) =>
+      buildTileTransformRequest(ownerToken ?? null)(url, resourceType),
+    [ownerToken],
   )
 
   const handleFilterChange = useCallback((layerId: string, ranges: number[][]) => {
@@ -805,6 +815,7 @@ export function MapPanel({
         style={{ position: "absolute", inset: 0 }}
         mapStyle={currentMapStyle}
         attributionControl={false}
+        transformRequest={transformRequest}
         {...({ preserveDrawingBuffer: true } as any)}
       >
         <MapActionHandler />

--- a/frontend/components/report/report-generator.tsx
+++ b/frontend/components/report/report-generator.tsx
@@ -145,10 +145,11 @@ export function ReportGenerator({ sessionId, onReportGenerated }: ReportGenerato
 
           <div className="flex gap-2">
             <a
-              href={getReportDownloadUrl(report.id)}
+              // #515: href 指向受保护下载端点，保留 href 会让中键/Ctrl+点击
+              // 绕过鉴权导航到 401 —— 去掉 href，只走鉴权 blob 下载。
               target="_blank"
               rel="noopener noreferrer"
-              className="flex-1 flex items-center justify-center gap-2 rounded-lg bg-green-600 text-white py-2 text-sm font-medium hover:bg-green-700 transition-colors"
+              className="flex-1 flex cursor-pointer items-center justify-center gap-2 rounded-lg bg-green-600 text-white py-2 text-sm font-medium hover:bg-green-700 transition-colors"
               onClick={(e) => {
                 e.preventDefault();
                 handleDownloadReport();

--- a/frontend/components/report/report-generator.tsx
+++ b/frontend/components/report/report-generator.tsx
@@ -9,6 +9,8 @@ import { useState } from "react";
 import { FileText, Download, Share2, Loader2, CheckCircle, XCircle } from "lucide-react";
 import type { ReportFormat, ReportInfo } from "@/lib/types/report";
 import { generateReport, getReportDownloadUrl, createShareLink } from "@/lib/api/report";
+import { downloadWithAuth } from "@/lib/api/authenticated-download";
+import { devOnly } from "@/lib/utils/logger";
 
 interface ReportGeneratorProps {
   sessionId: string | null;
@@ -49,6 +51,17 @@ export function ReportGenerator({ sessionId, onReportGenerated }: ReportGenerato
       setError(err instanceof Error ? err.message : "报告生成失败，请重试");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleDownloadReport = async () => {
+    if (!report) return;
+    // #515: /api/v1/reports/{id}/download 只认 Bearer，裸 <a target=_blank>
+    // 的新标签页无法携带 header → 恒 401。改走 transport 鉴权 blob 下载。
+    try {
+      await downloadWithAuth(getReportDownloadUrl(report.id));
+    } catch (err) {
+      devOnly.warn('[ReportGenerator] 报告下载失败:', err);
     }
   };
 
@@ -136,6 +149,10 @@ export function ReportGenerator({ sessionId, onReportGenerated }: ReportGenerato
               target="_blank"
               rel="noopener noreferrer"
               className="flex-1 flex items-center justify-center gap-2 rounded-lg bg-green-600 text-white py-2 text-sm font-medium hover:bg-green-700 transition-colors"
+              onClick={(e) => {
+                e.preventDefault();
+                handleDownloadReport();
+              }}
             >
               <Download className="h-4 w-4" />
               下载报告

--- a/frontend/components/report/report-preview.test.tsx
+++ b/frontend/components/report/report-preview.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { ReportPreview } from './report-preview'
 
@@ -7,6 +7,22 @@ vi.mock('@/lib/api/report', () => ({
   getReportDownloadUrl: vi.fn(() => 'http://localhost:8000/api/v1/reports/test-id/download'),
   getSharedReportUrl: vi.fn((code: string) => `http://localhost:8000/api/v1/reports/shared/${code}`),
 }))
+
+// #515: the HTML preview now fetches the report blob through the transport
+// (iframe src must carry Bearer → object URL). Stub it in tests.
+const apiFetchBlobMock = vi.fn()
+vi.mock('@/lib/api/transport', () => ({
+  apiFetchBlob: (...args: unknown[]) => apiFetchBlobMock(...args),
+}))
+
+function htmlBlob(): Blob {
+  return new Blob(['<html><body>report</body></html>'], { type: 'text/html' })
+}
+
+beforeEach(() => {
+  apiFetchBlobMock.mockReset()
+  apiFetchBlobMock.mockResolvedValue({ blob: htmlBlob(), filename: 'report_test.html' })
+})
 
 describe('ReportPreview', () => {
   it('shows empty state when no report', () => {
@@ -42,7 +58,7 @@ describe('ReportPreview', () => {
     expect(screen.getByText('下载查看')).toBeInTheDocument()
   })
 
-  it('shows iframe for HTML format', () => {
+  it('shows iframe for HTML format', async () => {
     const report = {
       id: 'test-id',
       session_id: 'session-1',
@@ -53,6 +69,10 @@ describe('ReportPreview', () => {
       created_at: new Date().toISOString(),
     }
     render(<ReportPreview report={report} />)
-    expect(screen.getByTitle('报告预览')).toBeInTheDocument()
+    // 等待 blob 拉取完成并渲染出 iframe（objectURL 驱动）。
+    await screen.findByTitle('报告预览')
+    expect(apiFetchBlobMock).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/reports/test-id/download'
+    )
   })
 })

--- a/frontend/components/report/report-preview.test.tsx
+++ b/frontend/components/report/report-preview.test.tsx
@@ -4,7 +4,7 @@ import { ReportPreview } from './report-preview'
 
 // Mock the API functions
 vi.mock('@/lib/api/report', () => ({
-  getReportDownloadUrl: vi.fn(() => 'http://localhost:8000/api/v1/reports/test-id/download'),
+  getReportDownloadUrl: vi.fn(),
   getSharedReportUrl: vi.fn((code: string) => `http://localhost:8000/api/v1/reports/shared/${code}`),
 }))
 
@@ -15,13 +15,29 @@ vi.mock('@/lib/api/transport', () => ({
   apiFetchBlob: (...args: unknown[]) => apiFetchBlobMock(...args),
 }))
 
+import { getReportDownloadUrl } from '@/lib/api/report'
+const getReportDownloadUrlMock = vi.mocked(getReportDownloadUrl)
+
 function htmlBlob(): Blob {
   return new Blob(['<html><body>report</body></html>'], { type: 'text/html' })
+}
+
+function htmlReport() {
+  return {
+    id: 'test-id',
+    session_id: 'session-1',
+    title: 'Test Report',
+    format: 'html' as const,
+    status: 'completed' as const,
+    download_url: '/api/v1/reports/test-id/download',
+    created_at: new Date().toISOString(),
+  }
 }
 
 beforeEach(() => {
   apiFetchBlobMock.mockReset()
   apiFetchBlobMock.mockResolvedValue({ blob: htmlBlob(), filename: 'report_test.html' })
+  getReportDownloadUrlMock.mockReset()
 })
 
 describe('ReportPreview', () => {
@@ -58,21 +74,32 @@ describe('ReportPreview', () => {
     expect(screen.getByText('下载查看')).toBeInTheDocument()
   })
 
-  it('shows iframe for HTML format', async () => {
-    const report = {
-      id: 'test-id',
-      session_id: 'session-1',
-      title: 'Test Report',
-      format: 'html' as const,
-      status: 'completed' as const,
-      download_url: '/api/v1/reports/test-id/download',
-      created_at: new Date().toISOString(),
-    }
+  it('shows iframe for HTML format — absolute dev URL is stripped to the relative path', async () => {
+    // Dev shape: getReportDownloadUrl returns an absolute URL under API_BASE.
+    // apiFetchBlob's buildRequest prepends API_BASE, so the component must
+    // hand it the origin-relative path — an absolute URL would double-prefix
+    // (API_BASE + absolute URL) and 404/blank the iframe.
+    getReportDownloadUrlMock.mockReturnValue('http://localhost:8001/api/v1/reports/test-id/download')
+    const report = htmlReport()
+
     render(<ReportPreview report={report} />)
-    // 等待 blob 拉取完成并渲染出 iframe（objectURL 驱动）。
     await screen.findByTitle('报告预览')
-    expect(apiFetchBlobMock).toHaveBeenCalledWith(
-      'http://localhost:8000/api/v1/reports/test-id/download'
-    )
+
+    expect(apiFetchBlobMock).toHaveBeenCalledWith('/api/v1/reports/test-id/download')
+    const arg = apiFetchBlobMock.mock.calls[0][0]
+    expect(arg).not.toContain('http://')
+    expect(arg).not.toMatch(/^\/\/api\//)
+  })
+
+  it('shows iframe for HTML format — production relative URL passes through unchanged', async () => {
+    // Prod shape: NEXT_PUBLIC_API_URL="" → getReportDownloadUrl is a relative
+    // same-origin path; it must reach apiFetchBlob without an origin prefix.
+    getReportDownloadUrlMock.mockReturnValue('/api/v1/reports/test-id/download')
+    const report = htmlReport()
+
+    render(<ReportPreview report={report} />)
+    await screen.findByTitle('报告预览')
+
+    expect(apiFetchBlobMock).toHaveBeenCalledWith('/api/v1/reports/test-id/download')
   })
 })

--- a/frontend/components/report/report-preview.tsx
+++ b/frontend/components/report/report-preview.tsx
@@ -10,6 +10,7 @@ import { FileText, ExternalLink, Loader2 } from "lucide-react";
 import type { ReportInfo } from "@/lib/types/report";
 import { getReportDownloadUrl, getSharedReportUrl } from "@/lib/api/report";
 import { apiFetchBlob } from "@/lib/api/transport";
+import { toApiPath } from "@/lib/api/first-party";
 import { downloadWithAuth } from "@/lib/api/authenticated-download";
 import { devOnly } from "@/lib/utils/logger";
 
@@ -40,8 +41,10 @@ export function ReportPreview({ report, shareCode }: ReportPreviewProps) {
         // #515: /api/v1/reports/{id}/download 只认 Bearer，iframe 的
         // 原生请求无法携带 header → 恒 401 白屏。先经 transport 取
         // blob（含鉴权/401 刷新），再以 objectURL 喂给 iframe。
+        // buildRequest 会前置 API_BASE —— 必须传 origin-relative path，
+        // 绝对 URL 会双前缀（API_BASE + 绝对 URL）导致 404/白屏。
         setLoading(true);
-        apiFetchBlob(getReportDownloadUrl(report.id))
+        apiFetchBlob(toApiPath(getReportDownloadUrl(report.id)))
           .then(({ blob }) => {
             if (cancelled) return;
             objectUrl = URL.createObjectURL(blob);

--- a/frontend/components/report/report-preview.tsx
+++ b/frontend/components/report/report-preview.tsx
@@ -9,6 +9,9 @@ import { useState, useEffect } from "react";
 import { FileText, ExternalLink, Loader2 } from "lucide-react";
 import type { ReportInfo } from "@/lib/types/report";
 import { getReportDownloadUrl, getSharedReportUrl } from "@/lib/api/report";
+import { apiFetchBlob } from "@/lib/api/transport";
+import { downloadWithAuth } from "@/lib/api/authenticated-download";
+import { devOnly } from "@/lib/utils/logger";
 
 interface ReportPreviewProps {
   report: ReportInfo | null;
@@ -20,17 +23,47 @@ export function ReportPreview({ report, shareCode }: ReportPreviewProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    const cleanup = () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+        objectUrl = null;
+      }
+    };
+
     if (shareCode) {
+      // 分享链路走公共通道（无鉴权），iframe 可直接加载。
       setPreviewUrl(getSharedReportUrl(shareCode));
     } else if (report && report.status === "completed") {
       if (report.format === "html") {
-        setPreviewUrl(getReportDownloadUrl(report.id));
+        // #515: /api/v1/reports/{id}/download 只认 Bearer，iframe 的
+        // 原生请求无法携带 header → 恒 401 白屏。先经 transport 取
+        // blob（含鉴权/401 刷新），再以 objectURL 喂给 iframe。
+        setLoading(true);
+        apiFetchBlob(getReportDownloadUrl(report.id))
+          .then(({ blob }) => {
+            if (cancelled) return;
+            objectUrl = URL.createObjectURL(blob);
+            setPreviewUrl(objectUrl);
+          })
+          .catch((err) => {
+            devOnly.warn('[ReportPreview] 报告预览加载失败:', err);
+            if (!cancelled) setPreviewUrl(null);
+          })
+          .finally(() => {
+            if (!cancelled) setLoading(false);
+          });
       } else {
         setPreviewUrl(null);
       }
     } else {
       setPreviewUrl(null);
     }
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
   }, [report, shareCode]);
 
   if (!report && !shareCode) {
@@ -63,6 +96,13 @@ export function ReportPreview({ report, shareCode }: ReportPreviewProps) {
           target="_blank"
           rel="noopener noreferrer"
           className="mt-4 flex items-center gap-2 text-primary hover:underline text-sm"
+          onClick={(e) => {
+            // #515: 下载端点只认 Bearer，裸 <a> 导航无法携带 → 401。
+            e.preventDefault();
+            downloadWithAuth(getReportDownloadUrl(report.id)).catch((err) => {
+              devOnly.warn('[ReportPreview] 报告下载失败:', err);
+            });
+          }}
         >
           <ExternalLink className="h-4 w-4" />
           下载查看

--- a/frontend/components/sidebar/chat-tab.render-scope.test.tsx
+++ b/frontend/components/sidebar/chat-tab.render-scope.test.tsx
@@ -110,8 +110,14 @@ describe('ChatTab render scope (D-F8)', () => {
     const { rerender } = renderWithStore(tree);
 
     // Settle: dynamic MiniMd resolves; `mounted` effect flips. Only priorMsg
-    // has non-empty content at mount → exactly one markdown parse.
-    await waitFor(() => expect(document.querySelectorAll('[data-testid="mini-md"]')).toHaveLength(1));
+    // has non-empty content at mount → exactly one markdown parse. Explicit
+    // generous timeout: mini-md's import graph grew (#515 auth download
+    // helpers), so under parallel test load resolution can exceed the 1s
+    // default waitFor window — the settle must not race the count below.
+    await waitFor(
+      () => expect(document.querySelectorAll('[data-testid="mini-md"]')).toHaveLength(1),
+      { timeout: 5000 },
+    );
     await act(async () => {});
     md.count = 0;
     md.texts = [];

--- a/frontend/components/sidebar/map-studio-tab.tsx
+++ b/frontend/components/sidebar/map-studio-tab.tsx
@@ -6,6 +6,7 @@ import type { ExportItem, ExportSettings } from '@/lib/store/hud-types';
 import { useMapAction } from '@/lib/contexts/map-action-context';
 import { Download, Printer, History, ChevronDown, Lock } from 'lucide-react';
 import { API_BASE } from '@/lib/api/config';
+import { downloadWithAuth } from '@/lib/api/authenticated-download';
 import { getAuthUser, subscribeAuth } from '@/lib/auth/tokenStore';
 import { IconButton } from '@/components/shared/icon-button';
 import { ConfirmAction } from '@/components/shared/confirm-action';
@@ -141,7 +142,7 @@ export function MapStudioTab() {
     };
   }, [activeSubTab, leftPanelOpen, updateExportSettings]);
 
-  const handleDownload = (item: ExportItem) => {
+  const handleDownload = async (item: ExportItem) => {
     // 审计 F37：downloadName 来自后端响应，但防御性校验路径穿越/特殊字符。
     // 只允许字母数字 + . _ -，拒绝 ../ ? # 等。
     const downloadName = item.filename || item.name;
@@ -149,10 +150,17 @@ export function MapStudioTab() {
       devOnly.warn('[MapStudioTab] 拒绝非法 download filename:', downloadName);
       return;
     }
-    const a = document.createElement('a');
-    a.href = `${API_BASE}/api/v1/export/download/${encodeURIComponent(downloadName)}`;
-    a.download = downloadName;
-    a.click();
+    // #515: 下载端点只认 Bearer；裸 <a> 导航无法携带 header → 恒 401。
+    // 改走 transport 的鉴权 blob 下载（含 401 刷新），文件名以后端
+    // Content-Disposition 为准，fallback 到校验过的 downloadName。
+    try {
+      await downloadWithAuth(
+        `${API_BASE}/api/v1/export/download/${encodeURIComponent(downloadName)}`,
+        { filename: downloadName },
+      );
+    } catch (err) {
+      devOnly.warn('[MapStudioTab] 导出下载失败:', err);
+    }
   };
 
   const handleDelete = (id: string) => {

--- a/frontend/lib/api/authenticated-download.test.ts
+++ b/frontend/lib/api/authenticated-download.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { API_BASE } from './config';
 import {
   isProtectedDownloadUrl,
   filenameFromUrl,
   downloadWithAuth,
 } from './authenticated-download';
+import { isFirstPartyUrl, toApiPath } from './first-party';
 
 // #515 regression: bare <a href> navigation / <img src> on the export and
 // report download routes can never attach the Bearer header → hard 401.
@@ -14,35 +14,91 @@ vi.mock('./transport', () => ({
   apiFetchBlob: (...args: unknown[]) => apiFetchBlobMock(...args),
 }));
 
+// API_BASE is '' in production and an absolute origin in dev.
+let mockApiBase = 'http://localhost:8001';
+vi.mock('./config', () => ({
+  get API_BASE() {
+    return mockApiBase;
+  },
+}));
+
 function exportUrl(name: string): string {
-  return `${API_BASE}/api/v1/export/download/${name}`;
+  return `${mockApiBase}/api/v1/export/download/${name}`;
 }
+
+describe('toApiPath', () => {
+  it('strips an absolute URL to its origin-relative path + query', () => {
+    expect(toApiPath('http://localhost:8001/api/v1/export/download/a.png?x=1')).toBe(
+      '/api/v1/export/download/a.png?x=1'
+    );
+    expect(toApiPath('http://localhost:8001/api/v1/export/download/a.png')).toBe(
+      '/api/v1/export/download/a.png'
+    );
+  });
+
+  it('passes relative URLs through unchanged', () => {
+    expect(toApiPath('/api/v1/export/download/a.png')).toBe('/api/v1/export/download/a.png');
+    expect(toApiPath('/api/v1/reports/r1/download')).toBe('/api/v1/reports/r1/download');
+  });
+});
+
+describe('isFirstPartyUrl', () => {
+  it('accepts same-origin absolute URLs when a base is configured', () => {
+    mockApiBase = 'http://localhost:8001';
+    expect(isFirstPartyUrl('http://localhost:8001/api/v1/export/download/a.png')).toBe(true);
+  });
+
+  it('rejects hosts that merely share the base origin as a prefix', () => {
+    mockApiBase = 'http://api.example.com';
+    expect(isFirstPartyUrl('http://api.example.com.evil.com/api/v1/x')).toBe(false);
+    expect(isFirstPartyUrl('http://api.example.com/api/v1/x')).toBe(true);
+  });
+
+  it('accepts relative paths when API_BASE is empty (production)', () => {
+    mockApiBase = '';
+    expect(isFirstPartyUrl('/api/v1/export/download/a.png')).toBe(true);
+    // protocol-relative URLs are absolute — never treated as first-party
+    expect(isFirstPartyUrl('//evil.example.com/api/v1/export/download/a.png')).toBe(false);
+  });
+});
 
 describe('isProtectedDownloadUrl', () => {
   it('matches export download URLs', () => {
+    mockApiBase = 'http://localhost:8001';
     expect(isProtectedDownloadUrl(exportUrl('map_export_abc123.png'))).toBe(true);
   });
 
   it('matches report download URLs', () => {
-    expect(isProtectedDownloadUrl(`${API_BASE}/api/v1/reports/report-id/download`)).toBe(true);
+    expect(isProtectedDownloadUrl('http://localhost:8001/api/v1/reports/report-id/download')).toBe(true);
   });
 
-  it('rejects third-party / non-download URLs', () => {
+  it('matches relative protected paths in the production build (API_BASE === "")', () => {
+    mockApiBase = '';
+    expect(isProtectedDownloadUrl('/api/v1/export/download/map_export_1.png')).toBe(true);
+    expect(isProtectedDownloadUrl('/api/v1/reports/report-id/download')).toBe(true);
+    // Relative but not a protected route
+    expect(isProtectedDownloadUrl('/api/v1/export')).toBe(false);
+    expect(isProtectedDownloadUrl('/api/v1/reports/report-id')).toBe(false);
+  });
+
+  it('rejects third-party / foreign-origin URLs even with a protected-looking path', () => {
+    mockApiBase = 'http://localhost:8001';
     expect(isProtectedDownloadUrl('https://tile.openstreetmap.org/1/2/3.png')).toBe(false);
-    expect(isProtectedDownloadUrl(`${API_BASE}/api/v1/export`)).toBe(false);
-    expect(isProtectedDownloadUrl(`${API_BASE}/api/v1/export/download/`)).toBe(true); // still the download path
+    expect(isProtectedDownloadUrl('https://evil.example/api/v1/export/download/x.png')).toBe(false);
+    expect(isProtectedDownloadUrl('//evil.example/api/v1/export/download/x.png')).toBe(false);
     expect(isProtectedDownloadUrl('')).toBe(false);
   });
 
-  it('rejects URLs outside API_BASE even with a download-looking path', () => {
-    expect(isProtectedDownloadUrl('https://evil.example/api/v1/export/download/x.png')).toBe(false);
+  it('rejects prefix-impersonation hosts', () => {
+    mockApiBase = 'http://api.example.com';
+    expect(isProtectedDownloadUrl('http://api.example.com.evil.com/api/v1/export/download/x.png')).toBe(false);
   });
 });
 
 describe('filenameFromUrl', () => {
   it('extracts the last path segment', () => {
     expect(filenameFromUrl(exportUrl('a.png'))).toBe('a.png');
-    expect(filenameFromUrl(`${API_BASE}/api/v1/reports/rep-1/download`)).toBe('download');
+    expect(filenameFromUrl('http://localhost:8001/api/v1/reports/rep-1/download')).toBe('download');
   });
 
   it('strips query strings and decodes', () => {
@@ -56,9 +112,8 @@ describe('downloadWithAuth', () => {
     apiFetchBlobMock.mockResolvedValue({ blob: new Blob(['data']), filename: null });
   });
 
-  it('fetches the blob through the transport and triggers a browser download', async () => {
-    const url = exportUrl('map_export_1.png');
-    // Capture the anchor the trigger creates so we can assert its attributes.
+  it('fetches the blob through the transport with the origin-relative path', async () => {
+    mockApiBase = 'http://localhost:8001';
     let captured: HTMLAnchorElement | null = null;
     const appendSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(((el: any) => {
       captured = el;
@@ -68,10 +123,10 @@ describe('downloadWithAuth', () => {
     const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-1');
     const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
 
-    await downloadWithAuth(url);
+    await downloadWithAuth(exportUrl('map_export_1.png'));
 
-    // transport called with the path (API_BASE stripped) + auth options
-    expect(apiFetchBlobMock).toHaveBeenCalledWith(`/api/v1/export/download/map_export_1.png`, expect.anything());
+    // transport called with the origin-relative path (buildRequest prepends API_BASE)
+    expect(apiFetchBlobMock).toHaveBeenCalledWith('/api/v1/export/download/map_export_1.png', expect.anything());
     expect(createSpy).toHaveBeenCalled();
     expect(revokeSpy).toHaveBeenCalled();
     expect(captured).not.toBeNull();
@@ -84,12 +139,19 @@ describe('downloadWithAuth', () => {
     revokeSpy.mockRestore();
   });
 
+  it('downloads relative URLs unchanged in the production build', async () => {
+    mockApiBase = '';
+    await downloadWithAuth('/api/v1/export/download/map_export_1.png');
+    expect(apiFetchBlobMock).toHaveBeenCalledWith('/api/v1/export/download/map_export_1.png', expect.anything());
+  });
+
   it('uses the Content-Disposition filename when the server provides one', async () => {
     apiFetchBlobMock.mockResolvedValue({
       blob: new Blob(['data']),
       filename: 'server-name.pdf',
     });
     let downloadAttr: string | null = null;
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-2');
     vi.spyOn(document.body, 'appendChild').mockImplementation(((a: any) => {
       downloadAttr = a.download ?? null;
       return a;

--- a/frontend/lib/api/authenticated-download.test.ts
+++ b/frontend/lib/api/authenticated-download.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { API_BASE } from './config';
+import {
+  isProtectedDownloadUrl,
+  filenameFromUrl,
+  downloadWithAuth,
+} from './authenticated-download';
+
+// #515 regression: bare <a href> navigation / <img src> on the export and
+// report download routes can never attach the Bearer header → hard 401.
+// These helpers route the fetch through the transport (auth + 401 refresh).
+const apiFetchBlobMock = vi.fn();
+vi.mock('./transport', () => ({
+  apiFetchBlob: (...args: unknown[]) => apiFetchBlobMock(...args),
+}));
+
+function exportUrl(name: string): string {
+  return `${API_BASE}/api/v1/export/download/${name}`;
+}
+
+describe('isProtectedDownloadUrl', () => {
+  it('matches export download URLs', () => {
+    expect(isProtectedDownloadUrl(exportUrl('map_export_abc123.png'))).toBe(true);
+  });
+
+  it('matches report download URLs', () => {
+    expect(isProtectedDownloadUrl(`${API_BASE}/api/v1/reports/report-id/download`)).toBe(true);
+  });
+
+  it('rejects third-party / non-download URLs', () => {
+    expect(isProtectedDownloadUrl('https://tile.openstreetmap.org/1/2/3.png')).toBe(false);
+    expect(isProtectedDownloadUrl(`${API_BASE}/api/v1/export`)).toBe(false);
+    expect(isProtectedDownloadUrl(`${API_BASE}/api/v1/export/download/`)).toBe(true); // still the download path
+    expect(isProtectedDownloadUrl('')).toBe(false);
+  });
+
+  it('rejects URLs outside API_BASE even with a download-looking path', () => {
+    expect(isProtectedDownloadUrl('https://evil.example/api/v1/export/download/x.png')).toBe(false);
+  });
+});
+
+describe('filenameFromUrl', () => {
+  it('extracts the last path segment', () => {
+    expect(filenameFromUrl(exportUrl('a.png'))).toBe('a.png');
+    expect(filenameFromUrl(`${API_BASE}/api/v1/reports/rep-1/download`)).toBe('download');
+  });
+
+  it('strips query strings and decodes', () => {
+    expect(filenameFromUrl(`${exportUrl('a%20b.png')}?session_id=x`)).toBe('a b.png');
+  });
+});
+
+describe('downloadWithAuth', () => {
+  beforeEach(() => {
+    apiFetchBlobMock.mockReset();
+    apiFetchBlobMock.mockResolvedValue({ blob: new Blob(['data']), filename: null });
+  });
+
+  it('fetches the blob through the transport and triggers a browser download', async () => {
+    const url = exportUrl('map_export_1.png');
+    // Capture the anchor the trigger creates so we can assert its attributes.
+    let captured: HTMLAnchorElement | null = null;
+    const appendSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(((el: any) => {
+      captured = el;
+      return el;
+    }) as any);
+    const removeSpy = vi.spyOn(document.body, 'removeChild').mockImplementation(((el: any) => el) as any);
+    const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-1');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    await downloadWithAuth(url);
+
+    // transport called with the path (API_BASE stripped) + auth options
+    expect(apiFetchBlobMock).toHaveBeenCalledWith(`/api/v1/export/download/map_export_1.png`, expect.anything());
+    expect(createSpy).toHaveBeenCalled();
+    expect(revokeSpy).toHaveBeenCalled();
+    expect(captured).not.toBeNull();
+    expect(captured!.download).toBe('map_export_1.png');
+    expect(captured!.href).toContain('blob:mock-1');
+
+    appendSpy.mockRestore();
+    removeSpy.mockRestore();
+    createSpy.mockRestore();
+    revokeSpy.mockRestore();
+  });
+
+  it('uses the Content-Disposition filename when the server provides one', async () => {
+    apiFetchBlobMock.mockResolvedValue({
+      blob: new Blob(['data']),
+      filename: 'server-name.pdf',
+    });
+    let downloadAttr: string | null = null;
+    vi.spyOn(document.body, 'appendChild').mockImplementation(((a: any) => {
+      downloadAttr = a.download ?? null;
+      return a;
+    }) as any);
+    vi.spyOn(document.body, 'removeChild').mockImplementation(((a: any) => a) as any);
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    await downloadWithAuth(exportUrl('fallback.png'));
+    expect(downloadAttr).toBe('server-name.pdf');
+    vi.restoreAllMocks();
+  });
+
+  it('propagates transport errors (401 → caller surfaces login requirement)', async () => {
+    apiFetchBlobMock.mockRejectedValue(new Error('401'));
+    await expect(downloadWithAuth(exportUrl('x.png'))).rejects.toThrow('401');
+  });
+});

--- a/frontend/lib/api/authenticated-download.ts
+++ b/frontend/lib/api/authenticated-download.ts
@@ -1,0 +1,67 @@
+import { API_BASE } from './config';
+import { apiFetchBlob, type ApiFetchOptions } from './transport';
+
+/**
+ * Authenticated download + preview of protected file endpoints.
+ *
+ * The backend's file-download routes (the map / report route modules'
+ * `get_current_user` dependency) require `Authorization: Bearer`. A bare
+ * `<a href>` navigation or `<img src>`/`<iframe>` fetch is a browser-native
+ * request that can never attach that header, so every such link/image was a
+ * hard 401. These helpers route those fetches through the transport so the
+ * Bearer (and refresh-on-401) machinery applies — same credential channel as
+ * the upload side.
+ */
+
+/** True when `url` points at a first-party protected download route. */
+export function isProtectedDownloadUrl(url: string): boolean {
+  if (!url || !API_BASE || !url.startsWith(API_BASE)) return false;
+  const path = url.slice(API_BASE.length);
+  // /api/v1/export/download/{filename}
+  if (path.startsWith('/api/v1/export/download/')) return true;
+  // /api/v1/reports/{id}/download
+  if (/^\/api\/v1\/reports\/[^/]+\/download$/.test(path)) return true;
+  return false;
+}
+
+/** Extract a file name from a download URL path (last non-empty segment). */
+export function filenameFromUrl(url: string): string {
+  const cleaned = url.split('?')[0] ?? url;
+  const segments = cleaned.split('/').filter(Boolean);
+  const last = segments[segments.length - 1] ?? 'download';
+  return decodeURIComponent(last);
+}
+
+/**
+ * Download a protected file through the transport and trigger the browser
+ * download. The filename comes from the server's Content-Disposition when
+ * present, otherwise from the URL path, otherwise the explicit fallback.
+ */
+export async function downloadWithAuth(
+  url: string,
+  options: ApiFetchOptions & { filename?: string } = {},
+): Promise<void> {
+  const path = isProtectedDownloadUrl(url) ? url.slice(API_BASE.length) : url;
+  const { blob, filename: dispositionName } = await apiFetchBlob(path, options);
+  const finalName =
+    options.filename ??
+    dispositionName ??
+    filenameFromUrl(url);
+  triggerBlobDownload(blob, finalName);
+}
+
+/**
+ * Trigger a browser save for a Blob. Mirrors `downloadBlob` in map-kit/exporter
+ * without pulling that heavy module into the transport layer.
+ */
+export function triggerBlobDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/lib/api/authenticated-download.ts
+++ b/frontend/lib/api/authenticated-download.ts
@@ -1,5 +1,6 @@
-import { API_BASE } from './config';
-import { apiFetchBlob, type ApiFetchOptions } from './transport';
+import type { ApiFetchOptions } from './transport';
+import { apiFetchBlob } from './transport';
+import { isFirstPartyUrl, toApiPath } from './first-party';
 
 /**
  * Authenticated download + preview of protected file endpoints.
@@ -13,10 +14,7 @@ import { apiFetchBlob, type ApiFetchOptions } from './transport';
  * the upload side.
  */
 
-/** True when `url` points at a first-party protected download route. */
-export function isProtectedDownloadUrl(url: string): boolean {
-  if (!url || !API_BASE || !url.startsWith(API_BASE)) return false;
-  const path = url.slice(API_BASE.length);
+function isProtectedPath(path: string): boolean {
   // /api/v1/export/download/{filename}
   if (path.startsWith('/api/v1/export/download/')) return true;
   // /api/v1/reports/{id}/download
@@ -24,10 +22,22 @@ export function isProtectedDownloadUrl(url: string): boolean {
   return false;
 }
 
+/** True when `url` points at a first-party protected download route. */
+export function isProtectedDownloadUrl(url: string): boolean {
+  if (!url) return false;
+  if (!isFirstPartyUrl(url)) return false;
+  const clean = url.split('#')[0] ?? url;
+  const path = clean.split('?')[0] ?? clean;
+  // isFirstPartyUrl already rejected protocol-relative and foreign hosts;
+  // strip any origin so the path predicates see only the API path.
+  return isProtectedPath(toApiPath(path));
+}
+
 /** Extract a file name from a download URL path (last non-empty segment). */
 export function filenameFromUrl(url: string): string {
   const cleaned = url.split('?')[0] ?? url;
-  const segments = cleaned.split('/').filter(Boolean);
+  const path = toApiPath(cleaned);
+  const segments = path.split('/').filter(Boolean);
   const last = segments[segments.length - 1] ?? 'download';
   return decodeURIComponent(last);
 }
@@ -41,7 +51,9 @@ export async function downloadWithAuth(
   url: string,
   options: ApiFetchOptions & { filename?: string } = {},
 ): Promise<void> {
-  const path = isProtectedDownloadUrl(url) ? url.slice(API_BASE.length) : url;
+  // apiFetchBlob's buildRequest prepends API_BASE — hand it the origin-
+  // relative path, never the absolute URL (double-prefix bug).
+  const path = toApiPath(url);
   const { blob, filename: dispositionName } = await apiFetchBlob(path, options);
   const finalName =
     options.filename ??

--- a/frontend/lib/api/first-party.ts
+++ b/frontend/lib/api/first-party.ts
@@ -1,0 +1,51 @@
+import { API_BASE } from './config';
+
+/**
+ * First-party URL guard for browser-native fetches that must carry session
+ * credentials (MapLibre tiles/images, authenticated downloads).
+ *
+ * `API_BASE` is empty in production (Dockerfiles build with
+ * `NEXT_PUBLIC_API_URL=""` so the bundle uses same-origin relative URLs
+ * behind the reverse proxy) and an absolute origin in dev
+ * (`http://localhost:8001`).
+ *
+ * - `API_BASE === ''`: any same-origin relative path qualifies. Protocol-
+ *   relative URLs (`//host/...`) are absolute and MUST be rejected — the
+ *   leading `//` would otherwise match the `/` check and leak the session
+ *   token to an arbitrary host.
+ * - `API_BASE` configured: the request URL's ORIGIN must equal the base's
+ *   origin exactly (never a prefix match — `http://api.example.com.evil.com`
+ *   must not satisfy `http://api.example.com`), and its path must fall under
+ *   the base's path prefix.
+ */
+export function isFirstPartyUrl(url: string): boolean {
+  if (!url) return false;
+  if (!API_BASE) {
+    return url.startsWith('/') && !url.startsWith('//');
+  }
+  try {
+    const base = new URL(API_BASE, 'http://localhost');
+    const target = new URL(url, base);
+    return target.origin === base.origin && target.pathname.startsWith(base.pathname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reduce a (possibly absolute) URL to its origin-relative path + query, the
+ * shape `apiFetch`/`apiFetchBlob` expect (their `buildRequest` prepends
+ * `API_BASE`). Relative URLs pass through unchanged.
+ */
+export function toApiPath(url: string): string {
+  if (!url) return url;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+    try {
+      const u = new URL(url);
+      return u.pathname + u.search;
+    } catch {
+      /* fall through to the relative passthrough below */
+    }
+  }
+  return url;
+}

--- a/frontend/lib/api/transport.auth.test.ts
+++ b/frontend/lib/api/transport.auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
-import { apiFetch, ApiError } from './transport';
+import { apiFetch, apiFetchBlob, ApiError } from './transport';
 import { setAuth, clearAuth, getAccessToken } from '../auth/tokenStore';
 import { installInMemoryLocalStorage } from '../../test/in-memory-local-storage';
 
@@ -154,5 +154,55 @@ describe('transport auth (Bearer attach + 401 recovery)', () => {
     const err = (await apiFetch('/x').catch((e: unknown) => e)) as ApiError;
     expect(err.status).toBe(500);
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('transport apiFetchBlob (#515: authenticated downloads)', () => {
+  const blobOk = (body = 'file-bytes', disposition: string | null = null) => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: (name: string) => (name === 'content-disposition' ? disposition : null) },
+    blob: () => Promise.resolve(new Blob([body])),
+  });
+
+  it('fetches the blob with the Bearer header attached', async () => {
+    setAuth({ accessToken: 'acc-dl', refreshToken: null }, null);
+    mockFetch.mockResolvedValueOnce(blobOk());
+
+    const out = await apiFetchBlob('/api/v1/export/download/x.png');
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers.Authorization).toBe('Bearer acc-dl');
+    expect(out.filename).toBeNull();
+    expect(out.blob).toBeInstanceOf(Blob);
+  });
+
+  it('parses the Content-Disposition filename when present', async () => {
+    setAuth({ accessToken: 'acc-dl', refreshToken: null }, null);
+    mockFetch.mockResolvedValueOnce(blobOk('x', 'attachment; filename="map_export_1.png"'));
+
+    const out = await apiFetchBlob('/api/v1/export/download/map_export_1.png');
+    expect(out.filename).toBe('map_export_1.png');
+  });
+
+  it('surfaces a non-ok status as ApiError (401 → caller shows login prompt)', async () => {
+    setAuth({ accessToken: 'stale-dl', refreshToken: null }, null);
+    mockFetch.mockResolvedValueOnce(errResponse(401));
+
+    const err = (await apiFetchBlob('/api/v1/export/download/x.png').catch((e: unknown) => e)) as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+  });
+
+  it('recovers ONCE from a 401 via the refresh token like apiFetch', async () => {
+    setAuth({ accessToken: 'stale-dl', refreshToken: 'ref-dl' }, null);
+    mockFetch
+      .mockResolvedValueOnce(errResponse(401))
+      .mockResolvedValueOnce(jsonOk({ access_token: 'fresh-dl', refresh_token: 'ref-2' }))
+      .mockResolvedValueOnce(blobOk('bytes'));
+
+    const out = await apiFetchBlob('/api/v1/export/download/x.png');
+    expect(out.blob).toBeInstanceOf(Blob);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 });

--- a/frontend/lib/api/transport.ts
+++ b/frontend/lib/api/transport.ts
@@ -344,6 +344,52 @@ async function apiFetchAttempt<T = unknown>(
 }
 
 /**
+ * Fetch a binary payload (file download) with the transport's auth and
+ * 401-refresh recovery, resolving to the response blob. The JSON parse path
+ * of `apiFetch` cannot return binary bodies, so downloads (export files,
+ * report files) go through here. Reads the server's Content-Disposition
+ * filename when present so the caller can name the saved file correctly.
+ */
+export async function apiFetchBlob(
+  path: string,
+  options: ApiFetchOptions = {},
+): Promise<{ blob: Blob; filename: string | null }> {
+  const attempt = async (): Promise<{ blob: Blob; filename: string | null }> => {
+    const method = (options.method ?? 'GET').toUpperCase();
+    const requestId = options.requestId ?? newRequestId();
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const { url, init } = buildRequest(path, options, method, requestId);
+    const response = await timedFetch(url, init, timeoutMs, requestId);
+    if (!response.ok) throw await toApiError(response, options.label, requestId);
+    const blob = await response.blob();
+    const disposition = response.headers?.get?.('content-disposition') ?? null;
+    return { blob, filename: dispositionFilename(disposition) };
+  };
+
+  try {
+    return await attempt();
+  } catch (err) {
+    if (
+      !options.skipAuth &&
+      err instanceof ApiError &&
+      err.status === 401 &&
+      getRefreshToken() !== null
+    ) {
+      const refreshed = await refreshAuthToken();
+      if (refreshed) return attempt();
+    }
+    throw err;
+  }
+}
+
+/** Extract `filename="..."` from a Content-Disposition header, if present. */
+function dispositionFilename(disposition: string | null): string | null {
+  if (!disposition) return null;
+  const match = /filename="?([^";]+)"?/.exec(disposition);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/**
  * Open a streaming (SSE) request: resolves with the Response once headers
  * arrive (connect timeout applied), throwing ApiError on a non-ok status. The
  * caller owns the body lifecycle — stream it and drive it with its own

--- a/frontend/lib/hooks/use-sse-stream.explorer.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.explorer.test.ts
@@ -35,6 +35,15 @@ vi.mock('@/lib/utils/logger', () => ({
 }));
 vi.mock('@/lib/api/config', () => ({ API_BASE: 'http://localhost:8000' }));
 
+// #518: the independent stream is owner-verified (Bearer) — anonymous
+// sessions (no tokens) rely on the post-turn chat-stream bridge instead.
+let mockAccessToken: string | null = 'jwt-test';
+let mockRefreshToken: string | null = 'refresh-test';
+vi.mock('@/lib/auth/tokenStore', () => ({
+  getAccessToken: () => mockAccessToken,
+  getRefreshToken: () => mockRefreshToken,
+}));
+
 const streamExplorerProgressMock = vi.hoisted(() => vi.fn());
 vi.mock('@/lib/api/explorer', () => ({
   streamExplorerProgress: (...args: unknown[]) => streamExplorerProgressMock(...args),
@@ -63,6 +72,9 @@ beforeEach(() => {
   bridgeMock.onEventCallback = null;
   streamExplorerProgressMock.mockReset();
   useHudStore.setState({ explorerTasks: [] });
+  // 默认已登录（有 tokens）→ 独立流可达
+  mockAccessToken = 'jwt-test';
+  mockRefreshToken = 'refresh-test';
 });
 
 describe('applyExplorerProgressToStore (normalization shared by chat + independent stream)', () => {
@@ -176,5 +188,44 @@ describe('useSSEStream — independent explorer progress stream (#518)', () => {
   it('does not start a stream for non-explorer results', async () => {
     await emitStepResult({ result: { type: 'FeatureCollection', features: [] } });
     expect(streamExplorerProgressMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the independent stream for anonymous sessions (chat-stream bridge delivers)', async () => {
+    mockAccessToken = null;
+    mockRefreshToken = null;
+    await emitStepResult({});
+    expect(streamExplorerProgressMock).not.toHaveBeenCalled();
+    // 匿名会话不触发独立流 —— 进度改由聊天流桥接（不会 401 噪音）。
+    expect(useHudStore.getState().explorerTasks).toHaveLength(0);
+  });
+
+  it('chat-stream and independent-stream events for the same task do not double-apply', async () => {
+    // 独立流正常到达……
+    streamExplorerProgressMock.mockImplementation(async function* () {
+      yield { event: 'explorer_progress', data: { stage: 'validate', task_id: 'exp-task-y', status: 'completed', context: { progress: 100 } } };
+    });
+    renderStream();
+    await act(async () => {
+      bridgeMock.onEventCallback?.({
+        event: 'step_result',
+        data: {
+          session_id: 'sid-explorer',
+          tool: 'deep_explore',
+          result: { type: 'explorer_task', task_id: 'exp-task-y', status: 'started' },
+        },
+      });
+    });
+    // ……同一任务的聊天流事件（如后端桥接也发了）再到达
+    await act(async () => {
+      bridgeMock.onEventCallback?.({
+        event: 'explorer_progress',
+        data: { stage: 'validate', task_id: 'exp-task-y', status: 'completed', context: { progress: 100 } },
+      });
+    });
+
+    const tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(1); // 不重复插入
+    expect(tasks[0].taskId).toBe('exp-task-y');
+    expect(tasks[0].status).toBe('completed');
   });
 });

--- a/frontend/lib/hooks/use-sse-stream.explorer.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.explorer.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSSEStream, applyExplorerProgressToStore } from './use-sse-stream';
+import { useHudStore } from '@/lib/store/useHudStore';
+
+/**
+ * #518 regression: explorer_progress had no producer into the chat stream and
+ * deep_explore's independent progress stream was unreachable (owner never
+ * registered). The frontend now:
+ *   - normalizes explorer_progress events into the explorerTasks store via
+ *     applyExplorerProgressToStore (shared by chat stream + independent
+ *     stream), and
+ *   - starts the independent /explorer/stream/{task_id} consumer when a
+ *     step_result carries an explorer_task result.
+ */
+
+const bridgeMock = vi.hoisted(() => ({
+  send: vi.fn().mockResolvedValue(undefined),
+  aiStatus: 'idle',
+  onEventCallback: null as ((event: {
+    event: string;
+    data: Record<string, unknown>;
+  }) => void) | null,
+}));
+
+vi.mock('./useMapBridge', () => ({
+  useMapBridge: (...args: unknown[]) => {
+    bridgeMock.onEventCallback = args[2] as typeof bridgeMock.onEventCallback;
+    return bridgeMock;
+  },
+}));
+vi.mock('@/lib/utils/logger', () => ({
+  devOnly: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  safeError: vi.fn(),
+}));
+vi.mock('@/lib/api/config', () => ({ API_BASE: 'http://localhost:8000' }));
+
+const streamExplorerProgressMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/explorer', () => ({
+  streamExplorerProgress: (...args: unknown[]) => streamExplorerProgressMock(...args),
+}));
+
+const setSessionId = vi.fn();
+const dispatchAction = vi.fn();
+const getMapSnapshot = vi.fn(() => null);
+
+function renderStream() {
+  return renderHook(() =>
+    useSSEStream(
+      'sid-explorer',
+      setSessionId,
+      { current: 'sid-explorer' },
+      dispatchAction,
+      getMapSnapshot,
+      null,
+      { current: null },
+    ),
+  );
+}
+
+beforeEach(() => {
+  bridgeMock.send.mockClear();
+  bridgeMock.onEventCallback = null;
+  streamExplorerProgressMock.mockReset();
+  useHudStore.setState({ explorerTasks: [] });
+});
+
+describe('applyExplorerProgressToStore (normalization shared by chat + independent stream)', () => {
+  it('inserts a task on first sight and updates it on progress events', () => {
+    applyExplorerProgressToStore({
+      stage: 'discover',
+      task_id: 'exp-task-1',
+      status: 'started',
+      context: { progress: 5 },
+    });
+    let tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].taskId).toBe('exp-task-1');
+    expect(tasks[0].stage).toBe('discover');
+    expect(tasks[0].status).toBe('discovering');
+
+    applyExplorerProgressToStore({
+      stage: 'geocode',
+      task_id: 'exp-task-1',
+      status: 'progress',
+      context: { progress: 70 },
+    });
+    tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].stage).toBe('geocode');
+    expect(tasks[0].status).toBe('geocoding');
+    expect(tasks[0].progress).toBe(70);
+  });
+
+  it('terminates on completed/failed and normalizes pending stage to discover', () => {
+    applyExplorerProgressToStore({
+      stage: 'validate',
+      task_id: 'exp-task-2',
+      status: 'completed',
+      context: { progress: 100 },
+    });
+    const tasks = useHudStore.getState().explorerTasks;
+    expect(tasks[0].status).toBe('completed');
+
+    applyExplorerProgressToStore({
+      stage: 'pending',
+      task_id: 'exp-task-3',
+      status: 'progress',
+      context: {},
+    });
+    expect(useHudStore.getState().explorerTasks[1].stage).toBe('discover');
+    expect(useHudStore.getState().explorerTasks[1].status).toBe('idle');
+  });
+
+  it('ignores malformed / empty events', () => {
+    applyExplorerProgressToStore(null);
+    applyExplorerProgressToStore(undefined);
+    applyExplorerProgressToStore({});
+    applyExplorerProgressToStore({ task_id: 42, stage: 'x', status: 'y' });
+    expect(useHudStore.getState().explorerTasks).toHaveLength(0);
+  });
+});
+
+describe('useSSEStream — independent explorer progress stream (#518)', () => {
+  async function emitStepResult(overrides: Record<string, unknown>) {
+    renderStream();
+    await act(async () => {
+      bridgeMock.onEventCallback?.({
+        event: 'step_result',
+        data: {
+          session_id: 'sid-explorer',
+          tool: 'deep_explore',
+          result: { type: 'explorer_task', task_id: 'exp-sess-1-123', status: 'started' },
+          ...overrides,
+        },
+      });
+    });
+  }
+
+  it('opens the independent progress stream when deep_explore returns an explorer_task', async () => {
+    streamExplorerProgressMock.mockImplementation(async function* () {
+      yield { event: 'explorer_progress', data: { stage: 'fetch', task_id: 'exp-sess-1-123', status: 'progress', context: { progress: 30 } } };
+      yield { event: 'explorer_progress', data: { stage: 'validate', task_id: 'exp-sess-1-123', status: 'completed', context: { progress: 100 } } };
+    });
+
+    await emitStepResult({});
+
+    expect(streamExplorerProgressMock).toHaveBeenCalledWith('exp-sess-1-123', expect.anything());
+    // 独立流的事件必须进入同一个 explorerTasks store
+    const tasks = useHudStore.getState().explorerTasks;
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].taskId).toBe('exp-sess-1-123');
+    expect(tasks[0].status).toBe('completed');
+  });
+
+  it('does not open a duplicate stream for the same task_id', async () => {
+    streamExplorerProgressMock.mockImplementation(async function* () {
+      yield { event: 'explorer_progress', data: { stage: 'discover', task_id: 'exp-task-x', status: 'started', context: {} } };
+    });
+
+    renderStream();
+    const step = {
+      event: 'step_result',
+      data: {
+        session_id: 'sid-explorer',
+        tool: 'deep_explore',
+        result: { type: 'explorer_task', task_id: 'exp-task-x', status: 'started' },
+      },
+    };
+    await act(async () => { bridgeMock.onEventCallback?.(step); });
+    await act(async () => { bridgeMock.onEventCallback?.(step); }); // 同 task 第二次 step_result
+
+    expect(streamExplorerProgressMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start a stream for non-explorer results', async () => {
+    await emitStepResult({ result: { type: 'FeatureCollection', features: [] } });
+    expect(streamExplorerProgressMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/lib/hooks/use-sse-stream.test.ts
+++ b/frontend/lib/hooks/use-sse-stream.test.ts
@@ -527,6 +527,66 @@ describe('canonical MapSpec runtime patch', () => {
   });
 });
 
+describe('useSSEStream — isThinking flips on done/task_complete, not on stream close (#518)', () => {
+  it('flips isThinking:false when done arrives even while the connection stays open', async () => {
+    // The post-turn explorer bridge keeps the chat SSE open up to 600s after
+    // `done` (anonymous deep_explore) — bridge.send only resolves when the
+    // connection physically closes. The thinking indicator must flip when the
+    // terminal event is processed, not when handleSend's await returns.
+    let closeStream: (() => void) | undefined;
+    const connectionOpen = new Promise<void>((resolve) => {
+      closeStream = resolve;
+    });
+    bridgeMock.send.mockReturnValueOnce(connectionOpen as never);
+
+    const { result } = renderStream();
+    let sendPromise: Promise<boolean> | undefined;
+    act(() => {
+      sendPromise = result.current.handleSend('深度搜索');
+    });
+
+    const thinkingMsg = () => {
+      const msgs = result.current.messages;
+      return msgs[msgs.length - 1];
+    };
+    expect(thinkingMsg().isThinking).toBe(true);
+
+    // Terminal event arrives while the connection is STILL OPEN.
+    act(() => {
+      bridgeMock.onEventCallback?.({
+        event: 'done',
+        data: { session_id: 'sid-fe4' },
+      });
+    });
+    expect(thinkingMsg().isThinking).toBe(false);
+
+    // Only now does the connection close; handleSend's own post-await flip
+    // is a no-op (already false).
+    await act(async () => {
+      closeStream?.();
+      await sendPromise;
+    });
+    expect(thinkingMsg().isThinking).toBe(false);
+  });
+
+  it('flips isThinking:false on task_complete too', () => {
+    const { result } = renderStream();
+    act(() => {
+      void result.current.handleSend('深度搜索');
+    });
+    const thinkingMsg = () => result.current.messages[result.current.messages.length - 1];
+    expect(thinkingMsg().isThinking).toBe(true);
+
+    act(() => {
+      bridgeMock.onEventCallback?.({
+        event: 'task_complete',
+        data: { session_id: 'sid-fe4', task_id: 't-1' },
+      });
+    });
+    expect(thinkingMsg().isThinking).toBe(false);
+  });
+});
+
 
 
 describe('useSSEStream — turn-scoped tool-arg evidence (#466)', () => {

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -839,6 +839,19 @@ export function useSSEStream(
             };
           }),
         );
+      } else if (event.event === 'done' || event.event === 'task_complete') {
+        // #518: 聊天流 post-turn 桥接（匿名 deep_explore）在 done 之后连接
+        // 仍保持打开最多 600s（explorer 进度推送）—— handleSend 的 await
+        // 要等连接关闭才返回，isThinking 必须在终态事件到达时就翻转，
+        // 否则已完成的回答一直藏在 ThinkingDots 后面。幂等：随后 handleSend
+        // 的后置翻转只处理仍为 isThinking 的消息。
+        if (thinkingId) {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === thinkingId && m.isThinking ? { ...m, isThinking: false } : m
+            )
+          );
+        }
       } else if (event.event === 'explorer_progress') {
         // #518: 归一化逻辑抽到 applyExplorerProgressToStore（与独立
         // /explorer/stream/{task_id} 消费者共用），聊天流与独立流一致。

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -14,6 +14,7 @@ import { createMessageIdGenerator } from './use-message-id';
 import { TokenBatcher } from './token-batcher';
 import { IncrementalThinkParser, parseThink } from './incremental-think';
 import { streamExplorerProgress } from '@/lib/api/explorer';
+import { getAccessToken, getRefreshToken } from '@/lib/auth/tokenStore';
 import type { ExplorerStage, ExplorerStatus } from '@/lib/types/explorer';
 
 
@@ -389,8 +390,14 @@ export function useSSEStream(
   // #518: 深度探索任务在后台跑数分钟，聊天 SSE 连接在 done 后关闭，进度
   // 必须经独立 /explorer/stream/{task_id}（owner-verified）推送到同一个
   // explorerTasks store。deep_explore 返回 explorer_task 结果时启动。
+  // 匿名会话无 Bearer → 独立流端点 401 不可达，其进度由后端 post-turn
+  // 聊天流桥接（bridge_session_explorer_progress）推送；此处跳过独立流，
+  // 避免 401 噪音 —— 聊天流 handler 与独立流消费者共用同一归一化逻辑。
   const startExplorerProgressStream = useCallback((taskId: string) => {
     if (explorerStreamsRef.current.has(taskId)) return;
+    // 已登录会话（有 access 或 refresh token）走 owner-verified 独立流；
+    // 匿名（两者皆无）依赖聊天流桥接。
+    if (!getAccessToken() && !getRefreshToken()) return;
     explorerStreamsRef.current.add(taskId);
     const signal = explorerAbortRef.current?.signal;
     (async () => {
@@ -398,6 +405,11 @@ export function useSSEStream(
         for await (const ev of streamExplorerProgress(taskId, signal)) {
           if (ev.event === 'explorer_progress' && ev.data && typeof ev.data === 'object') {
             applyExplorerProgressToStore(ev.data as Record<string, unknown>);
+            // 终态后释放 per-task 槽位：未来可重开流（断线恢复），且不再去重拦截。
+            const status = (ev.data as Record<string, unknown>).status;
+            if (status === 'completed' || status === 'failed') {
+              explorerStreamsRef.current.delete(taskId);
+            }
           }
         }
       } catch (err) {

--- a/frontend/lib/hooks/use-sse-stream.ts
+++ b/frontend/lib/hooks/use-sse-stream.ts
@@ -13,6 +13,8 @@ import type { MapActionPayload } from '@/lib/types';
 import { createMessageIdGenerator } from './use-message-id';
 import { TokenBatcher } from './token-batcher';
 import { IncrementalThinkParser, parseThink } from './incremental-think';
+import { streamExplorerProgress } from '@/lib/api/explorer';
+import type { ExplorerStage, ExplorerStatus } from '@/lib/types/explorer';
 
 
 import { devOnly } from "@/lib/utils/logger";
@@ -204,6 +206,64 @@ function extractEventSessionId(data: unknown): string | undefined {
   return undefined;
 }
 
+// stage → 进行时状态（geocode/validate 需去 e，不能裸拼 +ing）
+const EXPLORER_ACTIVE_STATUS: Record<string, ExplorerStatus> = {
+  discover: 'discovering',
+  fetch: 'fetching',
+  parse: 'parsing',
+  geocode: 'geocoding',
+  validate: 'validating',
+};
+
+/**
+ * #518: 将一条 explorer_progress 事件（后端 orchestrator.stream_progress
+ * 的 ExplorerPerceptionEvent 形状：task_id / stage / status / context）应用到
+ * explorerTasks store。聊天流 handler 与独立 /explorer/stream/{task_id}
+ * 消费者共用同一归一化逻辑，保证两条到达路径产生一致的 UI 状态。
+ */
+export function applyExplorerProgressToStore(
+  data: Record<string, unknown> | undefined | null,
+): void {
+  if (!data || typeof data !== 'object') return;
+  const taskId = data.task_id as string;
+  if (typeof taskId !== 'string' || !taskId) return;
+  const rawStage = typeof data.stage === 'string' ? data.stage : 'pending';
+  const stage = (rawStage === 'pending' ? 'discover' : rawStage) as ExplorerStage;
+  const status = data.status as string;
+  const context = (data.context as Record<string, unknown>) || {};
+  const nextStatus: ExplorerStatus =
+    status === 'completed'
+      ? 'completed'
+      : status === 'failed'
+        ? 'failed'
+        : status === 'decision_point'
+          ? 'decision_required'
+          : rawStage === 'pending'
+            ? 'idle'
+            : (EXPLORER_ACTIVE_STATUS[rawStage] ?? 'idle');
+  const progress = (context?.progress as number) || 0;
+  const store = useHudStore.getState();
+  if (!store.explorerTasks.some((tk) => tk.taskId === taskId)) {
+    store.addExplorerTask({
+      taskId,
+      status: nextStatus,
+      stage,
+      progress,
+      query:
+        (typeof context.query === 'string' && context.query) ||
+        `深度探索 ${taskId.slice(0, 8)}`,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+  } else {
+    store.updateExplorerTask(taskId, {
+      stage,
+      status: nextStatus,
+      progress,
+    });
+  }
+}
+
 export function useSSEStream(
   sessionId: string | undefined,
   setSessionId: (sid: string) => void,
@@ -249,6 +309,11 @@ export function useSSEStream(
   ).current; // stable identity: created once per hook instance
   const msgIdGen = useRef(createMessageIdGenerator());
   const layerFetchAbortRef = useRef<AbortController | null>(null);
+  // #518: 独立 /explorer/stream/{task_id} 消费者。deep_explore 返回的探索
+  // 任务在后台跑数分钟，聊天 SSE 在 done 后即关闭——进度必须经独立流推送。
+  // 会话切换/卸载时 abort 全部在飞流；同一 task_id 只开一条流。
+  const explorerAbortRef = useRef<AbortController | null>(null);
+  const explorerStreamsRef = useRef<Set<string>>(new Set());
 
   // D-F7 / F-FE-4: incremental think-block tracking. The batcher still
   // delivers full snapshots per flush, but instead of re-parsing the whole
@@ -308,6 +373,39 @@ export function useSSEStream(
       layerFetchAbortRef.current?.abort();
     };
   }, [sessionId]);
+
+  // #518: 会话切换/卸载时终止独立 explorer 进度流（任务归属随会话）。
+  useEffect(() => {
+    if (explorerAbortRef.current) {
+      explorerAbortRef.current.abort();
+    }
+    explorerAbortRef.current = new AbortController();
+    explorerStreamsRef.current.clear();
+    return () => {
+      explorerAbortRef.current?.abort();
+    };
+  }, [sessionId]);
+
+  // #518: 深度探索任务在后台跑数分钟，聊天 SSE 连接在 done 后关闭，进度
+  // 必须经独立 /explorer/stream/{task_id}（owner-verified）推送到同一个
+  // explorerTasks store。deep_explore 返回 explorer_task 结果时启动。
+  const startExplorerProgressStream = useCallback((taskId: string) => {
+    if (explorerStreamsRef.current.has(taskId)) return;
+    explorerStreamsRef.current.add(taskId);
+    const signal = explorerAbortRef.current?.signal;
+    (async () => {
+      try {
+        for await (const ev of streamExplorerProgress(taskId, signal)) {
+          if (ev.event === 'explorer_progress' && ev.data && typeof ev.data === 'object') {
+            applyExplorerProgressToStore(ev.data as Record<string, unknown>);
+          }
+        }
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        devOnly.warn('[useSSEStream] explorer progress stream failed:', err);
+      }
+    })();
+  }, []);
 
   const onEvent = useCallback(
     (event: SSEEvent) => {
@@ -405,6 +503,15 @@ export function useSSEStream(
             status: 'pending',
           };
           setMessages((prev) => prev.map((m) => (m.id === thinkingId ? { ...m, plan } : m)));
+        }
+        // #518: deep_explore 返回 explorer_task —— 任务在后台跑数分钟，聊天流
+        // 无法覆盖全生命周期。启动独立 /explorer/stream/{task_id} 消费进度。
+        if (
+          data.result?.type === 'explorer_task'
+          && typeof data.result?.task_id === 'string'
+          && data.result.task_id
+        ) {
+          startExplorerProgressStream(data.result.task_id);
         }
         // Layer auto-mount — hidden by default; AI calls display_layer to show final results
         if (data.geojson_ref || data.result?.image) {
@@ -721,59 +828,12 @@ export function useSSEStream(
           }),
         );
       } else if (event.event === 'explorer_progress') {
-        // 后端事件字段（orchestrator.stream_progress）：task_id / stage
-        // （含 "pending"，Celery PENDING 时 meta 为空）/ status（started |
-        // progress | decision_point | completed | failed）/ context.progress。
-        // 首次见到 task_id 时先插入任务条目（explorerTasks 此前恒空导致进度
-        // 永不可见），后续更新走 updateExplorerTask。
-        const taskId = data.task_id as string;
-        if (typeof taskId !== 'string' || !taskId) return;
-        const rawStage = typeof data.stage === 'string' ? data.stage : 'pending';
-        const stage = (rawStage === 'pending' ? 'discover' : rawStage) as import('@/lib/types/explorer').ExplorerStage;
-        const status = data.status as string;
-        const context = (data.context as Record<string, unknown>) || {};
-        // stage → 进行时状态（geocode/validate 需去 e，不能裸拼 +ing）
-        const ACTIVE_STATUS: Record<string, import('@/lib/types/explorer').ExplorerStatus> = {
-          discover: 'discovering',
-          fetch: 'fetching',
-          parse: 'parsing',
-          geocode: 'geocoding',
-          validate: 'validating',
-        };
-        const nextStatus: import('@/lib/types/explorer').ExplorerStatus =
-          status === 'completed'
-            ? 'completed'
-            : status === 'failed'
-            ? 'failed'
-            : status === 'decision_point'
-            ? 'decision_required'
-            : rawStage === 'pending'
-            ? 'idle'
-            : (ACTIVE_STATUS[rawStage] ?? 'idle');
-        const progress = (context?.progress as number) || 0;
-        const store = useHudStore.getState();
-        if (!store.explorerTasks.some((tk) => tk.taskId === taskId)) {
-          store.addExplorerTask({
-            taskId,
-            status: nextStatus,
-            stage,
-            progress,
-            query:
-              (typeof context.query === 'string' && context.query) ||
-              `深度探索 ${taskId.slice(0, 8)}`,
-            startedAt: Date.now(),
-            updatedAt: Date.now(),
-          });
-        } else {
-          store.updateExplorerTask(taskId, {
-            stage,
-            status: nextStatus,
-            progress,
-          });
-        }
+        // #518: 归一化逻辑抽到 applyExplorerProgressToStore（与独立
+        // /explorer/stream/{task_id} 消费者共用），聊天流与独立流一致。
+        applyExplorerProgressToStore(data as Record<string, unknown>);
       }
     },
-    [setSessionId, sessionIdRef, sessionTokenRef, rememberSessionToken, markToolCallStatus]
+    [setSessionId, sessionIdRef, sessionTokenRef, rememberSessionToken, markToolCallStatus, startExplorerProgressStream]
   );
 
   // DUP-1: bounded auto-reconnect for the chat stream. Opt-in by explicit

--- a/frontend/lib/map-kit/tile-auth.test.ts
+++ b/frontend/lib/map-kit/tile-auth.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { API_BASE } from '@/lib/api/config';
 import { getAccessToken } from '@/lib/auth/tokenStore';
 import { buildTileTransformRequest } from './tile-auth';
 
@@ -12,21 +11,32 @@ vi.mock('@/lib/auth/tokenStore', () => ({
   getAccessToken: vi.fn(),
 }));
 
+// API_BASE is '' in production (Dockerfile build arg) and an absolute origin
+// in dev. Make it mutable so both shapes are exercised.
+let mockApiBase = 'http://localhost:8001';
+vi.mock('@/lib/api/config', () => ({
+  get API_BASE() {
+    return mockApiBase;
+  },
+}));
+
 const mockGetAccessToken = vi.mocked(getAccessToken);
 
-function apiUrl(path: string): string {
-  return `${API_BASE}${path}`;
+/** The URL shape the frontend hands MapLibre for a ref layer's MVT tiles. */
+function tileUrl(path: string): string {
+  return `${mockApiBase}${path}`;
 }
 
-describe('buildTileTransformRequest', () => {
-  beforeEach(() => {
-    mockGetAccessToken.mockReset();
-    mockGetAccessToken.mockReturnValue(null);
-  });
+beforeEach(() => {
+  mockApiBase = 'http://localhost:8001';
+  mockGetAccessToken.mockReset();
+  mockGetAccessToken.mockReturnValue(null);
+});
 
+describe('buildTileTransformRequest', () => {
   it('injects X-Session-Token header for anonymous sessions with owner_token', () => {
-    const transform = buildTileTransformRequest('anon-owner-token-abc');
-    const url = apiUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-1');
+    const transform = buildTileTransformRequest(() => 'anon-owner-token-abc');
+    const url = tileUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-1');
     const result = transform(url, 'Tile');
     expect(result.url).toBe(url);
     expect(result.headers).toEqual({ 'X-Session-Token': 'anon-owner-token-abc' });
@@ -34,16 +44,16 @@ describe('buildTileTransformRequest', () => {
 
   it('injects Authorization Bearer header for logged-in sessions', () => {
     mockGetAccessToken.mockReturnValue('jwt-access-1');
-    const transform = buildTileTransformRequest(null);
-    const url = apiUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-2');
+    const transform = buildTileTransformRequest(() => null);
+    const url = tileUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-2');
     const result = transform(url, 'Tile');
     expect(result.headers).toEqual({ Authorization: 'Bearer jwt-access-1' });
   });
 
   it('sends both headers when both credentials exist (apiFetch parity)', () => {
     mockGetAccessToken.mockReturnValue('jwt-access-2');
-    const transform = buildTileTransformRequest('anon-owner-token-2');
-    const url = apiUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-3');
+    const transform = buildTileTransformRequest(() => 'anon-owner-token-2');
+    const url = tileUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-3');
     const result = transform(url, 'Tile');
     expect(result.headers).toEqual({
       Authorization: 'Bearer jwt-access-2',
@@ -53,31 +63,72 @@ describe('buildTileTransformRequest', () => {
 
   it('reads the access token fresh per request (rotated JWT picked up)', () => {
     mockGetAccessToken.mockReturnValueOnce('jwt-old');
-    const transform = buildTileTransformRequest(null);
-    const url = apiUrl('/api/v1/layers/data/ref:geojson-1/tiles/0/0/0.mvt?session_id=sess');
+    const transform = buildTileTransformRequest(() => null);
+    const url = tileUrl('/api/v1/layers/data/ref:geojson-1/tiles/0/0/0.mvt?session_id=sess');
     expect(transform(url).headers?.Authorization).toBe('Bearer jwt-old');
     mockGetAccessToken.mockReturnValueOnce('jwt-refreshed');
     expect(transform(url).headers?.Authorization).toBe('Bearer jwt-refreshed');
   });
 
+  it('reads the owner_token LIVE per request — SSE arrival + session switch take effect', () => {
+    // The token arrives via SSE AFTER the map is constructed (and MapLibre
+    // never re-applies transformRequest), so the getter must be consulted on
+    // every request rather than once at construction.
+    let currentToken: string | null = null;
+    const transform = buildTileTransformRequest(() => currentToken);
+    const url = tileUrl('/api/v1/layers/data/ref:geojson-1/tiles/0/0/0.mvt?session_id=sess');
+
+    expect(transform(url).headers).toBeUndefined();
+
+    // SSE owner_token arrival while the map is already mounted.
+    currentToken = 'anon-token-after-sse';
+    expect(transform(url).headers?.['X-Session-Token']).toBe('anon-token-after-sse');
+
+    // Session switch: the getter now returns the newly selected session's token.
+    currentToken = 'anon-token-session-b';
+    expect(transform(url).headers?.['X-Session-Token']).toBe('anon-token-session-b');
+
+    // Logout / token cleared: header disappears again.
+    currentToken = null;
+    expect(transform(url).headers).toBeUndefined();
+  });
+
+  it('handles the production same-origin build (API_BASE === "") with relative URLs', () => {
+    mockApiBase = '';
+    mockGetAccessToken.mockReturnValue(null);
+    const transform = buildTileTransformRequest(() => 'prod-owner-token');
+    const url = '/api/v1/layers/data/ref:geojson-9/tiles/0/0/0.mvt?session_id=sess';
+    const result = transform(url, 'Tile');
+    expect(result.headers).toEqual({ 'X-Session-Token': 'prod-owner-token' });
+  });
+
   it('never attaches credentials to third-party URLs (no owner_token leak)', () => {
-    const transform = buildTileTransformRequest('anon-owner-token-secret');
+    const transform = buildTileTransformRequest(() => 'anon-owner-token-secret');
     mockGetAccessToken.mockReturnValue('jwt-secret');
     const url = 'https://tile.openstreetmap.org/4/5/6.png';
     expect(transform(url, 'Tile')).toEqual({ url });
     expect(transform(url).headers).toBeUndefined();
   });
 
-  it('never attaches credentials to unrelated same-host style URLs (fonts/sprites CDN)', () => {
-    const transform = buildTileTransformRequest('anon-owner-token-secret');
-    const url = 'https://fonts.example.com/glyphs/{fontstack}/{range}.pbf';
-    expect(transform(url, 'Glyphs')).toEqual({ url });
+  it('never attaches credentials to hosts that merely share API_BASE as a prefix', () => {
+    // http://api.example.com.evil.com must NOT match API_BASE http://api.example.com
+    mockApiBase = 'http://api.example.com';
+    const transform = buildTileTransformRequest(() => 'secret');
+    const url = 'http://api.example.com.evil.com/api/v1/layers/data/ref:g/tiles/0/0/0.mvt?session_id=s';
+    expect(transform(url).headers).toBeUndefined();
+  });
+
+  it('rejects protocol-relative third-party URLs when API_BASE is empty', () => {
+    mockApiBase = '';
+    const transform = buildTileTransformRequest(() => 'secret');
+    const url = '//evil.example.com/api/v1/layers/data/ref:g/tiles/0/0/0.mvt?session_id=s';
+    expect(transform(url, 'Tile')).toEqual({ url });
     expect(transform(url).headers).toBeUndefined();
   });
 
   it('returns a bare request when no credentials are available', () => {
-    const transform = buildTileTransformRequest(null);
-    const url = apiUrl('/api/v1/layers/data/ref:geojson-1/tiles/0/0/0.mvt?session_id=sess');
+    const transform = buildTileTransformRequest(() => null);
+    const url = tileUrl('/api/v1/layers/data/ref:geojson-1/tiles/0/0/0.mvt?session_id=sess');
     expect(transform(url, 'Tile')).toEqual({ url });
     expect(transform(url).headers).toBeUndefined();
   });

--- a/frontend/lib/map-kit/tile-auth.test.ts
+++ b/frontend/lib/map-kit/tile-auth.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { API_BASE } from '@/lib/api/config';
+import { getAccessToken } from '@/lib/auth/tokenStore';
+import { buildTileTransformRequest } from './tile-auth';
+
+// #514 regression: MapLibre tile/image fetches are browser-native and cannot
+// carry headers, so the MVT tile endpoint (header-only require_owned_session)
+// used to 404 for every >5000-feature ref layer. The transformRequest must
+// inject the same credentials apiFetch sends — Bearer for logged-in sessions,
+// X-Session-Token for anonymous — and ONLY for first-party URLs.
+vi.mock('@/lib/auth/tokenStore', () => ({
+  getAccessToken: vi.fn(),
+}));
+
+const mockGetAccessToken = vi.mocked(getAccessToken);
+
+function apiUrl(path: string): string {
+  return `${API_BASE}${path}`;
+}
+
+describe('buildTileTransformRequest', () => {
+  beforeEach(() => {
+    mockGetAccessToken.mockReset();
+    mockGetAccessToken.mockReturnValue(null);
+  });
+
+  it('injects X-Session-Token header for anonymous sessions with owner_token', () => {
+    const transform = buildTileTransformRequest('anon-owner-token-abc');
+    const url = apiUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-1');
+    const result = transform(url, 'Tile');
+    expect(result.url).toBe(url);
+    expect(result.headers).toEqual({ 'X-Session-Token': 'anon-owner-token-abc' });
+  });
+
+  it('injects Authorization Bearer header for logged-in sessions', () => {
+    mockGetAccessToken.mockReturnValue('jwt-access-1');
+    const transform = buildTileTransformRequest(null);
+    const url = apiUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-2');
+    const result = transform(url, 'Tile');
+    expect(result.headers).toEqual({ Authorization: 'Bearer jwt-access-1' });
+  });
+
+  it('sends both headers when both credentials exist (apiFetch parity)', () => {
+    mockGetAccessToken.mockReturnValue('jwt-access-2');
+    const transform = buildTileTransformRequest('anon-owner-token-2');
+    const url = apiUrl('/api/v1/layers/data/ref:geojson-123/tiles/4/5/6.mvt?session_id=sess-3');
+    const result = transform(url, 'Tile');
+    expect(result.headers).toEqual({
+      Authorization: 'Bearer jwt-access-2',
+      'X-Session-Token': 'anon-owner-token-2',
+    });
+  });
+
+  it('reads the access token fresh per request (rotated JWT picked up)', () => {
+    mockGetAccessToken.mockReturnValueOnce('jwt-old');
+    const transform = buildTileTransformRequest(null);
+    const url = apiUrl('/api/v1/layers/data/ref:geojson-1/tiles/0/0/0.mvt?session_id=sess');
+    expect(transform(url).headers?.Authorization).toBe('Bearer jwt-old');
+    mockGetAccessToken.mockReturnValueOnce('jwt-refreshed');
+    expect(transform(url).headers?.Authorization).toBe('Bearer jwt-refreshed');
+  });
+
+  it('never attaches credentials to third-party URLs (no owner_token leak)', () => {
+    const transform = buildTileTransformRequest('anon-owner-token-secret');
+    mockGetAccessToken.mockReturnValue('jwt-secret');
+    const url = 'https://tile.openstreetmap.org/4/5/6.png';
+    expect(transform(url, 'Tile')).toEqual({ url });
+    expect(transform(url).headers).toBeUndefined();
+  });
+
+  it('never attaches credentials to unrelated same-host style URLs (fonts/sprites CDN)', () => {
+    const transform = buildTileTransformRequest('anon-owner-token-secret');
+    const url = 'https://fonts.example.com/glyphs/{fontstack}/{range}.pbf';
+    expect(transform(url, 'Glyphs')).toEqual({ url });
+    expect(transform(url).headers).toBeUndefined();
+  });
+
+  it('returns a bare request when no credentials are available', () => {
+    const transform = buildTileTransformRequest(null);
+    const url = apiUrl('/api/v1/layers/data/ref:geojson-1/tiles/0/0/0.mvt?session_id=sess');
+    expect(transform(url, 'Tile')).toEqual({ url });
+    expect(transform(url).headers).toBeUndefined();
+  });
+});

--- a/frontend/lib/map-kit/tile-auth.ts
+++ b/frontend/lib/map-kit/tile-auth.ts
@@ -1,0 +1,43 @@
+import type { RequestParameters } from 'maplibre-gl';
+import { API_BASE } from '@/lib/api/config';
+import { getAccessToken } from '@/lib/auth/tokenStore';
+
+/**
+ * Data-plane credential injection for MapLibre browser-native fetches.
+ *
+ * Tile/image requests made by MapLibre (vector tiles, raster tiles, image
+ * sources) are plain browser fetches — they do NOT go through `apiFetch`, so
+ * they can never carry the `Authorization` / `X-Session-Token` headers the
+ * backend's `require_owned_session` (SEC-08) demands. Without this, every
+ * >5000-feature ref layer that renders via the MVT tile endpoint 404s: the
+ * URL only carries `?session_id=`, and the backend refuses header-less
+ * requests for both anonymous (owner_token minted) and logged-in (Bearer)
+ * sessions.
+ *
+ * Mirrors the credential injection `apiFetch` performs (`transport.ts`):
+ * - logged-in sessions → `Authorization: Bearer <JWT>` (read fresh per
+ *   request so a rotated access token is picked up),
+ * - anonymous sessions → `X-Session-Token: <owner_token>`.
+ * When both exist, both are sent — identical to `apiFetch`, and the backend
+ * resolves whichever applies to the session.
+ *
+ * Credentials are ONLY attached to first-party URLs under `API_BASE`.
+ * Third-party tile servers (OSM basemap, fonts, sprites) never see a session
+ * credential — leaking the anonymous owner_token to a third party would be a
+ * cross-origin secret exposure.
+ */
+export function buildTileTransformRequest(
+  ownerToken: string | null,
+): (url: string, resourceType?: string) => RequestParameters {
+  return (url: string): RequestParameters => {
+    if (!API_BASE || !url.startsWith(API_BASE)) {
+      // Third-party or unknown host: never forward session credentials.
+      return { url };
+    }
+    const headers: Record<string, string> = {};
+    const accessToken = getAccessToken();
+    if (accessToken) headers['Authorization'] = `Bearer ${accessToken}`;
+    if (ownerToken) headers['X-Session-Token'] = ownerToken;
+    return Object.keys(headers).length > 0 ? { url, headers } : { url };
+  };
+}

--- a/frontend/lib/map-kit/tile-auth.ts
+++ b/frontend/lib/map-kit/tile-auth.ts
@@ -1,6 +1,6 @@
 import type { RequestParameters } from 'maplibre-gl';
-import { API_BASE } from '@/lib/api/config';
 import { getAccessToken } from '@/lib/auth/tokenStore';
+import { isFirstPartyUrl } from '@/lib/api/first-party';
 
 /**
  * Data-plane credential injection for MapLibre browser-native fetches.
@@ -17,26 +17,34 @@ import { getAccessToken } from '@/lib/auth/tokenStore';
  * Mirrors the credential injection `apiFetch` performs (`transport.ts`):
  * - logged-in sessions → `Authorization: Bearer <JWT>` (read fresh per
  *   request so a rotated access token is picked up),
- * - anonymous sessions → `X-Session-Token: <owner_token>`.
+ * - anonymous sessions → `X-Session-Token: <owner_token>` (read LIVE via the
+ *   `getSessionToken` getter: the owner_token arrives via SSE after the map
+ *   is constructed, and @vis.gl/react-maplibre never re-applies a
+ *   transformRequest when props change — a snapshot captured at construction
+ *   would be permanently stale and session switches would keep the old
+ *   token).
  * When both exist, both are sent — identical to `apiFetch`, and the backend
  * resolves whichever applies to the session.
  *
- * Credentials are ONLY attached to first-party URLs under `API_BASE`.
- * Third-party tile servers (OSM basemap, fonts, sprites) never see a session
+ * Credentials are ONLY attached to first-party URLs (`isFirstPartyUrl`):
+ * third-party tile servers (OSM basemap, fonts, sprites) never see a session
  * credential — leaking the anonymous owner_token to a third party would be a
- * cross-origin secret exposure.
+ * cross-origin secret exposure. Handles the production same-origin build
+ * (`API_BASE === ''` → relative URLs) and dev's absolute origin, comparing
+ * origins exactly (never a prefix match).
  */
 export function buildTileTransformRequest(
-  ownerToken: string | null,
+  getSessionToken: () => string | null,
 ): (url: string, resourceType?: string) => RequestParameters {
   return (url: string): RequestParameters => {
-    if (!API_BASE || !url.startsWith(API_BASE)) {
+    if (!isFirstPartyUrl(url)) {
       // Third-party or unknown host: never forward session credentials.
       return { url };
     }
     const headers: Record<string, string> = {};
     const accessToken = getAccessToken();
     if (accessToken) headers['Authorization'] = `Bearer ${accessToken}`;
+    const ownerToken = getSessionToken();
     if (ownerToken) headers['X-Session-Token'] = ownerToken;
     return Object.keys(headers).length > 0 ? { url, headers } : { url };
   };

--- a/frontend/test/page.render-scope.test.tsx
+++ b/frontend/test/page.render-scope.test.tsx
@@ -49,6 +49,10 @@ const stream = vi.hoisted(() => {
     setMessages: noop,
     handleSend: noop,
     handlePlanAction: noop,
+    // The real useWorkspaceSession returns a stable useRef object for
+    // sessionTokenRef (MapPanel consumes it as a prop; a fresh literal per
+    // render would defeat MemoMapPanel).
+    sessionTokenRef: { current: null } as { current: string | null },
   };
 });
 
@@ -69,7 +73,7 @@ vi.mock('@/lib/hooks/use-workspace-session', () => ({
     sessionId: 's1',
     setSessionId: stream.setMessages,
     sessionIdRef: { current: 's1' },
-    sessionTokenRef: { current: null },
+    sessionTokenRef: stream.sessionTokenRef,
     sessions: [],
     selectSession: stream.handleSend,
     startNewSession: stream.handleSend,

--- a/tests/test_deep_explore_owner_chain.py
+++ b/tests/test_deep_explore_owner_chain.py
@@ -200,7 +200,6 @@ async def test_start_exploration_registers_session_task():
 async def test_bridge_skips_owner_registered_tasks():
     """#518: 已注册 owner 的任务（登录会话）不走聊天流桥接 —— 独立流负责。"""
     from app.services.explorer.orchestrator import (
-        ExplorerOrchestrator,
         bridge_session_explorer_progress,
         register_session_task,
     )

--- a/tests/test_deep_explore_owner_chain.py
+++ b/tests/test_deep_explore_owner_chain.py
@@ -1,0 +1,152 @@
+"""#518 regression — deep_explore owner chain + explorer progress reachability.
+
+The `deep_explore` tool used to call `start_exploration(query, context)` with
+no session/user, so `register_owner` never ran (S42) and every owner-verified
+explorer endpoint (`/explorer/stream|status|abort/{task_id}`) 404'd even for
+the initiating user. These tests pin:
+  1. the tool forwards the dispatch-injected session_id + resolved owner
+     user_id to the orchestrator (trusted context, never LLM args),
+  2. `start_exploration(..., user_id=...)` registers ownership and
+     `verify_owner` gates correctly,
+  3. the HTTP stream endpoint rejects non-owners (404) and serves owners.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.task_queue import TaskQueueService
+
+
+@pytest.fixture(autouse=True)
+def _clean_task_owners():
+    TaskQueueService._task_owners.clear()
+    yield
+    TaskQueueService._task_owners.clear()
+
+
+@pytest.mark.asyncio
+async def test_deep_explore_forwards_session_and_owner_user_id():
+    """#518: deep_explore 把 registry 注入的 session_id 与解析出的归属
+    user_id 传给 start_exploration（可信上下文 —— session_id 由调度入口
+    注入、覆盖 LLM 参数，user_id 由 DB 按该 session 解析，LLM 无法伪造）。"""
+    from app.tools.explorer_tools import register_explorer_tools
+    from app.tools.registry import ToolRegistry
+
+    fake_orch = MagicMock()
+    fake_orch.start_exploration = AsyncMock(return_value="exp-sess-1-123")
+    registry = ToolRegistry()
+    with patch("app.tools.explorer_tools.ExplorerOrchestrator", return_value=fake_orch):
+        register_explorer_tools(registry)
+    with patch(
+        "app.tools.explorer_tools._resolve_session_owner_user_id",
+        AsyncMock(return_value="owner-u1"),
+    ):
+        result = await registry.dispatch(
+            "deep_explore", {"query": "海淀区学校"}, session_id="sess-1"
+        )
+
+    assert result["type"] == "explorer_task"
+    assert result["task_id"] == "exp-sess-1-123"
+    fake_orch.start_exploration.assert_awaited_once()
+    kwargs = fake_orch.start_exploration.await_args.kwargs
+    assert kwargs["session_id"] == "sess-1"
+    assert kwargs["user_id"] == "owner-u1"
+
+
+@pytest.mark.asyncio
+async def test_start_exploration_registers_owner_and_verify_owner_gates():
+    """#518/S42: start_exploration 带 user_id 时 register_owner 生效，
+    verify_owner 对归属用户放行、对他人拒绝。"""
+    from app.services.explorer.orchestrator import ExplorerOrchestrator
+    from app.services.explorer.models import SearchContext
+
+    orchestrator = ExplorerOrchestrator()
+
+    mock_result = MagicMock()
+    mock_result.id = "final_task_id"
+    node = mock_result
+    for _ in range(4):
+        parent = MagicMock()
+        parent.parent = None
+        node.parent = parent
+        node = parent
+    node.id = "first_task_id"
+
+    with patch("app.services.explorer.orchestrator.chain") as mock_chain:
+        mock_chain.return_value.apply_async.return_value = mock_result
+        task_id = await orchestrator.start_exploration(
+            query="海淀区学校",
+            context=SearchContext(query="海淀区学校"),
+            user_id="u1",
+        )
+
+    assert task_id == "final_task_id"
+    assert TaskQueueService.verify_owner(task_id, "u1") is True
+    assert TaskQueueService.verify_owner(task_id, "u2") is False
+    assert TaskQueueService.verify_owner("other-task", "u1") is False
+
+
+@pytest.mark.asyncio
+async def test_start_exploration_without_user_skips_owner_registration():
+    """#518: 匿名会话（user_id ""）不注册归属 —— verify_owner 恒 False，
+    与 S42「未注册即 404」语义一致。"""
+    from app.services.explorer.orchestrator import ExplorerOrchestrator
+    from app.services.explorer.models import SearchContext
+
+    orchestrator = ExplorerOrchestrator()
+    mock_result = MagicMock()
+    mock_result.id = "anon_final"
+    node = mock_result
+    for _ in range(4):
+        parent = MagicMock()
+        parent.parent = None
+        node.parent = parent
+        node = parent
+    node.id = "anon_first"
+
+    with patch("app.services.explorer.orchestrator.chain") as mock_chain:
+        mock_chain.return_value.apply_async.return_value = mock_result
+        task_id = await orchestrator.start_exploration(
+            query="q",
+            context=SearchContext(query="q"),
+        )
+    assert TaskQueueService.verify_owner(task_id, "u1") is False
+
+
+@pytest.mark.asyncio
+async def test_explorer_stream_owner_gating_http():
+    """#518/S42: /explorer/stream/{task_id} 对非归属用户 404，对归属用户 200
+    （verify_owner 门在生成器启动前执行）。"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.api.routes import explorer as _explorer_mod
+    from app.core.auth import get_current_user
+
+    TaskQueueService.register_owner("exp-task-1", "owner-u1")
+
+    app = FastAPI()
+    app.include_router(_explorer_mod.router, prefix="/api/v1")
+    # 让 stream_progress 立即收敛到终态（SUCCESS → 发一条 final 事件后退出）
+    with patch.object(
+        _explorer_mod.orchestrator,
+        "get_task_status",
+        AsyncMock(
+            return_value={
+                "task_id": "exp-task-1",
+                "status": "SUCCESS",
+                "stage": "validate",
+                "progress": 100,
+                "result": {"meta": {}},
+            }
+        ),
+    ):
+        app.dependency_overrides[get_current_user] = lambda: {"user_id": "owner-u1"}
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/explorer/stream/exp-task-1")
+            assert resp.status_code == 200
+            assert "explorer_progress" in resp.text
+
+            # 他人会话/无归属 → 404（不泄漏任务存在性）
+            app.dependency_overrides[get_current_user] = lambda: {"user_id": "intruder"}
+            resp2 = client.get("/api/v1/explorer/stream/exp-task-1")
+            assert resp2.status_code == 404

--- a/tests/test_deep_explore_owner_chain.py
+++ b/tests/test_deep_explore_owner_chain.py
@@ -150,3 +150,132 @@ async def test_explorer_stream_owner_gating_http():
             app.dependency_overrides[get_current_user] = lambda: {"user_id": "intruder"}
             resp2 = client.get("/api/v1/explorer/stream/exp-task-1")
             assert resp2.status_code == 404
+
+
+# ─── #518 (blocker round): post-turn chat-stream bridge for owner-less tasks ──
+
+
+@pytest.fixture(autouse=True)
+def _clean_session_tasks():
+    import app.services.explorer.orchestrator as orch_mod
+    orch_mod._session_tasks.clear()
+    yield
+    orch_mod._session_tasks.clear()
+
+
+@pytest.mark.asyncio
+async def test_start_exploration_registers_session_task():
+    """#518: start_exploration 带 session_id 时登记会话→任务映射（匿名也登记），
+    post-turn 聊天流桥接据此发现该任务。"""
+    from app.services.explorer.orchestrator import (
+        ExplorerOrchestrator, get_session_tasks,
+    )
+    from app.services.explorer.models import SearchContext
+
+    orchestrator = ExplorerOrchestrator()
+    mock_result = MagicMock()
+    mock_result.id = "final_task_id"
+    node = mock_result
+    for _ in range(4):
+        parent = MagicMock()
+        parent.parent = None
+        node.parent = parent
+        node = parent
+    node.id = "first_task_id"
+
+    with patch("app.services.explorer.orchestrator.chain") as mock_chain:
+        mock_chain.return_value.apply_async.return_value = mock_result
+        # 匿名会话：user_id ""，session_id 非空 → 登记但无 owner registration
+        await orchestrator.start_exploration(
+            query="q",
+            context=SearchContext(query="q"),
+            session_id="sess-anon",
+        )
+
+    tasks = get_session_tasks("sess-anon")
+    assert ("final_task_id", "") in tasks
+
+
+@pytest.mark.asyncio
+async def test_bridge_skips_owner_registered_tasks():
+    """#518: 已注册 owner 的任务（登录会话）不走聊天流桥接 —— 独立流负责。"""
+    from app.services.explorer.orchestrator import (
+        ExplorerOrchestrator,
+        bridge_session_explorer_progress,
+        register_session_task,
+    )
+
+    register_session_task("sess-owned", "task-1", "owner-u1")
+    TaskQueueService.register_owner("task-1", "owner-u1")
+
+    events = [
+        ev async for ev in bridge_session_explorer_progress("sess-owned", "owner-u1")
+    ]
+    assert events == []
+    # 任务仍在登记表中（等独立流侧完成；桥接不越权消费）
+    from app.services.explorer.orchestrator import get_session_tasks
+    assert get_session_tasks("sess-owned") == [("task-1", "owner-u1")]
+
+
+@pytest.mark.asyncio
+async def test_bridge_streams_ownerless_task_to_terminal():
+    """#518: 匿名（无 owner）任务经聊天流桥接推送 explorer_progress 至终态，
+    完成后从会话登记表剔除。"""
+    import app.services.explorer.orchestrator as orch_mod
+    from app.services.explorer.orchestrator import (
+        bridge_session_explorer_progress,
+        get_session_tasks,
+        register_session_task,
+    )
+
+    register_session_task("sess-anon", "task-anon-1", "")
+
+    async def fake_status(task_id):
+        return {
+            "task_id": task_id,
+            "status": "SUCCESS",
+            "stage": "validate",
+            "progress": 100,
+            "result": {"meta": {}},
+        }
+
+    with patch.object(orch_mod._bridge_orchestrator, "get_task_status", fake_status):
+        events = [
+            ev async for ev in bridge_session_explorer_progress("sess-anon", None)
+        ]
+
+    assert any("explorer_progress" in ev and '"completed"' in ev for ev in events)
+    assert get_session_tasks("sess-anon") == []
+
+
+@pytest.mark.asyncio
+async def test_bridge_caps_stuck_task_with_terminal_event():
+    """#518: 卡死任务（永在 PROGRESS）不能挂住聊天流 —— 有界 cap 后发显式
+    failed 终态，不静默丢弃。"""
+    import app.services.explorer.orchestrator as orch_mod
+    from app.services.explorer.orchestrator import (
+        bridge_session_explorer_progress,
+        register_session_task,
+    )
+
+    register_session_task("sess-stuck", "task-stuck-1", "")
+
+    async def fake_status(task_id):
+        return {
+            "task_id": task_id,
+            "status": "PROGRESS",
+            "stage": "fetch",
+            "progress": 10,
+            "result": {"meta": {}},
+        }
+
+    with patch.object(orch_mod, "_EXPLORER_BRIDGE_MAX_SECONDS", 0.05), \
+         patch.object(orch_mod._bridge_orchestrator, "get_task_status", fake_status):
+        events = [
+            ev async for ev in bridge_session_explorer_progress("sess-stuck", None)
+        ]
+
+    assert any('"failed"' in ev for ev in events), (
+        "stuck task must receive an explicit terminal event, not a silent hang"
+    )
+    assert any('"bridge timeout"' in ev for ev in events)

--- a/tests/test_map_export_download_auth.py
+++ b/tests/test_map_export_download_auth.py
@@ -1,0 +1,106 @@
+"""#515 regression — export download auth contract.
+
+The download route (`map.py::download_map_export`) requires `get_current_user`
+(Bearer) and, when ownership is recorded, the requesting user must own the
+file (审计 P0 IDOR guard). The frontend fix routes downloads through the
+authenticated transport; this file pins the backend contract the frontend
+now satisfies: anonymous → 401, owner → 200, non-owner → 403, missing → 404.
+"""
+import os
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from app.api.routes import map as _mod
+from app.core.auth import get_current_user
+
+_TEST_EXPORT_DIR = "/tmp/test_exports_download_auth"
+os.makedirs(_TEST_EXPORT_DIR, exist_ok=True)
+
+_owner_user = {"user_id": "file-owner"}
+_intruder_user = {"user_id": "other-user"}
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(_mod.router, prefix="/api/v1")
+    return app
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _write_export_file(name: str, content: bytes) -> str:
+    path = os.path.join(_TEST_EXPORT_DIR, name)
+    with open(path, "wb") as f:
+        f.write(content)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    _mod._EXPORT_OWNERS.clear()
+    for fn in os.listdir(_TEST_EXPORT_DIR):
+        os.remove(os.path.join(_TEST_EXPORT_DIR, fn))
+    yield
+    _mod._EXPORT_OWNERS.clear()
+
+
+@pytest.mark.asyncio
+async def test_download_requires_bearer(client):
+    """匿名（无 Bearer）→ 401：下载端点不得退化为公共路径。"""
+    name = "anon_map.png"
+    _write_export_file(name, b"png")
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_mod, "EXPORT_DIR", _TEST_EXPORT_DIR)
+        resp = await client.get(f"/api/v1/export/download/{name}")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_download_owner_bearer_succeeds(client):
+    """带有效 Bearer 且为文件所有者 → 200 + 文件体。"""
+    name = "owner_map.png"
+    _write_export_file(name, b"owner-png-bytes")
+    app = client._transport.app
+    app.dependency_overrides[get_current_user] = lambda: _owner_user
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_mod, "EXPORT_DIR", _TEST_EXPORT_DIR)
+        mp.setattr(_mod, "_EXPORT_OWNERS", {name: "file-owner"})
+        resp = await client.get(f"/api/v1/export/download/{name}")
+    assert resp.status_code == 200
+    assert resp.content == b"owner-png-bytes"
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_download_non_owner_forbidden(client):
+    """已认证但不是文件所有者 → 403（IDOR 守卫）。"""
+    name = "secret_map.png"
+    _write_export_file(name, b"secret")
+    app = client._transport.app
+    app.dependency_overrides[get_current_user] = lambda: _intruder_user
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_mod, "EXPORT_DIR", _TEST_EXPORT_DIR)
+        mp.setattr(_mod, "_EXPORT_OWNERS", {name: "file-owner"})
+        resp = await client.get(f"/api/v1/export/download/{name}")
+    assert resp.status_code == 403
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_download_missing_file_404(client):
+    """不存在文件 → 404（不泄漏文件存在性）。"""
+    app = client._transport.app
+    app.dependency_overrides[get_current_user] = lambda: _owner_user
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_mod, "EXPORT_DIR", "/tmp/nonexistent_exports_dir")
+        resp = await client.get("/api/v1/export/download/ghost.png")
+    assert resp.status_code == 404
+    app.dependency_overrides.clear()

--- a/tests/unit/test_tool_dispatch_service.py
+++ b/tests/unit/test_tool_dispatch_service.py
@@ -131,6 +131,120 @@ async def test_geojson_result_produces_ref(service, fake_registry, clean_session
     assert persisted["layers"][0]["provenance"]["result_ref"] == result.geojson_ref
 
 
+# ─── #517 回归锁定：to_llm_response() 的 data 包裹 FC 形状 ──────────
+
+
+@pytest.mark.asyncio
+async def test_data_wrapped_fc_produces_ref(service, fake_registry, clean_session):
+    """#517：to_llm_response() 形状 {success, summary, data: FeatureCollection}
+    必须走与顶层 FC 相同的挂载管线 → geojson_ref 非空且 mapspec 落库。"""
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [116.4, 39.9]}, "properties": {"v": 1}},
+        ],
+    }
+    fake_registry.dispatch.return_value = {
+        "success": True,
+        "summary": "1 point buffered",
+        "data": fc,
+        "bbox": "116.4,39.9,116.4,39.9",
+    }
+    result = await service.dispatch(_tc("buffer_analysis", {"radius": 100}, tc_id="call_517_1"), clean_session, set())
+    assert result.status == "ok"
+    assert result.geojson_ref is not None
+    assert result.geojson_ref.startswith("ref:geojson-")
+    # data 包裹的 FC 也要经过 MapSpec authoring（前端靠 runtime_patch/挂载）
+    assert result.raw_result["runtime_patch"]["result_ref"] == result.geojson_ref
+    assert result.map_actions[0]["command"] == "add_layer"
+
+
+@pytest.mark.asyncio
+async def test_data_wrapped_fc_geometry_persisted(service, fake_registry, clean_session):
+    """#517 几何真值：data 包裹 FC 落 ref 后可从 session_data_manager 读回，
+    要素数与几何类型与输入一致（不是"不抛异常"的假通过）。"""
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]}, "properties": {}},
+            {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[2, 2], [3, 2], [3, 3], [2, 2]]]}, "properties": {}},
+        ],
+    }
+    fake_registry.dispatch.return_value = {
+        "success": True,
+        "summary": "2 polygons",
+        "data": fc,
+    }
+    result = await service.dispatch(_tc("buffer_analysis", {"radius": 50}, tc_id="call_517_2"), clean_session, set())
+    assert result.status == "ok" and result.geojson_ref
+
+    res = await session_data_manager.get_ref_data(clean_session, result.geojson_ref)
+    assert res.success and res.data
+    persisted = res.data
+    assert persisted.get("type") == "FeatureCollection"
+    assert len(persisted["features"]) == 2
+    assert {f["geometry"]["type"] for f in persisted["features"]} == {"Polygon"}
+
+
+@pytest.mark.asyncio
+async def test_llm_payload_carries_ref_id_for_data_wrapped_fc(service, fake_registry, clean_session):
+    """#517：summary 分支的 LLM 载荷必须携带 ref_id == geojson_ref，
+    LLM 才拿得到 ref 去 display_layer。"""
+    fc = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [0, 0]}, "properties": {}}],
+    }
+    fake_registry.dispatch.return_value = {
+        "success": True,
+        "summary": "done",
+        "data": fc,
+    }
+    result = await service.dispatch(_tc("kde_surface", {"bandwidth": 5}, tc_id="call_517_3"), clean_session, set())
+    assert result.status == "ok" and result.geojson_ref
+    assert '"ref_id"' in result.llm_payload
+    import json as _json
+    payload = _json.loads(result.llm_payload)
+    assert payload.get("ref_id") == result.geojson_ref
+
+
+@pytest.mark.asyncio
+async def test_slim_event_excludes_data_key(service, fake_registry, clean_session):
+    """#517 性能面 sibling：slim_event（SSE 事件载荷）不得再携带未裁剪的
+    data FC 全量传输。"""
+    big_fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "geometry": {"type": "Point", "coordinates": [i, i]}, "properties": {"p": i}}
+            for i in range(100)
+        ],
+    }
+    fake_registry.dispatch.return_value = {
+        "success": True,
+        "summary": "big",
+        "data": big_fc,
+    }
+    result = await service.dispatch(_tc("spatial_stats", {}, tc_id="call_517_4"), clean_session, set())
+    assert result.status == "ok"
+    slim = result.slim_event
+    assert isinstance(slim, dict)
+    assert "data" not in slim
+    assert "geojson" not in slim
+    assert "features" not in slim
+
+
+@pytest.mark.asyncio
+async def test_data_wrapped_non_fc_produces_no_ref(service, fake_registry, clean_session):
+    """#517 守卫：data 不是 FC dict（list / 普通 dict）时不得误挂载。"""
+    fake_registry.dispatch.return_value = {
+        "success": True,
+        "summary": "tabular",
+        "data": [{"a": 1}, {"a": 2}],
+    }
+    result = await service.dispatch(_tc("some_table_tool", {}, tc_id="call_517_5"), clean_session, set())
+    assert result.status == "ok"
+    assert result.geojson_ref is None
+
+
 @pytest.mark.asyncio
 async def test_mapspec_authoring_failure_keeps_ref_but_drops_feature_body(
     service, fake_registry, clean_session, monkeypatch,

--- a/tests/unit/test_tool_dispatch_service.py
+++ b/tests/unit/test_tool_dispatch_service.py
@@ -11,6 +11,7 @@ import shutil
 from unittest.mock import AsyncMock, MagicMock
 
 from app.services.tool_dispatch_service import (
+    LEGACY_TOOL_NAME_MAP,
     ToolDispatchResult,
     ToolDispatchService,
     normalize_tool_name,
@@ -377,13 +378,82 @@ async def test_failed_dispatch_does_not_occupy_dedup_slot(service, fake_registry
 
 
 def test_tool_name_normalization_table():
-    """断言 legacy 工具名被正确映射为 webgis_* canonical 名称。"""
+    """断言 legacy 工具名被正确映射为 webgis_* canonical 名称。
+
+    #516：remove_layer / zoom_to_layer 已是 registry 现役工具，别名表不得
+    再改写它们（schema 不兼容：layer_ref vs layer_id / 全可选 view args），
+    否则 LLM 的合法调用被重定向后校验失败或静默无操作。LLM 按目录可见名
+    调用即命中现役工具。
+    """
     assert normalize_tool_name("add_layer") == "webgis_layer_upsert"
     assert normalize_tool_name("set_layer_style") == "webgis_layer_upsert"
     assert normalize_tool_name("set_view") == "webgis_view_set"
-    assert normalize_tool_name("remove_layer") == "webgis_layer_remove"
+    # #516：现役工具名不再被别名表改写
+    assert normalize_tool_name("remove_layer") == "remove_layer"
+    assert normalize_tool_name("zoom_to_layer") == "zoom_to_layer"
     assert normalize_tool_name("init_project") == "webgis_project_init"
     assert normalize_tool_name("unknown_tool") == "unknown_tool"
+
+
+def test_legacy_alias_map_never_shadows_registered_tool_names():
+    """契约：别名表键 ∩ registry 注册名 == ∅（防 #516 复发）。
+
+    别名表只应包含不再注册的旧名；一旦某工具以现役名注册
+    （remove_layer / zoom_to_layer），dispatch 入口的 normalize 会把
+    LLM 对现役工具的合法调用重写为 schema 不兼容的 webgis_* 工具。
+    """
+    from app.tools import init_tools
+    from app.tools.registry import ToolRegistry
+
+    r = ToolRegistry()
+    init_tools(r)
+    registered = set(r.all_metadata().keys())
+    conflict = set(LEGACY_TOOL_NAME_MAP.keys()) & registered
+    assert conflict == set(), (
+        f"LEGACY_TOOL_NAME_MAP 键与 registry 注册名冲突，会被 normalize "
+        f"错误改写: {conflict}"
+    )
+    # #516 的两个现役工具必须在 registry 中且不在别名表中
+    assert "remove_layer" in registered
+    assert "zoom_to_layer" in registered
+    assert "remove_layer" not in LEGACY_TOOL_NAME_MAP
+    assert "zoom_to_layer" not in LEGACY_TOOL_NAME_MAP
+
+
+@pytest.mark.asyncio
+async def test_dispatch_does_not_rewrite_active_tool_names(
+    service, fake_registry, clean_session,
+):
+    """#516：现役工具 remove_layer / zoom_to_layer 经 dispatch 不被改写，
+    且参数 schema 按现役定义校验（layer_ref 必须原样到达 registry）。"""
+    fake_registry.dispatch.return_value = {"summary": "removed"}
+    tc = _tc("remove_layer", {"layer_ref": "ref:geojson-1"})
+
+    result = await service.dispatch(tc, clean_session, set())
+
+    assert result.status == "ok"
+    fake_registry.dispatch.assert_called_once()
+    called_name, called_args = fake_registry.dispatch.call_args[0][0], fake_registry.dispatch.call_args[0][1]
+    assert called_name == "remove_layer"
+    assert called_args == {"layer_ref": "ref:geojson-1"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_zoom_to_layer_passes_padding_through(
+    service, fake_registry, clean_session,
+):
+    """#516：zoom_to_layer 的 layer_ref/padding 原样到达 registry（改写为
+    webgis_view_set 会吞掉这两个参数，缩放命令永不触发）。"""
+    fake_registry.dispatch.return_value = {"summary": "zoomed"}
+    tc = _tc("zoom_to_layer", {"layer_ref": "ref:geojson-2", "padding": 120})
+
+    result = await service.dispatch(tc, clean_session, set())
+
+    assert result.status == "ok"
+    fake_registry.dispatch.assert_called_once()
+    called_name, called_args = fake_registry.dispatch.call_args[0][0], fake_registry.dispatch.call_args[0][1]
+    assert called_name == "zoom_to_layer"
+    assert called_args == {"layer_ref": "ref:geojson-2", "padding": 120}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Issues

Fixes #514
Fixes #515
Fixes #516
Fixes #517
Fixes #518

## Root causes

- #514: MVT tile/image fetches are browser-native and cannot attach headers; the tile endpoint is Bearer/X-Session-Token only, so >5000-feature ref layers 404'd for both anonymous and logged-in sessions.
- #515: export/report download endpoints accept only Authorization: Bearer, but all consumers used bare `<a>`/`<img>`/`<iframe>` browser-native requests → hard 401 (incl. chat-embedded links/images and report previews).
- #516: LEGACY_TOOL_NAME_MAP rewrote the active tools remove_layer/zoom_to_layer into schema-incompatible webgis_* names → dispatch failed structurally.
- #517: the geojson-ref mounting predicate only recognized top-level FeatureCollections / `geojson` keys; ~29 to_llm_response() sites return {success, summary, data: FC} and bypassed mounting entirely.
- #518: explorer_progress was only emitted on the standalone /explorer/stream endpoint, which anonymous sessions cannot pass owner verification for; deep_explore never passed user_id so register_owner never ran; the chat stream had no producer.

## Changes

- #514: MapLibre transformRequest injects the same credentials apiFetch sends; token read live per request (survives SSE owner_token arrival + session switch); first-party detection via origin comparison with relative-URL support (API_BASE === '').
- #515: new apiFetchBlob authenticated transport (401-refresh + Content-Disposition filename); chat links/images, map-studio export, report generator/preview all routed through it; path-based protected-URL detection; report-generator anchor href removed to close middle-click bypass.
- #516: remove_layer/zoom_to_layer removed from LEGACY_TOOL_NAME_MAP; pinned test flipped; alias∩registry=∅ contract test added.
- #517: dispatch predicate extended to data-wrapped FeatureCollections; `data` added to SSE slim exclude set; geometry round-trip tests.
- #518: deep_explore resolves owner user_id from DB (registry-injected session_id, not LLM-controlled) and registers it; logged-in sessions get the owner-verified independent stream; owner-less (anonymous) sessions get explorer_progress bridged into the session-isolated chat SSE (bounded 600s, explicit failed terminal event, no silent hang); frontend shares one normalizer with per-task dedup so dual-path delivery cannot double-apply; isThinking flips on done/task_complete so the bridge cannot hide the finished answer; explorer progress panel uses theme tokens.

## Tests

- Backend: tests/unit full suite 1976 passed, 1 skipped; targeted suites (owner chain, download auth matrix, dispatch, explorer chain, SSE resume/keepalive) green; new auth-matrix tests cover 401/200/403/404.
- Frontend: full vitest 1449 passed, 3 skipped; tsc --noEmit (both configs) clean; eslint 0 warnings.
- New regression tests per issue: tile-auth (10), authenticated-download/transport, mini-md, report-preview (rewritten to assert the real path), dispatch alias contract, data-FC mounting (5), deep-explore owner chain + bridge (anonymous stream-to-terminal, owner-skip, stuck-task cap), use-sse-stream explorer + isThinking.

## Regression protection

Alias∩registry contract test; data-FC predicate tests; explorer bridge terminal-event tests; download auth matrix; tile-auth live-token + origin-impersonation tests.

## Risk

Medium: touches auth-adjacent request paths (tile/download) and the chat SSE lifecycle. Backend auth contract is byte-identical (purely additive client-side credential injection); ownership enforcement unchanged (verified by auth-matrix tests). The chat SSE may stay open up to 10 min post-done for owner-less explorer tasks (bounded, explicit terminal, aborts cleanly on new turn/session switch). Independent read-only review completed; 4 blockers found and fixed. No CI/workflow changes in this PR.